### PR TITLE
chore: refactor assign signatory components to use speakeasy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@gusto/embedded-api": "^0.5.4",
+        "@gusto/embedded-api": "^0.5.6",
         "@hookform/error-message": "^2.0.1",
         "@hookform/resolvers": "^3.9.0",
         "@internationalized/date": "^3.5.6",
@@ -1620,9 +1620,9 @@
       }
     },
     "node_modules/@gusto/embedded-api": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@gusto/embedded-api/-/embedded-api-0.5.4.tgz",
-      "integrity": "sha512-gRa9Tpf6PkEidY6I/2zBmDR25jL+f9MD4eHwR3zSnDWg2QHTnCiDfR0oV95xGp+mmtUTjDkmQZqQwJeTXVPF9g==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@gusto/embedded-api/-/embedded-api-0.5.6.tgz",
+      "integrity": "sha512-nmxovRoPGVZFEEggKEuE5arX0+UFeI+40+yPeSgcyGOz3SfHpxjB5+ct4WrlyQumjagzRo62Q8vVVQuMth3PtQ==",
       "peerDependencies": {
         "@tanstack/react-query": "^5",
         "react": "^18 || ^19",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "@gusto/embedded-api": "^0.5.4",
+    "@gusto/embedded-api": "^0.5.6",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^3.9.0",
     "@internationalized/date": "^3.5.6",

--- a/src/components/Company/AssignSignatory/AssignSignatory.tsx
+++ b/src/components/Company/AssignSignatory/AssignSignatory.tsx
@@ -51,14 +51,14 @@ export function AssignSignatory(props: AssignSignatoryProps & BaseComponentInter
 }
 
 export const SignatoryAssignmentMode = {
-  create_signatory: 'create_signatory',
-  invite_signatory: 'invite_signatory',
+  createSignatory: 'createSignatory',
+  inviteSignatory: 'inviteSignatory',
 } as const
 
 const AssignSignatorySelectionSchema = v.object({
   signatoryAssignmentMode: v.union([
-    v.literal(SignatoryAssignmentMode.create_signatory),
-    v.literal(SignatoryAssignmentMode.invite_signatory),
+    v.literal(SignatoryAssignmentMode.createSignatory),
+    v.literal(SignatoryAssignmentMode.inviteSignatory),
   ]),
 })
 
@@ -77,7 +77,7 @@ function Root({
   const formMethods = useForm<AssignSignatorySelectionInputs>({
     resolver: valibotResolver(AssignSignatorySelectionSchema),
     defaultValues: {
-      signatoryAssignmentMode: SignatoryAssignmentMode.create_signatory,
+      signatoryAssignmentMode: SignatoryAssignmentMode.createSignatory,
     },
   })
 

--- a/src/components/Company/AssignSignatory/AssignSignatorySelection.tsx
+++ b/src/components/Company/AssignSignatory/AssignSignatorySelection.tsx
@@ -20,11 +20,11 @@ export const AssignSignatorySelection = () => {
         options={[
           {
             label: t('signingOptions.selfSign'),
-            value: SignatoryAssignmentMode.create_signatory,
+            value: SignatoryAssignmentMode.createSignatory,
           },
           {
             label: t('signingOptions.appointOther'),
-            value: SignatoryAssignmentMode.invite_signatory,
+            value: SignatoryAssignmentMode.inviteSignatory,
           },
         ]}
       />

--- a/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatory.test.tsx
+++ b/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatory.test.tsx
@@ -85,8 +85,8 @@ describe('CreateSignatory', () => {
       await waitFor(() => {
         expect(mockOnEvent).toHaveBeenCalledWith(companyEvents.COMPANY_SIGNATORY_CREATED, {
           uuid: 'new-signatory-uuid',
-          first_name: 'Michael',
-          last_name: 'Bluth',
+          firstName: 'Michael',
+          lastName: 'Bluth',
           email: 'michael.bluth@example.com',
           title: 'President',
         })
@@ -163,16 +163,16 @@ describe('CreateSignatory', () => {
       await waitFor(() => {
         expect(mockOnEvent).toHaveBeenCalledWith(companyEvents.COMPANY_SIGNATORY_UPDATED, {
           uuid: 'signatory-123',
-          first_name: 'John',
-          last_name: 'Doe',
+          firstName: 'John',
+          lastName: 'Doe',
           email: 'john.doe@example.com',
           title: 'CEO',
-          has_ssn: true,
+          hasSsn: true,
           phone: '(555) 123-4567',
           birthday: '1980-01-01',
-          home_address: {
-            street_1: '123 Main St',
-            street_2: 'Apt 4B',
+          homeAddress: {
+            street1: '123 Main St',
+            street2: 'Apt 4B',
             city: 'San Francisco',
             state: 'CA',
             zip: '94105',

--- a/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatory.tsx
+++ b/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatory.tsx
@@ -3,6 +3,11 @@ import { FormProvider, useForm } from 'react-hook-form'
 import { valibotResolver } from '@hookform/resolvers/valibot'
 import classNames from 'classnames'
 import { parseDate } from '@internationalized/date'
+import { type Signatory } from '@gusto/embedded-api/models/components/signatory'
+import { useSignatoriesListSuspense } from '@gusto/embedded-api/react-query/signatoriesList'
+import { useSignatoriesCreateMutation } from '@gusto/embedded-api/react-query/signatoriesCreate'
+import { useSignatoriesUpdateMutation } from '@gusto/embedded-api/react-query/signatoriesUpdate'
+import { useSignatoriesDeleteMutation } from '@gusto/embedded-api/react-query/signatoriesDelete'
 import { type CreateSignatoryInputs, generateCreateSignatorySchema } from './CreateSignatoryForm'
 import { CreateSignatoryForm } from './CreateSignatoryForm'
 import { Actions } from './Actions'
@@ -16,30 +21,15 @@ import {
   createCompoundContext,
 } from '@/components/Base'
 import { Flex } from '@/components/Common'
-import {
-  useGetAllSignatories,
-  useCreateSignatory as useCreateSignatoryMutation,
-  useUpdateSignatory,
-  useDeleteSignatory,
-} from '@/api/queries/company'
-import { Schemas } from '@/types/schema'
 import { companyEvents } from '@/shared/constants'
 import { RequireAtLeastOne } from '@/types/Helpers'
 import { normalizePhone } from '@/helpers/phone'
 
-export const SignatoryAssignmentMode = {
-  create_signatory: 'create_signatory',
-  invite_signatory: 'invite_signatory',
-} as const
-
 export type CreateSignatoryDefaultValues = RequireAtLeastOne<
-  Pick<
-    Schemas['Signatory'],
-    'first_name' | 'last_name' | 'email' | 'title' | 'phone' | 'birthday'
-  > &
+  Pick<Signatory, 'firstName' | 'lastName' | 'email' | 'title' | 'phone' | 'birthday'> &
     Pick<
-      NonNullable<Schemas['Signatory']['home_address']>,
-      'street_1' | 'street_2' | 'city' | 'state' | 'zip'
+      NonNullable<Signatory['homeAddress']>,
+      'street1' | 'street2' | 'city' | 'state' | 'zip'
     > & {
       ssn?: string
     }
@@ -53,7 +43,7 @@ interface CreateSignatoryProps extends CommonComponentInterface {
 
 type CreateSignatoryContextType = {
   isPending: boolean
-  currentSignatory?: Schemas['Signatory']
+  currentSignatory?: Signatory
 }
 
 const [useCreateSignatory, CreateSignatoryProvider] =
@@ -79,46 +69,51 @@ function Root({
   useI18n('Company.AssignSignatory')
   const { onEvent, baseSubmitHandler } = useBase()
 
-  const { data: signatories } = useGetAllSignatories(companyId)
+  const {
+    data: { signatoryList },
+  } = useSignatoriesListSuspense({
+    companyUuid: companyId,
+  })
+  const signatories = signatoryList!
+
   const currentSignatory = signatories.find(signatory => signatory.uuid === signatoryId)
 
-  const createSignatoryMutation = useCreateSignatoryMutation(companyId)
-  const updateSignatoryMutation = useUpdateSignatory(companyId)
-  const deleteSignatoryMutation = useDeleteSignatory(companyId)
+  const createSignatoryMutation = useSignatoriesCreateMutation()
+  const updateSignatoryMutation = useSignatoriesUpdateMutation()
+  const deleteSignatoryMutation = useSignatoriesDeleteMutation()
 
   const defaultBirthday = currentSignatory?.birthday ?? defaultValues?.birthday
 
   const createSignatoryDefaultValues = {
-    first_name: currentSignatory?.first_name ?? defaultValues?.first_name ?? '',
-    last_name: currentSignatory?.last_name ?? defaultValues?.last_name ?? '',
+    firstName: currentSignatory?.firstName ?? defaultValues?.firstName ?? '',
+    lastName: currentSignatory?.lastName ?? defaultValues?.lastName ?? '',
     email: currentSignatory?.email ?? defaultValues?.email ?? '',
     title: currentSignatory?.title ?? defaultValues?.title ?? '',
     phone: normalizePhone(currentSignatory?.phone ?? defaultValues?.phone ?? ''),
-    ssn: currentSignatory?.has_ssn ? '' : defaultValues?.ssn,
-    street_1: currentSignatory?.home_address?.street_1 ?? defaultValues?.street_1,
-    street_2: currentSignatory?.home_address?.street_2 ?? defaultValues?.street_2,
-    city: currentSignatory?.home_address?.city ?? defaultValues?.city,
-    state: currentSignatory?.home_address?.state ?? defaultValues?.state,
-    zip: currentSignatory?.home_address?.zip ?? defaultValues?.zip,
+    ssn: currentSignatory?.hasSsn ? '' : defaultValues?.ssn,
+    street1: currentSignatory?.homeAddress?.street1 ?? defaultValues?.street1,
+    street2: currentSignatory?.homeAddress?.street2 ?? defaultValues?.street2,
+    city: currentSignatory?.homeAddress?.city ?? defaultValues?.city,
+    state: currentSignatory?.homeAddress?.state ?? defaultValues?.state,
+    zip: currentSignatory?.homeAddress?.zip ?? defaultValues?.zip,
     ...(defaultBirthday ? { birthday: parseDate(defaultBirthday) } : {}),
   }
 
   const formMethods = useForm<CreateSignatoryInputs>({
-    resolver: valibotResolver(generateCreateSignatorySchema(currentSignatory)),
+    resolver: valibotResolver(generateCreateSignatorySchema(currentSignatory?.hasSsn)),
     defaultValues: createSignatoryDefaultValues,
   })
 
   const onSubmit = async (data: CreateSignatoryInputs) => {
     await baseSubmitHandler(data, async payload => {
-      const { street_1, street_2, city, state, zip, birthday, email, ssn, ...signatoryData } =
-        payload
+      const { street1, street2, city, state, zip, birthday, email, ssn, ...signatoryData } = payload
 
       const commonData = {
         ...signatoryData,
         birthday: birthday.toString(),
-        home_address: {
-          street_1,
-          street_2,
+        homeAddress: {
+          street1,
+          street2,
           city,
           state,
           zip,
@@ -127,25 +122,38 @@ function Root({
 
       if (currentSignatory) {
         const updateSignatoryResponse = await updateSignatoryMutation.mutateAsync({
-          signatory_id: currentSignatory.uuid,
-          body: {
-            version: currentSignatory.version,
-            ...(ssn ? { ssn } : {}),
-            ...commonData,
+          request: {
+            companyUuid: companyId,
+            signatoryUuid: currentSignatory.uuid,
+            requestBody: {
+              version: currentSignatory.version,
+              ...(ssn ? { ssn } : {}),
+              ...commonData,
+            },
           },
         })
 
-        onEvent(companyEvents.COMPANY_SIGNATORY_UPDATED, updateSignatoryResponse)
+        onEvent(companyEvents.COMPANY_SIGNATORY_UPDATED, updateSignatoryResponse.signatory)
       } else {
         if (signatories[0]?.uuid) {
-          await deleteSignatoryMutation.mutateAsync(signatories[0].uuid)
+          await deleteSignatoryMutation.mutateAsync({
+            request: {
+              companyUuid: companyId,
+              signatoryUuid: signatories[0].uuid,
+            },
+          })
         }
         const createSignatoryResponse = await createSignatoryMutation.mutateAsync({
-          email,
-          ssn,
-          ...commonData,
+          request: {
+            companyUuid: companyId,
+            requestBody: {
+              email,
+              ssn: ssn || '',
+              ...commonData,
+            },
+          },
         })
-        onEvent(companyEvents.COMPANY_SIGNATORY_CREATED, createSignatoryResponse)
+        onEvent(companyEvents.COMPANY_SIGNATORY_CREATED, createSignatoryResponse.signatory)
       }
       onEvent(companyEvents.COMPANY_CREATE_SIGNATORY_DONE)
     })

--- a/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatoryForm.tsx
+++ b/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatoryForm.tsx
@@ -13,12 +13,12 @@ import { TitleSelect } from '@/components/Company/AssignSignatory/TitleSelect'
 import { normalizePhone } from '@/helpers/phone'
 import { removeNonDigits } from '@/helpers/formattedStrings'
 
-const createSSNValidation = (currentSignatory?: { has_ssn?: boolean }) =>
+const createSSNValidation = (hasSsn?: boolean) =>
   v.pipe(
     v.string(),
     v.custom(value => {
       // If they have an SSN on file and haven't modified the field (it's empty), it's valid
-      if (currentSignatory?.has_ssn && !value) {
+      if (hasSsn && !value) {
         return true
       }
 
@@ -30,17 +30,17 @@ const createSSNValidation = (currentSignatory?: { has_ssn?: boolean }) =>
     }),
   )
 
-export const generateCreateSignatorySchema = (currentSignatory?: { has_ssn?: boolean }) =>
+export const generateCreateSignatorySchema = (hasSsn?: boolean) =>
   v.object({
-    first_name: nameValidation,
-    last_name: nameValidation,
+    firstName: nameValidation,
+    lastName: nameValidation,
     email: v.pipe(v.string(), v.nonEmpty(), v.email()),
     title: v.pipe(v.string(), v.nonEmpty()),
     phone: phoneValidation,
-    ssn: createSSNValidation(currentSignatory),
+    ssn: createSSNValidation(hasSsn),
     birthday: v.instance(CalendarDate),
-    street_1: v.pipe(v.string(), v.nonEmpty()),
-    street_2: v.optional(v.string()),
+    street1: v.pipe(v.string(), v.nonEmpty()),
+    street2: v.optional(v.string()),
     city: v.pipe(v.string(), v.nonEmpty()),
     state: v.pipe(v.string(), v.nonEmpty()),
     zip: zipValidation,
@@ -52,7 +52,7 @@ export const CreateSignatoryForm = () => {
   const { currentSignatory } = useCreateSignatory()
   const { t } = useTranslation('Company.AssignSignatory')
   const { control, setValue } = useFormContext()
-  const placeholderSSN = usePlaceholderSSN(currentSignatory?.has_ssn)
+  const placeholderSSN = usePlaceholderSSN(currentSignatory?.hasSsn)
 
   return (
     <Flex flexDirection="column" gap={32}>
@@ -65,14 +65,14 @@ export const CreateSignatoryForm = () => {
         <Grid gridTemplateColumns={{ base: '1fr', small: ['1fr', '1fr'] }} gap={20}>
           <TextField
             control={control}
-            name="first_name"
+            name="firstName"
             label={t('signatoryDetails.firstName')}
             isRequired
             errorMessage={t('validations.firstName')}
           />
           <TextField
             control={control}
-            name="last_name"
+            name="lastName"
             label={t('signatoryDetails.lastName')}
             isRequired
             errorMessage={t('validations.lastName')}
@@ -105,7 +105,7 @@ export const CreateSignatoryForm = () => {
             name="ssn"
             label={t('signatoryDetails.ssn')}
             errorMessage={t('validations.ssn', { ns: 'common' })}
-            isRequired={!currentSignatory?.has_ssn}
+            isRequired={!currentSignatory?.hasSsn}
             inputProps={{
               placeholder: placeholderSSN,
               onChange: event => {
@@ -132,12 +132,12 @@ export const CreateSignatoryForm = () => {
         <Grid gridTemplateColumns={{ base: '1fr', small: ['1fr', '1fr'] }} gap={20}>
           <TextField
             control={control}
-            name="street_1"
+            name="street1"
             label={t('address.street1')}
             isRequired
             errorMessage={t('validations.address.street1')}
           />
-          <TextField control={control} name="street_2" label={t('address.street2')} />
+          <TextField control={control} name="street2" label={t('address.street2')} />
           <TextField
             control={control}
             name="city"

--- a/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatoryForm.tsx
+++ b/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatoryForm.tsx
@@ -10,15 +10,15 @@ const emailMismatchError = 'email_mismatch'
 
 export const InviteSignatorySchema = v.pipe(
   v.object({
-    first_name: nameValidation,
-    last_name: nameValidation,
+    firstName: nameValidation,
+    lastName: nameValidation,
     email: v.pipe(v.string(), v.nonEmpty(), v.email()),
-    confirm_email: v.pipe(v.string(), v.nonEmpty(), v.email()),
+    confirmEmail: v.pipe(v.string(), v.nonEmpty(), v.email()),
     title: v.pipe(v.string(), v.nonEmpty()),
   }),
   v.forward(
-    v.check(({ email, confirm_email }) => email === confirm_email, emailMismatchError),
-    ['confirm_email'],
+    v.check(({ email, confirmEmail }) => email === confirmEmail, emailMismatchError),
+    ['confirmEmail'],
   ),
 )
 
@@ -37,17 +37,17 @@ export const InviteSignatoryForm = () => {
 
   // Some workarounds here to also ensure that modifying the email field
   // sets and clears the confirm_email field error state
-  const confirmEmail = watch('confirm_email')
+  const confirmEmail = watch('confirmEmail')
 
   const handleEmailChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (isSubmitted) {
       const value = event.target.value
       if (value === confirmEmail) {
-        clearErrors('confirm_email')
+        clearErrors('confirmEmail')
       }
 
       if (value !== confirmEmail) {
-        setError('confirm_email', { message: emailMismatchError })
+        setError('confirmEmail', { message: emailMismatchError })
       }
     }
   }
@@ -72,25 +72,25 @@ export const InviteSignatoryForm = () => {
         />
         <TextField
           control={control}
-          name="confirm_email"
+          name="confirmEmail"
           label={t('inviteSignatory.confirmEmail')}
           isRequired
           errorMessage={
-            errors.confirm_email?.message === emailMismatchError
+            errors.confirmEmail?.message === emailMismatchError
               ? t('validations.emailMismatch')
               : t('validations.email')
           }
         />
         <TextField
           control={control}
-          name="first_name"
+          name="firstName"
           label={t('inviteSignatory.firstName')}
           isRequired
           errorMessage={t('validations.firstName')}
         />
         <TextField
           control={control}
-          name="last_name"
+          name="lastName"
           label={t('inviteSignatory.lastName')}
           isRequired
           errorMessage={t('validations.lastName')}

--- a/src/components/Company/AssignSignatory/SignatoryForm.tsx
+++ b/src/components/Company/AssignSignatory/SignatoryForm.tsx
@@ -12,7 +12,7 @@ export const SignatoryForm = () => {
 
   return (
     <>
-      {signatoryAssignmentMode === SignatoryAssignmentMode.create_signatory ? (
+      {signatoryAssignmentMode === SignatoryAssignmentMode.createSignatory ? (
         <CreateSignatory
           companyId={companyId}
           signatoryId={signatoryId}

--- a/src/components/Employee/Taxes/Taxes.tsx
+++ b/src/components/Employee/Taxes/Taxes.tsx
@@ -72,6 +72,7 @@ const Root = (props: TaxesProps) => {
 
   const defaultValues = {
     ...employeeFederalTax,
+    filingStatus: employeeFederalTax.filingStatus ?? undefined,
     twoJobs: employeeFederalTax.twoJobs ? 'true' : 'false',
     deductions: employeeFederalTax.deductions ? Number(employeeFederalTax.deductions) : 0,
     dependentsAmount: employeeFederalTax.dependentsAmount


### PR DESCRIPTION
This updates the assign signatory components to use speakeasy including the create and invite signatory forms.

## Proof of functionality

### Create signatory working as before
https://github.com/user-attachments/assets/9bc68633-0953-42be-9533-c930ecaf1fcd

### Update signatory working as before
https://github.com/user-attachments/assets/49511b5c-ebb5-4554-bafe-e0e3d53c08bc

### Invite signatory working as before
https://github.com/user-attachments/assets/44e5ff04-2895-4308-9972-19dc6c028c47
