### PR TITLE
feat: update Flex component to have responsive props

### DIFF
--- a/src/components/Common/Alert/Alert.module.scss
+++ b/src/components/Common/Alert/Alert.module.scss
@@ -6,7 +6,7 @@
     --borderColor: var(--g-colors-gray-900);
 
     border: 1px solid var(--borderColor);
-    border-radius: var(--g-spacing-radius);
+    border-radius: var(--g-radius);
     padding: var(--g-spacing-20);
     padding-left: calc(var(--g-spacing-20) + toRem(18));
     margin-bottom: var(--g-spacing-20);

--- a/src/components/Common/Flex/Flex.module.scss
+++ b/src/components/Common/Flex/Flex.module.scss
@@ -1,30 +1,17 @@
-@mixin justifyContent($vals) {
-  @each $val in $vals {
-    justify-content: $val;
-  }
-}
-.flex {
+.flexContainer {
+  container-type: inline-size;
   width: 100%;
-  display: flex;
-  @each $val in normal center flex-start flex-end space-between space-around space-evenly {
-    &-jc-#{$val} {
-      justify-content: $val;
-    }
-  }
-  @each $val in column row {
-    &-fd-#{$val} {
-      flex-direction: $val;
-    }
-  }
-  @each $val in center flex-start flex-end stretch {
-    &-ai-#{$val} {
-      align-items: $val;
-    }
-  }
+}
 
-  @each $key, $val in (sm: 8, md: 16, lg: 24, xl: 32, '2xl': 40) {
-    &-gap-#{$key} {
-      gap: var(--g-spacing-#{$val});
-    }
-  }
+.flex {
+  display: flex;
+
+  @include responsive-properties(
+    (
+      'flex-direction': row,
+      'justify-content': normal,
+      'align-items': normal,
+      'gap': normal,
+    )
+  );
 }

