### PR TITLE
refactor: cyclical component graph; emit selection event

### DIFF
--- a/src/components/Company/Industry/Actions.tsx
+++ b/src/components/Company/Industry/Actions.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { ActionsLayout, Button } from '@/components/Common'
-import { useIndustryApiState } from './Industry'
+import { useIndustryApiState } from './Context'
 
 export const Actions = () => {
   const { t } = useTranslation('Company.Industry')

--- a/src/components/Company/Industry/Context.tsx
+++ b/src/components/Company/Industry/Context.tsx
@@ -1,0 +1,12 @@
+import { createCompoundContext } from '@/components/Base'
+import { ComboBoxItem } from '@/components/Common'
+
+const [useIndustryItems, IndustryItemsProvider] = createCompoundContext('IndustryItems', {
+  items: [] as ComboBoxItem[],
+})
+
+const [useIndustryApiState, IndustryApiStateProvider] = createCompoundContext('IndustryApi', {
+  isPending: false,
+})
+
+export { IndustryApiStateProvider, IndustryItemsProvider, useIndustryItems, useIndustryApiState }

--- a/src/components/Company/Industry/Edit.tsx
+++ b/src/components/Company/Industry/Edit.tsx
@@ -1,7 +1,11 @@
 import { ComboBox } from '@/components/Common'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { IndustryFormFields, useIndustryItems } from './Industry'
+import { useIndustryItems } from './Context'
+
+export interface IndustryFormFields {
+  naics_code: string
+}
 
 export const Edit = () => {
   const { t } = useTranslation('Company.Industry')

--- a/src/components/Company/Industry/Industry.stories.tsx
+++ b/src/components/Company/Industry/Industry.stories.tsx
@@ -1,5 +1,6 @@
 import { action } from '@ladle/react'
-import { Industry, IndustrySelect } from './Industry'
+import { IndustrySelect } from './IndustrySelect'
+import { Industry } from './Industry'
 
 export const Select = () => {
   return <IndustrySelect onValid={action('industrySelect/submit') as () => Promise<void>} />

--- a/src/components/Company/Industry/Industry.tsx
+++ b/src/components/Company/Industry/Industry.tsx
@@ -1,91 +1,20 @@
-import { FormProvider, useForm } from 'react-hook-form'
-import { loadAll } from '@/models/NAICSCodes'
-import { ComboBoxItem } from '@/components/Common/Inputs/Combobox'
-import { Form } from 'react-aria-components'
-import { PropsWithChildren, useCallback, useEffect, useState, type HTMLAttributes } from 'react'
-import {
-  BaseComponent,
-  createCompoundContext,
-  useBase,
-  type BaseComponentInterface,
-} from '@/components/Base'
+import { useCallback, type HTMLAttributes } from 'react'
+import { BaseComponent, useBase, type BaseComponentInterface } from '@/components/Base'
+import { componentEvents } from '@/shared/constants'
+import { useGetCompanyIndustry, useUpdateCompanyIndustry } from '@/api/queries'
 import { Actions } from './Actions'
 import { Head } from './Head'
-import { useGetCompanyIndustry, useUpdateCompanyIndustry } from '@/api/queries'
-import { Edit } from './Edit'
+import { Edit, IndustryFormFields } from './Edit'
+import { IndustryApiStateProvider } from './Context'
+import { IndustrySelect } from './IndustrySelect'
 
 export type IndustryProps<T> = Pick<BaseComponentInterface, 'onEvent'> &
   Partial<Pick<HTMLAttributes<T>, 'children' | 'className'>> & {
     companyId: string
   }
 
-export interface IndustryFormFields {
-  naics_code: string
-}
-
-export interface IndustryFormContext {
-  isPending: boolean
-  items: ComboBoxItem[]
-}
-
-const [useIndustryItems, IndustryItemsProvider] = createCompoundContext('IndustryItems', {
-  items: [] as ComboBoxItem[],
-})
-
-const [useIndustryApiState, IndustryApiStateProvider] = createCompoundContext('IndustryApi', {
-  isPending: false,
-})
-
-export { useIndustryItems, useIndustryApiState }
-
-interface IndustrySelectProps extends PropsWithChildren {
-  naics_code?: string | null | undefined
-  onValid?: (data: IndustryFormFields) => Promise<void>
-}
-
-export function IndustrySelect({
-  children,
-  naics_code,
-  onValid = () => Promise.resolve(),
-}: IndustrySelectProps) {
-  const formMethods = useForm<IndustryFormFields>()
-  const { handleSubmit, setValue } = formMethods
-  const [items, setItems] = useState<ComboBoxItem[]>([])
-
-  useEffect(() => {
-    const loadItems = async () => {
-      setItems((await loadAll()).map(({ title: name, code: id }) => ({ id, name })))
-    }
-    void loadItems()
-  }, [])
-
-  useEffect(() => {
-    if (naics_code) {
-      setValue('naics_code', naics_code)
-    }
-  }, [naics_code, setValue])
-
-  return (
-    <IndustryItemsProvider value={{ items }}>
-      <FormProvider {...formMethods}>
-        <Form onSubmit={handleSubmit(onValid)}>
-          {children ? (
-            children
-          ) : (
-            <>
-              <Head />
-              <Edit />
-              <Actions />
-            </>
-          )}
-        </Form>
-      </FormProvider>
-    </IndustryItemsProvider>
-  )
-}
-
 function Root<T>({ children, className, companyId }: IndustryProps<T>) {
-  const { baseSubmitHandler } = useBase()
+  const { baseSubmitHandler, onEvent } = useBase()
 
   const {
     data: { naics_code },
@@ -101,9 +30,10 @@ function Root<T>({ children, className, companyId }: IndustryProps<T>) {
             naics_code,
           },
         })
+        onEvent(componentEvents.COMPANY_INDUSTRY_SELECTED, { naics_code })
       })
     },
