### PR TITLE
chore: minor version bump for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Changelog
+
+## 0.2.0
+
+- Upgraded React to v19

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-react-sdk",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@hookform/error-message": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "module": "./dist/index.js",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Bumped to 0.2 since the peer dep on React is a potential breaking change.

In NPM-flavored semver a minor bump signifies a breaking change for a prerelease (0.x) package
https://docs.npmjs.com/cli/v6/using-npm/semver#caret-ranges-123-025-004