### PR TITLE
chore: bump to v0.1.1 prepublish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-react-sdk",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@hookform/error-message": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "module": "./dist/index.js",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Bumping to v0.1.1 to enable testing the new top level await removal with codesandbox