### PR TITLE
chore: add test coverage for employee list

### DIFF
--- a/src/components/Employee/EmployeeList/EmployeeList.test.tsx
+++ b/src/components/Employee/EmployeeList/EmployeeList.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { EmployeeList } from './EmployeeList'
+import { render, screen } from '@testing-library/react'
+import { GustoApiProvider } from '@/contexts'
+
+describe('EmployeeList', () => {
+  it('renders a list of employees', async () => {
+    render(
+      <GustoApiProvider>
+        <EmployeeList companyId="some-company-uuid" onEvent={() => {}} />
+      </GustoApiProvider>,
+    )
+
+    await screen.findByText('Your employees')
+
+    expect(screen.queryAllByRole('row')[1]).toHaveTextContent('Steel, Maximus')
+  })
+})

--- a/src/contexts/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/contexts/ThemeProvider/ThemeProvider.test.tsx
@@ -1,5 +1,4 @@
-import { render } from '@testing-library/react'
-import { screen } from './test-utils'
+import { render, screen } from '@testing-library/react'
 import { ThemeProvider } from './ThemeProvider'
 import { describe, test, expect } from 'vitest'
 

--- a/src/contexts/ThemeProvider/test-utils.tsx
+++ b/src/contexts/ThemeProvider/test-utils.tsx
@@ -17,5 +17,4 @@ const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
 const customRender = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
   render(ui, { wrapper: AllTheProviders, ...options })
 
-export * from '@testing-library/react'
 export { customRender as render }


### PR DESCRIPTION
Added some initial test coverage for employee list.

One thing that troubles me about it right now is how hard it is to tell *why* the test passes. 

The setup is far, far away in the `/test` folder.

I may want in a followup PR to see if I can separate out the API tests into their own "shared setup" segment so that I can move the setup for this specific test closer.