### PR TITLE
chore: revert automatic versioning for now

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,11 +13,7 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - run: npm run generate
-      - run: npm version minor --no-commit-hooks --message "[skip ci] Version bump" #HACK: this is fair while we are pre-production only
       - run: npm run build
       - run: npm publish --access public
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,5 +70,5 @@ TBD
 
 ## Cutting a new release
 
-- Get the main branch into a state where it contains the code to be released
-- Run the `Publish to NPM` GitHub action [here](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish.yaml) by clicking `Run workflow` and choose the main branch
+- Get your changes and a version increase in the package.json `version` field into the main branch however you want
+- Run the `Publish to NPM` GitHub action [here](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish.yaml) by clicking `Run workflow`


### PR DESCRIPTION
Automatic versioning is going to require a service user or github app to provide a PAT, and we don't have that right now. 

This gets us back into a state where we can perform a manual release to keep things in a clean state.