### PR TITLE
feat: add CheckboxGroup separated from react hook form

### DIFF
--- a/.ladle/helpers/FormWrapper.module.scss
+++ b/.ladle/helpers/FormWrapper.module.scss
@@ -1,0 +1,5 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: toRem(16);
+}

--- a/.ladle/helpers/FormWrapper.tsx
+++ b/.ladle/helpers/FormWrapper.tsx
@@ -3,6 +3,7 @@ import type React from 'react'
 import { useEffect } from 'react'
 import type { DefaultValues } from 'react-hook-form'
 import { FormProvider, useForm } from 'react-hook-form'
+import styles from './FormWrapper.module.scss'
 
 // Use unknown instead of any for better type safety
 type FormWrapperProps<T extends Record<string, unknown>> = {
@@ -43,9 +44,15 @@ export const FormWrapper = <T extends Record<string, unknown> = Record<string, u
     }
   }, [methods, actionName])
 
+  const handleSubmit = (data: T) => {
+    action('Form submitted')(data)
+  }
+
   return (
     <FormProvider {...methods}>
-      <div>{children}</div>
+      <form className={styles.form} onSubmit={methods.handleSubmit(handleSubmit)}>
+        {children}
+      </form>
     </FormProvider>
   )
 }

--- a/.ladle/helpers/LadleState.tsx
+++ b/.ladle/helpers/LadleState.tsx
@@ -31,6 +31,12 @@ export function useLadleState<T>(actionName: string, initialValue?: T) {
     return newValue
   }
 
