### PR TITLE
feat: truncate Select component value

### DIFF
--- a/src/styles/_Select.scss
+++ b/src/styles/_Select.scss
@@ -45,6 +45,12 @@
     }
 
     .react-aria-SelectValue {
+      width: 100%;
+      text-align: start;
+      text-wrap: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+
       &[data-placeholder] {
         color: var(--g-input-placeholderColor);
       }


### PR DESCRIPTION
This updates the Select component to truncate the value.

[See thread here for accessibility considerations related to truncation](https://gustohq.slack.com/archives/C071WFJUNF5/p1738102048398099). The outcome of that convo was that we should be able to truncate in this case given that the full text is available when the list is expanded. We did additional verification to ensure that React Aria does bring the selected option into view regardless of how many options there are (see proof of functionality below)

## Proof of functionality

### Text truncating for value and option available when select is expanded

https://github.com/user-attachments/assets/8c59b2e1-dd70-4ee5-a6cc-032d425b93cf

### Voice over still reading the selected option even when truncated

<img width="1512" alt="Screenshot 2025-01-28 at 4 05 18 PM" src="https://github.com/user-attachments/assets/ba016e7b-7814-4fb7-ae41-5a7d0b62e20d" />
