### PR TITLE
chore: add tests for create signatory and signature form

### DIFF
--- a/src/components/Common/SignatureForm/SignatureFormFields.tsx
+++ b/src/components/Common/SignatureForm/SignatureFormFields.tsx
@@ -6,6 +6,7 @@ interface SignatureFormFieldsProps {
   signatureLabel: string
   signatureDescription?: string
   signatureError?: string
+  confirmationGroupLabel: string
   confirmationLabel: string
   confirmationError?: string
 }
@@ -14,6 +15,7 @@ export function SignatureFormFields({
   signatureLabel,
   signatureDescription = '',
   signatureError = '',
+  confirmationGroupLabel,
   confirmationLabel,
   confirmationError = '',
 }: SignatureFormFieldsProps) {
@@ -33,7 +35,7 @@ export function SignatureFormFields({
         control={control}
         name="confirmSignature"
         isRequired
-        aria-label={confirmationLabel}
+        aria-label={confirmationGroupLabel}
         errorMessage={confirmationError}
         options={[{ name: 'agree', label: confirmationLabel }]}
       />

--- a/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatory.test.tsx
+++ b/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatory.test.tsx
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HttpResponse } from 'msw'
+import { CreateSignatory } from './CreateSignatory'
+import { GustoTestApiProvider } from '@/test/GustoTestApiProvider'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { companyEvents } from '@/shared/constants'
+import {
+  handleGetAllSignatories,
+  handleCreateSignatory,
+  handleUpdateSignatory,
+} from '@/test/mocks/apis/company_signatories'
+import { server } from '@/test/mocks/server'
+
+describe('CreateSignatory', () => {
+  const mockOnEvent = vi.fn()
+
+  beforeEach(() => {
+    setupApiTestMocks()
+    mockOnEvent.mockClear()
+    vi.resetModules()
+  })
+
+  describe('when user is creating a signatory', () => {
+    beforeEach(() => {
+      server.use(
+        handleCreateSignatory(() =>
+          HttpResponse.json({
+            uuid: 'new-signatory-uuid',
+            first_name: 'Michael',
+            last_name: 'Bluth',
+            email: 'michael.bluth@example.com',
+            title: 'President',
+          }),
+        ),
+      )
+    })
+
+    it('fires the correct created events when form is submitted successfully', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <GustoTestApiProvider>
+          <CreateSignatory companyId="company-123" onEvent={mockOnEvent} />
+        </GustoTestApiProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Signatory person details')).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByLabelText('First name'), 'John')
+      await user.type(screen.getByLabelText('Last name'), 'Doe')
+      await user.type(screen.getByLabelText('Email address'), 'john.doe@example.com')
+      await user.type(screen.getByLabelText('Phone number'), '5551234567')
+      await user.type(screen.getByLabelText('Social security number'), '123456789')
+
+      const titleControl = screen.getByRole('button', {
+        name: /Select an item/i,
+        expanded: false,
+      })
+      await user.click(titleControl)
+      const ownerOption = screen.getByRole('option', { name: 'Owner' })
+      await user.click(ownerOption)
+
+      const dateOfBirthInput = screen.getByRole('group', { name: 'Date of birth' })
+      await user.type(within(dateOfBirthInput).getByRole('spinbutton', { name: /month/i }), '01')
+      await user.type(within(dateOfBirthInput).getByRole('spinbutton', { name: /day/i }), '01')
+      await user.type(within(dateOfBirthInput).getByRole('spinbutton', { name: /year/i }), '1995')
+
+      await user.type(screen.getByLabelText('Street 1'), '123 Main St')
+      await user.type(screen.getByLabelText('City'), 'San Francisco')
+
+      const stateControl = screen.getByLabelText('State')
+      await user.click(stateControl)
+      const californiaOption = screen.getByRole('option', { name: 'California' })
+      await user.click(californiaOption)
+
+      await user.type(screen.getByLabelText('Zip'), '94105')
+
+      const submitButton = screen.getByRole('button', { name: 'Sign documents' })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockOnEvent).toHaveBeenCalledWith(companyEvents.COMPANY_SIGNATORY_CREATED, {
+          uuid: 'new-signatory-uuid',
+          first_name: 'Michael',
+          last_name: 'Bluth',
+          email: 'michael.bluth@example.com',
+          title: 'President',
+        })
+        expect(mockOnEvent).toHaveBeenCalledWith(companyEvents.COMPANY_CREATE_SIGNATORY_DONE)
+      })
+    })
+  })
+
+  describe('when user is updating a signatory', () => {
+    beforeEach(() => {
+      const testSignatory = {
+        uuid: 'signatory-123',
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'john.doe@example.com',
+        title: 'CEO',
+        has_ssn: true,
+        phone: '(555) 123-4567',
+        birthday: '1980-01-01',
+        home_address: {
+          street_1: '123 Main St',
+          street_2: 'Apt 4B',
+          city: 'San Francisco',
+          state: 'CA',
+          zip: '94105',
+          country: 'USA',
+        },
+      }
+
+      server.use(
+        handleGetAllSignatories(() => HttpResponse.json([testSignatory])),
+        handleUpdateSignatory(() => HttpResponse.json(testSignatory)),
+      )
+    })
+
+    it('disables email input', async () => {
+      render(
+        <GustoTestApiProvider>
+          <CreateSignatory
+            companyId="company-123"
+            signatoryId="signatory-123"
+            onEvent={mockOnEvent}
+          />
+        </GustoTestApiProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Signatory person details')).toBeInTheDocument()
+      })
+
+      expect(screen.getByLabelText('Email address')).toBeDisabled()
+    })
+
+    it('fires the correct updated events when form is submitted successfully', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <GustoTestApiProvider>
+          <CreateSignatory
+            companyId="company-123"
+            signatoryId="signatory-123"
+            onEvent={mockOnEvent}
+          />
+        </GustoTestApiProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Signatory person details')).toBeInTheDocument()
+      })
+
+      const submitButton = screen.getByRole('button', { name: 'Sign documents' })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockOnEvent).toHaveBeenCalledWith(companyEvents.COMPANY_SIGNATORY_UPDATED, {
+          uuid: 'signatory-123',
+          first_name: 'John',
+          last_name: 'Doe',
+          email: 'john.doe@example.com',
+          title: 'CEO',
+          has_ssn: true,
+          phone: '(555) 123-4567',
+          birthday: '1980-01-01',
+          home_address: {
+            street_1: '123 Main St',
+            street_2: 'Apt 4B',
+            city: 'San Francisco',
+            state: 'CA',
+            zip: '94105',
+            country: 'USA',
+          },
+        })
+        expect(mockOnEvent).toHaveBeenCalledWith(companyEvents.COMPANY_CREATE_SIGNATORY_DONE)
+      })
+    })
+  })
+})