+  const handleCheckboxGroupChange = (newValue: T) => {
+    action(actionName)(newValue)
+    setValue(newValue)
+    return newValue
+  }
+
   // For select elements that directly pass the value
   const handleSelectChange = (newValue: T) => {
     action(actionName)(newValue)
@@ -49,6 +55,7 @@ export function useLadleState<T>(actionName: string, initialValue?: T) {
     handleAction,
     handleInputChange,
     handleCheckboxChange,
+    handleCheckboxGroupChange,
     handleSelectChange,
     handleBlur,
   }

--- a/src/components/Common/Fields/CheckboxGroupField/CheckboxGroupField.stories.tsx
+++ b/src/components/Common/Fields/CheckboxGroupField/CheckboxGroupField.stories.tsx
@@ -1,0 +1,74 @@
+import type { Story } from '@ladle/react'
+import { FormWrapper } from '../../../../../.ladle/helpers/FormWrapper'
+import { CheckboxGroupField } from './CheckboxGroupField'
+
+const categories = [
+  { value: 'electronics', label: 'Electronics' },
+  { value: 'clothing', label: 'Clothing' },
+  { value: 'books', label: 'Books' },
+  { value: 'home', label: 'Home & Garden' },
+  { value: 'sports', label: 'Sports' },
+]
+
+const features = [
+  { value: 'feature1', label: 'Feature 1' },
+  { value: 'feature2', label: 'Feature 2' },
+  { value: 'feature3', label: 'Feature 3' },
+  { value: 'feature4', label: 'Feature 4' },
+]
+
+const notifications = [
+  { value: 'email', label: 'Email Notifications' },
+  { value: 'sms', label: 'SMS Notifications' },
+  { value: 'push', label: 'Push Notifications' },
+  { value: 'in-app', label: 'In-App Notifications' },
+]
+
+export const Default: Story = () => (
+  <FormWrapper>
+    <CheckboxGroupField name="categories" label="Categories" options={categories} />
+    <CheckboxGroupField name="features" label="Features" options={features} />
+    <CheckboxGroupField name="notifications" label="Notifications" options={notifications} />
+  </FormWrapper>
+)
+
+export const Required: Story = () => (
+  <FormWrapper>
+    <CheckboxGroupField
+      name="categories"
+      label="Categories"
+      options={categories}
+      isRequired
+      errorMessage="At least one category is required"
+    />
+    <CheckboxGroupField
+      name="features"
+      label="Features"
+      options={features}
+      isRequired
+      errorMessage="At least one feature is required"
+    />
+    <CheckboxGroupField
+      name="notifications"
+      label="Notifications"
+      options={notifications}
+      isRequired
+      errorMessage="At least one notification type is required"
+    />
+    <button type="submit">Submit</button>
+  </FormWrapper>
+)
+
+export const WithDefaultValues: Story = () => (
+  <FormWrapper
+    defaultValues={{
+      categories: ['electronics', 'books'],
+      features: ['feature1', 'feature3'],
+      notifications: ['email', 'push'],
+    }}
+  >
+    <CheckboxGroupField name="categories" label="Categories" options={categories} />
+    <CheckboxGroupField name="features" label="Features" options={features} />
+    <CheckboxGroupField name="notifications" label="Notifications" options={notifications} />
+  </FormWrapper>
+)

--- a/src/components/Common/Fields/CheckboxGroupField/CheckboxGroupField.tsx
+++ b/src/components/Common/Fields/CheckboxGroupField/CheckboxGroupField.tsx
@@ -1,0 +1,29 @@
+import { useField, type UseFieldProps } from '@/components/Common/Fields/hooks/useField'
+import { CheckboxGroup, type CheckboxGroupProps } from '@/components/Common/UI/CheckboxGroup'
+
+export interface CheckboxGroupFieldProps
+  extends Omit<CheckboxGroupProps, 'value'>,
+    UseFieldProps<string[], string[]> {}
+
+export const CheckboxGroupField: React.FC<CheckboxGroupFieldProps> = ({
+  rules,
+  defaultValue,
+  name,
+  errorMessage,
+  isRequired,
+  onChange,
+  transform,
+  ...checkboxGroupProps
+}: CheckboxGroupFieldProps) => {
+  const fieldProps = useField({
+    name,
+    rules,
+    defaultValue,
+    errorMessage,
+    isRequired,
+    onChange,
+    transform,
+  })
+
+  return <CheckboxGroup {...fieldProps} {...checkboxGroupProps} />
+}

--- a/src/components/Common/Fields/CheckboxGroupField/index.ts
+++ b/src/components/Common/Fields/CheckboxGroupField/index.ts
@@ -1,0 +1,1 @@
+export { CheckboxGroupField, type CheckboxGroupFieldProps } from './CheckboxGroupField'

--- a/src/components/Common/UI/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/Common/UI/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -1,0 +1,135 @@
+import type { Story } from '@ladle/react'
+import { useLadleState } from '../../../../../.ladle/helpers/LadleState'
+import { CheckboxGroup } from './CheckboxGroup'
+
+const options = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Cherry', value: 'cherry' },
+  { label: 'Date', value: 'date' },
+  { label: 'Elderberry', value: 'elderberry' },
+]
+
+function useCheckboxGroupState() {
+  const { value, handleCheckboxGroupChange } = useLadleState<string[]>('CheckboxGroupChange', [])
+  return { value, handleCheckboxGroupChange }
+}
+
+export const Default: Story = () => {
+  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  return (
+    <CheckboxGroup
+      label="Select options"
+      options={options}
+      value={value}
+      onChange={handleCheckboxGroupChange}
+    />
+  )
+}
+
+export const WithDescription: Story = () => {
+  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  return (
+    <CheckboxGroup
+      label="Select your favorite fruits"
+      options={options}
+      onChange={handleCheckboxGroupChange}
+      description="Please select one or more options"
+      value={value}
+    />
+  )
+}
+
+export const WithError: Story = () => {
+  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  return (
+    <CheckboxGroup
+      label="Select your favorite fruits"
+      options={options}
+      onChange={handleCheckboxGroupChange}
+      value={value}
+      isInvalid
+      errorMessage="Please select at least one fruit"
+    />
+  )
+}
+
+export const Disabled: Story = () => {
+  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  return (
+    <CheckboxGroup
+      label="Select your favorite fruits"
+      options={options}
+      onChange={handleCheckboxGroupChange}
+      value={value}
+      isDisabled
+    />
+  )
+}
+
+export const Required: Story = () => {
+  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  return (
+    <CheckboxGroup
+      label="Select your favorite fruits"
+      options={options}
+      onChange={handleCheckboxGroupChange}
+      value={value}
+      isRequired
+    />
+  )
+}
+
+export const WithDisabledOptions: Story = () => {
+  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+
+  const optionsWithDisabled = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana', isDisabled: true },
+    { label: 'Cherry', value: 'cherry' },
+    { label: 'Date', value: 'date', isDisabled: true },
+    { label: 'Elderberry', value: 'elderberry' },
+  ]
+
+  return (
+    <CheckboxGroup
+      label="Select your favorite fruits"
+      options={optionsWithDisabled}
+      onChange={handleCheckboxGroupChange}
+      value={value}
+    />
+  )
+}
+
+export const WithOptionDescriptions: Story = () => {
+  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+
+  const optionsWithDescriptions = [
+    { label: 'Apple', value: 'apple', description: 'Kind of mid' },
+    { label: 'Banana', value: 'banana', description: 'Depends on the banana' },
+    { label: 'Cherry', value: 'cherry', description: 'Good in pies' },
+    { label: 'Date', value: 'date', description: 'Not my favorite' },
+    { label: 'Elderberry', value: 'elderberry', description: 'What even is this?' },
+  ]
+
+  return (
+    <CheckboxGroup
+      label="Select your favorite fruits"
+      options={optionsWithDescriptions}
+      onChange={handleCheckboxGroupChange}
+      value={value}
+    />
+  )
+}
+
+export const WithPreselectedValues: Story = () => {
+  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  return (
+    <CheckboxGroup
+      label="Select your favorite fruits"
+      options={options}
+      onChange={handleCheckboxGroupChange}
+      value={value}
+    />
+  )
+}

