### PR TITLE
fix: restore checkbox connection to react hook form

### DIFF
--- a/src/components/Common/Inputs/Checkbox.tsx
+++ b/src/components/Common/Inputs/Checkbox.tsx
@@ -70,6 +70,7 @@ export const Checkbox = <C extends FieldValues, N extends FieldPath<C>>({
 
   return (
     <DisconnectedCheckbox
+      {...field}
       {...props}
       description={description}
       isSelected={field.value}


### PR DESCRIPTION
Overlooked checkbox receiving the field props in this PR https://github.com/Gusto/embedded-react-sdk/pull/85 which resulted in it being non functional when used outside of a group.

This restores it.

## Proof of functionality

### Before

https://github.com/user-attachments/assets/2a3ef78a-06f0-4bb7-a8f1-589d8d0d7d2e

### After

https://github.com/user-attachments/assets/b36edb0f-e35d-4aab-b22c-0b716bf3f923
