### PR TITLE
build: remove deprecated `generate` step from publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,6 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm run generate
       - run: npm run build
       - run: npm publish --access public
         env:


### PR DESCRIPTION
It was removed here https://github.com/Gusto/embedded-react-sdk/pull/218/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519

It looks like we can just run `build` since the openapi part of `generate` is no longer necessary and `build` runs the `i18n:generate` step