### PR TITLE
chore: add test coverage for manage signatories and invite signatories

### DIFF
--- a/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatory.test.tsx
+++ b/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatory.test.tsx
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { InviteSignatory } from './InviteSignatory'
+import { GustoTestApiProvider } from '@/test/GustoTestApiProvider'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { companyEvents } from '@/shared/constants'
+
+describe('InviteSignatory', () => {
+  const mockOnEvent = vi.fn()
+
+  beforeEach(() => {
+    setupApiTestMocks()
+    mockOnEvent.mockClear()
+  })
+
+  it('shows error when emails do not match', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <GustoTestApiProvider>
+        <InviteSignatory companyId="company-123" onEvent={mockOnEvent} />
+      </GustoTestApiProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Invite a signatory')).toBeInTheDocument()
+    })
+
+    const emailInput = screen.getByLabelText('Signatory email')
+    await user.type(emailInput, 'test@example.com')
+
+    const confirmEmailInput = screen.getByLabelText('Confirm signatory email')
+    await user.type(confirmEmailInput, 'different@example.com')
+
+    const firstNameInput = screen.getByLabelText('First name')
+    await user.type(firstNameInput, 'John')
+
+    const lastNameInput = screen.getByLabelText('Last name')
+    await user.type(lastNameInput, 'Doe')
+
+    const titleControl = screen.getByRole('button', {
+      name: /Select an item/i,
+      expanded: false,
+    })
+
+    await user.click(titleControl)
+
+    const ownerOption = screen.getByRole('option', { name: 'Owner' })
+    await user.click(ownerOption)
+
+    const submitButton = screen.getByRole('button', { name: 'Invite signatory' })
+    await user.click(submitButton)
+
+    expect(screen.getByText('Email addresses must match')).toBeInTheDocument()
+    expect(mockOnEvent).not.toHaveBeenCalled()
+
+    await user.clear(confirmEmailInput)
+    await user.type(confirmEmailInput, 'test@example.com')
+
+    await user.click(submitButton)
+
+    expect(screen.queryByText('Email addresses must match')).not.toBeInTheDocument()
+    expect(mockOnEvent).toHaveBeenCalledWith(
+      companyEvents.COMPANY_SIGNATORY_INVITED,
+      expect.any(Object),
+    )
+  })
+
+  it('successfully submits form when all fields are valid', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <GustoTestApiProvider>
+        <InviteSignatory companyId="company-123" onEvent={mockOnEvent} />
+      </GustoTestApiProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Invite a signatory')).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByLabelText('First name'), 'John')
+    await user.type(screen.getByLabelText('Last name'), 'Doe')
+    await user.type(screen.getByLabelText('Signatory email'), 'john.doe@example.com')
+    await user.type(screen.getByLabelText('Confirm signatory email'), 'john.doe@example.com')
+
+    const titleControl = screen.getByRole('button', {
+      name: /Select an item/i,
+      expanded: false,
+    })
+
+    await user.click(titleControl)
+
+    const ownerOption = screen.getByRole('option', { name: 'Owner' })
+    await user.click(ownerOption)
+
+    const submitButton = screen.getByRole('button', { name: 'Invite signatory' })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockOnEvent).toHaveBeenCalledWith(
+        companyEvents.COMPANY_SIGNATORY_INVITED,
+        expect.any(Object),
+      )
+      expect(mockOnEvent).toHaveBeenCalledWith(companyEvents.COMPANY_INVITE_SIGNATORY_DONE)
+    })
+  })
+})

--- a/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatory.tsx
+++ b/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatory.tsx
@@ -37,14 +37,11 @@ export type InviteSignatoryDefaultValues = RequireAtLeastOne<
 
 interface InviteSignatoryProps extends CommonComponentInterface {
   companyId: string
-  signatoryId?: string
   defaultValues?: InviteSignatoryDefaultValues
 }
 
 type InviteSignatoryContextType = {
   isPending: boolean
-  signatoryId?: string
-  currentSignatory?: Schemas['Signatory']
 }
 
 const [useInviteSignatory, InviteSignatoryProvider] =
