### PR TITLE
chore: fix & elide typescript errors; error fail CI build

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "./CHANGELOG.md"
   ],
   "scripts": {
-    "build": "npm run build:clean && npm run generate && vite build",
+    "build": "npm run build:clean && npm run generate && npm run tsc && vite build",
     "build:clean": "rm -rf ./dist && mkdir ./dist",
     "commitlint": "commitlint --edit",
     "dev": "node ./build/prompt.js && npm run build && vite build --watch",

--- a/src/components/Common/TaxInputs/TaxInputs.tsx
+++ b/src/components/Common/TaxInputs/TaxInputs.tsx
@@ -38,6 +38,7 @@ export function SelectInput({ question, requirement, control }: EmpQ | CompR) {
     <Select
       control={control}
       name={key as string}
+      // @ts-expect-error HACK value is insufficiently narrowed here
       defaultSelectedKey={value}
       label={label}
       description={description}
@@ -60,6 +61,7 @@ export function TextInput({ question, requirement, control }: EmpQ | CompR) {
       control={control}
       name={key as string}
       label={label}
+      // @ts-expect-error HACK value is insufficiently narrowed here
       defaultValue={value}
       description={description}
     />

--- a/src/components/Company/DocumentSigner/DocumentList/Head.tsx
+++ b/src/components/Company/DocumentSigner/DocumentList/Head.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 
 export function Head() {
+  // @ts-expect-error HACK missing translations
   const { t } = useTranslation('Company.DocumentSigner')
 
   return <h2>{t('documentListTitle')}</h2>

--- a/src/components/Company/DocumentSigner/DocumentList/List.tsx
+++ b/src/components/Company/DocumentSigner/DocumentList/List.tsx
@@ -5,6 +5,7 @@ import { useDocumentList } from './DocumentList'
 function List() {
   const { companyForms, handleRequestFormToSign, documentListError, isSelfSignatory } =
     useDocumentList()
+  // @ts-expect-error HACK missing translations
   const { t } = useTranslation('Company.DocumentSigner')
 
   const onRequestSign = (requestedForm: FormData) => {

--- a/src/components/Company/DocumentSigner/DocumentList/ManageSignatories.tsx
+++ b/src/components/Company/DocumentSigner/DocumentList/ManageSignatories.tsx
@@ -13,6 +13,7 @@ function isValidSignatoryTitle(
 }
 
 function ManageSignatories() {
+  // @ts-expect-error HACK missing translations
   const { t } = useTranslation('Company.DocumentSigner')
   const { isSelfSignatory, signatory, handleChangeSignatory } = useDocumentList()
 

--- a/src/components/Employee/EmployeeList/EmployeeList.test.tsx
+++ b/src/components/Employee/EmployeeList/EmployeeList.test.tsx
@@ -7,7 +7,9 @@ import { handleGetCompanyEmployees } from '@/test/mocks/apis/employees'
 import { HttpResponse } from 'msw'
 import { mockResizeObserver } from 'jsdom-testing-mocks'
 
-const resizeObserver = mockResizeObserver()
+beforeEach(() => {
+  mockResizeObserver()
+})
 
 describe('EmployeeList', () => {
   beforeEach(() => {

--- a/src/components/Employee/EmployeeList/EmployeeList.tsx
+++ b/src/components/Employee/EmployeeList/EmployeeList.tsx
@@ -139,6 +139,7 @@ function Root({ companyId, className, children }: EmployeeListProps) {
           handleNew,
           handleReview,
           handleDelete,
+          // @ts-expect-error HACK fix employee typing inconsistency
           employees,
           currentPage,
           totalPages,

--- a/src/components/Employee/EmployeeList/List.tsx
+++ b/src/components/Employee/EmployeeList/List.tsx
@@ -37,7 +37,7 @@ export const List = () => {
   } = useEmployeeList()
 
   const { t } = useTranslation('Employee.EmployeeList')
-  const [deleting, setDeleting] = useState<Set<string>>(new Set())
+  const [_, setDeleting] = useState<Set<string>>(new Set())
   const { ...dataViewProps } = useDataView({
     data: employees,
     columns: [

--- a/src/components/Employee/Profile/Actions.tsx
+++ b/src/components/Employee/Profile/Actions.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { ActionsLayout, Button, Flex } from '@/components/Common'
+import { ActionsLayout, Button } from '@/components/Common'
 import { useProfile } from '@/components/Employee/Profile/Profile'
 
 export const Actions = () => {

--- a/src/components/Employee/Profile/Profile.tsx
+++ b/src/components/Employee/Profile/Profile.tsx
@@ -294,6 +294,7 @@ const Root = ({ isAdmin = false, ...props }: ProfileProps) => {
           const workAddressData = await mutateEmployeeWorkAddress({
             work_address_uuid: mergedData.current.workAddress.uuid,
             body: {
+              // @ts-expect-error HACK fix disagreement between args and API expectation
               version: mergedData.current.workAddress.version,
               location_uuid: work_address,
             },

--- a/src/components/Flow/StateMachines/employeeSelfOnboarding.ts
+++ b/src/components/Flow/StateMachines/employeeSelfOnboarding.ts
@@ -1,6 +1,5 @@
 import { transition, reduce, state } from 'robot3'
 import { componentEvents } from '@/shared/constants'
-import type { EmployeeSelfOnboardingContextInterface } from '@/components/Flow/EmployeeSelfOnboardingFlow'
 import {
   Profile,
   Taxes,
@@ -9,6 +8,7 @@ import {
   OnboardingSummary,
 } from '@/components/Flow/EmployeeSelfOnboardingFlow/EmployeeSelfOnboardingComponents'
 import { SDKI18next } from '@/contexts'
+import { EmployeeSelfOnboardingContextInterface } from '@/components/Flow/EmployeeSelfOnboardingFlow/EmployeeSelfOnboardingFlow'
 
 export const employeeSelfOnboardingMachine = {
   index: state(

--- a/src/contexts/ThemeProvider/ThemeProvider.tsx
+++ b/src/contexts/ThemeProvider/ThemeProvider.tsx
@@ -45,6 +45,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   }, [partnerTheme, t])
 
   return (
+    // @ts-expect-error HACK fix mismatch where containerRef allows null
     <ThemeContext.Provider value={{ container: containerRef }}>
       <section className="GSDK" data-testid="GSDK" ref={containerRef}>
         {children}

--- a/src/test/mocks/apis/homeAddresses.ts
+++ b/src/test/mocks/apis/homeAddresses.ts
@@ -49,6 +49,7 @@ const getEmployeeHomeAddresses = http.get<
 const createEmployeeHomeAddress = http.post<
   PathParams<'post-v1-employees-employee_id-home_addresses'>,
   RequestBodyParams<'post-v1-employees-employee_id-home_addresses'>,
+  // @ts-expect-error HACK re-check after Speakeasy implementation
   ResponseType<'post-v1-employees-employee_id-home_addresses', 200>
 >(`${API_BASE_URL}/v1/employees/:employee_id/home_addresses`, async ({ request }) => {
   const requestBody = await request.json()

--- a/src/test/mocks/apis/typeHelpers.ts
+++ b/src/test/mocks/apis/typeHelpers.ts
@@ -3,6 +3,7 @@ import { operations } from '@/types/schema'
 // Type Helpers
 export type PathParams<Operation extends keyof operations> =
   operations[Operation]['parameters']['path']
+// @ts-expect-error HACK revisit after Speakeasy implementation
 export type RequestBodyParams<Operation extends keyof operations> = NonNullable<
   operations[Operation]['requestBody']
 >['content']['application/json']

--- a/src/test/mocks/fixtures/company_location.ts
+++ b/src/test/mocks/fixtures/company_location.ts
@@ -7,6 +7,7 @@ export const COMPANY_LOCATION_FORM_PAYLOAD = {
   city: 'Anytown',
   state: 'ABC',
   zip: '12345',
+  // @ts-expect-error HACK fix `country` typings
   country: 'USA',
   mailing_address: true,
   filing_address: false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "module": "ESNext",
     "moduleDetection": "force",
     "allowJs": true,
-    "noEmit": false,
+    "noEmit": true,
     "jsx": "react-jsx",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,


### PR DESCRIPTION
For simple typescript errors I fixed them inline.

For more complicated ones I added a `@ts-expect-error` for us to go fix in a future PR so that we can get back to good as quickly as possible.

