### PR TITLE
fix: update radio to avoid getting squished on mobile

### DIFF
--- a/src/styles/_RadioGroup.scss
+++ b/src/styles/_RadioGroup.scss
@@ -28,19 +28,19 @@
   .react-aria-Radio {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: toRem(10);
     font-size: toRem(15);
     color: var(--g-radio-labelColor);
     forced-color-adjust: none;
 
     &:before {
       content: '';
-      display: block;
-      width: 20px;
-      height: 20px;
+      flex-shrink: 0;
+      flex: 0 0 toRem(20);
+      height: toRem(20);
       box-sizing: border-box;
       border: var(--g-radio-borderWidth) solid var(--g-radio-borderColor);
-      border-radius: 9999px;
+      border-radius: toRem(10);
       transition: all 200ms;
     }
 


### PR DESCRIPTION
Small styling fix to prevent radios from getting squished on mobile

## Proof of functionality

### Before

<img width="383" alt="Screenshot 2025-01-21 at 3 43 34 PM" src="https://github.com/user-attachments/assets/83aeb574-da3a-4191-ac2d-9ccc749064f5" />

### After

<img width="380" alt="Screenshot 2025-01-21 at 3 44 07 PM" src="https://github.com/user-attachments/assets/7882922a-0600-4a36-b099-e0ba0816b7f3" />

