### PR TITLE
chore: centralize ladle actions for form components

### DIFF
--- a/.ladle/helpers/ActionHandler.tsx
+++ b/.ladle/helpers/ActionHandler.tsx
@@ -1,0 +1,55 @@
+import { action } from '@ladle/react'
+import { useState } from 'react'
+
+/**
+ * Creates a handler that logs actions to Ladle's action panel and optionally manages state
+ * @param actionName The name of the action to display in Ladle
+ * @returns Functions and state for handling component events
+ */
+export function useActionHandler<T>(actionName: string, initialValue?: T) {
+  const [value, setValue] = useState<T | undefined>(initialValue)
+
+  const handleAction = (newValue: T) => {
+    action(actionName)(newValue)
+    setValue(newValue)
+    return newValue
+  }
+
+  // For input elements that pass event objects
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value as unknown as T
+    action(actionName)(newValue)
+    setValue(newValue)
+    return newValue
+  }
+
+  // For checkbox elements that pass checked event
+  const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.checked as unknown as T
+    action(actionName)(newValue)
+    setValue(newValue)
+    return newValue
+  }
+
+  // For select elements that directly pass the value
+  const handleSelectChange = (newValue: T) => {
+    action(actionName)(newValue)
+    setValue(newValue)
+    return newValue
+  }
+
+  // For blur events
+  const handleBlur = () => {
+    action(`${actionName}Blur`)('Component blurred')
+  }
+
+  return {
+    value,
+    setValue,
+    handleAction,
+    handleInputChange,
+    handleCheckboxChange,
+    handleSelectChange,
+    handleBlur,
+  }
+}

