### PR TITLE
fix: restore validation for self onboarding profile form

### DIFF
--- a/src/components/Employee/Profile/HomeAddress.tsx
+++ b/src/components/Employee/Profile/HomeAddress.tsx
@@ -1,5 +1,5 @@
 import { Alert, Checkbox, Grid, Select, TextField } from '@/components/Common'
-import { EmployeeOnboardingStatus, STATES_ABBR } from '@/shared/constants'
+import { STATES_ABBR } from '@/shared/constants'
 import { Link, ListBoxItem } from 'react-aria-components'
 import { useFormContext } from 'react-hook-form'
 import { Trans, useTranslation } from 'react-i18next'
@@ -17,7 +17,7 @@ export const HomeAddressSchema = v.variant('self_onboarding', [
       v.check(zip => /(^\d{5}$)|(^\d{5}-\d{4}$)/.test(zip)),
     ),
     courtesy_withholding: v.boolean(),
-    self_onboarding: v.literal(false),
+    self_onboarding: v.union([v.literal(false), v.undefined()]),
   }),
   v.object({ self_onboarding: v.literal(true) }),
 ])


### PR DESCRIPTION
We were running into an issue with Profile form where validation was failing because self_onboarding was undefined which was causing validation to fail.

This removes the self_onboarding property from home address validation so that it is properly ignored when we are onboarding as self and the checkbox for self_onboarding is not present.

## Proof of functionality

### Before: submit handler failing with self_onboarding undefined
<img width="2166" alt="profile-form-bug" src="https://github.com/user-attachments/assets/2a83460b-2bab-4c67-84d0-9759947be7ef" />

### After: submit handler succeeding for self onboarding

https://github.com/user-attachments/assets/76f50b5a-53fe-435f-b814-dcd4590d09b9

### Address validation for admin only fires when self onboarding is not selected
When it is selected, validation does not fire and form submits correctly

https://github.com/user-attachments/assets/48727c07-b130-4ed8-a5de-336ff4e10649

