### PR TITLE
feat: add infrastructure for decoupling React Hook Form from inputs

### DIFF
--- a/src/components/Common/Fields/TextInputField/TextInputField.stories.tsx
+++ b/src/components/Common/Fields/TextInputField/TextInputField.stories.tsx
@@ -1,0 +1,80 @@
+import type { Story } from '@ladle/react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { TextInputField } from './TextInputField'
+
+interface FormWrapperProps {
+  children: React.ReactNode
+  defaultValues?: {
+    firstName?: string
+    lastName?: string
+    favoriteFood?: string
+    test?: number
+  }
+}
+
+const FormWrapper = ({ children, defaultValues = {} }: FormWrapperProps) => {
+  const methods = useForm({
+    defaultValues: {
+      firstName: defaultValues.firstName || '',
+      lastName: defaultValues.lastName || '',
+      favoriteFood: defaultValues.favoriteFood || '',
+      test: defaultValues.test || 0,
+    },
+    mode: 'onTouched',
+  })
+
+  return (
+    <FormProvider {...methods}>
+      <div>{children}</div>
+    </FormProvider>
+  )
+}
+
+export const Default: Story = () => (
+  <FormWrapper>
+    <TextInputField label="First Name" name="firstName" />
+    <TextInputField label="Last Name" name="lastName" />
+    <TextInputField label="Favorite Food" name="favoriteFood" />
+  </FormWrapper>
+)
+
+export const Required: Story = () => {
+  return (
+    <FormWrapper>
+      <TextInputField
+        label="First Name"
+        name="firstName"
+        isRequired
+        errorMessage="First Name is required"
+      />
+      <TextInputField
+        label="Last Name"
+        name="lastName"
+        isRequired
+        errorMessage="Last Name is required"
+      />
+      <TextInputField
+        label="Favorite Food"
+        name="favoriteFood"
+        isRequired
+        errorMessage="Favorite Food is required"
+      />
+    </FormWrapper>
+  )
+}
+
+export const WithDefaultValues: Story = () => {
+  return (
+    <FormWrapper
+      defaultValues={{
+        firstName: 'Angela',
+        lastName: 'Merkel',
+        favoriteFood: 'Rissotto',
+      }}
+    >
+      <TextInputField label="First Name" name="firstName" />
+      <TextInputField label="Last Name" name="lastName" />
+      <TextInputField label="Favorite Food" name="favoriteFood" />
+    </FormWrapper>
+  )
+}

--- a/src/components/Common/Fields/TextInputField/TextInputField.tsx
+++ b/src/components/Common/Fields/TextInputField/TextInputField.tsx
@@ -1,0 +1,30 @@
+import type { ChangeEvent } from 'react'
+import { useField, type UseFieldProps } from '@/components/Common/Fields/hooks/useField'
+import { TextInput, type TextInputProps } from '@/components/Common/UI/TextInput'
+
+interface TextInputFieldProps
+  extends Omit<TextInputProps, 'name'>,
+    UseFieldProps<ChangeEvent<HTMLInputElement>> {}
+
+export const TextInputField: React.FC<TextInputFieldProps> = ({
+  rules,
+  defaultValue,
+  name,
+  errorMessage,
+  isRequired,
+  onChange,
+  transform,
+  ...textInputProps
+}: TextInputFieldProps) => {
+  const fieldProps = useField({
+    name,
+    rules,
+    defaultValue,
+    errorMessage,
+    isRequired,
+    onChange,
+    transform,
+  })
+
+  return <TextInput {...fieldProps} {...textInputProps} />
+}

--- a/src/components/Common/Fields/TextInputField/index.ts
+++ b/src/components/Common/Fields/TextInputField/index.ts
@@ -1,0 +1,1 @@
+export { TextInputField } from './TextInputField'

