### PR TITLE
fix: support nested error list returned from speakeasy client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@gusto/embedded-api": "^0.5.6",
+        "@gusto/embedded-api": "0.5.9",
         "@hookform/error-message": "^2.0.1",
         "@hookform/resolvers": "^3.10.0",
         "@internationalized/date": "^3.7.0",
@@ -1617,9 +1617,9 @@
       }
     },
     "node_modules/@gusto/embedded-api": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@gusto/embedded-api/-/embedded-api-0.5.6.tgz",
-      "integrity": "sha512-nmxovRoPGVZFEEggKEuE5arX0+UFeI+40+yPeSgcyGOz3SfHpxjB5+ct4WrlyQumjagzRo62Q8vVVQuMth3PtQ==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@gusto/embedded-api/-/embedded-api-0.5.9.tgz",
+      "integrity": "sha512-WXDiKLEt/u+oWvBpzQtc1F+4z7XRJZd9zWRT1ltL2T9EvA/m8SdpLG4c1MA14HK7D/dLNZX4hadJTfIELtfQXA==",
       "peerDependencies": {
         "@tanstack/react-query": "^5",
         "react": "^18 || ^19",
@@ -5854,9 +5854,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.69.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.69.0.tgz",
-      "integrity": "sha512-Kn410jq6vs1P8Nm+ZsRj9H+U3C0kjuEkYLxbiCyn3MDEiYor1j2DGVULqAz62SLZtUZ/e9Xt6xMXiJ3NJ65WyQ==",
+      "version": "5.71.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.71.1.tgz",
+      "integrity": "sha512-4+ZswCHOfJX+ikhXNoocamTUmJcHtB+Ljjz/oJkC7/eKB5IrzEwR4vEwZUENiPi+wISucJHR5TUbuuJ26w3kdQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -5866,14 +5866,14 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.69.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.69.0.tgz",
-      "integrity": "sha512-Ift3IUNQqTcaFa1AiIQ7WCb/PPy8aexZdq9pZWLXhfLcLxH0+PZqJ2xFImxCpdDZrFRZhLJrh76geevS5xjRhA==",
+      "version": "5.71.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.71.1.tgz",
+      "integrity": "sha512-6BTkaSIGT58MroI4kIGXNdx/NhirXPU+75AJObLq+WBa39WmoxhzSk0YX+hqWJ/bvqZJFxslbEU4qIHaRZq+8Q==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@tanstack/query-core": "5.69.0"
+        "@tanstack/query-core": "5.71.1"
       },
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "@gusto/embedded-api": "^0.5.6",
+    "@gusto/embedded-api": "^0.5.9",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^3.10.0",
     "@internationalized/date": "^3.7.0",

--- a/src/helpers/formattedStrings.test.ts
+++ b/src/helpers/formattedStrings.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from 'vitest'
-import { removeNonDigits, snakeCaseToCamelCase } from './formattedStrings'
+import { removeNonDigits, snakeCaseToCamelCase, camelCaseToSnakeCase } from './formattedStrings'
 
 describe('formattedStrings', () => {
   describe('removeNonDigits', () => {
@@ -27,6 +27,32 @@ describe('formattedStrings', () => {
 
     it('should handle empty string', () => {
       expect(snakeCaseToCamelCase('')).toBe('')
+    })
+  })
+
+  describe('camelCaseToSnakeCase', () => {
+    it('should convert camelCase to snake_case', () => {
+      expect(camelCaseToSnakeCase('helloWorld')).toBe('hello_world')
+    })
+
+    it('should handle multiple capital letters', () => {
+      expect(camelCaseToSnakeCase('firstNameLastName')).toBe('first_name_last_name')
+    })
+
+    it('should handle single word without capital letters', () => {
+      expect(camelCaseToSnakeCase('hello')).toBe('hello')
+    })
+
+    it('should handle empty string', () => {
+      expect(camelCaseToSnakeCase('')).toBe('')
+    })
+
+    it('should handle consecutive capital letters', () => {
+      expect(camelCaseToSnakeCase('myXMLParser')).toBe('my_xml_parser')
+    })
+
+    it('should handle consecutive capital letters at start', () => {
+      expect(camelCaseToSnakeCase('XMLParser')).toBe('xml_parser')
     })
   })
 })

--- a/src/helpers/formattedStrings.ts
+++ b/src/helpers/formattedStrings.ts
@@ -60,3 +60,17 @@ export const removeNonDigits = (value: string): string => {
 export const snakeCaseToCamelCase = (s: string) => {
   return s.replace(/_([a-z])/g, (_: string, char: string) => char.toUpperCase())
 }
+
+export const camelCaseToSnakeCase = (s: string) => {
+  return s
+    .replace(
+      /([a-z0-9])([A-Z])/g,
+      (_: string, group1: string, group2: string) => `${group1}_${group2.toLowerCase()}`,
+    )
+    .replace(
+      /([A-Z])([A-Z])(?=[a-z])/g,
+      (_: string, group1: string, group2: string) =>
+        `${group1.toLowerCase()}_${group2.toLowerCase()}`,
+    )
+    .toLowerCase()
+}


### PR DESCRIPTION
This change does the following
- Enables error list to come from OpenAPI (Meta data needed to be updated)
- Adds error_key prefix to nested error list logic to create valid nested keys
- Introduced camelCaseToSnakeCase which will be used to convert from/to various cases