### PR TITLE
chore: release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,84 @@
 # Changelog
 
+## 0.6.0
+
+- Allow for default value for flsa_status (employment type field) in compensation
+- The default font that ships with the SDK has been updated to 'Geist' so that will update if you do not have a default font specified in your theme
+- Update company Industry component to use speakeasy
+- Update Employee List component to use speakeasy
+- Add a CalendarDisplay component and introduce it to Company PaySchedule component
+- Add `isSelfOnboardingEnabled` prop to Employee profile components to disallow self onboarding
+- Add company PaySchedule component
+- Add styling to SDK internal error component
+
+### Breaking changes
+
+> Note: We are pre alpha and are regularly iterating on the SDK as we learn more about our consumers and their needs which sometimes involves breaking changes. [Read more about our current versioning strategy here](./docs/04/01/versioning.md).
+
+#### Update GustoApiProvider `baseUrl` property to use an absolute URL
+
+Ex. previously you could set a `baseUrl` to a relative URL as follows
+
+```ts
+<GustoApiProvider
+  config={{
+    baseUrl: `some/url/path/`,
+  }}
+  ...
+>
+...
+</GustoApiProvider>
+```
+
+Moving forward, we require setting an absolute URL. Ex updating to be:
+
+```ts
+<GustoApiProvider
+  config={{
+    baseUrl: `https://api.example.com/some/url/path/`,
+  }}
+  ...
+>
+...
+</GustoApiProvider>
+```
+
+#### fontWeight override for typography theme has been changed from `book` to `regular`
+
+Ex. so if you were overriding the `fontWeight` property before using `book`
+
+```ts
+<GustoApiProvider
+  theme={{
+    typography: {
+      fontWeight: {
+        book: 400,
+      },
+    },
+  }}
+  ...
+>
+...
+</GustoApiProvider>
+```
+
+You will want to update to use `regular` instead as follows
+
+```ts
+<GustoApiProvider
+  theme={{
+    typography: {
+      fontWeight: {
+        regular: 400,
+      },
+    },
+  }}
+  ...
+>
+...
+</GustoApiProvider>
+```
+
 ## 0.5.0
 
 - Update to require proxy to add IP address via `x-gusto-client-ip` header

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-react-sdk",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@gusto/embedded-api": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "homepage": "https://github.com/Gusto/embedded-react-sdk",
   "bugs": {
     "url": "https://github.com/Gusto/embedded-react-sdk/issues"


### PR DESCRIPTION
Runs the release for 0.6.0. Note: be sure to check the changelog and verify that documentation around breaking changes makes sense.