--- a/src/components/Common/Fields/hooks/useField.test.tsx
+++ b/src/components/Common/Fields/hooks/useField.test.tsx
@@ -1,0 +1,110 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, test, expect, vi } from 'vitest'
+import { FormProvider, useForm } from 'react-hook-form'
+import { useField } from './useField'
+
+const FormWrapper = ({ children }: { children: React.ReactNode }) => {
+  const methods = useForm({
+    mode: 'onTouched',
+  })
+  return <FormProvider {...methods}>{children}</FormProvider>
+}
+
+describe('useField', () => {
+  test('should set isInvalid when fieldState has an error', async () => {
+    const { result } = renderHook(
+      () =>
+        useField({
+          name: 'testField',
+          isRequired: true,
+        }),
+      {
+        wrapper: FormWrapper,
+      },
+    )
+
+    expect(result.current.isInvalid).toBe(false)
+
+    act(() => {
+      result.current.onBlur()
+    })
+
+    await waitFor(() => {
+      expect(result.current.isInvalid).toBe(true)
+    })
+  })
+
+  test('should not return an error message if fieldState has no error', () => {
+    const { result } = renderHook(
+      () => useField({ name: 'testField', errorMessage: 'test error message' }),
+      { wrapper: FormWrapper },
+    )
+
+    expect(result.current.errorMessage).toBeUndefined()
+  })
+
+  test('should use provided errorMessage over fieldState error message if both exist', async () => {
+    const customErrorMessage = 'Props error message'
+    const { result } = renderHook(
+      () =>
+        useField({
+          name: 'testField',
+          rules: {
+            required: 'hook form error message',
+          },
+          errorMessage: customErrorMessage,
+        }),
+      {
+        wrapper: FormWrapper,
+      },
+    )
+
+    act(() => {
+      result.current.onBlur()
+    })
+
+    await waitFor(() => {
+      expect(result.current.errorMessage).toBe(customErrorMessage)
+    })
+  })
+
+  test('should call custom onChange handler when provided', () => {
+    const customOnChange = vi.fn()
+    const { result } = renderHook(
+      () =>
+        useField({
+          name: 'testField',
+          onChange: customOnChange,
+        }),
+      {
+        wrapper: FormWrapper,
+      },
+    )
+
+    act(() => {
+      result.current.onChange('test value')
+    })
+
+    expect(customOnChange).toHaveBeenCalledWith('test value')
+    expect(result.current.value).toBe('test value')
+  })
+
+  test('should properly transform the value', () => {
+    const { result } = renderHook(
+      () =>
+        useField({
+          name: 'testField',
+          transform: (value: string) => value.split(' ').join('-'),
+        }),
+      {
+        wrapper: FormWrapper,
+      },
+    )
+
+    act(() => {
+      result.current.onChange('some test value')
+    })
+
+    expect(result.current.value).toBe('some-test-value')
+  })
+})

--- a/src/components/Common/Fields/hooks/useField.ts
+++ b/src/components/Common/Fields/hooks/useField.ts
@@ -1,0 +1,54 @@
+import type { RegisterOptions } from 'react-hook-form'
+import { useController, useFormContext } from 'react-hook-form'
+
+export type Transform<TEvent, TValue> = (event: TEvent) => TValue
+
+export interface UseFieldProps<TEvent, TValue = string> {
+  name: string
+  rules?: RegisterOptions
+  defaultValue?: TValue
+  errorMessage?: string
+  isRequired?: boolean
+  onChange?: (event: TEvent) => void
+  transform?: Transform<TEvent, TValue>
+}
+
+export function useField<TEvent, TValue = string>({
+  name,
+  rules = {},
+  defaultValue,
+  errorMessage,
+  isRequired = false,
+  onChange,
+  transform,
+}: UseFieldProps<TEvent, TValue>) {
+  const { control } = useFormContext()
+  const { field, fieldState } = useController({
+    name,
+    control,
+    rules: {
+      required: isRequired,
+      ...rules,
+    },
+    defaultValue,
+  })
+
+  const { ref, ...restFieldProps } = field
+
+  const handleChange = (event: TEvent) => {
+    const value = transform ? transform(event) : event
+    field.onChange(value)
+    onChange?.(event)
+  }
+
+  const isInvalid = !!fieldState.error
+
+  return {
+    ...restFieldProps,
+    inputRef: ref,
+    isInvalid,
+    errorMessage: isInvalid ? (errorMessage ?? fieldState.error?.message) : undefined,
+    onChange: handleChange,
+    isRequired,
+  }
+}

