### PR TITLE
chore: update Select and SelectField to have consistent API for options

### DIFF
--- a/src/components/Common/Fields/SelectField/SelectField.stories.tsx
+++ b/src/components/Common/Fields/SelectField/SelectField.stories.tsx
@@ -30,22 +30,16 @@ export const Default: Story = () => (
     <SelectField
       name="category"
       label="Category"
-      items={categories}
+      options={categories}
       placeholder="Select a category"
-    >
-      {item => <div>{item.label}</div>}
-    </SelectField>
+    />
     <SelectField
       name="priority"
       label="Priority"
-      items={priorities}
+      options={priorities}
       placeholder="Select a priority"
-    >
-      {item => <div>{item.label}</div>}
-    </SelectField>
-    <SelectField name="status" label="Status" items={statuses} placeholder="Select a status">
-      {item => <div>{item.label}</div>}
-    </SelectField>
+    />
+    <SelectField name="status" label="Status" options={statuses} placeholder="Select a status" />
   </FormWrapper>
 )
 
@@ -54,33 +48,27 @@ export const Required: Story = () => (
     <SelectField
       name="category"
       label="Category"
-      items={categories}
+      options={categories}
       placeholder="Select a category"
       isRequired
       errorMessage="Category is required"
-    >
-      {item => <div>{item.label}</div>}
-    </SelectField>
+    />
     <SelectField
       name="priority"
       label="Priority"
-      items={priorities}
+      options={priorities}
       placeholder="Select a priority"
       isRequired
       errorMessage="Priority is required"
-    >
-      {item => <div>{item.label}</div>}
-    </SelectField>
+    />
     <SelectField
       name="status"
       label="Status"
-      items={statuses}
+      options={statuses}
       placeholder="Select a status"
       isRequired
       errorMessage="Status is required"
-    >
-      {item => <div>{item.label}</div>}
-    </SelectField>
+    />
   </FormWrapper>
 )
 
@@ -95,22 +83,16 @@ export const WithDefaultValues: Story = () => (
     <SelectField
       name="category"
       label="Category"
-      items={categories}
+      options={categories}
       placeholder="Select a category"
-    >
-      {item => <div>{item.label}</div>}
-    </SelectField>
+    />
     <SelectField
       name="priority"
       label="Priority"
-      items={priorities}
+      options={priorities}
       placeholder="Select a priority"
-    >
-      {item => <div>{item.label}</div>}
-    </SelectField>
-    <SelectField name="status" label="Status" items={statuses} placeholder="Select a status">
-      {item => <div>{item.label}</div>}
-    </SelectField>
+    />
+    <SelectField name="status" label="Status" options={statuses} placeholder="Select a status" />
   </FormWrapper>
 )
 
@@ -119,29 +101,23 @@ export const WithDescription: Story = () => (
     <SelectField
       name="category"
       label="Category"
-      items={categories}
+      options={categories}
       placeholder="Select a category"
       description="Choose the product category"
-    >
-      {item => <div>{item.label}</div>}
-    </SelectField>
+    />
     <SelectField
       name="priority"
       label="Priority"
-      items={priorities}
+      options={priorities}
       placeholder="Select a priority"
       description="Set the task priority level"
-    >
-      {item => <div>{item.label}</div>}
-    </SelectField>
+    />
     <SelectField
       name="status"
       label="Status"
-      items={statuses}
+      options={statuses}
       placeholder="Select a status"
       description="Update the current status"
-    >
-      {item => <div>{item.label}</div>}
-    </SelectField>
+    />
   </FormWrapper>
 )

--- a/src/components/Common/Fields/SelectField/SelectField.tsx
+++ b/src/components/Common/Fields/SelectField/SelectField.tsx
@@ -1,13 +1,9 @@
-import type { SelectItem } from '../../UI/Select/Select'
 import { useField, type UseFieldProps } from '@/components/Common/Fields/hooks/useField'