-    [baseSubmitHandler, companyId, mutateIndustry],
+    [baseSubmitHandler, companyId, mutateIndustry, onEvent],
   )
 
   return (

--- a/src/components/Company/Industry/IndustrySelect.tsx
+++ b/src/components/Company/Industry/IndustrySelect.tsx
@@ -1,0 +1,56 @@
+import { PropsWithChildren, useState, useEffect } from 'react'
+import { Form } from 'react-aria-components'
+import { useForm, FormProvider } from 'react-hook-form'
+import { ComboBoxItem } from '@/components/Common'
+import { loadAll } from '@/models/NAICSCodes'
+import { Actions } from './Actions'
+import { IndustryItemsProvider } from './Context'
+import { Edit } from './Edit'
+import { Head } from './Head'
+import { IndustryFormFields } from './Edit'
+
+interface IndustrySelectProps extends PropsWithChildren {
+  naics_code?: string | null | undefined
+  onValid?: (data: IndustryFormFields) => Promise<void>
+}
+
+export function IndustrySelect({
+  children,
+  naics_code,
+  onValid = () => Promise.resolve(),
+}: IndustrySelectProps) {
+  const formMethods = useForm<IndustryFormFields>()
+  const { handleSubmit, setValue } = formMethods
+  const [items, setItems] = useState<ComboBoxItem[]>([])
+
+  useEffect(() => {
+    const loadItems = async () => {
+      setItems((await loadAll()).map(({ title: name, code: id }) => ({ id, name })))
+    }
+    void loadItems()
+  }, [])
+
+  useEffect(() => {
+    if (naics_code) {
+      setValue('naics_code', naics_code)
+    }
+  }, [naics_code, setValue])
+
+  return (
+    <IndustryItemsProvider value={{ items }}>
+      <FormProvider {...formMethods}>
+        <Form onSubmit={handleSubmit(onValid)}>
+          {children ? (
+            children
+          ) : (
+            <>
+              <Head />
+              <Edit />
+              <Actions />
+            </>
+          )}
+        </Form>
+      </FormProvider>
+    </IndustryItemsProvider>
+  )
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -49,6 +49,7 @@ export const companyEvents = {
   COMPANY_ADDRESSES: 'company/addresses',
   COMPANY_ADDRESSE_EDIT: 'company/address/edit',
   COMPANY_INDUSTRY: 'company/industry',
+  COMPANY_INDUSTRY_SELECTED: 'company/industry/selected',
   COMPANY_FEDERAL_TAXES_UPDATED: 'company/federalTaxes/updated',
 } as const
 


### PR DESCRIPTION
I wanted to re-extract IndustrySelect (I had pushed it down into Industry a few PR's ago when trying to match existing structure). While I was doing that I took a look at the dependency graph of the components and noticed some cycles (Industry depends on imports from IndustrySelect depends on imports from Industry) that I fixed via extracting and re-arranging where some props/types lived.

I cheated and also added one non-refactor change -- the event is now emitted when an industry is selected.