--- a/src/components/Common/UI/FieldLayout/FieldLayout.module.scss
+++ b/src/components/Common/UI/FieldLayout/FieldLayout.module.scss
@@ -1,0 +1,53 @@
+.root {
+  display: flex;
+  flex-direction: column;
+}
+
+.labelAndDescription {
+  display: flex;
+  flex-direction: column;
+
+  &.withMargin {
+    margin-bottom: var(--g-spacing-8);
+  }
+}
+
+.label {
+  font-size: var(--g-input-labelFontSize);
+  font-weight: var(--g-input-labelFontWeight);
+  color: var(--g-input-labelColor);
+}
+
+.optionalLabel {
+  content: var(--g-optionalLabel);
+  font-size: smaller;
+  color: var(--g-input-placeholderColor);
+}
+
+.description {
+  display: block;
+  font-size: var(--g-typography-fontSize-small);
+  font-weight: var(--g-typography-fontWeight-regular);
+  line-height: toRem(20);
+  color: var(--g-input-descriptionColor);
+}
+
+.errorMessage {
+  display: flex;
+  align-items: center;
+  margin-top: toRem(4);
+  font-size: toRem(14);
+  line-height: toRem(18);
+  color: var(--g-colors-error-500);
+
+  &::before {
+    content: '';
+    display: block;
+    padding: 2px;
+    margin-right: 4px;
+    width: toRem(20);
+    height: toRem(20);
+    background: url('@/assets/icons/error.svg') no-repeat 50% 50% transparent;
+    flex-shrink: 0;
+  }
+}

--- a/src/components/Common/UI/FieldLayout/FieldLayout.stories.tsx
+++ b/src/components/Common/UI/FieldLayout/FieldLayout.stories.tsx
@@ -1,0 +1,36 @@
+import type { Story } from '@ladle/react'
+import { FieldLayout } from './FieldLayout'
+
+export const Default: Story = () => (
+  <FieldLayout htmlFor="email" label="Email" errorMessageId="email-error">
+    <input id="email" type="text" placeholder="Enter your email" />
+  </FieldLayout>
+)
+
+export const WithDescription: Story = () => (
+  <FieldLayout
+    htmlFor="email"
+    label="Email"
+    description="This is a description"
+    errorMessageId="email-error"
+  >
+    <input id="email" type="text" placeholder="Enter your email" />
+  </FieldLayout>
+)
+
+export const WithError: Story = () => (
+  <FieldLayout
+    htmlFor="email"
+    label="Email"
+    errorMessage="This is an error message"
+    errorMessageId="email-error"
+  >
+    <input id="email" type="text" placeholder="Enter your email" />
+  </FieldLayout>
+)
+
+export const WithRequired: Story = () => (
+  <FieldLayout htmlFor="email" label="Email" isRequired errorMessageId="email-error">
+    <input id="email" type="text" placeholder="Enter your email" />
+  </FieldLayout>
+)