-import { Select } from '@/components/Common/UI/Select'
+import { Select, type SelectProps } from '@/components/Common/UI/Select'
 
 interface SelectFieldProps
-  extends Omit<React.ComponentProps<typeof Select>, 'name' | 'onChange' | 'onBlur' | 'options'>,
-    UseFieldProps<string> {
-  items: SelectItem[]
-  children?: (item: SelectItem) => React.ReactNode
-}
+  extends Omit<SelectProps, 'name' | 'value' | 'onChange' | 'onBlur'>,
+    UseFieldProps<string> {}
 
 export const SelectField: React.FC<SelectFieldProps> = ({
   rules,
@@ -17,8 +13,6 @@ export const SelectField: React.FC<SelectFieldProps> = ({
   isRequired,
   onChange,
   transform,
-  items,
-  children,
   ...selectProps
 }: SelectFieldProps) => {
   const fieldProps = useField({
@@ -31,5 +25,5 @@ export const SelectField: React.FC<SelectFieldProps> = ({
     transform,
   })
 
-  return <Select {...fieldProps} options={items.map(item => item)} {...selectProps} />
+  return <Select {...fieldProps} {...selectProps} />
 }

--- a/src/components/Common/Fields/hooks/useField.ts
+++ b/src/components/Common/Fields/hooks/useField.ts
@@ -9,7 +9,7 @@ export interface UseFieldProps<TChangeArg, TValue = string> {
   defaultValue?: TValue
   errorMessage?: string
   isRequired?: boolean
-  onChange?: (event: TChangeArg) => void
+  onChange?: (changeArg: TChangeArg) => void
   transform?: Transform<TChangeArg, TValue>
 }
 

--- a/src/components/Common/UI/Select/Select.tsx
+++ b/src/components/Common/UI/Select/Select.tsx
@@ -8,7 +8,7 @@ import {
   SelectValue,
 } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
-import type { FocusEvent, SelectHTMLAttributes } from 'react'
+import type { FocusEvent, Ref, SelectHTMLAttributes } from 'react'
 import { useMemo } from 'react'
 import { useFieldIds } from '../hooks/useFieldIds'
 import type { SharedFieldLayoutProps } from '../FieldLayout'
@@ -28,10 +28,11 @@ export interface SelectProps
   isInvalid?: boolean
   label: string
   onChange: (value: string) => void
-  onBlur: (e: FocusEvent) => void
+  onBlur?: (e: FocusEvent) => void
   options: SelectItem[]
   placeholder?: string
   value?: string
+  inputRef?: Ref<HTMLButtonElement>
 }
 
 export const Select = ({
@@ -50,6 +51,7 @@ export const Select = ({
   shouldVisuallyHideLabel,
   name,
   className,
+  inputRef,
   ...props
 }: SelectProps) => {
   const { t } = useTranslation()
@@ -90,7 +92,7 @@ export const Select = ({
         aria-describedby={ariaDescribedBy}
         name={name}
       >
-        <Button>
+        <Button ref={inputRef}>
           <SelectValue>
             {({ defaultChildren, isPlaceholder }) => {
               return isPlaceholder && placeholder ? placeholder : defaultChildren

--- a/src/components/Common/UI/Select/index.ts
+++ b/src/components/Common/UI/Select/index.ts
@@ -1,1 +1,1 @@
-export { Select } from './Select'
+export { Select, type SelectProps } from './Select'


### PR DESCRIPTION
This PR updates SelectField to have `options` instead of `items` + `children` for the API. It also updates to add an `inputRef` prop to the select field.

## Proof of functionality

Field stories working using the options prop and firing the correct values for the form

https://github.com/user-attachments/assets/af75bd86-d868-4bd3-a948-79ab627b7501

inputRef working

https://github.com/user-attachments/assets/7a4d384c-eb29-4c99-9b7f-83a5a4a6dab9