@@ -60,18 +57,11 @@ export function InviteSignatory(props: InviteSignatoryProps & BaseComponentInter
   )
 }
 
-function Root({
-  companyId,
-  signatoryId,
-  defaultValues,
-  className,
-  children,
-}: InviteSignatoryProps) {
+function Root({ companyId, defaultValues, className, children }: InviteSignatoryProps) {
   useI18n('Company.AssignSignatory')
   const { onEvent, baseSubmitHandler } = useBase()
 
   const { data: signatories } = useGetAllSignatories(companyId)
-  const currentSignatory = signatories.find(signatory => signatory.uuid === signatoryId)
 
   const inviteSignatoryMutation = useInviteSignatoryMutation(companyId)
   const deleteSignatoryMutation = useDeleteSignatory(companyId)
@@ -95,6 +85,7 @@ function Root({
       if (signatories[0]?.uuid) {
         await deleteSignatoryMutation.mutateAsync(signatories[0].uuid)
       }
+
       const inviteSignatoryResponse = await inviteSignatoryMutation.mutateAsync(signatoryData)
 
       onEvent(companyEvents.COMPANY_SIGNATORY_INVITED, inviteSignatoryResponse)
@@ -107,7 +98,6 @@ function Root({
       <InviteSignatoryProvider
         value={{
           isPending: inviteSignatoryMutation.isPending,
-          currentSignatory,
         }}
       >
         <FormProvider {...formMethods}>

--- a/src/components/Company/AssignSignatory/SignatoryForm.tsx
+++ b/src/components/Company/AssignSignatory/SignatoryForm.tsx
@@ -22,7 +22,6 @@ export const SignatoryForm = () => {
       ) : (
         <InviteSignatory
           companyId={companyId}
-          signatoryId={signatoryId}
           onEvent={onSignatoryFormEvent}
           defaultValues={defaultValues?.invite}
         />

--- a/src/components/Company/DocumentSigner/DocumentList/DocumentList.test.tsx
+++ b/src/components/Company/DocumentSigner/DocumentList/DocumentList.test.tsx
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { HttpResponse } from 'msw'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DocumentList } from './DocumentList'
+import { GustoTestApiProvider } from '@/test/GustoTestApiProvider'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { companyEvents } from '@/shared/constants'
+import { handleGetAllSignatories } from '@/test/mocks/apis/company_signatories'
+import { handleGetAllCompanyForms } from '@/test/mocks/apis/company_forms'
+import { server } from '@/test/mocks/server'
+
+vi.mock('@/hooks/useContainerBreakpoints/useContainerBreakpoints', async () => {
+  const actual = await vi.importActual('@/hooks/useContainerBreakpoints/useContainerBreakpoints')
+  return {
+    ...actual,
+    default: () => ['base', 'small', 'medium'],
+    useContainerBreakpoints: () => ['base', 'small', 'medium'],
+  }
+})
+
+describe('DocumentList', () => {
+  beforeEach(() => {
+    setupApiTestMocks()
+  })
+
+  describe('when user is the signatory', () => {
+    beforeEach(() => {
+      server.use(
+        handleGetAllSignatories(() =>
+          HttpResponse.json([
+            {
+              uuid: 'signatory-123',
+              first_name: 'John',
+              last_name: 'Doe',
+              email: 'john.doe@example.com',
+              title: 'CEO',
+            },
+          ]),
+        ),
+        handleGetAllCompanyForms(() =>
+          HttpResponse.json([
+            {
+              uuid: 'form-123',
+              title: 'Test Form',
+              name: 'test name',
+              description: 'test description',
+              requires_signing: true,
+            },
+          ]),
+        ),
+      )
+    })
+
+    it('fires the correct event when requesting to sign a form', async () => {
+      const user = userEvent.setup()
+      const onEvent = vi.fn()
+
+      render(
+        <GustoTestApiProvider>
+          <DocumentList companyId="company-123" signatoryId="signatory-123" onEvent={onEvent} />
+        </GustoTestApiProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Form')).toBeInTheDocument()
+      })
+
+      const signButton = screen.getByRole('button', { name: 'Sign document' })
+      await user.click(signButton)
+
+      expect(onEvent).toHaveBeenCalledWith(companyEvents.COMPANY_VIEW_FORM_TO_SIGN, {
+        uuid: 'form-123',
+        title: 'Test Form',
+        name: 'test name',
+        description: 'test description',
+        requires_signing: true,
+      })
+    })
+
+    it('fires the correct event when changing signatory', async () => {
+      const user = userEvent.setup()
+      const onEvent = vi.fn()
+
+      render(
+        <GustoTestApiProvider>
+          <DocumentList companyId="company-123" onEvent={onEvent} />
+        </GustoTestApiProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Form')).toBeInTheDocument()
+      })
+
+      const changeSignatoryButton = screen.getByRole('button', { name: 'Change signatory' })
+      await user.click(changeSignatoryButton)
+
+      expect(onEvent).toHaveBeenCalledWith(companyEvents.COMPANY_FORM_EDIT_SIGNATORY, {
+        uuid: 'signatory-123',
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'john.doe@example.com',
+        title: 'CEO',
+      })
+    })
+
+    it('fires the correct event when continuing', async () => {
+      const user = userEvent.setup()
+      const onEvent = vi.fn()
+
+      render(
+        <GustoTestApiProvider>
+          <DocumentList companyId="company-123" onEvent={onEvent} />
+        </GustoTestApiProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Form')).toBeInTheDocument()
+      })
+
+      const continueButton = screen.getByRole('button', { name: 'Continue' })
+      await user.click(continueButton)
+
+      expect(onEvent).toHaveBeenCalledWith(companyEvents.COMPANY_FORMS_DONE)
+    })
+  })
+
+  describe('when user is not the signatory', () => {
+    beforeEach(() => {
+      server.use(
+        handleGetAllSignatories(() => HttpResponse.json([])),
+        handleGetAllCompanyForms(() =>
+          HttpResponse.json([
+            {
+              uuid: 'form-123',
+              title: 'Test Form',
+              name: 'test name',
+              description: 'test description',
+              requires_signing: true,
+            },
+          ]),
+        ),
+      )
+    })
+
+    it('does not allow the user to sign the form', async () => {
+      render(
+        <GustoTestApiProvider>
+          <DocumentList companyId="company-123" signatoryId="signatory-123" onEvent={() => {}} />
+        </GustoTestApiProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Form')).toBeInTheDocument()
+      })
+
+      expect(screen.queryByRole('button', { name: 'Sign document' })).not.toBeInTheDocument()
+      expect(screen.getByText('Not signed')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/Company/DocumentSigner/DocumentList/ManageSignatories.test.tsx
+++ b/src/components/Company/DocumentSigner/DocumentList/ManageSignatories.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { ManageSignatories } from './ManageSignatories'
+import { useDocumentList } from '@/components/Company/DocumentSigner/DocumentList/DocumentList'
+
+vi.mock('./DocumentList')
+
+const mockUseDocumentList = vi.mocked(useDocumentList)
+
+const defaultMockValues = {
+  isSelfSignatory: false,
+  signatory: undefined,
+  handleChangeSignatory: () => {},
+  companyForms: [],
+  documentListError: null,
+  handleRequestFormToSign: () => {},
+  handleContinue: () => {},
+}
+
+describe('ManageSignatories', () => {
+  const mockHandleChangeSignatory = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('when no signatory is assigned', () => {
+    mockUseDocumentList.mockReturnValue({
+      ...defaultMockValues,
+      isSelfSignatory: false,
+      signatory: undefined,
+    })
+
+    render(<ManageSignatories />)
+
+    expect(screen.getByRole('heading')).toHaveTextContent('otherSignatoryTitle')
+    expect(screen.getByRole('paragraph')).toHaveTextContent('noSignatorySubtext')
+    expect(screen.getByRole('button')).toHaveTextContent('assignSignatoryCta')
+  })
+
+  test('when user is the signatory', () => {
+    mockUseDocumentList.mockReturnValue({
+      ...defaultMockValues,
+      isSelfSignatory: true,
+      signatory: {
+        first_name: 'John',
+        last_name: 'Doe',
+        title: 'CEO',
+        uuid: '123',
+      },
+    })
+
+    render(<ManageSignatories />)
+
+    expect(screen.getByRole('heading')).toHaveTextContent('selfSignatoryTitle')
+    expect(screen.getByRole('paragraph')).toHaveTextContent('selfSignatorySubtext')
+    expect(screen.getByRole('button')).toHaveTextContent('changeSignatoryCta')
+  })
+
+  test('when another user is the signatory', () => {
+    mockUseDocumentList.mockReturnValue({
+      ...defaultMockValues,
+      isSelfSignatory: false,
+      signatory: {
+        first_name: 'Jane',
+        last_name: 'Smith',
+        title: 'CEO',
+        uuid: '456',
+      },
+    })
+
+    render(<ManageSignatories />)
+
+    expect(screen.getByRole('heading')).toHaveTextContent('otherSignatoryTitle')
+    expect(screen.getByRole('paragraph')).toHaveTextContent('otherSignatorySubtext')
+    expect(screen.getByRole('button')).toHaveTextContent('changeSignatoryCta')
+  })
+
+  test('handles change signatory button click', async () => {
+    mockUseDocumentList.mockReturnValue({
+      ...defaultMockValues,
+      handleChangeSignatory: mockHandleChangeSignatory,
+    })
+
+    render(<ManageSignatories />)
+
+    await userEvent.click(screen.getByRole('button'))
+    expect(mockHandleChangeSignatory).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/test/mocks/apis/company_forms.ts
+++ b/src/test/mocks/apis/company_forms.ts
@@ -1,0 +1,44 @@
+import { http, HttpResponse, HttpResponseResolver } from 'msw'
+import { PathParams, RequestBodyParams, ResponseType } from './typeHelpers'
+import { API_BASE_URL } from '@/api/constants'
+
+const basicForm = {
+  uuid: 'form-123',
+  name: 'Test Form',
+  status: 'not_signed',
+  form_type: 'company',
+  created_at: '2024-05-29T12:00:00Z',
+  updated_at: '2024-05-29T12:30:00Z',
+  requires_signing: true,
+}
+
+export function handleGetAllCompanyForms(
+  resolver: HttpResponseResolver<
+    PathParams<'get-v1-company-forms'>,
+    RequestBodyParams<'get-v1-company-forms'>,
+    ResponseType<'get-v1-company-forms', 200>
+  >,
+) {
+  return http.get(`${API_BASE_URL}/v1/companies/:company_id/forms`, resolver)
+}
+
+const getAllCompanyForms = handleGetAllCompanyForms(() => HttpResponse.json([basicForm]))
+
+const getCompanyFormPdf = http.get<
+  PathParams<'get-v1-company-form-pdf'>,
+  RequestBodyParams<'get-v1-company-form-pdf'>,
+  ResponseType<'get-v1-company-form-pdf', 200>
+>(`${API_BASE_URL}/v1/forms/:form_id/pdf`, () =>
+  HttpResponse.json({
+    uuid: 'form-123',
+    document_url: 'data:application/pdf;base64,JVBE',
+  }),
+)
+
+const signCompanyForm = http.put<
+  PathParams<'put-v1-company-form-sign'>,
+  RequestBodyParams<'put-v1-company-form-sign'>,
+  ResponseType<'put-v1-company-form-sign', 200>
+>(`${API_BASE_URL}/v1/forms/:form_id/sign`, () => HttpResponse.json(basicForm))
+
+export default [getAllCompanyForms, getCompanyFormPdf, signCompanyForm]

--- a/src/test/mocks/apis/company_signatories.ts
+++ b/src/test/mocks/apis/company_signatories.ts
@@ -1,0 +1,54 @@
+import { http, HttpResponse, HttpResponseResolver } from 'msw'
+import { PathParams, RequestBodyParams, ResponseType } from './typeHelpers'
+import { API_BASE_URL } from '@/api/constants'
+
+const basicSignatory = {
+  uuid: '123e4567-e89b-12d3-a456-426614174000',
+  company_uuid: '789e4567-e89b-12d3-a456-426614174001',
+  first_name: 'John',
+  last_name: 'Doe',
+  email: 'john.doe@example.com',
+  title: 'CEO',
+  created_at: '2024-05-29T12:00:00Z',
+  updated_at: '2024-05-29T12:30:00Z',
+}
+
+export function handleGetAllSignatories(
+  resolver: HttpResponseResolver<
+    PathParams<'get-v1-companies-company_uuid-signatories'>,
+    RequestBodyParams<'get-v1-companies-company_uuid-signatories'>,
+    ResponseType<'get-v1-companies-company_uuid-signatories', 200>
+  >,
+) {
+  return http.get(`${API_BASE_URL}/v1/companies/:company_id/signatories`, resolver)
+}
+
+const getAllSignatories = handleGetAllSignatories(() => HttpResponse.json([basicSignatory]))
+
+const inviteSignatory = http.post<
+  PathParams<'post-v1-companies-company_uuid-signatories-invite'>,
+  RequestBodyParams<'post-v1-companies-company_uuid-signatories-invite'>,
+  ResponseType<'post-v1-companies-company_uuid-signatories-invite', 201>
+>(`${API_BASE_URL}/v1/companies/:company_id/signatories/invite`, async ({ request }) => {
+  const requestBody = await request.json()
+
+  return HttpResponse.json({
+    uuid: 'new_signatory_uuid',
+    first_name: requestBody.first_name,
+    last_name: requestBody.last_name,
+    email: requestBody.email,
+    title: requestBody.title,
+  })
+})
+
+const deleteSignatory = http.delete<
+  PathParams<'delete-v1-companies-company_uuid-signatories-signatory_uuid'>,
+  RequestBodyParams<'delete-v1-companies-company_uuid-signatories-signatory_uuid'>,
+  ResponseType<'delete-v1-companies-company_uuid-signatories-signatory_uuid', 204>
+>(`${API_BASE_URL}/v1/companies/:company_id/signatories/:signatory_id`, () => {
+  return new HttpResponse(null, {
+    status: 204,
+  })
+})
+
+export default [getAllSignatories, inviteSignatory, deleteSignatory]

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -7,6 +7,8 @@ import TokenHandlers from './apis/tokens.js'
 import CompensationHandlers from './apis/compensations'
 import EmployeeBankAccountsHandlers from './apis/employeesBankAccounts.js'
 import PayrollsHandler from './apis/payrolls'
+import CompanySignatoryHandlers from './apis/company_signatories'
+import CompanyForms from './apis/company_forms'
 
 export const handlers = [
   ...EmployeeHandlers,
@@ -18,4 +20,6 @@ export const handlers = [
   ...EmployeeBankAccountsHandlers,
   ...CompanyFederalTaxHandlers,
   ...PayrollsHandler,
+  ...CompanySignatoryHandlers,
+  ...CompanyForms,
 ]


### PR DESCRIPTION
This adds some minimal test coverage for the manage signatories and invite signatories form.