### PR TITLE
fix: update menu styles to prevent icons shrinking

### DIFF
--- a/src/components/Common/Hamburger/Hamburger.module.scss
+++ b/src/components/Common/Hamburger/Hamburger.module.scss
@@ -1,0 +1,3 @@
+.menuIcon {
+  flex-shrink: 0;
+}

--- a/src/components/Common/Hamburger/Hamburger.tsx
+++ b/src/components/Common/Hamburger/Hamburger.tsx
@@ -12,6 +12,8 @@ import { Button } from '@/components/Common'
 import { useTheme } from '@/contexts'
 import Spinner from '@/assets/icons/spinner_small.svg?react'
 
+import styles from './Hamburger.module.scss'
+
 interface HamburgerProps<T> extends MenuProps<T>, Omit<MenuTriggerProps, 'children'> {
   title: string
   isPending?: boolean
@@ -43,7 +45,7 @@ export function HamburgerItem(props: MenuItemProps & { icon?: React.ReactNode })
   return (
     <MenuItem {...props} textValue={textValue}>
       <>
-        {props.icon && props.icon}
+        {props.icon && <div className={styles.menuIcon}>{props.icon}</div>}
         {props.children}
       </>
     </MenuItem>

--- a/src/styles/_Menu.scss
+++ b/src/styles/_Menu.scss
@@ -8,6 +8,8 @@
     box-sizing: border-box;
     overflow: auto;
     outline: none;
+    width: max-content;
+    max-width: toRem(250);
   }
   .react-aria-MenuItem {
     padding: toRem(10) toRem(16);


### PR DESCRIPTION
Icons and text in menu items were displaying compact on mobile devices. Text was wrapping even with sufficient space and icons were shrinking. This PR corrects both

## Proof of functionality

### Menu before

<img width="360" alt="Screenshot 2025-01-29 at 3 46 08 PM" src="https://github.com/user-attachments/assets/f67b6ac8-a099-4df8-8e11-059cb0d93dcf" />

### Menu after

<img width="370" alt="Screenshot 2025-01-29 at 3 43 49 PM" src="https://github.com/user-attachments/assets/3f78f18c-04fa-4670-8000-bb79eadd2f16" />

#### Max width configured for text wrapping

<img width="371" alt="Screenshot 2025-01-29 at 3 38 07 PM" src="https://github.com/user-attachments/assets/a10668bd-4451-40ab-8333-cc281a78954a" />

