### PR TITLE
feat: add continue button to company document list

### DIFF
--- a/src/components/Company/DocumentSigner/DocumentList/Actions.tsx
+++ b/src/components/Company/DocumentSigner/DocumentList/Actions.tsx
@@ -1,0 +1,19 @@
+import { ActionsLayout, Button } from '@/components/Common'
+
+import { useTranslation } from 'react-i18next'
+import { useDocumentList } from './DocumentList'
+
+interface ActionsProps {
+  continueCtaLabel?: string
+}
+
+export function Actions({ continueCtaLabel }: ActionsProps) {
+  const { t } = useTranslation('Company.DocumentList')
+  const { handleContinue } = useDocumentList()
+
+  return (
+    <ActionsLayout>
+      <Button onPress={handleContinue}>{continueCtaLabel || t('continueCta')}</Button>
+    </ActionsLayout>
+  )
+}

--- a/src/components/Company/DocumentSigner/DocumentList/DocumentList.tsx
+++ b/src/components/Company/DocumentSigner/DocumentList/DocumentList.tsx
@@ -15,12 +15,13 @@ import { companyEvents } from '@/shared/constants'
 import { Head } from './Head'
 import { List } from './List'
 import { ManageSignatories } from './ManageSignatories'
-
+import { Actions } from './Actions'
 type DocumentListContextType = {
   companyForms: Schemas['Form'][]
   documentListError: Error | null
   handleRequestFormToSign: (form: Schemas['Form']) => void
   handleChangeSignatory: () => void
+  handleContinue: () => void
   isSelfSignatory: boolean
   signatory?: Schemas['Signatory']
 }
@@ -74,6 +75,10 @@ function Root({ companyId, signatoryId, className, children }: DocumentListProps
     onEvent(companyEvents.COMPANY_FORM_EDIT_SIGNATORY, signatory)
   }
 
+  const handleContinue = () => {
+    onEvent(companyEvents.COMPANY_FORMS_DONE)
+  }
+
   return (
     <section className={className}>
       <DocumentListProvider
@@ -82,6 +87,7 @@ function Root({ companyId, signatoryId, className, children }: DocumentListProps
           documentListError,
           handleRequestFormToSign,
           handleChangeSignatory,
+          handleContinue,
           isSelfSignatory,
           signatory,
         }}
@@ -94,6 +100,7 @@ function Root({ companyId, signatoryId, className, children }: DocumentListProps
               <Head />
               <ManageSignatories />
               <List />
+              <Actions />
             </>
           )}
         </Flex>
@@ -105,3 +112,4 @@ function Root({ companyId, signatoryId, className, children }: DocumentListProps
 DocumentList.Head = Head
 DocumentList.ManageSignatories = ManageSignatories
 DocumentList.List = List
+DocumentList.Actions = Actions

--- a/src/components/Company/DocumentSigner/DocumentList/Head.tsx
+++ b/src/components/Company/DocumentSigner/DocumentList/Head.tsx
@@ -1,8 +1,7 @@
 import { useTranslation } from 'react-i18next'
 
 export function Head() {
-  // @ts-expect-error HACK missing translations
-  const { t } = useTranslation('Company.DocumentSigner')
+  const { t } = useTranslation('Company.DocumentList')
 
   return <h2>{t('documentListTitle')}</h2>
 }

--- a/src/components/Company/DocumentSigner/DocumentList/List.tsx
+++ b/src/components/Company/DocumentSigner/DocumentList/List.tsx
@@ -5,8 +5,8 @@ import { useDocumentList } from './DocumentList'
 function List() {
   const { companyForms, handleRequestFormToSign, documentListError, isSelfSignatory } =
     useDocumentList()
-  // @ts-expect-error HACK missing translations
-  const { t } = useTranslation('Company.DocumentSigner')
+
+  const { t } = useTranslation('Company.DocumentList')
 
   const onRequestSign = (requestedForm: FormData) => {
     const companyForm = companyForms.find(currentForm => currentForm.uuid === requestedForm.uuid)

--- a/src/components/Company/DocumentSigner/DocumentList/ManageSignatories.tsx
+++ b/src/components/Company/DocumentSigner/DocumentList/ManageSignatories.tsx
@@ -13,8 +13,7 @@ function isValidSignatoryTitle(
 }
 
 function ManageSignatories() {
-  // @ts-expect-error HACK missing translations
-  const { t } = useTranslation('Company.DocumentSigner')
+  const { t } = useTranslation('Company.DocumentList')
   const { isSelfSignatory, signatory, handleChangeSignatory } = useDocumentList()
 
   let signatorySubtext = t('noSignatorySubtext')

--- a/src/i18n/en/Company.DocumentList.json
+++ b/src/i18n/en/Company.DocumentList.json
@@ -14,5 +14,6 @@
   "signDocumentComplete": "Complete",
   "notSigned": "Not signed",
   "documentListError": "Could not load your documents, try again later.",
-  "emptyTableTitle": "No documents found"
+  "emptyTableTitle": "No documents found",
+  "continueCta": "Continue"
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -60,6 +60,7 @@ export const companyEvents = {
   COMPANY_ASSIGN_SIGNATORY_DONE: 'company/signatory/assignSignatory/done',
   COMPANY_VIEW_FORM_TO_SIGN: 'company/forms/view',
   COMPANY_FORM_EDIT_SIGNATORY: 'company/forms/editSignatory',
+  COMPANY_FORMS_DONE: 'company/forms/done',
 } as const
 
 export const componentEvents = {

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -101,6 +101,7 @@ export interface CompanyDocumentList{
 "notSigned":string;
 "documentListError":string;
 "emptyTableTitle":string;
+"continueCta":string;
 };
 export interface CompanyFederalTaxes{
 "pageTitle":string;


### PR DESCRIPTION
This adds a continue action to the company document list.

## Proof of functionality

### Event firing for document signing done when continue button is selected

https://github.com/user-attachments/assets/803e371c-1045-4496-b9ca-d0eeb2869f80

### Continue button enabled if not the signatory regardless of document signing status

<img width="918" alt="Screenshot 2025-02-24 at 5 03 57 PM" src="https://github.com/user-attachments/assets/cd97feb6-50da-403d-83e6-66b878c73091" />

### Continue button disabled if self signatory and has documents to sign

<img width="918" alt="Screenshot 2025-02-24 at 5 04 30 PM" src="https://github.com/user-attachments/assets/ff298546-ad35-4a6d-9d96-de6a943d9975" />

### Continue button enabled if self signatory and all documents are signed

<img width="913" alt="Screenshot 2025-02-24 at 5 05 06 PM" src="https://github.com/user-attachments/assets/65d93042-0100-4fef-972e-f37f6f82e77f" />