--- a/.ladle/helpers/FormWrapper.tsx
+++ b/.ladle/helpers/FormWrapper.tsx
@@ -1,0 +1,51 @@
+import { action } from '@ladle/react'
+import type React from 'react'
+import { useEffect } from 'react'
+import type { DefaultValues } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
+
+// Use unknown instead of any for better type safety
+type FormWrapperProps<T extends Record<string, unknown>> = {
+  children: React.ReactNode
+  defaultValues?: Partial<T>
+  mode?: 'onSubmit' | 'onChange' | 'onBlur' | 'onTouched' | 'all'
+  actionName?: string
+}
+
+export const FormWrapper = <T extends Record<string, unknown> = Record<string, unknown>>({
+  children,
+  defaultValues = {} as Partial<T>,
+  mode = 'onTouched',
+  actionName = 'Form State Changed',
+}: FormWrapperProps<T>) => {
+  const methods = useForm<T>({
+    defaultValues: defaultValues as DefaultValues<T>,
+    mode,
+  })
+
+  // Log form state changes using Ladle action
+  useEffect(() => {
+    const subscription = methods.watch((value, { name, type }) => {
+      action(actionName)({
+        values: value,
+        name,
+        type,
+        errors: methods.formState.errors,
+        touchedFields: methods.formState.touchedFields,
+        dirtyFields: methods.formState.dirtyFields,
+        isDirty: methods.formState.isDirty,
+        isValid: methods.formState.isValid,
+      })
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [methods, actionName])
+
+  return (
+    <FormProvider {...methods}>
+      <div>{children}</div>
+    </FormProvider>
+  )
+}

--- a/.ladle/helpers/LadleState.tsx
+++ b/.ladle/helpers/LadleState.tsx
@@ -2,11 +2,11 @@ import { action } from '@ladle/react'
 import { useState } from 'react'
 
 /**
- * Creates a handler that logs actions to Ladle's action panel and optionally manages state
+ * Creates a handler that logs actions to Ladle's action panel and manages component state
  * @param actionName The name of the action to display in Ladle
  * @returns Functions and state for handling component events
  */
-export function useActionHandler<T>(actionName: string, initialValue?: T) {
+export function useLadleState<T>(actionName: string, initialValue?: T) {
   const [value, setValue] = useState<T | undefined>(initialValue)
 
   const handleAction = (newValue: T) => {

--- a/src/components/Common/Fields/CheckboxField/CheckboxField.stories.tsx
+++ b/src/components/Common/Fields/CheckboxField/CheckboxField.stories.tsx
@@ -1,32 +1,6 @@
 import type { Story } from '@ladle/react'
-import { FormProvider, useForm } from 'react-hook-form'
+import { FormWrapper } from '../../../../../.ladle/helpers/FormWrapper'
 import { CheckboxField } from './CheckboxField'
-
-interface FormWrapperProps {
-  children: React.ReactNode
-  defaultValues?: {
-    acceptTerms?: boolean
-    subscribeNewsletter?: boolean
-    enableNotifications?: boolean
-  }
-}
-
-const FormWrapper = ({ children, defaultValues = {} }: FormWrapperProps) => {
-  const methods = useForm({
-    defaultValues: {
-      acceptTerms: defaultValues.acceptTerms ?? false,
-      subscribeNewsletter: defaultValues.subscribeNewsletter ?? false,
-      enableNotifications: defaultValues.enableNotifications ?? false,
-    },
-    mode: 'onTouched',
-  })
-
-  return (
-    <FormProvider {...methods}>
-      <form onSubmit={methods.handleSubmit(() => {})}>{children}</form>
-    </FormProvider>
-  )
-}
 
 export const Default: Story = () => (
   <FormWrapper>

--- a/src/components/Common/Fields/NumberInputField/NumberInputField.stories.tsx
+++ b/src/components/Common/Fields/NumberInputField/NumberInputField.stories.tsx
@@ -1,35 +1,7 @@
 import type { Story } from '@ladle/react'
-import { FormProvider, useForm } from 'react-hook-form'
+import { FormWrapper } from '../../../../../.ladle/helpers/FormWrapper'
 import { NumberInputField } from './NumberInputField'
 import { LocaleProvider } from '@/contexts/LocaleProvider'
-
-interface FormWrapperProps {
-  children: React.ReactNode
-  defaultValues?: {
-    test?: number
-    amount?: number
-    quantity?: number
-    percentage?: number
-  }
-}
-
-const FormWrapper = ({ children, defaultValues = {} }: FormWrapperProps) => {
-  const methods = useForm({
-    defaultValues: {
-      test: defaultValues.test || 0,
-      amount: defaultValues.amount || 0,
-      quantity: defaultValues.quantity || 0,
-      percentage: defaultValues.percentage || 0,
-    },
-    mode: 'onTouched',
-  })
-
-  return (
-    <FormProvider {...methods}>
-      <div>{children}</div>
-    </FormProvider>
-  )
-}
 
 export const Default: Story = () => {
   return (

--- a/src/components/Common/Fields/SelectField/SelectField.stories.tsx
+++ b/src/components/Common/Fields/SelectField/SelectField.stories.tsx
@@ -1,54 +1,6 @@
 import type { Story } from '@ladle/react'
-import { FormProvider, useForm } from 'react-hook-form'
-import { useEffect } from 'react'
-import { action } from '@ladle/react'
+import { FormWrapper } from '../../../../../.ladle/helpers/FormWrapper'
 import { SelectField } from './SelectField'
-
-interface FormWrapperProps {
-  children: React.ReactNode
-  defaultValues?: {
-    category?: string
-    priority?: string
-    status?: string
-  }
-}
-
-const FormWrapper = ({ children, defaultValues = {} }: FormWrapperProps) => {
-  const methods = useForm({
-    defaultValues: {
-      category: defaultValues.category || '',
-      priority: defaultValues.priority || '',
-      status: defaultValues.status || '',
-    },
-    mode: 'onTouched',
-  })
-
-  // Log form state changes using Ladle action
-  useEffect(() => {
-    const subscription = methods.watch((value, { name, type }) => {
-      action('Form State Changed')({
-        values: value,
-        name,
-        type,
-        errors: methods.formState.errors,
-        touchedFields: methods.formState.touchedFields,
-        dirtyFields: methods.formState.dirtyFields,
-        isDirty: methods.formState.isDirty,
-        isValid: methods.formState.isValid,
-      })
-    })
-
-    return () => {
-      subscription.unsubscribe()
-    }
-  }, [methods])
-
-  return (
-    <FormProvider {...methods}>
-      <div>{children}</div>
-    </FormProvider>
-  )
-}
 
 const categories = [
   { value: '1', label: 'Electronics' },
@@ -72,131 +24,124 @@ const statuses = [
   { value: 'completed', label: 'Completed' },
 ]
 
-export const Default: Story = () => {
-  return (
-    <FormWrapper>
-      <SelectField
-        name="category"
-        label="Category"
-        items={categories}
-        placeholder="Select a category"
-      >
-        {item => <div>{item.label}</div>}
-      </SelectField>
-      <SelectField
-        name="priority"
-        label="Priority"
-        items={priorities}
-        placeholder="Select a priority"
-      >
-        {item => <div>{item.label}</div>}
-      </SelectField>
-      <SelectField name="status" label="Status" items={statuses} placeholder="Select a status">
-        {item => <div>{item.label}</div>}
-      </SelectField>
-    </FormWrapper>
-  )
-}
-
-export const Required: Story = () => {
-  return (
-    <FormWrapper>
-      <SelectField
-        name="category"
-        label="Category"
-        items={categories}
-        placeholder="Select a category"
-        isRequired
-        errorMessage="Category is required"
-      >
-        {item => <div>{item.label}</div>}
-      </SelectField>
-      <SelectField
-        name="priority"
-        label="Priority"
-        items={priorities}
-        placeholder="Select a priority"
-        isRequired
-        errorMessage="Priority is required"
-      >
-        {item => <div>{item.label}</div>}
-      </SelectField>
-      <SelectField
-        name="status"
-        label="Status"
-        items={statuses}
-        placeholder="Select a status"
-        isRequired
-        errorMessage="Status is required"
-      >
-        {item => <div>{item.label}</div>}
-      </SelectField>
-    </FormWrapper>
-  )
-}
-
-export const WithDefaultValues: Story = () => {
-  return (
-    <FormWrapper
-      defaultValues={{
-        category: '3',
-        priority: 'high',
-        status: 'review',
-      }}
+// We're temporarily skipping the generic type parameter to avoid TypeScript issues
+export const Default: Story = () => (
+  <FormWrapper>
+    <SelectField
+      name="category"
+      label="Category"
+      items={categories}
+      placeholder="Select a category"
     >
-      <SelectField
-        name="category"
-        label="Category"
-        items={categories}
-        placeholder="Select a category"
-      >
-        {item => <div>{item.label}</div>}
-      </SelectField>
-      <SelectField
-        name="priority"
-        label="Priority"
-        items={priorities}
-        placeholder="Select a priority"
-      >
-        {item => <div>{item.label}</div>}
-      </SelectField>
-      <SelectField name="status" label="Status" items={statuses} placeholder="Select a status">
-        {item => <div>{item.label}</div>}
-      </SelectField>
-    </FormWrapper>
-  )
-}
+      {item => <div>{item.label}</div>}
+    </SelectField>
+    <SelectField
+      name="priority"
+      label="Priority"
+      items={priorities}
+      placeholder="Select a priority"
+    >
+      {item => <div>{item.label}</div>}
+    </SelectField>
+    <SelectField name="status" label="Status" items={statuses} placeholder="Select a status">
+      {item => <div>{item.label}</div>}
+    </SelectField>
+  </FormWrapper>
+)
 
-export const WithDescription: Story = () => {
-  return (
-    <FormWrapper>
-      <SelectField
-        name="category"
-        label="Category"
-        items={categories}
-        placeholder="Select a category"
-        description="Choose the product category"
-      >
-        {item => <div>{item.label}</div>}
-      </SelectField>
-      <SelectField
-        name="priority"
-        label="Priority"
-        items={priorities}
-        placeholder="Select a priority"
-        description="Set the task priority level"
-      >
-        {item => <div>{item.label}</div>}
-      </SelectField>
-      <SelectField
-        name="status"
-        label="Status"
-        items={statuses}
-        placeholder="Select a status"
-        description="Update the current status"
-      >
-        {item => <div>{item.label}</div>}
-      </SelectField>
-    </FormWrapper>
-  )
-}
+export const Required: Story = () => (
+  <FormWrapper>
+    <SelectField
+      name="category"
+      label="Category"
+      items={categories}
+      placeholder="Select a category"
+      isRequired
+      errorMessage="Category is required"
+    >
+      {item => <div>{item.label}</div>}
+    </SelectField>
+    <SelectField
+      name="priority"
+      label="Priority"
+      items={priorities}
+      placeholder="Select a priority"
+      isRequired
+      errorMessage="Priority is required"
+    >
+      {item => <div>{item.label}</div>}
+    </SelectField>
+    <SelectField
+      name="status"
+      label="Status"
+      items={statuses}
+      placeholder="Select a status"
+      isRequired
+      errorMessage="Status is required"
+    >
+      {item => <div>{item.label}</div>}
+    </SelectField>
+  </FormWrapper>
+)
+
+export const WithDefaultValues: Story = () => (
+  <FormWrapper
+    defaultValues={{
+      category: '3',
+      priority: 'high',
+      status: 'review',
+    }}
+  >
+    <SelectField
+      name="category"
+      label="Category"
+      items={categories}
+      placeholder="Select a category"
+    >
+      {item => <div>{item.label}</div>}
+    </SelectField>
+    <SelectField
+      name="priority"
+      label="Priority"
+      items={priorities}
+      placeholder="Select a priority"
+    >
+      {item => <div>{item.label}</div>}
+    </SelectField>
+    <SelectField name="status" label="Status" items={statuses} placeholder="Select a status">
+      {item => <div>{item.label}</div>}
+    </SelectField>
+  </FormWrapper>
+)
+
+export const WithDescription: Story = () => (
+  <FormWrapper>
+    <SelectField
+      name="category"
+      label="Category"
+      items={categories}
+      placeholder="Select a category"
+      description="Choose the product category"
+    >
+      {item => <div>{item.label}</div>}
+    </SelectField>
+    <SelectField
+      name="priority"
+      label="Priority"
+      items={priorities}
+      placeholder="Select a priority"
+      description="Set the task priority level"
+    >
+      {item => <div>{item.label}</div>}
+    </SelectField>
+    <SelectField
+      name="status"
+      label="Status"
+      items={statuses}
+      placeholder="Select a status"
+      description="Update the current status"
+    >
+      {item => <div>{item.label}</div>}
+    </SelectField>
+  </FormWrapper>
+)

--- a/src/components/Common/Fields/TextInputField/TextInputField.stories.tsx
+++ b/src/components/Common/Fields/TextInputField/TextInputField.stories.tsx
@@ -1,34 +1,6 @@
 import type { Story } from '@ladle/react'
-import { FormProvider, useForm } from 'react-hook-form'
+import { FormWrapper } from '../../../../../.ladle/helpers/FormWrapper'
 import { TextInputField } from './TextInputField'
-
-interface FormWrapperProps {
-  children: React.ReactNode
-  defaultValues?: {
-    firstName?: string
-    lastName?: string
-    favoriteFood?: string
-    test?: number
-  }
-}
-
-const FormWrapper = ({ children, defaultValues = {} }: FormWrapperProps) => {
-  const methods = useForm({
-    defaultValues: {
-      firstName: defaultValues.firstName || '',
-      lastName: defaultValues.lastName || '',
-      favoriteFood: defaultValues.favoriteFood || '',
-      test: defaultValues.test || 0,
-    },
-    mode: 'onTouched',
-  })
-
-  return (
-    <FormProvider {...methods}>
-      <div>{children}</div>
-    </FormProvider>
-  )
-}
 
 export const Default: Story = () => (
   <FormWrapper>

--- a/src/components/Common/UI/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Common/UI/Checkbox/Checkbox.stories.tsx
@@ -1,38 +1,34 @@
 import type { Story } from '@ladle/react'
-import { useState } from 'react'
+import { useLadleState } from '../../../../../.ladle/helpers/LadleState'
 import { Checkbox } from './Checkbox'
 
 export const Default: Story = () => {
-  const [checked, setChecked] = useState(false)
+  const { value, handleCheckboxChange } = useLadleState<boolean>('CheckboxChange', false)
   return (
     <Checkbox
       label="Accept terms and conditions"
       name="terms"
-      checked={checked}
-      onChange={event => {
-        setChecked(event.target.checked)
-      }}
+      checked={value}
+      onChange={handleCheckboxChange}
     />
   )
 }
 
 export const WithDescription: Story = () => {
-  const [checked, setChecked] = useState(false)
+  const { value, handleCheckboxChange } = useLadleState<boolean>('CheckboxChange', false)
   return (
     <Checkbox
       label="Subscribe to newsletter"
       name="newsletter"
       description="Receive updates about new features and promotions"
-      checked={checked}
-      onChange={event => {
-        setChecked(event.target.checked)
-      }}
+      checked={value}
+      onChange={handleCheckboxChange}
     />
   )
 }
 
 export const WithError: Story = () => {
-  const [checked, setChecked] = useState(false)
+  const { value, handleCheckboxChange } = useLadleState<boolean>('CheckboxChange', false)
   return (
     <Checkbox
       label="Accept terms and conditions"
@@ -40,10 +36,8 @@ export const WithError: Story = () => {
       isInvalid
       errorMessage="You must accept the terms to continue"
       description="Receive updates about new features and promotions"
-      checked={checked}
-      onChange={event => {
-        setChecked(event.target.checked)
-      }}
+      checked={value}
+      onChange={handleCheckboxChange}
     />
   )
 }

--- a/src/components/Common/UI/NumberInput/NumberInput.stories.tsx
+++ b/src/components/Common/UI/NumberInput/NumberInput.stories.tsx
@@ -1,20 +1,20 @@
 import type { Story } from '@ladle/react'
-import { useState } from 'react'
+import { useLadleState } from '../../../../../.ladle/helpers/LadleState'
 import { NumberInput } from './NumberInput'
 import { LocaleProvider } from '@/contexts/LocaleProvider'
 
 export const Default: Story = () => {
-  const [value, setValue] = useState(0)
+  const { value, handleAction } = useLadleState<number>('NumberInputChange', 0)
 
   return (
     <LocaleProvider locale="en-US" currency="USD">
-      <NumberInput label="Amount" name="amount" value={value} onChange={setValue} />
+      <NumberInput label="Amount" name="amount" value={value} onChange={handleAction} />
     </LocaleProvider>
   )
 }
 
 export const Currency: Story = () => {
-  const [value, setValue] = useState(0)
+  const { value, handleAction } = useLadleState<number>('NumberInputChange', 0)
 
   return (
     <LocaleProvider locale="en-US" currency="USD">
@@ -22,7 +22,7 @@ export const Currency: Story = () => {
         label="Price"
         name="price"
         value={value}
-        onChange={setValue}
+        onChange={handleAction}
         format="currency"
         currencyDisplay="symbol"
       />
@@ -31,7 +31,7 @@ export const Currency: Story = () => {
 }
 
 export const Percent: Story = () => {
-  const [value, setValue] = useState(0)
+  const { value, handleAction } = useLadleState<number>('NumberInputChange', 0)
 
   return (
     <LocaleProvider locale="en-US" currency="USD">
@@ -39,7 +39,7 @@ export const Percent: Story = () => {
         label="Discount"
         name="discount"
         value={value}
-        onChange={setValue}
+        onChange={handleAction}
         format="percent"
         description="Enter discount percentage"
       />
@@ -48,7 +48,7 @@ export const Percent: Story = () => {
 }
 
 export const Decimal: Story = () => {
-  const [value, setValue] = useState(0)
+  const { value, handleAction } = useLadleState<number>('NumberInputChange', 0)
 
   return (
     <LocaleProvider locale="en-US" currency="USD">
@@ -56,7 +56,7 @@ export const Decimal: Story = () => {
         label="Quantity"
         name="quantity"
         value={value}
-        onChange={setValue}
+        onChange={handleAction}
         format="decimal"
       />
     </LocaleProvider>
@@ -64,7 +64,7 @@ export const Decimal: Story = () => {
 }
 
 export const WithDescription: Story = () => {
-  const [value, setValue] = useState(0)
+  const { value, handleAction } = useLadleState<number>('NumberInputChange', 0)
 
   return (
     <LocaleProvider locale="en-US" currency="USD">
@@ -72,7 +72,7 @@ export const WithDescription: Story = () => {
         label="Quantity"
         name="quantity"
         value={value}
-        onChange={setValue}
+        onChange={handleAction}
         description="Enter the number of items"
       />
     </LocaleProvider>
@@ -80,7 +80,7 @@ export const WithDescription: Story = () => {
 }
 
 export const WithError: Story = () => {
-  const [value, setValue] = useState(0)
+  const { value, handleAction } = useLadleState<number>('NumberInputChange', 0)
 
   return (
     <LocaleProvider locale="en-US" currency="USD">
@@ -88,7 +88,7 @@ export const WithError: Story = () => {
         label="Age"
         name="age"
         value={value}
-        onChange={setValue}
+        onChange={handleAction}
         isInvalid
         errorMessage="Please enter a valid age"
       />

--- a/src/components/Common/UI/Select/Select.stories.tsx
+++ b/src/components/Common/UI/Select/Select.stories.tsx
@@ -1,5 +1,5 @@
 import type { Story } from '@ladle/react'
-import { action } from '@ladle/react'
+import { useLadleState } from '../../../../../.ladle/helpers/LadleState'
 import { Select } from './Select'
 
 const options = [
@@ -10,57 +10,56 @@ const options = [
   { label: 'Option 5', value: '5o', id: '5o' },
 ]
 
-// Handler for onChange events
-const handleChange = (value: string) => {
-  action('onChange')(value)
-}
-
 export const Default: Story = () => {
+  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleChange}
-      onBlur={() => {}}
+      onChange={handleSelectChange}
+      onBlur={handleBlur}
     />
   )
 }
 
 export const WithPlaceholder: Story = () => {
+  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleChange}
-      onBlur={() => {}}
+      onChange={handleSelectChange}
+      onBlur={handleBlur}
       placeholder="Choose an option"
     />
   )
 }
 
 export const WithDescription: Story = () => {
+  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleChange}
-      onBlur={() => {}}
+      onChange={handleSelectChange}
+      onBlur={handleBlur}
       description="Please select one of the available options"
     />
   )
 }
 
 export const WithError: Story = () => {
+  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleChange}
-      onBlur={() => {}}
+      onChange={handleSelectChange}
+      onBlur={handleBlur}
       isInvalid
       errorMessage="Please select a valid option"
     />
@@ -68,42 +67,42 @@ export const WithError: Story = () => {
 }
 
 export const Disabled: Story = () => {
+  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleChange}
-      onBlur={() => {}}
+      onChange={handleSelectChange}
+      onBlur={handleBlur}
       isDisabled
     />
   )
 }
 
 export const Required: Story = () => {
+  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleChange}
-      onBlur={() => {}}
+      onChange={handleSelectChange}
+      onBlur={handleBlur}
       isRequired={true}
     />
   )
 }
 
 export const WithOnBlur: Story = () => {
+  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleChange}
-      onBlur={() => {
-        // eslint-disable-next-line no-console
-        console.log('Select has been blurred')
-      }}
+      onChange={handleSelectChange}
+      onBlur={handleBlur}
     />
   )
 }

--- a/src/components/Common/UI/TextInput/TextInput.stories.tsx
+++ b/src/components/Common/UI/TextInput/TextInput.stories.tsx
@@ -1,24 +1,16 @@
 import type { Story } from '@ladle/react'
-import { useState } from 'react'
+import { useLadleState } from '../../../../../.ladle/helpers/LadleState'
 import { TextInput } from './TextInput'
 
 export const Default: Story = () => {
-  const [value, setValue] = useState('')
+  const { value, handleInputChange } = useLadleState<string>('TextInputChange', '')
   return (
-    <TextInput
-      label="Email"
-      name="email"
-      type="email"
-      value={value}
-      onChange={event => {
-        setValue(event.target.value)
-      }}
-    />
+    <TextInput label="Email" name="email" type="email" value={value} onChange={handleInputChange} />
   )
 }
 
 export const Description: Story = () => {
-  const [value, setValue] = useState('')
+  const { value, handleInputChange } = useLadleState<string>('TextInputChange', '')
   return (
     <TextInput
       label="Email"
@@ -26,15 +18,13 @@ export const Description: Story = () => {
       type="email"
       value={value}
       description="Please enter your email address"
-      onChange={event => {
-        setValue(event.target.value)
-      }}
+      onChange={handleInputChange}
     />
   )
 }
 
 export const Error: Story = () => {
-  const [value, setValue] = useState('')
+  const { value, handleInputChange } = useLadleState<string>('TextInputChange', '')
   return (
     <TextInput
       label="Email"
@@ -43,9 +33,7 @@ export const Error: Story = () => {
       value={value}
       isInvalid
       errorMessage="Please enter a valid email address"
-      onChange={event => {
-        setValue(event.target.value)
-      }}
+      onChange={handleInputChange}
     />
   )
 }


### PR DESCRIPTION
This PR Aims to do the following
- Centralize `action` calls into a helper utility for FormFields
- Centralize `action` calls into a helper utility for Input's w/o React Hook Forms
- Update existing stories to take advantage of these improvements