--- a/src/components/Common/UI/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/Common/UI/CheckboxGroup/CheckboxGroup.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CheckboxGroup } from './CheckboxGroup'
+
+const mockOptions = [
+  { label: 'Option 1', value: 'option1' },
+  { label: 'Option 2', value: 'option2' },
+  { label: 'Option 3', value: 'option3', isDisabled: true },
+]
+
+describe('CheckboxGroup', () => {
+  it('renders all options with correct labels', () => {
+    render(<CheckboxGroup label="Test Group" options={mockOptions} />)
+
+    mockOptions.forEach(option => {
+      expect(screen.getByText(option.label)).toBeInTheDocument()
+    })
+  })
+
+  it('uses legend element for label', () => {
+    const label = 'Test Group'
+    render(<CheckboxGroup label={label} options={mockOptions} />)
+
+    const legend = screen.getByText(label)
+    expect(legend.tagName.toLowerCase()).toBe('legend')
+  })
+
+  it('associates error message with fieldset when error is present', () => {
+    const errorMessage = 'This field is required'
+    render(<CheckboxGroup label="Test Group" options={mockOptions} errorMessage={errorMessage} />)
+
+    const errorElement = screen.getByRole('alert')
+
+    // Workaround for multiple groups present in the DOM
+    const group = screen
+      .getAllByRole('group')
+      .find(el => el.getAttribute('aria-describedby') === errorElement.id)
+
+    expect(group).toHaveAttribute('aria-describedby', errorElement.id)
+  })
+
+  it('calls onChange handler when options are selected', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(<CheckboxGroup label="Test Group" options={mockOptions} onChange={onChange} />)
+
+    const firstCheckbox = screen.getByLabelText('Option 1')
+    await user.click(firstCheckbox)
+
+    expect(onChange).toHaveBeenCalledWith(['option1'])
+  })
+
+  it('disables all checkboxes when isDisabled is true', () => {
+    render(<CheckboxGroup label="Test Group" options={mockOptions} isDisabled />)
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    checkboxes.forEach(checkbox => {
+      expect(checkbox).toBeDisabled()
+    })
+  })
+
+  it('respects individual option disabled state', () => {
+    render(<CheckboxGroup label="Test Group" options={mockOptions} />)
+
+    const disabledCheckbox = screen.getByLabelText('Option 3')
+    expect(disabledCheckbox).toBeDisabled()
+
+    const enabledCheckboxes = screen
+      .getAllByRole('checkbox')
+      .filter(
+        (checkbox): checkbox is HTMLInputElement =>
+          checkbox instanceof HTMLInputElement && !checkbox.disabled,
+      )
+
+    expect(enabledCheckboxes).toHaveLength(2)
+  })
+
+  it('displays description when provided', () => {
+    const description = 'Helpful description'
+    render(<CheckboxGroup label="Test Group" options={mockOptions} description={description} />)
+
+    expect(screen.getByText(description)).toBeInTheDocument()
+  })
+})