--- a/src/components/Company/DocumentSigner/SignatureForm/Form.tsx
+++ b/src/components/Company/DocumentSigner/SignatureForm/Form.tsx
@@ -9,6 +9,7 @@ export function Form() {
       signatureLabel={t('signatureLabel')}
       signatureDescription={t('signatureDescription')}
       signatureError={t('signatureError')}
+      confirmationGroupLabel={t('confirmationGroupLabel')}
       confirmationLabel={t('confirmationLabel')}
       confirmationError={t('confirmationError')}
     />

--- a/src/components/Company/DocumentSigner/SignatureForm/SignatureForm.test.tsx
+++ b/src/components/Company/DocumentSigner/SignatureForm/SignatureForm.test.tsx
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HttpResponse } from 'msw'
+import { SignatureForm } from './SignatureForm'
+import { GustoTestApiProvider } from '@/test/GustoTestApiProvider'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { companyEvents } from '@/shared/constants'
+import { server } from '@/test/mocks/server'
+import { handleSignCompanyForm } from '@/test/mocks/apis/company_forms'
+
+vi.mock('@/hooks/useContainerBreakpoints/useContainerBreakpoints', async () => {
+  const actual = await vi.importActual('@/hooks/useContainerBreakpoints/useContainerBreakpoints')
+  return {
+    ...actual,
+    default: () => ['base', 'small', 'medium'],
+    useContainerBreakpoints: () => ['base', 'small', 'medium'],
+  }
+})
+
+const testForm = {
+  uuid: 'form-123',
+  name: 'Test Form',
+  status: 'not_signed',
+  form_type: 'company',
+  created_at: '2024-05-29T12:00:00Z',
+  updated_at: '2024-05-29T12:30:00Z',
+  requires_signing: true,
+}
+
+describe('SignatureForm', () => {
+  const mockOnEvent = vi.fn()
+
+  beforeEach(() => {
+    setupApiTestMocks()
+    mockOnEvent.mockClear()
+    vi.resetModules()
+
+    server.use(handleSignCompanyForm(() => HttpResponse.json(testForm)))
+  })
+
+  it('fires the correct events when form is submitted successfully', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <GustoTestApiProvider>
+        <SignatureForm form={testForm} companyId="company-123" onEvent={mockOnEvent} />
+      </GustoTestApiProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/Signature required for/)).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByLabelText('Signature'), 'John Doe')
+
+    const checkbox = screen.getByLabelText('I am the signatory and I agree to sign electronically')
+
+    await user.click(checkbox)
+
+    const submitButton = screen.getByRole('button', { name: 'Sign form' })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockOnEvent).toHaveBeenCalledWith(companyEvents.COMPANY_SIGN_FORM, testForm)
+      expect(mockOnEvent).toHaveBeenCalledWith(companyEvents.COMPANY_SIGN_FORM_DONE)
+    })
+  })
+
+  it('fires the back event when back button is clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <GustoTestApiProvider>
+        <SignatureForm form={testForm} companyId="company-123" onEvent={mockOnEvent} />
+      </GustoTestApiProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/Signature required for/)).toBeInTheDocument()
+    })
+
+    const backButton = screen.getByRole('button', { name: 'Back' })
+    await user.click(backButton)
+
+    expect(mockOnEvent).toHaveBeenCalledWith(companyEvents.COMPANY_SIGN_FORM_BACK)
+  })
+})

