### PR TITLE
fix: fix infinite loading in payment method

### DIFF
--- a/src/components/Employee/PaymentMethod/PaymentMethod.tsx
+++ b/src/components/Employee/PaymentMethod/PaymentMethod.tsx
@@ -178,10 +178,11 @@ const Root = ({ employeeId, className }: PaymentMethodProps) => {
   const watchedType = formMethods.watch('type')
 
   const { reset: resetForm } = formMethods
+  const { mutate: mutatePaymentMethod } = paymentMethodMutation
 
   useEffect(() => {
     if (paymentMethod.splits?.length === 1 && paymentMethod.type === 'Direct Deposit') {
-      paymentMethodMutation.mutate({
+      mutatePaymentMethod({
         body: {
           split_by: SPLIT_BY.percentage,
           splits: paymentMethod.splits.map(split => ({
@@ -194,7 +195,7 @@ const Root = ({ employeeId, className }: PaymentMethodProps) => {
         },
       })
     }
-  }, [paymentMethod, paymentMethodMutation])
+  }, [paymentMethod, mutatePaymentMethod])
 
   useEffect(() => {
     resetForm(defaultValues)
@@ -274,6 +275,7 @@ const Root = ({ employeeId, className }: PaymentMethodProps) => {
   const handleSplit = () => {
     setMode('SPLIT')
   }
+
   return (
     <section className={className}>
       <PaymentMethodProvider


### PR DESCRIPTION
There was an infinite loading bug introduced here https://github.com/Gusto/embedded-react-sdk/pull/87

This was because a full mutation was included in the dependency array. See here https://github.com/trojanowski/react-apollo-hooks/issues/205#issuecomment-1032336686

## Proof of functionality

### Before

https://github.com/user-attachments/assets/9b9dfa84-6822-452d-9475-f9884c3d909c

### After

https://github.com/user-attachments/assets/8417ac50-0a6f-46ba-b836-4a3b02f9e8fe

### Verifying no regressions

Attempted to verify fix introduced no other regressions. Created multiple accounts with a fixed amount and then verified that when we reduced to just one account it got updated to have the full percentage allocation. Lmk if there's a misunderstanding on my part of the intent of https://github.com/Gusto/embedded-react-sdk/pull/87

https://github.com/user-attachments/assets/511f91de-23e5-407a-a899-6835e5bc3073
