### PR TITLE
feat: update UI form components to accept data props

### DIFF
--- a/src/components/Common/UI/Checkbox/Checkbox.tsx
+++ b/src/components/Common/UI/Checkbox/Checkbox.tsx
@@ -36,6 +36,7 @@ export const Checkbox = ({
   onBlur,
   inputProps,
   className,
+  ...props
 }: CheckboxProps) => {
   const { inputId, errorMessageId, descriptionId, ariaDescribedBy } = useFieldIds({
     inputId: id,
@@ -60,6 +61,7 @@ export const Checkbox = ({
       errorMessageId={errorMessageId}
       descriptionId={descriptionId}
       className={className}
+      {...props}
     >
       <div className={styles.checkboxWrapper}>
         <input

--- a/src/components/Common/UI/FieldLayout/FieldLayout.test.tsx
+++ b/src/components/Common/UI/FieldLayout/FieldLayout.test.tsx
@@ -5,7 +5,12 @@ import { FieldLayout } from './FieldLayout'
 describe('FieldLayout', () => {
   it('renders label with correct htmlFor value', () => {
     render(
-      <FieldLayout label="Test Label" htmlFor="test-input" errorMessageId="error-id">
+      <FieldLayout
+        label="Test Label"
+        htmlFor="test-input"
+        errorMessageId="error-id"
+        descriptionId="description-id"
+      >
         <input id="test-input" />
       </FieldLayout>,
     )
@@ -21,6 +26,7 @@ describe('FieldLayout', () => {
         shouldVisuallyHideLabel
         htmlFor="test-input"
         errorMessageId="error-id"
+        descriptionId="description-id"
       >
         <input id="test-input" />
       </FieldLayout>,
@@ -36,6 +42,7 @@ describe('FieldLayout', () => {
         htmlFor="test-input"
         errorMessageId="error-id"
         isRequired={false}
+        descriptionId="description-id"
       >
         <input id="test-input" />
       </FieldLayout>,
@@ -51,6 +58,7 @@ describe('FieldLayout', () => {
         htmlFor="test-input"
         errorMessageId="error-id"
         errorMessage="Test error message"
+        descriptionId="description-id"
       >
         <input id="test-input" />
       </FieldLayout>,
@@ -58,5 +66,25 @@ describe('FieldLayout', () => {
 
     const errorMessage = screen.getByText('Test error message')
     expect(errorMessage).toHaveAttribute('id', 'error-id')
+  })
+
+  it('should forward data attributes', () => {
+    render(
+      <FieldLayout
+        label="Test Label"
+        htmlFor="test-input"
+        errorMessageId="error-id"
+        descriptionId="description-id"
+        data-testid="field-layout"
+        data-bool={true}
+        data-number={123}
+      >
+        <input id="test-input" />
+      </FieldLayout>,
+    )
+
+    const fieldLayout = screen.getByTestId('field-layout')
+    expect(fieldLayout).toHaveAttribute('data-bool', 'true')
+    expect(fieldLayout).toHaveAttribute('data-number', '123')
   })
 })

--- a/src/components/Common/UI/FieldLayout/FieldLayout.tsx
+++ b/src/components/Common/UI/FieldLayout/FieldLayout.tsx
@@ -4,8 +4,10 @@ import classNames from 'classnames'
 import { FieldDescription } from '../FieldDescription'
 import { FieldErrorMessage } from '../FieldErrorMessage'
 import styles from './FieldLayout.module.scss'
+import type { DataAttributes } from '@/types/Helpers'
+import { getDataProps } from '@/helpers/getDataProps'
 
-export interface SharedFieldLayoutProps {
+export interface SharedFieldLayoutProps extends DataAttributes {
   description?: React.ReactNode
   errorMessage?: string
   isRequired?: boolean
@@ -34,6 +36,7 @@ export const FieldLayout: React.FC<FieldLayoutProps> = ({
   htmlFor,
   shouldVisuallyHideLabel = false,
   className,
+  ...props
 }: FieldLayoutProps) => {
   const { t } = useTranslation('common')
 
@@ -45,7 +48,7 @@ export const FieldLayout: React.FC<FieldLayoutProps> = ({
   )
 
   return (
-    <div className={classNames(styles.root, className)}>
+    <div className={classNames(styles.root, className)} {...getDataProps(props)}>
       <div
         className={classNames(styles.labelAndDescription, {
           [styles.withVisibleLabel as string]: !shouldVisuallyHideLabel,

--- a/src/components/Common/UI/HorizontalFieldLayout/HorizontalFieldLayout.tsx
+++ b/src/components/Common/UI/HorizontalFieldLayout/HorizontalFieldLayout.tsx
@@ -3,7 +3,7 @@ import { FieldErrorMessage } from '../FieldErrorMessage'
 import { FieldDescription } from '../FieldDescription'
 import type { SharedFieldLayoutProps, InternalFieldLayoutProps } from '../FieldLayout'
 import styles from './HorizontalFieldLayout.module.scss'
-
+import { getDataProps } from '@/helpers/getDataProps'
 export type SharedHorizontalFieldLayoutProps = Omit<
   SharedFieldLayoutProps,
   'shouldVisuallyHideLabel'
@@ -20,9 +20,10 @@ export const HorizontalFieldLayout: React.FC<HorizontalFieldLayoutProps> = ({
   children,
   htmlFor,
   className,
+  ...props
 }: HorizontalFieldLayoutProps) => {
   return (
-    <div className={classNames(styles.root, className)}>
+    <div className={classNames(styles.root, className)} {...getDataProps(props)}>
       <div className={styles.children}>{children}</div>
       <label className={styles.label} htmlFor={htmlFor}>
         {label}

--- a/src/components/Common/UI/NumberInput/NumberInput.tsx
+++ b/src/components/Common/UI/NumberInput/NumberInput.tsx
@@ -40,6 +40,8 @@ export function NumberInput({
   label,
   min,
   max,
+  shouldVisuallyHideLabel,
+  className,
   ...props
 }: NumberInputProps) {
   const { currency } = useLocale()
@@ -61,6 +63,9 @@ export function NumberInput({
       htmlFor={inputId}
       errorMessageId={errorMessageId}
       descriptionId={descriptionId}
+      shouldVisuallyHideLabel={shouldVisuallyHideLabel}
+      className={className}
+      {...props}
     >
       <AriaNumberField
         value={value}

--- a/src/components/Common/UI/Select/Select.test.tsx
+++ b/src/components/Common/UI/Select/Select.test.tsx
@@ -109,7 +109,6 @@ describe('Select Component', () => {
 
   test('should call onBlur when focus is lost', () => {
     const onBlur = vi.fn()
-    const user = userEvent.setup()
 
     render(
       <ThemeProvider>

--- a/src/components/Common/UI/Select/Select.tsx
+++ b/src/components/Common/UI/Select/Select.tsx
@@ -8,7 +8,7 @@ import {
   SelectValue,
 } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
-import type { FocusEvent, SelectHTMLAttributes, AriaAttributes } from 'react'
+import type { FocusEvent, SelectHTMLAttributes } from 'react'
 import { useMemo } from 'react'
 import { useFieldIds } from '../hooks/useFieldIds'
 import type { SharedFieldLayoutProps } from '../FieldLayout'
@@ -21,16 +21,9 @@ export interface SelectItem {
   label: string
 }
 
-// Define a type for data attributes
-type DataAttributes = {
-  [key: `data-${string}`]: string | number | boolean
-}
-
 export interface SelectProps
   extends SharedFieldLayoutProps,
-    Pick<SelectHTMLAttributes<HTMLSelectElement>, 'id' | 'name'>,
-    AriaAttributes,
-    DataAttributes {
+    Pick<SelectHTMLAttributes<HTMLSelectElement>, 'id' | 'name' | 'className'> {
   isDisabled?: boolean
   isInvalid?: boolean
   label: string
@@ -54,6 +47,9 @@ export const Select = ({
   options,
   placeholder,
   value,
+  shouldVisuallyHideLabel,
+  name,
+  className,
   ...props
 }: SelectProps) => {
   const { t } = useTranslation()
@@ -77,6 +73,9 @@ export const Select = ({
       descriptionId={descriptionId}
       isRequired={isRequired}
       description={description}
+      shouldVisuallyHideLabel={shouldVisuallyHideLabel}
+      className={className}
+      {...props}
     >
       <AriaSelect
         aria-label={label}
@@ -89,7 +88,7 @@ export const Select = ({
         id={inputId}
         selectedKey={value ? (value as Key) : undefined}
         aria-describedby={ariaDescribedBy}
-        {...props}
+        name={name}
       >
         <Button>
           <SelectValue>

--- a/src/components/Common/UI/TextInput/TextInput.tsx
+++ b/src/components/Common/UI/TextInput/TextInput.tsx
@@ -35,6 +35,8 @@ export function TextInput({
   onBlur,
   inputProps,
   className,
+  shouldVisuallyHideLabel,
+  ...props
 }: TextInputProps) {
   const { inputId, errorMessageId, descriptionId, ariaDescribedBy } = useFieldIds({
     inputId: id,
@@ -59,6 +61,8 @@ export function TextInput({
       errorMessageId={errorMessageId}
       descriptionId={descriptionId}
       className={classNames(styles.root, className)}
+      shouldVisuallyHideLabel={shouldVisuallyHideLabel}
+      {...props}
     >
       <Input
         id={inputId}

--- a/src/helpers/getDataProps.test.ts
+++ b/src/helpers/getDataProps.test.ts
@@ -1,0 +1,42 @@
+import { expect, describe, it } from 'vitest'
+import { getDataProps } from './getDataProps'
+
+describe('getDataProps', () => {
+  it('should return empty object for empty input', () => {
+    expect(getDataProps({})).toEqual({})
+  })
+
+  it('should extract data-* attributes', () => {
+    const props = {
+      'data-string': 'value',
+      'data-bool': true,
+      'data-number': 123,
+    }
+    expect(getDataProps(props)).toEqual(props)
+  })
+
+  it('should ignore non-data-* attributes', () => {
+    const props = {
+      'data-test': 'value',
+      className: 'test-class',
+      id: 'test-id',
+      style: { color: 'red' },
+    }
+    expect(getDataProps(props)).toEqual({
+      'data-test': 'value',
+    })
+  })
+
+  it('should ignore data-* attributes with invalid value types', () => {
+    const props = {
+      'data-test': 'value',
+      'data-object': { key: 'value' },
+      'data-array': [1, 2, 3],
+      'data-null': null,
+      'data-undefined': undefined,
+    }
+    expect(getDataProps(props)).toEqual({
+      'data-test': 'value',
+    })
+  })
+})

--- a/src/helpers/getDataProps.ts
+++ b/src/helpers/getDataProps.ts
@@ -1,0 +1,24 @@
+import type { DataAttributes } from '@/types/Helpers'
+
+type DataAttributeEntry = [key: keyof DataAttributes, value: DataAttributes[keyof DataAttributes]]
+
+const isDataProp = (entry: [string, unknown]): entry is DataAttributeEntry => {
+  const [key, value] = entry
+  return (
+    key.startsWith('data-') &&
+    (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean')
+  )
+}
+
+export function getDataProps(props: Record<string, unknown>): DataAttributes {
+  const result: DataAttributes = {}
+
+  Object.entries(props).forEach(entry => {
+    if (isDataProp(entry)) {
+      const [key, value] = entry
+      result[key] = value
+    }
+  })
+
+  return result
+}

--- a/src/types/Helpers.d.ts
+++ b/src/types/Helpers.d.ts
@@ -22,3 +22,7 @@ export type MachineEventType<
 
 //Makes specific property in the given type required
 export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
+
+export type DataAttributes = {
+  [key: `data-${string}`]: string | number | boolean
+}


### PR DESCRIPTION
This updates our UI form components to accept data attributes
* Any `data-` prefixed props are accepted
* data props are forwarded to the root of the field layout component

## Proof of functionality

The following JSX

<img width="586" alt="Screenshot 2025-04-09 at 1 49 50 PM" src="https://github.com/user-attachments/assets/5e81d73e-985a-498e-8ac7-64b455d8012b" />

Results in

<img width="1857" alt="Screenshot 2025-04-09 at 1 49 37 PM" src="https://github.com/user-attachments/assets/09a41163-171e-43cc-b2da-88e3c80cc374" />