--- a/src/components/Common/UI/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/Common/UI/CheckboxGroup/CheckboxGroup.tsx
@@ -1,0 +1,140 @@
+import { useContext, useRef } from 'react'
+import type { FieldsetHTMLAttributes, Ref } from 'react'
+import {
+  CheckboxGroup as AriaCheckboxGroup,
+  CheckboxGroupStateContext,
+  type CheckboxGroupRenderProps,
+} from 'react-aria-components'
+import { useCheckboxGroupItem } from 'react-aria'
+import type { AriaCheckboxProps } from 'react-aria'
+import type React from 'react'
+import type { SharedFieldLayoutProps } from '../FieldLayout'
+import { Fieldset } from '../Fieldset'
+import { Checkbox } from '../Checkbox'
+import { useForkRef } from '@/hooks/useForkRef/useForkRef'
+
+export type CheckboxGroupOptions = {
+  label: React.ReactNode
+  value: string
+  isDisabled?: boolean
+  description?: React.ReactNode
+}
+
+export interface CheckboxGroupProps
+  extends SharedFieldLayoutProps,
+    Pick<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'className'> {
+  isInvalid?: boolean
+  isDisabled?: boolean
+  options: Array<CheckboxGroupOptions>
+  value?: string[]
+  onChange?: (value: string[]) => void
+  inputRef?: Ref<HTMLInputElement>
+}
+
+// Checkbox implementation specific to React Aria to get our checkbox to connect
+// to their CheckboxGroup component
+interface ReactAriaCheckboxProps extends Omit<AriaCheckboxProps, 'value'> {
+  label: React.ReactNode
+  description?: React.ReactNode
+  value: string
+  groupState: CheckboxGroupRenderProps['state']
+  inputRef?: Ref<HTMLInputElement>
+}
+
+function ReactAriaCheckbox({
+  label,
+  description,
+  value,
+  groupState,
+  inputRef: inputRefFromProps,
+  ...props
+}: ReactAriaCheckboxProps) {
+  const internalInputRef = useRef<HTMLInputElement>(null)
+  const handleInputRef = useForkRef(inputRefFromProps, internalInputRef)
+
+  const { inputProps, isSelected, isDisabled, isInvalid } = useCheckboxGroupItem(
+    {
+      ...props,
+      value,
+      // Hack to suppress aria-label warning from React Aria. We don't actually
+      // use children for the mapping of our checkbox to React Aria and we already
+      // configure a label for our checkboxes.
+      children: ' ',
+      isRequired: false,
+    },
+    groupState,
+    internalInputRef,
+  )
+
+  return (
+    <Checkbox
+      label={label}
+      inputRef={handleInputRef}
+      checked={isSelected}
+      isDisabled={isDisabled}
+      isInvalid={isInvalid}
+      description={description}
+      onChange={inputProps.onChange}
+      value={inputProps.value}
+      name={inputProps.name}
+    />
+  )
+}
+
+function ReactAriaCheckboxWrapper(props: Omit<ReactAriaCheckboxProps, 'groupState'>) {
+  const groupState = useContext(CheckboxGroupStateContext)
+  // We can't render hooks conditionally so we have to use useCheckboxGroupItem above but
+  // groupState is only defined if the component is rendered within a CheckboxGroup
+  // This wrapper component gets around that by checking if groupState is defined which
+  // should always be the case for us since this component is only used within a CheckboxGroup
+  return groupState ? <ReactAriaCheckbox groupState={groupState} {...props} /> : null
+}
+
+export function CheckboxGroup({
+  label,
+  description,
+  errorMessage,
+  isRequired = false,
+  isInvalid = false,
+  isDisabled = false,
+  options,
+  shouldVisuallyHideLabel = false,
+  value,
+  onChange,
+  className,
+  inputRef,
+  ...props
+}: CheckboxGroupProps) {
+  return (
+    <Fieldset
+      legend={label}
+      description={description}
+      errorMessage={errorMessage}
+      isRequired={isRequired}
+      shouldVisuallyHideLegend={shouldVisuallyHideLabel}
+      className={className}
+      {...props}
+    >
+      <AriaCheckboxGroup
+        isInvalid={isInvalid}
+        isRequired={isRequired}
+        validationBehavior="aria"
+        value={value}
+        onChange={onChange}
+        isDisabled={isDisabled}
+        aria-labelledby=" "
+      >
+        {options.map(({ value, label, isDisabled = false, description }, index) => (
+          <ReactAriaCheckboxWrapper
+            isDisabled={isDisabled}
+            key={value}
+            value={value}
+            description={description}
+            label={label}
+            inputRef={index === 0 ? inputRef : undefined}
+          />
+        ))}
+      </AriaCheckboxGroup>
+    </Fieldset>
+  )
+}