--- a/src/components/Common/UI/FieldLayout/FieldLayout.test.tsx
+++ b/src/components/Common/UI/FieldLayout/FieldLayout.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { FieldLayout } from './FieldLayout'
+
+describe('FieldLayout', () => {
+  it('renders label with correct htmlFor value', () => {
+    render(
+      <FieldLayout label="Test Label" htmlFor="test-input" errorMessageId="error-id">
+        <input id="test-input" />
+      </FieldLayout>,
+    )
+
+    const label = screen.getByText('Test Label')
+    expect(label).toHaveAttribute('for', 'test-input')
+  })
+
+  it('renders label when it is visually hidden', () => {
+    render(
+      <FieldLayout
+        label="Test Label"
+        shouldVisuallyHideLabel
+        htmlFor="test-input"
+        errorMessageId="error-id"
+      >
+        <input id="test-input" />
+      </FieldLayout>,
+    )
+
+    expect(screen.getByLabelText(/Test Label/)).toBeInTheDocument()
+  })
+
+  it('shows optional label when isRequired is false', () => {
+    render(
+      <FieldLayout
+        label="Test Label"
+        htmlFor="test-input"
+        errorMessageId="error-id"
+        isRequired={false}
+      >
+        <input id="test-input" />
+      </FieldLayout>,
+    )
+
+    expect(screen.getByText('optionalLabel')).toBeInTheDocument()
+  })
+
+  it('renders error message with correct id when provided', () => {
+    render(
+      <FieldLayout
+        label="Test Label"
+        htmlFor="test-input"
+        errorMessageId="error-id"
+        errorMessage="Test error message"
+      >
+        <input id="test-input" />
+      </FieldLayout>,
+    )
+
+    const errorMessage = screen.getByText('Test error message')
+    expect(errorMessage).toHaveAttribute('id', 'error-id')
+  })
+})

