### PR TITLE
fix: restore correct ssn validation

### DIFF
--- a/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatoryForm.tsx
+++ b/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatoryForm.tsx
@@ -11,6 +11,7 @@ import { CalendarDate } from '@internationalized/date'
 import { TitleSelect } from '@/components/Company/AssignSignatory/TitleSelect'
 import { normalizePhone } from '@/helpers/phone'
 import { useCreateSignatory } from './CreateSignatory'
+import { removeNonDigits } from '@/helpers/formattedStrings'
 
 const createSSNValidation = (currentSignatory?: { has_ssn?: boolean }) =>
   v.pipe(
@@ -25,7 +26,7 @@ const createSSNValidation = (currentSignatory?: { has_ssn?: boolean }) =>
         return false
       }
 
-      return SSN_REGEX.test(value)
+      return SSN_REGEX.test(removeNonDigits(value))
     }),
   )
 

--- a/src/components/Employee/Profile/PersonalDetailsInputs.tsx
+++ b/src/components/Employee/Profile/PersonalDetailsInputs.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Select, TextField, Grid } from '@/components/Common'
 import { DatePicker } from '@/components/Common/Inputs/DatePicker'
-import { addressInline } from '@/helpers/formattedStrings'
+import { addressInline, removeNonDigits } from '@/helpers/formattedStrings'
 import { normalizeSSN, usePlaceholderSSN } from '@/helpers/ssn'
 import { CalendarDate, getLocalTimeZone, today, parseDate } from '@internationalized/date'
 import { ListBoxItem } from 'react-aria-components'
@@ -124,7 +124,7 @@ export function AdminInputs({ companyLocations }: AdminInputsProps) {
 export const SocialSecurityNumberSchema = v.object({
   ssn: v.pipe(
     v.string(),
-    v.transform(input => input.match(/\d*/g)?.join('') ?? ''),
+    v.transform(input => removeNonDigits(input)),
     v.check(input => {
       return SSN_REGEX.test(input)
     }),

--- a/src/helpers/formattedStrings.test.ts
+++ b/src/helpers/formattedStrings.test.ts
@@ -1,0 +1,14 @@
+import { expect, describe, it } from 'vitest'
+import { removeNonDigits } from './formattedStrings'
+
+describe('formattedStrings', () => {
+  describe('removeNonDigits', () => {
+    it('should return empty string for empty input', () => {
+      expect(removeNonDigits('')).toBe('')
+    })
+
+    it('should remove non-digits', () => {
+      expect(removeNonDigits('a12-34/5 6b_78@90)')).toBe('1234567890')
+    })
+  })
+})

--- a/src/helpers/formattedStrings.ts
+++ b/src/helpers/formattedStrings.ts
@@ -47,3 +47,7 @@ export function createMarkup(dirty: string) {
   if (!dirty) return { __html: '' }
   return { __html: DOMPurify.sanitize(dirty, dompurifyConfig) }
 }
+
+export const removeNonDigits = (value: string): string => {
+  return value.replace(/\D/g, '')
+}

--- a/src/helpers/phone.test.ts
+++ b/src/helpers/phone.test.ts
@@ -1,17 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { normalizePhone, removeNonDigits } from './phone'
+import { normalizePhone } from './phone'
 
 describe('phone', () => {
-  describe('removeNonDigits', () => {
-    it('should return empty string for empty input', () => {
-      expect(removeNonDigits('')).toBe('')
-    })
-
-    it('should remove non-digits', () => {
-      expect(removeNonDigits('a12-34/5 6b_78@90)')).toBe('1234567890')
-    })
-  })
-
   describe('normalizePhone', () => {
     it('should return empty string for empty input', () => {
       expect(normalizePhone('')).toBe('')
@@ -27,10 +17,6 @@ describe('phone', () => {
 
     it('should add hyphen when exceeding 6 digits', () => {
       expect(normalizePhone('1234567')).toBe('(123) 456-7')
-    })
-
-    it('should strip non-digits before formatting', () => {
-      expect(normalizePhone('(123) abc 456-7890')).toBe('(123) 456-7890')
     })
 
     it('should truncate input longer than 10 digits', () => {

--- a/src/helpers/phone.ts
+++ b/src/helpers/phone.ts
@@ -1,6 +1,4 @@
-export const removeNonDigits = (value: string): string => {
-  return value.replace(/\D/g, '')
-}
+import { removeNonDigits } from '@/helpers/formattedStrings'
 
 export const normalizePhone = (value: string): string => {
   const digits = removeNonDigits(value)

--- a/src/helpers/validations.ts
+++ b/src/helpers/validations.ts
@@ -1,5 +1,6 @@
 import * as v from 'valibot'
-import { normalizePhone, removeNonDigits } from '@/helpers/phone'
+import { normalizePhone } from '@/helpers/phone'
+import { removeNonDigits } from '@/helpers/formattedStrings'
 
 export const NAME_REGEX = /^([a-zA-Z\xC0-\uFFFF]+([ \-']{0,1}[a-zA-Z\xC0-\uFFFF]+)*[.]{0,1}){1,2}$/
 
@@ -10,7 +11,7 @@ export const zipValidation = v.pipe(
   v.check(zip => /(^\d{5}$)|(^\d{5}-\d{4}$)/.test(zip)),
 )
 
-export const SSN_REGEX = /^(?!000|666)[0-8][0-9]{2}-(?!00)[0-9]{2}-(?!0000)[0-9]{4}$/
+export const SSN_REGEX = /^(?!(000|666|9))\d{3}(?!00)\d{2}(?!0000)\d{4}$/
 
 export const phoneValidation = v.pipe(
   v.string(),


### PR DESCRIPTION
While centralizing the SSN regex for assign signatory, there was actually a mismatch between how ssn was being validated in profile and signatory. In profile, we were stripping all non digits and then testing against the regex. In signatory we were using a regex to validate the full string.

This caused regressions in the profile form since the ssn regex was now expecting non digit characters.

This PR updates to make SSN validation more consistent
* Updates the SSN regex to assume non digits consistently between profile and signatory
* Moves the strip non digits function used for phone numbers to the format string utility file since it has uses beyond phone
* Updates to use that function in both ssn inputs to remove non digit input prior to validation
* Updates the SSN regex to just validate the digits

Note: 

## Proof of functionality

### Profile Before

https://github.com/user-attachments/assets/da8de004-e952-4c98-b8ef-9dd83020b7ea

### Profile After

https://github.com/user-attachments/assets/a3c777e8-c7dd-4104-8aaf-c1ed4995e326

### No regressions in signatory

https://github.com/user-attachments/assets/c295b544-f650-4596-9db8-59d465a6c35b