--- a/src/components/Common/UI/CheckboxGroup/index.ts
+++ b/src/components/Common/UI/CheckboxGroup/index.ts
@@ -1,0 +1,1 @@
+export { CheckboxGroup, type CheckboxGroupProps, type CheckboxGroupOptions } from './CheckboxGroup'

--- a/src/components/Common/UI/FieldCaption/FieldCaption.module.scss
+++ b/src/components/Common/UI/FieldCaption/FieldCaption.module.scss
@@ -1,0 +1,13 @@
+.root {
+  font-size: var(--g-input-labelFontSize);
+  font-weight: var(--g-input-labelFontWeight);
+  color: var(--g-input-labelColor);
+  margin: 0;
+  padding: 0;
+}
+
+.optionalLabel {
+  content: var(--g-optionalLabel);
+  font-size: smaller;
+  color: var(--g-input-placeholderColor);
+}

--- a/src/components/Common/UI/FieldCaption/FieldCaption.stories.tsx
+++ b/src/components/Common/UI/FieldCaption/FieldCaption.stories.tsx
@@ -1,0 +1,10 @@
+import type { Story } from '@ladle/react'
+import { FieldCaption } from './FieldCaption'
+
+export const Default: Story = () => <FieldCaption htmlFor="input-field">Field Label</FieldCaption>
+
+export const Required: Story = () => (
+  <FieldCaption htmlFor="required-field" isRequired>
+    Required Field
+  </FieldCaption>
+)

--- a/src/components/Common/UI/FieldCaption/FieldCaption.tsx
+++ b/src/components/Common/UI/FieldCaption/FieldCaption.tsx
@@ -1,0 +1,37 @@
+import { VisuallyHidden } from 'react-aria'
+import { useTranslation } from 'react-i18next'
+import classNames from 'classnames'
+import styles from './FieldCaption.module.scss'
+
+export interface FieldCaptionProps {
+  children: React.ReactNode
+  as?: 'label' | 'legend'
+  htmlFor?: string
+  isRequired?: boolean
+  isVisuallyHidden?: boolean
+  className?: string
+}
+
+export const FieldCaption: React.FC<FieldCaptionProps> = ({
+  children,
+  as = 'label',
+  htmlFor,
+  isRequired = false,
+  isVisuallyHidden = false,
+  className,
+}: FieldCaptionProps) => {
+  const { t } = useTranslation('common')
+  const Component = as
+
+  const content = (
+    <Component
+      className={classNames(styles.root, className)}
+      htmlFor={as === 'label' ? htmlFor : undefined}
+    >
+      {children}
+      {!isRequired && <span className={styles.optionalLabel}>{t('optionalLabel')}</span>}
+    </Component>
+  )
+
+  return isVisuallyHidden ? <VisuallyHidden>{content}</VisuallyHidden> : content
+}

--- a/src/components/Common/UI/FieldCaption/index.ts
+++ b/src/components/Common/UI/FieldCaption/index.ts
@@ -1,0 +1,1 @@
+export { FieldCaption } from './FieldCaption'

--- a/src/components/Common/UI/FieldDescription/FieldDescription.module.scss
+++ b/src/components/Common/UI/FieldDescription/FieldDescription.module.scss
@@ -2,6 +2,6 @@
   display: block;
   font-size: var(--g-typography-fontSize-small);
   font-weight: var(--g-typography-fontWeight-regular);
-  line-height: 1;
+  line-height: 1.3;
   color: var(--g-input-descriptionColor);
 }

--- a/src/components/Common/UI/FieldErrorMessage/FieldErrorMessage.module.scss
+++ b/src/components/Common/UI/FieldErrorMessage/FieldErrorMessage.module.scss
@@ -4,6 +4,7 @@
   font-size: toRem(14);
   line-height: toRem(18);
   color: var(--g-colors-error-500);