--- a/src/components/Common/UI/FieldLayout/FieldLayout.tsx
+++ b/src/components/Common/UI/FieldLayout/FieldLayout.tsx
@@ -1,0 +1,68 @@
+import { VisuallyHidden } from 'react-aria'
+import { useTranslation } from 'react-i18next'
+import classNames from 'classnames'
+import styles from './FieldLayout.module.scss'
+import { createMarkup } from '@/helpers/formattedStrings'
+
+export interface BaseFieldLayoutProps {
+  description?: React.ReactNode
+  errorMessage?: string
+  isRequired?: boolean
+  label: React.ReactNode
+  shouldVisuallyHideLabel?: boolean
+}
+
+interface FieldLayoutProps extends BaseFieldLayoutProps {
+  children: React.ReactNode
+  htmlFor: string
+  errorMessageId: string
+  className?: string
+}
+
+export const FieldLayout: React.FC<FieldLayoutProps> = ({
+  label,
+  description,
+  errorMessage,
+  errorMessageId,
+  children,
+  isRequired = false,
+  htmlFor,
+  shouldVisuallyHideLabel = false,
+  className,
+}: FieldLayoutProps) => {
+  const { t } = useTranslation('common')
+
+  const labelContent = (
+    <label className={styles.label} htmlFor={htmlFor}>
+      {label}
+      {!isRequired ? <span className={styles.optionalLabel}>{t('optionalLabel')}</span> : null}
+    </label>
+  )
+
+  return (
+    <div className={classNames(styles.root, className)}>
+      <div
+        className={classNames(styles.labelAndDescription, {
+          [styles.withMargin as string]: !shouldVisuallyHideLabel || Boolean(description),
+        })}
+      >
+        {shouldVisuallyHideLabel ? <VisuallyHidden>{labelContent}</VisuallyHidden> : labelContent}
+        {description &&
+          (typeof description === 'string' ? (
+            <div
+              className={styles.description}
+              dangerouslySetInnerHTML={createMarkup(description)}
+            />
+          ) : (
+            <div className={styles.description}>{description}</div>
+          ))}
+      </div>
+      {children}
+      {errorMessage && (
+        <div id={errorMessageId} className={styles.errorMessage}>
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Common/UI/FieldLayout/index.ts
+++ b/src/components/Common/UI/FieldLayout/index.ts
@@ -1,0 +1,2 @@
+export { FieldLayout } from './FieldLayout'
+export type { BaseFieldLayoutProps as FieldLayoutProps } from './FieldLayout'

--- a/src/components/Common/UI/TextInput/TextInput.module.scss
+++ b/src/components/Common/UI/TextInput/TextInput.module.scss
@@ -1,0 +1,33 @@
+.root {
+  width: 100%;
+
+  :global(.react-aria-Input) {
+    height: var(--g-input-height);
+    padding: var(--g-input-paddingY) var(--g-input-paddingX);
+    margin: 0;
+    border: var(--g-input-borderWidth) solid var(--g-input-borderColor);
+    border-radius: 6px;
+    background: var(--g-input-background);
+    font-size: var(--g-input-fontSize);
+    color: var(--g-input-textColor);
+    line-height: toRem(24);
+
+    &[data-focused] {
+      @include formFocusOutline;
+
+      &[data-invalid] {
+        @include formFocusError;
+      }
+    }
+
+    &[data-invalid] {
+      border-color: var(--g-colors-error-500);
+    }
+
+    &[data-disabled] {
+      border-color: var(--g-input-disabled-border);
+      color: var(--g-input-disabled-color);
+      background-color: var(--g-input-disabled-bg);
+    }
+  }
+}

--- a/src/components/Common/UI/TextInput/TextInput.stories.tsx
+++ b/src/components/Common/UI/TextInput/TextInput.stories.tsx
@@ -1,0 +1,51 @@
+import type { Story } from '@ladle/react'
+import { useState } from 'react'
+import { TextInput } from './TextInput'
+
+export const Default: Story = () => {
+  const [value, setValue] = useState('')
+  return (
+    <TextInput
+      label="Email"
+      name="email"
+      type="email"
+      value={value}
+      onChange={event => {
+        setValue(event.target.value)
+      }}
+    />
+  )
+}
+
+export const Description: Story = () => {
+  const [value, setValue] = useState('')
+  return (
+    <TextInput
+      label="Email"
+      name="email"
+      type="email"
+      value={value}
+      description="Please enter your email address"
+      onChange={event => {
+        setValue(event.target.value)
+      }}
+    />
+  )
+}
+
+export const Error: Story = () => {
+  const [value, setValue] = useState('')
+  return (
+    <TextInput
+      label="Email"
+      name="email"
+      type="email"
+      value={value}
+      isInvalid
+      errorMessage="Please enter a valid email address"
+      onChange={event => {
+        setValue(event.target.value)
+      }}
+    />
+  )
+}

--- a/src/components/Common/UI/TextInput/TextInput.test.tsx
+++ b/src/components/Common/UI/TextInput/TextInput.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { ChangeEvent } from 'react'
+import { TextInput } from './TextInput'
+
+describe('TextInput', () => {
+  it('associates error message with input via aria-describedby', () => {
+    const errorMessage = 'This field is required'
+    render(<TextInput label="Test Input" errorMessage={errorMessage} />)
+
+    const input = screen.getByRole('textbox')
+    const errorMessageId = input.getAttribute('aria-describedby')
+    expect(screen.getByText(errorMessage)).toHaveAttribute('id', errorMessageId)
+  })
+
+  it('associates label with input via htmlFor', () => {
+    const label = 'Test Input'
+    render(<TextInput label={label} />)
+
+    const input = screen.getByRole('textbox')
+    const labelElement = screen.getByText(label)
+    expect(labelElement).toHaveAttribute('for', input.id)
+  })
+
+  it('calls both onChange handlers when input changes', () => {
+    const onChangeFromProps = vi.fn<(event: ChangeEvent<HTMLInputElement>) => void>()
+    const onChangeFromInputProps = vi.fn<(event: ChangeEvent<HTMLInputElement>) => void>()
+
+    const testValue = 'test value'
+
+    render(
+      <TextInput
+        label="Test label"
+        onChange={onChangeFromProps}
+        inputProps={{ onChange: onChangeFromInputProps }}
+      />,
+    )
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: testValue } })
+
+    expect(onChangeFromProps).toHaveBeenCalledTimes(1)
+    expect(onChangeFromInputProps).toHaveBeenCalledTimes(1)
+
+    expect(onChangeFromProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ value: testValue }),
+      }),
+    )
+    expect(onChangeFromInputProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ value: testValue }),
+      }),
+    )
+  })
+})

