### PR TITLE
refactor: separate industry select from api

### DIFF
--- a/src/components/Company/Industry/Actions.tsx
+++ b/src/components/Company/Industry/Actions.tsx
@@ -1,10 +1,10 @@
 import { useTranslation } from 'react-i18next'
 import { ActionsLayout, Button } from '@/components/Common'
-import { useIndustryForm } from './Industry'
+import { useIndustryApiState } from './Industry'
 
 export const Actions = () => {
   const { t } = useTranslation('Company.Industry')
-  const { isPending } = useIndustryForm()
+  const { isPending } = useIndustryApiState()
 
   return (
     <ActionsLayout>

--- a/src/components/Company/Industry/Edit.tsx
+++ b/src/components/Company/Industry/Edit.tsx
@@ -1,12 +1,12 @@
 import { ComboBox } from '@/components/Common'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { IndustryFormFields, useIndustryForm } from './Industry'
+import { IndustryFormFields, useIndustryItems } from './Industry'
 
 export const Edit = () => {
   const { t } = useTranslation('Company.Industry')
   const { control } = useFormContext<IndustryFormFields>()
-  const { items } = useIndustryForm()
+  const { items } = useIndustryItems()
 
   return (
     <ComboBox

--- a/src/components/Company/Industry/Industry.stories.tsx
+++ b/src/components/Company/Industry/Industry.stories.tsx
@@ -1,5 +1,16 @@
-import { Industry } from '.'
+import { action } from '@ladle/react'
+import { Industry, IndustrySelect } from './Industry'
 
-export const Default = () => {
-  return <Industry companyId="abcdefg" onEvent={() => {}} />
+export const Select = () => {
+  return <IndustrySelect onValid={action('industrySelect/submit') as () => Promise<void>} />
+}
+
+export const WithCustomization = () => {
+  return (
+    <IndustrySelect onValid={action('industrySelect/submit') as () => Promise<void>}>
+      <Industry.Actions />
+      <Industry.Head />
+      <Industry.Edit />
+    </IndustrySelect>
+  )
 }


### PR DESCRIPTION
I've been struck a bit by complexity in our form components, and I wanted to demonstrate a potential refactoring that helps keep us from having "big ball of mud" hook code attached to stateful form components.

In this case, I was unhappy that there was no separation between loading the industry items, itself a complex case since it depends on a local config file, and the resolution/submission of its selection to the API results.

Here's a proof of concept of a potential refactoring for Industry that accomplishes these goals:

* separation of API payload load from Industry combobox item load
* easier testing due to separation of concerns
* enables stories to be built demonstrating re-arrangement of child components, etc, without needing attachment to the API or mocks.

https://github.com/user-attachments/assets/77d89a0c-2b07-466d-a4ac-1ef2d548fc3e