+  margin: 0;
 
   &::before {
     content: '';

--- a/src/components/Common/UI/FieldErrorMessage/FieldErrorMessage.tsx
+++ b/src/components/Common/UI/FieldErrorMessage/FieldErrorMessage.tsx
@@ -1,18 +1,18 @@
+import type { HTMLAttributes } from 'react'
 import classNames from 'classnames'
 import styles from './FieldErrorMessage.module.scss'
 
-interface FieldErrorMessageProps {
-  children: React.ReactNode
-  id: string
-  className?: string
-}
-
-export function FieldErrorMessage({ children, id, className }: FieldErrorMessageProps) {
+export function FieldErrorMessage({
+  children,
+  id,
+  className,
+  ...props
+}: HTMLAttributes<HTMLParagraphElement>) {
   return (
     children && (
-      <div id={id} className={classNames(styles.root, className)}>
+      <p id={id} className={classNames(styles.root, className)} {...props}>
         {children}
-      </div>
+      </p>
     )
   )
 }

--- a/src/components/Common/UI/FieldLayout/FieldLayout.tsx
+++ b/src/components/Common/UI/FieldLayout/FieldLayout.tsx
@@ -1,8 +1,7 @@
-import { VisuallyHidden } from 'react-aria'
-import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'
 import { FieldDescription } from '../FieldDescription'
 import { FieldErrorMessage } from '../FieldErrorMessage'
+import { FieldCaption } from '../FieldCaption/FieldCaption'
 import styles from './FieldLayout.module.scss'
 import type { DataAttributes } from '@/types/Helpers'
 import { getDataProps } from '@/helpers/getDataProps'
@@ -38,15 +37,6 @@ export const FieldLayout: React.FC<FieldLayoutProps> = ({
   className,
   ...props
 }: FieldLayoutProps) => {
-  const { t } = useTranslation('common')
-
-  const labelContent = (
-    <label className={styles.label} htmlFor={htmlFor}>
-      {label}{' '}
-      {!isRequired ? <span className={styles.optionalLabel}>{t('optionalLabel')}</span> : null}
-    </label>
-  )
-
   return (
     <div className={classNames(styles.root, className)} {...getDataProps(props)}>
       <div
@@ -55,7 +45,13 @@ export const FieldLayout: React.FC<FieldLayoutProps> = ({
           [styles.withDescription as string]: Boolean(description),
         })}
       >
-        {shouldVisuallyHideLabel ? <VisuallyHidden>{labelContent}</VisuallyHidden> : labelContent}
+        <FieldCaption
+          htmlFor={htmlFor}
+          isRequired={isRequired}
+          isVisuallyHidden={shouldVisuallyHideLabel}
+        >
+          {label}
+        </FieldCaption>
         <FieldDescription id={descriptionId}>{description}</FieldDescription>
       </div>
       {children}

--- a/src/components/Common/UI/Fieldset/Fieldset.module.scss
+++ b/src/components/Common/UI/Fieldset/Fieldset.module.scss
@@ -2,13 +2,16 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  border: none;
+  padding: 0;
+  margin: 0;
 }
 
-.labelAndDescription {
+.legendAndDescription {
   display: flex;
   flex-direction: column;
 
-  &.withVisibleLabel {
+  &.withVisibleLegend {
     margin-bottom: var(--g-spacing-4);
   }
 

--- a/src/components/Common/UI/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Common/UI/Fieldset/Fieldset.stories.tsx
@@ -1,0 +1,64 @@
+import type { Story } from '@ladle/react'
+import { Fieldset } from './Fieldset'
+
+const Layout = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--g-spacing-4)' }}>
+    {children}
+  </div>
+)
+
+export const Default: Story = () => (
+  <Fieldset legend="Contact Information">
+    <Layout>
+      <label htmlFor="firstName">
+        First Name
+        <input id="firstName" type="text" placeholder="Enter your first name" />
+      </label>
+      <label htmlFor="lastName">
+        Last Name
+        <input id="lastName" type="text" placeholder="Enter your last name" />
+      </label>
+      <label htmlFor="email">
+        Email
+        <input id="email" type="email" placeholder="Enter your email" />
+      </label>
+    </Layout>
+  </Fieldset>
+)
+
+export const WithDescription: Story = () => (
+  <Fieldset
+    legend="Account Settings"
+    description="Configure your account preferences and notification settings"
+  >
+    <Layout>
+      <label htmlFor="notifications">
+        Enable notifications
+        <input type="checkbox" id="notifications" />
+      </label>
+      <label htmlFor="newsletter">
+        Subscribe to newsletter
+        <input type="checkbox" id="newsletter" />
+      </label>
+    </Layout>
+  </Fieldset>
+)
+
+export const WithError: Story = () => (
+  <Fieldset legend="Payment Information" errorMessage="Please provide valid payment details">
+    <Layout>
+      <label htmlFor="cardNumber">
+        Card Number
+        <input id="cardNumber" type="text" placeholder="Enter card number" />
+      </label>
+      <label htmlFor="expiryDate">
+        Expiry Date
+        <input id="expiryDate" type="text" placeholder="MM/YY" />
+      </label>
+      <label htmlFor="cvv">
+        CVV
+        <input id="cvv" type="text" placeholder="Enter CVV" />
+      </label>
+    </Layout>
+  </Fieldset>
+)

--- a/src/components/Common/UI/Fieldset/Fieldset.test.tsx
+++ b/src/components/Common/UI/Fieldset/Fieldset.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Fieldset } from './Fieldset'
+
+describe('Fieldset', () => {
+  it('renders legend with correct content', () => {
+    render(
+      <Fieldset legend="Test Legend">
+        <div>Fieldset content</div>
+      </Fieldset>,
+    )
+
+    const legend = screen.getByText('Test Legend')
+    expect(legend).toBeInTheDocument()
+  })
+
+  it('renders legend when it is visually hidden', () => {
+    render(
+      <Fieldset legend="Test Legend" shouldVisuallyHideLegend>
+        <div>Fieldset content</div>
+      </Fieldset>,
+    )
+
+    expect(screen.getByText('Test Legend')).toBeInTheDocument()
+  })
+
+  it('renders description when provided', () => {
+    render(
+      <Fieldset legend="Test Legend" description="Test description">
+        <div>Fieldset content</div>
+      </Fieldset>,
+    )
+
+    expect(screen.getByText('Test description')).toBeInTheDocument()
+  })
+
+  it('renders error message when provided', () => {
+    render(
+      <Fieldset legend="Test Legend" errorMessage="Test error message">
+        <div>Fieldset content</div>
+      </Fieldset>,
+    )
+
+    const errorMessage = screen.getByText('Test error message')
+    expect(errorMessage).toBeInTheDocument()
+    expect(errorMessage).toHaveAttribute('role', 'alert')
+    expect(errorMessage).toHaveAttribute('aria-live', 'polite')
+
+    const errorMessageId = errorMessage.getAttribute('id')
+    const fieldset = screen.getByRole('group')
+    expect(fieldset).toHaveAttribute('aria-describedby', errorMessageId)
+  })
+})

--- a/src/components/Common/UI/Fieldset/Fieldset.tsx
+++ b/src/components/Common/UI/Fieldset/Fieldset.tsx
@@ -1,0 +1,66 @@
+import { useId } from 'react'
+import classNames from 'classnames'
+import { FieldDescription } from '../FieldDescription'
+import { FieldErrorMessage } from '../FieldErrorMessage'
+import { FieldCaption } from '../FieldCaption'
+import type { SharedFieldLayoutProps } from '../FieldLayout'
+import styles from './Fieldset.module.scss'
+import { getDataProps } from '@/helpers/getDataProps'
+
+export interface FieldsetProps
+  extends Omit<SharedFieldLayoutProps, 'label' | 'shouldVisuallyHideLabel'> {
+  children: React.ReactNode
+  description?: React.ReactNode
+  errorMessage?: string
+  isRequired?: boolean
+  legend: React.ReactNode
+  shouldVisuallyHideLegend?: boolean
+  className?: string
+}
+
+export const Fieldset: React.FC<FieldsetProps> = ({
+  children,
+  description,
+  errorMessage,
+  isRequired = false,
+  legend,
+  shouldVisuallyHideLegend = false,
+  className,
+  ...props
+}: FieldsetProps) => {
+  const generatedErrorMessageId = useId()
+  const errorMessageId = `error-message-${generatedErrorMessageId}`
+
+  return (
+    <fieldset
+      className={classNames(styles.root, className)}
+      aria-describedby={errorMessage ? errorMessageId : undefined}
+      {...getDataProps(props)}
+    >
+      <div
+        className={classNames(styles.legendAndDescription, {
+          [styles.withVisibleLegend as string]: !shouldVisuallyHideLegend,
+          [styles.withDescription as string]: Boolean(description),
+        })}
+      >
+        <FieldCaption
+          as="legend"
+          isRequired={isRequired}
+          isVisuallyHidden={shouldVisuallyHideLegend}
+        >
+          {legend}
+        </FieldCaption>
+        <FieldDescription>{description}</FieldDescription>
+      </div>
+      {children}
+      <FieldErrorMessage
+        id={errorMessageId}
+        className={styles.errorMessage}
+        aria-live="polite"
+        role="alert"
+      >
+        {errorMessage}
+      </FieldErrorMessage>
+    </fieldset>
+  )
+}

--- a/src/components/Common/UI/Fieldset/index.ts
+++ b/src/components/Common/UI/Fieldset/index.ts
@@ -1,0 +1,1 @@
+export { Fieldset, type FieldsetProps } from './Fieldset'

--- a/src/components/Common/UI/HorizontalFieldLayout/HorizontalFieldLayout.module.scss
+++ b/src/components/Common/UI/HorizontalFieldLayout/HorizontalFieldLayout.module.scss
@@ -22,7 +22,6 @@
   font-size: var(--g-input-labelFontSize);
   font-weight: var(--g-input-labelFontWeight);
   color: var(--g-input-labelColor);
-  cursor: pointer;
   forced-color-adjust: none;
   height: 100%;
   display: flex;

--- a/src/hooks/useForkRef/index.ts
+++ b/src/hooks/useForkRef/index.ts
@@ -1,0 +1,1 @@
+export { useForkRef } from './useForkRef'

--- a/src/hooks/useForkRef/useForkRef.test.tsx
+++ b/src/hooks/useForkRef/useForkRef.test.tsx
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react'
+import { describe, test, expect, vi } from 'vitest'
+import type { RefObject } from 'react'
+import { useForkRef } from './useForkRef'
+
+describe('useForkRef', () => {
+  test('should return null when all refs are null or undefined', () => {
+    const { result } = renderHook(() => useForkRef(null))
+    expect(result.current).toBeNull()
+  })
+
+  test('should set ref object values correctly', () => {
+    const ref1: RefObject<string | null> = { current: null }
+    const ref2: RefObject<string | null> = { current: null }
+
+    const { result } = renderHook(() => useForkRef(ref1, ref2))
+
+    result.current?.('test-value')
+
+    expect(ref1.current).toBe('test-value')
+    expect(ref2.current).toBe('test-value')
+  })
+
+  test('should call ref functions correctly', () => {
+    const refFn1 = vi.fn()
+    const refFn2 = vi.fn()
+
+    const { result } = renderHook(() => useForkRef(refFn1, refFn2))
+
+    result.current?.('test-value')
+
+    expect(refFn1).toHaveBeenCalledWith('test-value')
+    expect(refFn2).toHaveBeenCalledWith('test-value')
+  })
+
+  test('should handle mixed ref types (object and function)', () => {
+    const refObj: RefObject<string | null> = { current: null }
+    const refFn = vi.fn()
+
+    const { result } = renderHook(() => useForkRef(refObj, refFn))
+
+    result.current?.('test-value')
+
+    expect(refObj.current).toBe('test-value')
+    expect(refFn).toHaveBeenCalledWith('test-value')
+  })
+})

--- a/src/hooks/useForkRef/useForkRef.ts
+++ b/src/hooks/useForkRef/useForkRef.ts
@@ -1,0 +1,30 @@
+import { type Ref, type RefCallback, type RefObject, useMemo } from 'react'
+
+const setRef = <T>(
+  ref: RefObject<T | null> | ((instance: T | null) => void) | null | undefined,
+  value: T | null,
+) => {
+  if (typeof ref === 'function') ref(value)
+  else if (ref) ref.current = value
+}
+
+/**
+ * Sets multiple refs with a single handler.
+ * @param refs - The refs to set.
+ * @returns A single ref handler that sets all the provided refs which can be passed to the `ref` prop of a component.
+ */
+export const useForkRef = <Instance>(
+  ...refs: Array<Ref<Instance> | undefined>
+): RefCallback<Instance> | null => {
+  return useMemo(() => {
+    if (refs.every(ref => ref == null)) {
+      return null
+    }
+
+    return instance => {
+      refs.forEach(ref => {
+        setRef(ref, instance)
+      })
+    }
+  }, [refs])
+}


### PR DESCRIPTION
This PR adds a CheckboxGroup component separated from React Hook Form. It also
* Implements a reusable Fieldset component which manages the layout concerns for checkbox group (and eventually radio group)
* Breaks out FieldCaption for consistent styling with label/legend
* Implements a connected React Hook Form version of CheckboxGroup with CheckboxGroupField

## Proof of functionality

Values correctly updating for hook form
https://github.com/user-attachments/assets/3b6909c1-5af0-4dae-93fe-8db82f1f022a

Focus correctly being managed for the first checkbox input (will focus the first input in the group when the submission fails)

https://github.com/user-attachments/assets/0700dad4-36fa-47b5-a1e5-377a4abd68ff