--- a/src/components/Employee/DocumentSigner/SignatureForm.tsx
+++ b/src/components/Employee/DocumentSigner/SignatureForm.tsx
@@ -27,6 +27,7 @@ export function SignatureForm() {
           signatureLabel="Signature"
           signatureDescription={t('signatureFieldDescription')}
           signatureError={t('signatureFieldError')}
+          confirmationGroupLabel={t('confirmationGroupLabel')}
           confirmationLabel={t('confirmSignatureCheckboxLabel')}
           confirmationError={t('confirmSignatureError')}
         />

--- a/src/i18n/en/Company.SignatureForm.json
+++ b/src/i18n/en/Company.SignatureForm.json
@@ -5,6 +5,7 @@
   "signatureLabel": "Signature",
   "signatureDescription": "Type your full, legal name.",
   "signatureError": "Signature is required",
+  "confirmationGroupLabel": "Agreement to sign electronically",
   "confirmationLabel": "I am the signatory and I agree to sign electronically",
   "confirmationError": "You must agree to sign electronically",
   "backCta": "Back",

--- a/src/i18n/en/Employee.DocumentSigner.json
+++ b/src/i18n/en/Employee.DocumentSigner.json
@@ -14,6 +14,7 @@
   "signatureFieldLabel": "Signature",
   "signatureFieldDescription": "Type your full, legal name.",
   "signatureFieldError": "Signature is required",
+  "confirmationGroupLabel": "Agreement to sign electronically",
   "confirmSignatureCheckboxLabel": "I am the employee and I agree to sign electronically",
   "confirmSignatureError": "You must agree to sign electronically",
   "backCta": "Back",

--- a/src/test/mocks/apis/company_forms.ts
+++ b/src/test/mocks/apis/company_forms.ts
@@ -22,23 +22,35 @@ export function handleGetAllCompanyForms(
   return http.get(`${API_BASE_URL}/v1/companies/:company_id/forms`, resolver)
 }
 
+export function handleGetCompanyFormPdf(
+  resolver: HttpResponseResolver<
+    PathParams<'get-v1-company-form-pdf'>,
+    RequestBodyParams<'get-v1-company-form-pdf'>,
+    ResponseType<'get-v1-company-form-pdf', 200>
+  >,
+) {
+  return http.get(`${API_BASE_URL}/v1/forms/:form_id/pdf`, resolver)
+}
+
+export function handleSignCompanyForm(
+  resolver: HttpResponseResolver<
+    PathParams<'put-v1-company-form-sign'>,
+    RequestBodyParams<'put-v1-company-form-sign'>,
+    ResponseType<'put-v1-company-form-sign', 200>
+  >,
+) {
+  return http.put(`${API_BASE_URL}/v1/forms/:form_id/sign`, resolver)
+}
+
 const getAllCompanyForms = handleGetAllCompanyForms(() => HttpResponse.json([basicForm]))
 
-const getCompanyFormPdf = http.get<
-  PathParams<'get-v1-company-form-pdf'>,
-  RequestBodyParams<'get-v1-company-form-pdf'>,
-  ResponseType<'get-v1-company-form-pdf', 200>
->(`${API_BASE_URL}/v1/forms/:form_id/pdf`, () =>
+const getCompanyFormPdf = handleGetCompanyFormPdf(() =>
   HttpResponse.json({
     uuid: 'form-123',
     document_url: 'data:application/pdf;base64,JVBE',
   }),
 )
 
-const signCompanyForm = http.put<
-  PathParams<'put-v1-company-form-sign'>,
-  RequestBodyParams<'put-v1-company-form-sign'>,
-  ResponseType<'put-v1-company-form-sign', 200>
->(`${API_BASE_URL}/v1/forms/:form_id/sign`, () => HttpResponse.json(basicForm))
+const signCompanyForm = handleSignCompanyForm(() => HttpResponse.json(basicForm))
 
 export default [getAllCompanyForms, getCompanyFormPdf, signCompanyForm]

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -149,6 +149,7 @@ export interface CompanySignatureForm{
 "signatureLabel":string;
 "signatureDescription":string;
 "signatureError":string;
+"confirmationGroupLabel":string;
 "confirmationLabel":string;
 "confirmationError":string;
 "backCta":string;
@@ -283,6 +284,7 @@ export interface EmployeeDocumentSigner{
 "signatureFieldLabel":string;
 "signatureFieldDescription":string;
 "signatureFieldError":string;
+"confirmationGroupLabel":string;
 "confirmSignatureCheckboxLabel":string;
 "confirmSignatureError":string;
 "backCta":string;


### PR DESCRIPTION
This adds the rest of the tests for company document signer. It provides coverage for the create signatory and signature form, primarily around ensuring events are correctly firing as expected.