--- a/src/components/Common/UI/TextInput/TextInput.tsx
+++ b/src/components/Common/UI/TextInput/TextInput.tsx
@@ -1,0 +1,81 @@
+import type {
+  Ref,
+  InputHTMLAttributes,
+  ChangeEventHandler,
+  FocusEventHandler,
+  ChangeEvent,
+} from 'react'
+import { Input } from 'react-aria-components'
+import { useId } from 'react'
+import classNames from 'classnames'
+import { FieldLayout, type FieldLayoutProps } from '../FieldLayout'
+import styles from './TextInput.module.scss'
+
+export interface TextInputProps extends FieldLayoutProps {
+  name?: string
+  type?: 'text' | 'email' | 'password' | 'tel' | 'search' | 'url'
+  inputRef?: Ref<HTMLInputElement>
+  id?: string
+  value?: string
+  placeholder?: string
+  isInvalid?: boolean
+  onChange?: ChangeEventHandler<HTMLInputElement>
+  onBlur?: FocusEventHandler<HTMLInputElement>
+  inputProps?: InputHTMLAttributes<HTMLInputElement>
+  className?: string
+}
+
+export function TextInput({
+  name,
+  label,
+  description,
+  errorMessage,
+  isRequired,
+  type = 'text',
+  inputRef,
+  isInvalid = false,
+  id: providedLabelId,
+  value,
+  placeholder,
+  onChange: onChangeFromTextInputProps,
+  onBlur,
+  inputProps,
+  className,
+}: TextInputProps) {
+  const generatedLabelId = useId()
+  const id = providedLabelId || generatedLabelId
+  const generatedErrorMessageId = useId()
+
+  const { onChange: onChangeFromInputProps, ...restInputProps } = inputProps ?? {}
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChangeFromTextInputProps?.(event)
+    onChangeFromInputProps?.(event)
+  }
+
+  return (
+    <FieldLayout
+      label={label}
+      description={description}
+      errorMessage={errorMessage}
+      isRequired={isRequired}
+      htmlFor={id}
+      errorMessageId={generatedErrorMessageId}
+      className={classNames(styles.root, className)}
+    >
+      <Input
+        id={id}
+        ref={inputRef}
+        name={name}
+        type={type}
+        value={value}
+        placeholder={placeholder}
+        onChange={handleChange}
+        onBlur={onBlur}
+        aria-describedby={generatedErrorMessageId}
+        aria-invalid={isInvalid}
+        {...restInputProps}
+      />
+    </FieldLayout>
+  )
+}

--- a/src/components/Common/UI/TextInput/index.ts
+++ b/src/components/Common/UI/TextInput/index.ts
@@ -1,0 +1,1 @@
+export { TextInput, type TextInputProps } from './TextInput'


### PR DESCRIPTION
This PR creates the infrastructure for the work to decouple React Hook Form from our form inputs. It does the following:
* Creates a new FieldLayout component which can be reused for arranging label, description, and error text along with an input
* Creates a new TextInput component that is separated from React Hook Form dependencies
* Creates a new useField hook that allows us to easily access React Hook Form context and map React Hook Form values onto common input props
* Implements a TextInputField component that creates a React Hook Form connected version of the TextInput

## Proof of functionality

You can inspect the new components on ladle

https://github.com/user-attachments/assets/74e7872b-b5ae-4460-95d3-c48d5f4769ad

### Integration with profile form
There will be follow up work to integrate this new TextInputField component with our existing forms and that is beyond the scope of this PR and is not included. However, to ensure this behaves as expected I did some quick working ahead to add this to profile for proof of functionality to ensure everything was working as expected in an existing form. That can be seen here:

https://github.com/user-attachments/assets/9dfa4e0a-3ae0-4d52-be24-c8fd77dba863

And here:

https://github.com/user-attachments/assets/97d40057-3faf-4809-a461-23ee96d3cd4f