--- a/src/components/Common/Flex/Flex.tsx
+++ b/src/components/Common/Flex/Flex.tsx
@@ -1,9 +1,16 @@
+import {
+  setResponsiveCustomProperties,
+  transformResponsiveSpacingValue,
+  type Responsive,
+  type ResponsiveSpacing,
+} from '@/helpers/responsive'
+
 import style from './Flex.module.scss'
 
 export interface FlexProps {
   children: React.ReactNode
-  flexDirection?: 'row' | 'column'
-  justifyContent?:
+  flexDirection?: Responsive<'row' | 'column'>
+  justifyContent?: Responsive<
     | 'space-between'
     | 'center'
     | 'flex-start'
@@ -11,8 +18,9 @@ export interface FlexProps {
     | 'space-around'
     | 'space-evenly'
     | 'normal'
-  alignItems?: 'center' | 'flex-start' | 'flex-end' | 'stretch'
-  gap?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'
+  >
+  alignItems?: Responsive<'center' | 'flex-start' | 'flex-end' | 'stretch'>
+  gap?: ResponsiveSpacing
 }
 
 export function Flex({
@@ -20,19 +28,20 @@ export function Flex({
   flexDirection = 'row',
   justifyContent = 'normal',
   alignItems = 'flex-start',
-  gap = 'lg',
+  gap = 24,
 }: FlexProps) {
+  const properties = setResponsiveCustomProperties({
+    'flex-direction': flexDirection,
+    'justify-content': justifyContent,
+    'align-items': alignItems,
+    gap: transformResponsiveSpacingValue(gap),
+  })
+
   return (
-    <div
-      className={[
-        style.flex,
-        style[`flex-jc-${justifyContent}`],
-        style[`flex-fd-${flexDirection}`],
-        style[`flex-ai-${alignItems}`],
-        style[`flex-gap-${gap}`],
-      ].join(' ')}
-    >
-      {children}
+    <div className={style.flexContainer}>
+      <div className={style.flex} style={properties}>
+        {children}
+      </div>
     </div>
   )
 }

--- a/src/components/Common/Grid/Grid.tsx
+++ b/src/components/Common/Grid/Grid.tsx
@@ -3,8 +3,10 @@ import cn from 'classnames'
 import styles from './Grid.module.scss'
 import {
   setResponsiveCustomProperties,
+  transformResponsiveSpacingValue,
   type CustomPropertyValue,
   type Responsive,
+  type ResponsiveSpacing,
 } from '@/helpers/responsive'
 
 type Flow = 'row' | 'column' | 'row dense' | 'column dense'
@@ -12,7 +14,7 @@ type Alignment = 'start' | 'end' | 'center' | 'stretch'
 
 export interface GridProps {
   children: ReactNode
-  gap?: Responsive<CustomPropertyValue>
+  gap?: ResponsiveSpacing
   gridTemplateColumns?: Responsive<CustomPropertyValue[]>
   gridTemplateRows?: Responsive<CustomPropertyValue[]>
   gridTemplateAreas?: Responsive<string>
@@ -34,7 +36,7 @@ export function Grid({
   className,
 }: GridProps) {
   const properties = setResponsiveCustomProperties({
-    gap,
+    gap: transformResponsiveSpacingValue(gap),
     'grid-template-columns': gridTemplateColumns,
     'grid-template-rows': gridTemplateRows,
     'grid-template-areas': gridTemplateAreas,

--- a/src/components/Employee/DocumentSigner/DocumentList.tsx
+++ b/src/components/Employee/DocumentSigner/DocumentList.tsx
@@ -24,7 +24,7 @@ function DocumentList() {
 
   return (
     <section className={styles.documentList}>
-      <Flex flexDirection="column" gap="xl">
+      <Flex flexDirection="column" gap={32}>
         <Table aria-label={t('documentListLabel')}>
           <TableHeader>
             <Column isRowHeader>{t('formColumnLabel')}</Column>

--- a/src/components/Employee/DocumentSigner/SignatureFormActions.tsx
+++ b/src/components/Employee/DocumentSigner/SignatureFormActions.tsx
@@ -8,7 +8,7 @@ export function SignatureFormActions() {
   const { t } = useTranslation('Employee.DocumentSigner')
 
   return (
-    <Flex gap="sm" justifyContent="flex-end">
+    <Flex gap={8} justifyContent="flex-end">
       <Button variant="secondary" type="button" onPress={handleBack}>
         {t('backCta')}
       </Button>

--- a/src/components/Employee/EmployeeList/List.module.scss
+++ b/src/components/Employee/EmployeeList/List.module.scss
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/src/components/Employee/EmployeeList/List.tsx
+++ b/src/components/Employee/EmployeeList/List.tsx
@@ -18,6 +18,8 @@ import classNames from 'classnames'
 import { EmployeeOnboardingStatus, EmployeeSelfOnboardingStatuses } from '@/shared/constants'
 import { firstLastName } from '@/helpers/formattedStrings'
 
+import style from './List.module.scss'
+
 /**List of employees slot for EmployeeList component */
 export const List = () => {
   const {
@@ -40,7 +42,7 @@ export const List = () => {
   const [deleting, setDeleting] = useState<Set<string>>(new Set())
   return (
     <>
-      <div>
+      <div className={style.container}>
         <Table aria-label={t('employeeListLabel')} key={currentPage}>
           <TableHeader>
             <Column isRowHeader>{t('nameLabel')}</Column>

--- a/src/components/Employee/Landing/Landing.tsx
+++ b/src/components/Employee/Landing/Landing.tsx
@@ -41,12 +41,12 @@ const Root = ({ employeeId, companyId, className }: SummaryProps) => {
 
   return (
     <section className={className}>
-      <Flex alignItems="center" flexDirection="column" gap="xl">
-        <Flex alignItems="center" flexDirection="column" gap="sm">
+      <Flex alignItems="center" flexDirection="column" gap={32}>
+        <Flex alignItems="center" flexDirection="column" gap={8}>
           <h2>{t('landingSubtitle', { firstName, companyName })}</h2>
           <p>{t('landingDescription')}</p>
         </Flex>
-        <Flex flexDirection="column" gap="sm">
+        <Flex flexDirection="column" gap={8}>
           <h3>{t('stepsSubtitle')}</h3>
           <ul>
             <li>{t('steps.personalInfo')}</li>
@@ -54,7 +54,7 @@ const Root = ({ employeeId, companyId, className }: SummaryProps) => {
             <li>{t('steps.bankInfo')}</li>
           </ul>
         </Flex>
-        <Flex flexDirection="column" alignItems="center" gap="sm">
+        <Flex flexDirection="column" alignItems="center" gap={8}>
           <Button
             variant="secondary"
             onPress={() => {

--- a/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
+++ b/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
@@ -43,8 +43,8 @@ const Root = ({ employeeId, className, isAdmin = false }: SummaryProps) => {
     onboarding_steps.findIndex(step => step.required && !step.completed) > -1
   return (
     <section className={className}>
-      <Flex flexDirection="column" gap="xl">
-        <Flex alignItems="center" flexDirection="column" gap="sm">
+      <Flex flexDirection="column" gap={32}>
+        <Flex alignItems="center" flexDirection="column" gap={8}>
           {isAdmin ? (
             onboarding_status === EmployeeOnboardingStatus.ONBOARDING_COMPLETED ||
             (!hasMissingRequirements &&

--- a/src/components/Employee/Profile/Actions.tsx
+++ b/src/components/Employee/Profile/Actions.tsx
@@ -6,7 +6,7 @@ export const Actions = () => {
   const { isPending } = useProfile()
   const { t } = useTranslation('Employee.Profile')
   return (
-    <Flex gap="sm" justifyContent="flex-end">
+    <Flex gap={8} justifyContent="flex-end">
       <Button type="submit" isLoading={isPending}>
         {t('submitCta')}
       </Button>

--- a/src/contexts/ThemeProvider/createTheme.test.ts
+++ b/src/contexts/ThemeProvider/createTheme.test.ts
@@ -20,11 +20,11 @@ describe('createTheme', () => {
     const defaultTheme = createTheme()
     const themeWithOverrides = createTheme({
       spacing: {
-        radius: '2px',
+        8: '2px',
       },
     })
 
-    expect(themeWithOverrides.spacing.radius).toBe('2px')
+    expect(themeWithOverrides.spacing[8]).toBe('2px')
     expect(themeWithOverrides.spacing[4]).toBe(defaultTheme.spacing[4])
   })
 

--- a/src/contexts/ThemeProvider/createTheme.ts
+++ b/src/contexts/ThemeProvider/createTheme.ts
@@ -1,5 +1,5 @@
 import merge from 'deepmerge'
-import { GTheme, GThemeColors, GThemeSpacing, GThemeTypography } from '@/types/GTheme'
+import { GTheme, GThemeColors, GThemeSpacing, GThemeRadius, GThemeTypography } from '@/types/GTheme'
 import { DeepPartial } from '@/types/Helpers'
 import { toRem, getRootFontSize } from '@/helpers/rem'
 
@@ -48,8 +48,11 @@ const defaultSpacing: GThemeSpacing = {
   24: toRem(24),
   28: toRem(28),
   32: toRem(32),
-  radius: '4px',
+  36: toRem(36),
+  40: toRem(40),
 }
+
+const defaultRadius = '4px'
 
 const createTypographyTheme = ({
   colors = defaultColors,
@@ -82,17 +85,19 @@ const createTypographyTheme = ({
 
 type ComponentThemes = Omit<
   GTheme,
-  'colors' | 'spacing' | 'typography' | 'rootFS' | 'optionalLabel'
+  'colors' | 'spacing' | 'typography' | 'radius' | 'rootFS' | 'optionalLabel'
 >
 
 const createComponentThemes = ({
   colors = defaultColors,
   typography = createTypographyTheme({ colors }),
   spacing = defaultSpacing,
+  radius = defaultRadius,
 }: {
   colors?: GThemeColors
   typography?: GThemeTypography
   spacing?: GThemeSpacing
+  radius?: GThemeRadius
 }): ComponentThemes => ({
   focus: {
     color: colors.gray[1000],
@@ -119,7 +124,7 @@ const createComponentThemes = ({
     fontSize: toRem(16),
     fontWeight: typography.fontWeight.medium,
     borderWidth: '1px',
-    borderRadius: spacing.radius,
+    borderRadius: radius,
     textStyle: 'none',
     paddingX: toRem(24),
     paddingY: toRem(12),
@@ -219,6 +224,7 @@ export const createTheme = (overrides: DeepPartial<GTheme> = {}) => {
     colors: partnerColors = {},
     spacing: partnerSpacing = {},
     typography: partnerTypography = {},
+    radius: partnerRadius,
     rootFS: partnerRootFS,
     optionalLabel: partnerOptionalLabel,
     ...partnerTheme
@@ -230,9 +236,10 @@ export const createTheme = (overrides: DeepPartial<GTheme> = {}) => {
     createTypographyTheme({ colors }),
     partnerTypography,
   )
+  const radius = partnerRadius ?? defaultRadius
 
   const componentThemes = merge<ComponentThemes, DeepPartial<ComponentThemes>>(
-    createComponentThemes({ colors, typography, spacing }),
+    createComponentThemes({ colors, typography, spacing, radius }),
     partnerTheme,
   )
 
@@ -240,6 +247,7 @@ export const createTheme = (overrides: DeepPartial<GTheme> = {}) => {
     spacing,
     typography,
     colors,
+    radius,
     rootFS: partnerRootFS ?? getRootFontSize(),
     optionalLabel: partnerOptionalLabel ?? ' (optional)',
     ...componentThemes,

--- a/src/helpers/responsive.test.ts
+++ b/src/helpers/responsive.test.ts
@@ -4,6 +4,8 @@ import {
   isResponsiveValue,
   setResponsiveCustomProperties,
   toRemIfNumeric,
+  transformResponsiveValue,
+  transformResponsiveSpacingValue,
 } from './responsive'
 
 describe('toRemIfNumeric', () => {
@@ -70,5 +72,39 @@ describe('setResponsiveCustomProperties', () => {
 
   it('returns empty object when no properties provided', () => {
     expect(setResponsiveCustomProperties()).toEqual({})
+  })
+})
+
+describe('transformResponsiveValue', () => {
+  it('transforms a value using the provided transform function', () => {
+    const result = transformResponsiveValue(16, value => `${value}px`)
+    expect(result).toEqual({ base: '16px' })
+  })
+
+  it('transforms responsive values using the provided transform function', () => {
+    const result = transformResponsiveValue({ small: 24 }, value => `${value}px`)
+
+    expect(result).toEqual({
+      small: '24px',
+    })
+  })
+})
+
+describe('transformResponsiveSpacingValue', () => {
+  it('converts spacing token to CSS custom property', () => {
+    const result = transformResponsiveSpacingValue({
+      small: 32,
+    })
+
+    expect(result).toEqual({
+      small: 'var(--g-spacing-32)',
+    })
+  })
+
+  it('handles sets 0 when value is 0', () => {
+    const result = transformResponsiveSpacingValue(0)
+    expect(result).toEqual({
+      base: '0',
+    })
   })
 })

--- a/src/helpers/responsive.ts
+++ b/src/helpers/responsive.ts
@@ -1,5 +1,6 @@
 import { toRem } from '@/helpers/rem'
 import { BREAKPOINTS } from '@/shared/constants'
+import { GThemeSpacing } from '@/types/GTheme'
 
 type BreakpointKey = (typeof BREAKPOINTS)[keyof typeof BREAKPOINTS]
 
@@ -11,9 +12,32 @@ export type Responsive<T> =
 
 export type CustomPropertyValue = string | number
 
+export type ResponsiveSpacing = Responsive<keyof GThemeSpacing | 0>
+
 export function isResponsiveValue(value: Responsive<CustomPropertyValue | CustomPropertyValue[]>) {
   return Object.values(BREAKPOINTS).some(
     breakpoint => typeof value === 'object' && breakpoint in value,
+  )
+}
+
+export function transformResponsiveValue(
+  value: Responsive<CustomPropertyValue | CustomPropertyValue[]>,
+  transformValue: (value: CustomPropertyValue | CustomPropertyValue[]) => string,
+) {
+  const responsiveValue = isResponsiveValue(value) ? value : { base: value }
+
+  const transformedResponsiveValue: Record<string, string> = {}
+
+  Object.entries(responsiveValue).forEach(([key, value]) => {
+    transformedResponsiveValue[key] = transformValue(value)
+  })
+
+  return transformedResponsiveValue
+}
+
+export function transformResponsiveSpacingValue(responsiveValue: ResponsiveSpacing) {
+  return transformResponsiveValue(responsiveValue, value =>
+    value === 0 ? '0' : `var(--g-spacing-${value})`,
   )
 }
 

--- a/src/styles/_Base.scss
+++ b/src/styles/_Base.scss
@@ -13,10 +13,6 @@
     box-sizing: border-box;
   }
 
-  div {
-    width: 100%;
-  }
-
   // Balance text wrapping on headings
   h1,
   h2,

--- a/src/styles/_Checkbox.scss
+++ b/src/styles/_Checkbox.scss
@@ -25,7 +25,7 @@
       width: 1.143rem;
       height: 1.143rem;
       border: var(--g-checkbox-borderWidth) solid var(--g-checkbox-borderColor);
-      border-radius: var(--g-spacing-radius);
+      border-radius: var(--g-radius);
       transition: all 200ms;
       display: flex;
       align-items: center;

--- a/src/styles/_DateInput.scss
+++ b/src/styles/_DateInput.scss
@@ -20,7 +20,7 @@
 
   .react-aria-DateInput:not(.react-aria-DatePicker *) {
     border: var(--g-input-borderWidth) solid var(--g-input-borderColor);
-    border-radius: var(--g-spacing-radius);
+    border-radius: var(--g-radius);
     &[data-focus-within] {
       @include formFocusOutline;
     }

--- a/src/styles/_DatePicker.scss
+++ b/src/styles/_DatePicker.scss
@@ -9,7 +9,7 @@
       width: 100%;
       align-items: center;
       border: var(--g-input-borderWidth) solid var(--g-input-borderColor);
-      border-radius: var(--g-spacing-radius);
+      border-radius: var(--g-radius);
 
       &[data-focus-within] {
         &[data-invalid] {

--- a/src/styles/_Group.scss
+++ b/src/styles/_Group.scss
@@ -4,7 +4,7 @@
     display: flex;
     align-items: center;
     width: fit-content;
-    border-radius: var(--g-spacing-radius);
+    border-radius: var(--g-radius);
     overflow: hidden;
 
     &[data-hovered] {

--- a/src/styles/_Menu.scss
+++ b/src/styles/_Menu.scss
@@ -11,7 +11,7 @@
   }
   .react-aria-MenuItem {
     padding: toRem(10) toRem(16);
-    border-radius: var(--g-spacing-radius);
+    border-radius: var(--g-radius);
     outline: none;
     cursor: pointer;
     color: var(--g-typography-textColor);

--- a/src/styles/_NumberField.scss
+++ b/src/styles/_NumberField.scss
@@ -13,7 +13,7 @@
     .react-aria-Group {
       display: flex;
       width: 100%;
-      border-radius: var(--g-spacing-radius);
+      border-radius: var(--g-radius);
 
       &[data-focus-within] {
         outline: var(--g-focus-borderWidth) solid var(--g-focus-color);
@@ -33,7 +33,7 @@
     .react-aria-Input {
       background: var(--g-input-background);
       border: var(--g-input-borderWidth) solid var(--g-input-borderColor);
-      border-radius: var(--g-spacing-radius);
+      border-radius: var(--g-radius);
       color: var(--g-input-textColor);
       font-size: var(--g-input-fontSize);
       padding: var(--g-input-padding);

--- a/src/styles/_Popover.scss
+++ b/src/styles/_Popover.scss
@@ -8,7 +8,7 @@
     gap: toRem(20);
     align-items: flex-start;
     box-shadow: var(--g-shadow-200);
-    border-radius: var(--g-spacing-radius);
+    border-radius: var(--g-radius);
     border: 1px solid var(--g-colors-gray-500);
     background: var(--background-color);
     color: var(--g-typography-textColor);

--- a/src/styles/_Select.scss
+++ b/src/styles/_Select.scss
@@ -10,7 +10,7 @@
 
     .react-aria-Button {
       border: var(--g-input-borderWidth) solid var(--g-input-borderColor);
-      border-radius: var(--g-spacing-radius);
+      border-radius: var(--g-radius);
       padding: var(--g-input-padding);
       display: flex;
       justify-content: space-between;

--- a/src/types/GTheme.d.ts
+++ b/src/types/GTheme.d.ts
@@ -16,8 +16,12 @@ export interface GThemeSpacing {
   24: string
   28: string
   32: string
-  radius: string
+  36: string
+  40: string
 }
+
+export type GThemeRadius = string
+
 export interface GThemeTypography {
   font: string
   textColor: ThemeColor
@@ -183,6 +187,7 @@ export interface GTheme {
   focus: GThemeFocus
   shadow: GThemeShadow
   spacing: GThemeSpacing
+  radius: GThemeRadius
   typography: GThemeTypography
   input: GThemeInput
   button: GThemeButton


### PR DESCRIPTION
This follows the same approach here https://github.com/Gusto/embedded-react-sdk/pull/112 we used for Grid to make Flex a component with responsive props.

This also aligns the approach for gap sizing between the two components (see slack discussion here https://gustohq.slack.com/archives/C071WFJUNF5/p1738001128173869) Rather than having t shirt sizing, we can just use the keys in the spacing theme constant.

In order to more cleanly leverage the spacing constant, I broke radius out into a separate property. It's possible we will need different sizes of radii in the future so this will create a cleaner separation there for that eventuality.

## Proof of functionality

### Verifying responsive behavior
The following demonstrates using `<Flex justifyContent={{ base: 'flex-start', small: 'flex-end' }} alignItems="center" gap={{ base: 8, small: 24 }}>`

https://github.com/user-attachments/assets/85c93628-998a-449d-a134-91dcff3378a1

### Verifying no regressions

Sampling of screens on employee onboarding to make sure flex containers are still properly applying

https://github.com/user-attachments/assets/7631c4d1-7c14-4e29-b68c-62a4f2fb8feb
