### PR TITLE
chore: standardize change handlers and values for all form components

### DIFF
--- a/.ladle/helpers/LadleState.tsx
+++ b/.ladle/helpers/LadleState.tsx
@@ -9,63 +9,11 @@ import { useState } from 'react'
 export function useLadleState<T>(actionName: string, initialValue?: T) {
   const [value, setValue] = useState<T | undefined>(initialValue)
 
-  const handleAction = (newValue: T) => {
+  const handleChange = (newValue: T) => {
     action(actionName)(newValue)
     setValue(newValue)
     return newValue
   }
-
-  // For input elements that pass event objects
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.target.value as unknown as T
-    action(actionName)(newValue)
-    setValue(newValue)
-    return newValue
-  }
-
-  // For checkbox elements that pass checked event
-  const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.target.checked as unknown as T
-    action(actionName)(newValue)
-    setValue(newValue)
-    return newValue
-  }
-
-  // For switch components that directly pass the checked value
-  const handleSwitchChange = (checked: boolean) => {
-    const newValue = checked as unknown as T
-    action(actionName)(newValue)
-    setValue(newValue)
-    return newValue
-  }
-
-  const handleRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.target.checked as unknown as T
-    action(actionName)(newValue)
-    setValue(newValue)
-    return newValue
-  }
-
-  const handleCheckboxGroupChange = (newValue: T) => {
-    action(actionName)(newValue)
-    setValue(newValue)
-    return newValue
-  }
-
-  const handleRadioGroupChange = (newValue: T) => {
-    action(actionName)(newValue)
-    setValue(newValue)
-    return newValue
-  }
-
-  // For select elements that directly pass the value
-  const handleSelectChange = (newValue: T) => {
-    action(actionName)(newValue)
-    setValue(newValue)
-    return newValue
-  }
-
-  // For blur events
   const handleBlur = () => {
     action(`${actionName}Blur`)('Component blurred')
   }
@@ -73,14 +21,7 @@ export function useLadleState<T>(actionName: string, initialValue?: T) {
   return {
     value,
     setValue,
-    handleAction,
-    handleInputChange,
-    handleCheckboxChange,
-    handleSwitchChange,
-    handleRadioChange,
-    handleCheckboxGroupChange,
-    handleRadioGroupChange,
-    handleSelectChange,
+    handleChange,
     handleBlur,
   }
 }

--- a/src/components/Common/CalendarDisplay/CalendarDisplay.test.tsx
+++ b/src/components/Common/CalendarDisplay/CalendarDisplay.test.tsx
@@ -208,7 +208,6 @@ describe('CalendarDisplayLegend', () => {
     expect(screen.getByText(/January 10/)).toBeInTheDocument()
     expect(screen.getByText(/January 12/)).toBeInTheDocument()
 
-    screen.debug()
     // Check if legend markers are present using class name instead of inline style
     const legendMarkers = await screen.findAllByTestId('calendar-legend-item')
     expect(legendMarkers.length).toBe(2)

--- a/src/components/Common/Card/Card.tsx
+++ b/src/components/Common/Card/Card.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from '../UI/Checkbox/Checkbox'
 import styles from './Card.module.scss'
 
 interface CardProps {
-  onSelect?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onSelect?: (checked: boolean) => void
   children: React.ReactNode
   menu?: React.ReactNode
   className?: string

--- a/src/components/Common/DataView/DataCards/DataCards.tsx
+++ b/src/components/Common/DataView/DataCards/DataCards.tsx
@@ -28,8 +28,8 @@ export const DataCards = <T,>({
             menu={itemMenu && itemMenu(item)}
             onSelect={
               onSelect
-                ? (event: React.ChangeEvent<HTMLInputElement>) => {
-                    onSelect(item, event.target.checked)
+                ? (checked: boolean) => {
+                    onSelect(item, checked)
                   }
                 : undefined
             }

--- a/src/components/Common/DataView/DataTable/DataTable.tsx
+++ b/src/components/Common/DataView/DataTable/DataTable.tsx
@@ -51,8 +51,8 @@ export const DataTable = <T,>({
             {onSelect && (
               <Cell>
                 <Checkbox
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    onSelect(item, event.target.checked)
+                  onChange={(checked: boolean) => {
+                    onSelect(item, checked)
                   }}
                   label={t('table.selectRowLabel')}
                   shouldVisuallyHideLabel

--- a/src/components/Common/Fields/CheckboxField/CheckboxField.tsx
+++ b/src/components/Common/Fields/CheckboxField/CheckboxField.tsx
@@ -1,11 +1,10 @@
-import type { ChangeEvent } from 'react'
 import { useField, type UseFieldProps } from '@/components/Common/Fields/hooks/useField'
 import { Checkbox } from '@/components/Common/UI/Checkbox'
 import type { CheckboxProps } from '@/components/Common/UI/Checkbox/CheckboxTypes'
 
 export interface CheckboxFieldProps
   extends Omit<CheckboxProps, 'name' | 'value'>,
-    UseFieldProps<ChangeEvent<HTMLInputElement>, boolean> {}
+    UseFieldProps<boolean> {}
 
 export const CheckboxField: React.FC<CheckboxFieldProps> = ({
   rules,
@@ -17,7 +16,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
   transform,
   ...checkboxProps
 }: CheckboxFieldProps) => {
-  const { value, ...fieldProps } = useField({
+  const fieldProps = useField({
     name,
     rules,
     defaultValue,
@@ -27,5 +26,5 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
     transform,
   })
 
-  return <Checkbox {...fieldProps} {...checkboxProps} checked={value} />
+  return <Checkbox {...fieldProps} {...checkboxProps} />
 }

--- a/src/components/Common/Fields/CheckboxGroupField/CheckboxGroupField.tsx
+++ b/src/components/Common/Fields/CheckboxGroupField/CheckboxGroupField.tsx
@@ -3,7 +3,7 @@ import { CheckboxGroup } from '@/components/Common/UI/CheckboxGroup'
 import type { CheckboxGroupProps } from '@/components/Common/UI/CheckboxGroup/CheckboxGroupTypes'
 export interface CheckboxGroupFieldProps
   extends Omit<CheckboxGroupProps, 'value'>,
-    UseFieldProps<string[], string[]> {}
+    UseFieldProps<string[]> {}
 
 export const CheckboxGroupField: React.FC<CheckboxGroupFieldProps> = ({
   rules,

--- a/src/components/Common/Fields/ComboBoxField/ComboBoxField.tsx
+++ b/src/components/Common/Fields/ComboBoxField/ComboBoxField.tsx
@@ -3,7 +3,7 @@ import { ComboBox } from '@/components/Common/UI/ComboBox/ComboBox'
 import type { ComboBoxProps } from '@/components/Common/UI/ComboBox/ComboBoxTypes'
 interface ComboBoxFieldProps
   extends Omit<ComboBoxProps, 'name' | 'onChange' | 'onBlur'>,
-    UseFieldProps<string> {}
+    UseFieldProps {}
 
 export const ComboBoxField: React.FC<ComboBoxFieldProps> = ({
   rules,

--- a/src/components/Common/Fields/DatePickerField/DatePickerField.tsx
+++ b/src/components/Common/Fields/DatePickerField/DatePickerField.tsx
@@ -4,7 +4,7 @@ import type { DatePickerProps } from '@/components/Common/UI/DatePicker/DatePick
 
 interface DatePickerFieldProps
   extends Omit<DatePickerProps, 'name' | 'onChange' | 'onBlur'>,
-    UseFieldProps<Date | null, Date | null> {}
+    UseFieldProps<Date | null> {}
 
 export const DatePickerField: React.FC<DatePickerFieldProps> = ({
   rules,

--- a/src/components/Common/Fields/NumberInputField/NumberInputField.tsx
+++ b/src/components/Common/Fields/NumberInputField/NumberInputField.tsx
@@ -4,7 +4,7 @@ import type { NumberInputProps } from '@/components/Common/UI/NumberInput/Number
 
 export interface NumberInputFieldProps
   extends Omit<NumberInputProps, 'name' | 'value'>,
-    UseFieldProps<number, number> {}
+    UseFieldProps<number> {}
 
 export const NumberInputField: React.FC<NumberInputFieldProps> = ({
   rules: providedRules,

--- a/src/components/Common/Fields/RadioGroupField/RadioGroupField.tsx
+++ b/src/components/Common/Fields/RadioGroupField/RadioGroupField.tsx
@@ -1,9 +1,7 @@
 import { useField, type UseFieldProps } from '@/components/Common/Fields/hooks/useField'
 import { RadioGroup } from '@/components/Common/UI/RadioGroup'
 import type { RadioGroupProps } from '@/components/Common/UI/RadioGroup/RadioGroupTypes'
-export interface RadioGroupFieldProps
-  extends Omit<RadioGroupProps, 'value'>,
-    UseFieldProps<string> {}
+export interface RadioGroupFieldProps extends Omit<RadioGroupProps, 'value'>, UseFieldProps {}
 
 export const RadioGroupField: React.FC<RadioGroupFieldProps> = ({
   rules,

--- a/src/components/Common/Fields/SelectField/SelectField.tsx
+++ b/src/components/Common/Fields/SelectField/SelectField.tsx
@@ -3,7 +3,7 @@ import { Select } from '@/components/Common/UI/Select'
 import type { SelectProps } from '@/components/Common/UI/Select/SelectTypes'
 interface SelectFieldProps
   extends Omit<SelectProps, 'name' | 'value' | 'onChange' | 'onBlur'>,
-    UseFieldProps<string> {}
+    UseFieldProps {}
 
 export const SelectField: React.FC<SelectFieldProps> = ({
   rules,

--- a/src/components/Common/Fields/SwitchField/SwitchField.tsx
+++ b/src/components/Common/Fields/SwitchField/SwitchField.tsx
@@ -3,7 +3,7 @@ import { Switch } from '@/components/Common/UI/Switch'
 import type { SwitchProps } from '@/components/Common/UI/Switch/SwitchTypes'
 export interface SwitchFieldProps
   extends Omit<SwitchProps, 'name' | 'checked' | 'onChange'>,
-    UseFieldProps<boolean, boolean> {}
+    UseFieldProps<boolean> {}
 
 export const SwitchField: React.FC<SwitchFieldProps> = ({
   rules,
@@ -15,7 +15,7 @@ export const SwitchField: React.FC<SwitchFieldProps> = ({
   transform,
   ...switchProps
 }: SwitchFieldProps) => {
-  const { value, inputRef, ...fieldProps } = useField({
+  const fieldProps = useField({
     name,
     rules,
     defaultValue,
@@ -25,5 +25,5 @@ export const SwitchField: React.FC<SwitchFieldProps> = ({
     transform,
   })
 
-  return <Switch {...fieldProps} {...switchProps} checked={value} />
+  return <Switch {...fieldProps} {...switchProps} />
 }

--- a/src/components/Common/Fields/TextInputField/TextInputField.tsx
+++ b/src/components/Common/Fields/TextInputField/TextInputField.tsx
@@ -1,11 +1,10 @@
-import { type ChangeEvent } from 'react'
 import { TextInput } from '../../UI/TextInput'
 import { useField, type UseFieldProps } from '@/components/Common/Fields/hooks/useField'
 import type { TextInputProps } from '@/components/Common/UI/TextInput/TextInputTypes'
 
 export interface TextInputFieldProps
   extends Omit<TextInputProps, 'name' | 'value'>,
-    UseFieldProps<ChangeEvent<HTMLInputElement>> {}
+    UseFieldProps {}
 
 export const TextInputField: React.FC<TextInputFieldProps> = ({
   rules,

--- a/src/components/Common/Fields/hooks/useField.ts
+++ b/src/components/Common/Fields/hooks/useField.ts
@@ -1,19 +1,19 @@
 import type { RegisterOptions } from 'react-hook-form'
 import { useController, useFormContext } from 'react-hook-form'
 
-export type Transform<TChangeArg, TValue> = (changeArg: TChangeArg) => TValue
+export type Transform<TValue> = (value: TValue) => TValue
 
-export interface UseFieldProps<TChangeArg, TValue = string> {
+export interface UseFieldProps<TValue = string> {
   name: string
   rules?: RegisterOptions
   defaultValue?: TValue
   errorMessage?: string
   isRequired?: boolean
-  onChange?: (changeArg: TChangeArg) => void
-  transform?: Transform<TChangeArg, TValue>
+  onChange?: (value: TValue) => void
+  transform?: Transform<TValue>
 }
 
-export function useField<TChangeArg, TValue = string>({
+export function useField<TValue = string>({
   name,
   rules = {},
   defaultValue,
@@ -21,7 +21,7 @@ export function useField<TChangeArg, TValue = string>({
   isRequired = false,
   onChange,
   transform,
-}: UseFieldProps<TChangeArg, TValue>) {
+}: UseFieldProps<TValue>) {
   const { control } = useFormContext()
   const { field, fieldState } = useController({
     name,
@@ -35,16 +35,17 @@ export function useField<TChangeArg, TValue = string>({
 
   const { ref, ...restFieldProps } = field
 
-  const handleChange = (changeArg: TChangeArg) => {
-    const value = transform ? transform(changeArg) : changeArg
+  const handleChange = (updatedValue: TValue) => {
+    const value = transform ? transform(updatedValue) : updatedValue
     field.onChange(value)
-    onChange?.(changeArg)
+    onChange?.(value)
   }
 
   const isInvalid = !!fieldState.error
 
   return {
     ...restFieldProps,
+    value: field.value as TValue,
     inputRef: ref,
     isInvalid,
     errorMessage: isInvalid ? (errorMessage ?? fieldState.error?.message) : undefined,

--- a/src/components/Common/UI/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Common/UI/Checkbox/Checkbox.stories.tsx
@@ -2,38 +2,37 @@ import type { Story } from '@ladle/react'
 import { useLadleState } from '../../../../../.ladle/helpers/LadleState'
 import { Checkbox } from './Checkbox'
 
-// Adding a meta object for title
 export default {
-  title: 'UI/Form/Inputs/Checkbox', // Updated to be under UI/Form instead of top-level Form
+  title: 'UI/Form/Inputs/Checkbox',
 }
 
 export const Default: Story = () => {
-  const { value, handleCheckboxChange } = useLadleState<boolean>('CheckboxChange', false)
+  const { value, handleChange } = useLadleState<boolean>('CheckboxChange', false)
   return (
     <Checkbox
       label="Accept terms and conditions"
       name="terms"
-      checked={value}
-      onChange={handleCheckboxChange}
+      value={value}
+      onChange={handleChange}
     />
   )
 }
 
 export const WithDescription: Story = () => {
-  const { value, handleCheckboxChange } = useLadleState<boolean>('CheckboxChange', false)
+  const { value, handleChange } = useLadleState<boolean>('CheckboxChange', false)
   return (
     <Checkbox
       label="Subscribe to newsletter"
       name="newsletter"
       description="Receive updates about new features and promotions"
-      checked={value}
-      onChange={handleCheckboxChange}
+      value={value}
+      onChange={handleChange}
     />
   )
 }
 
 export const WithError: Story = () => {
-  const { value, handleCheckboxChange } = useLadleState<boolean>('CheckboxChange', false)
+  const { value, handleChange } = useLadleState<boolean>('CheckboxChange', false)
   return (
     <Checkbox
       label="Accept terms and conditions"
@@ -41,8 +40,8 @@ export const WithError: Story = () => {
       isInvalid
       errorMessage="You must accept the terms to continue"
       description="Receive updates about new features and promotions"
-      checked={value}
-      onChange={handleCheckboxChange}
+      value={value}
+      onChange={handleChange}
     />
   )
 }
@@ -57,7 +56,7 @@ export const DisabledChecked: Story = () => {
       label="This option is not available"
       name="disabled-checked"
       isDisabled
-      checked={true}
+      value={true}
     />
   )
 }

--- a/src/components/Common/UI/Checkbox/Checkbox.test.tsx
+++ b/src/components/Common/UI/Checkbox/Checkbox.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import type { ChangeEvent } from 'react'
 import { Checkbox } from './Checkbox'
 
 describe('Checkbox', () => {
@@ -32,19 +31,12 @@ describe('Checkbox', () => {
     expect(screen.getByText(description)).toHaveAttribute('id', descriptionId)
   })
 
-  it('calls both onChange handlers when clicked', async () => {
+  it('calls onChange handler when clicked', async () => {
     const user = userEvent.setup()
 
-    const onChangeFromProps = vi.fn<(event: ChangeEvent<HTMLInputElement>) => void>()
-    const onChangeFromInputProps = vi.fn<(event: ChangeEvent<HTMLInputElement>) => void>()
+    const onChange = vi.fn<(checked: boolean) => void>()
 
-    render(
-      <Checkbox
-        label="Test label"
-        onChange={onChangeFromProps}
-        inputProps={{ onChange: onChangeFromInputProps }}
-      />,
-    )
+    render(<Checkbox label="Test label" onChange={onChange} />)
 
     const input = screen.getByRole('checkbox')
 
@@ -53,19 +45,8 @@ describe('Checkbox', () => {
     await user.click(input)
 
     expect(input).toBeChecked()
-    expect(onChangeFromProps).toHaveBeenCalledTimes(1)
-    expect(onChangeFromInputProps).toHaveBeenCalledTimes(1)
-
-    expect(onChangeFromProps).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: expect.objectContaining({ checked: true }),
-      }),
-    )
-    expect(onChangeFromInputProps).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: expect.objectContaining({ checked: true }),
-      }),
-    )
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(true)
   })
 
   it('applies disabled attribute when isDisabled is true', () => {

--- a/src/components/Common/UI/Checkbox/Checkbox.tsx
+++ b/src/components/Common/UI/Checkbox/Checkbox.tsx
@@ -1,5 +1,4 @@
 import type { ChangeEvent } from 'react'
-import classNames from 'classnames'
 import { useFieldIds } from '../hooks/useFieldIds'
 import { HorizontalFieldLayout } from '../HorizontalFieldLayout'
 import styles from './Checkbox.module.scss'
@@ -13,15 +12,14 @@ export const Checkbox = ({
   errorMessage,
   isRequired,
   inputRef,
-  checked,
   value,
   isInvalid = false,
   isDisabled = false,
   id,
-  onChange: onChangeFromCheckboxProps,
+  onChange,
   onBlur,
-  inputProps,
   className,
+  shouldVisuallyHideLabel,
   ...props
 }: CheckboxProps) => {
   const { inputId, errorMessageId, descriptionId, ariaDescribedBy } = useFieldIds({
@@ -30,11 +28,8 @@ export const Checkbox = ({
     description,
   })
 
-  const { onChange: onChangeFromInputProps, ...restInputProps } = inputProps ?? {}
-
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onChangeFromCheckboxProps?.(event)
-    onChangeFromInputProps?.(event)
+    onChange?.(event.target.checked)
   }
 
   return (
@@ -46,6 +41,7 @@ export const Checkbox = ({
       htmlFor={inputId}
       errorMessageId={errorMessageId}
       descriptionId={descriptionId}
+      shouldVisuallyHideLabel={shouldVisuallyHideLabel}
       className={className}
       {...props}
     >
@@ -56,16 +52,14 @@ export const Checkbox = ({
           disabled={isDisabled}
           aria-invalid={isInvalid}
           aria-describedby={ariaDescribedBy}
-          checked={checked}
+          checked={value}
           id={inputId}
           ref={inputRef}
           onBlur={onBlur}
           onChange={handleChange}
-          value={value}
           className={styles.checkboxInput}
-          {...restInputProps}
         />
-        <div className={classNames(styles.checkbox, { [styles.checked as string]: checked })}>
+        <div className={styles.checkbox}>
           <IconChecked className={styles.check} />
         </div>
       </div>

--- a/src/components/Common/UI/Checkbox/CheckboxTypes.ts
+++ b/src/components/Common/UI/Checkbox/CheckboxTypes.ts
@@ -3,12 +3,10 @@ import type { SharedHorizontalFieldLayoutProps } from '../HorizontalFieldLayout/
 
 export interface CheckboxProps
   extends SharedHorizontalFieldLayoutProps,
-    Pick<
-      InputHTMLAttributes<HTMLInputElement>,
-      'name' | 'id' | 'className' | 'onChange' | 'onBlur' | 'checked' | 'value'
-    > {
+    Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id' | 'className' | 'onBlur'> {
+  value?: boolean
+  onChange?: (value: boolean) => void
   inputRef?: Ref<HTMLInputElement>
   isInvalid?: boolean
   isDisabled?: boolean
-  inputProps?: InputHTMLAttributes<HTMLInputElement>
 }

--- a/src/components/Common/UI/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/src/components/Common/UI/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -2,9 +2,8 @@ import type { Story } from '@ladle/react'
 import { useLadleState } from '../../../../../.ladle/helpers/LadleState'
 import { CheckboxGroup } from './CheckboxGroup'
 
-// Adding a meta object for title
 export default {
-  title: 'UI/Form/Inputs/CheckboxGroup', // Updated to be under UI/Form instead of top-level Form
+  title: 'UI/Form/Inputs/CheckboxGroup',
 }
 
 const options = [
@@ -16,29 +15,24 @@ const options = [
 ]
 
 function useCheckboxGroupState() {
-  const { value, handleCheckboxGroupChange } = useLadleState<string[]>('CheckboxGroupChange', [])
-  return { value, handleCheckboxGroupChange }
+  const { value, handleChange } = useLadleState<string[]>('CheckboxGroupChange', [])
+  return { value, handleChange }
 }
 
 export const Default: Story = () => {
-  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  const { value, handleChange } = useCheckboxGroupState()
   return (
-    <CheckboxGroup
-      label="Select options"
-      options={options}
-      value={value}
-      onChange={handleCheckboxGroupChange}
-    />
+    <CheckboxGroup label="Select options" options={options} value={value} onChange={handleChange} />
   )
 }
 
 export const WithDescription: Story = () => {
-  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  const { value, handleChange } = useCheckboxGroupState()
   return (
     <CheckboxGroup
       label="Select your favorite fruits"
       options={options}
-      onChange={handleCheckboxGroupChange}
+      onChange={handleChange}
       description="Please select one or more options"
       value={value}
     />
@@ -46,12 +40,12 @@ export const WithDescription: Story = () => {
 }
 
 export const WithError: Story = () => {
-  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  const { value, handleChange } = useCheckboxGroupState()
   return (
     <CheckboxGroup
       label="Select your favorite fruits"
       options={options}
-      onChange={handleCheckboxGroupChange}
+      onChange={handleChange}
       value={value}
       isInvalid
       errorMessage="Please select at least one fruit"
@@ -60,12 +54,12 @@ export const WithError: Story = () => {
 }
 
 export const Disabled: Story = () => {
-  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  const { value, handleChange } = useCheckboxGroupState()
   return (
     <CheckboxGroup
       label="Select your favorite fruits"
       options={options}
-      onChange={handleCheckboxGroupChange}
+      onChange={handleChange}
       value={value}
       isDisabled
     />
@@ -73,12 +67,12 @@ export const Disabled: Story = () => {
 }
 
 export const Required: Story = () => {
-  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  const { value, handleChange } = useCheckboxGroupState()
   return (
     <CheckboxGroup
       label="Select your favorite fruits"
       options={options}
-      onChange={handleCheckboxGroupChange}
+      onChange={handleChange}
       value={value}
       isRequired
     />
@@ -86,7 +80,7 @@ export const Required: Story = () => {
 }
 
 export const WithDisabledOptions: Story = () => {
-  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  const { value, handleChange } = useCheckboxGroupState()
 
   const optionsWithDisabled = [
     { label: 'Apple', value: 'apple' },
@@ -100,14 +94,14 @@ export const WithDisabledOptions: Story = () => {
     <CheckboxGroup
       label="Select your favorite fruits"
       options={optionsWithDisabled}
-      onChange={handleCheckboxGroupChange}
+      onChange={handleChange}
       value={value}
     />
   )
 }
 
 export const WithOptionDescriptions: Story = () => {
-  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  const { value, handleChange } = useCheckboxGroupState()
 
   const optionsWithDescriptions = [
     { label: 'Apple', value: 'apple', description: 'Kind of mid' },
@@ -121,19 +115,19 @@ export const WithOptionDescriptions: Story = () => {
     <CheckboxGroup
       label="Select your favorite fruits"
       options={optionsWithDescriptions}
-      onChange={handleCheckboxGroupChange}
+      onChange={handleChange}
       value={value}
     />
   )
 }
 
 export const WithPreselectedValues: Story = () => {
-  const { value, handleCheckboxGroupChange } = useCheckboxGroupState()
+  const { value, handleChange } = useCheckboxGroupState()
   return (
     <CheckboxGroup
       label="Select your favorite fruits"
       options={options}
-      onChange={handleCheckboxGroupChange}
+      onChange={handleChange}
       value={value}
     />
   )

--- a/src/components/Common/UI/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/Common/UI/CheckboxGroup/CheckboxGroup.test.tsx
@@ -51,6 +51,25 @@ describe('CheckboxGroup', () => {
     expect(onChange).toHaveBeenCalledWith(['option1'])
   })
 
+  it('calls onChange handler when options are deselected', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <CheckboxGroup
+        label="Test Group"
+        value={['option1']}
+        options={mockOptions}
+        onChange={onChange}
+      />,
+    )
+
+    const firstCheckbox = screen.getByLabelText('Option 1')
+    await user.click(firstCheckbox)
+
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
   it('disables all checkboxes when isDisabled is true', () => {
     render(<CheckboxGroup label="Test Group" options={mockOptions} isDisabled />)
 

--- a/src/components/Common/UI/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/Common/UI/CheckboxGroup/CheckboxGroup.tsx
@@ -50,16 +50,23 @@ function ReactAriaCheckbox({
     internalInputRef,
   )
 
+  const handleChange = (checked: boolean) => {
+    if (checked) {
+      groupState.addValue(value)
+    } else {
+      groupState.removeValue(value)
+    }
+  }
+
   return (
     <Checkbox
       label={label}
       inputRef={handleInputRef}
-      checked={isSelected}
       isDisabled={isDisabled}
       isInvalid={isInvalid}
       description={description}
-      onChange={inputProps.onChange}
-      value={inputProps.value}
+      onChange={handleChange}
+      value={isSelected}
       name={inputProps.name}
     />
   )

--- a/src/components/Common/UI/ComboBox/ComboBox.stories.tsx
+++ b/src/components/Common/UI/ComboBox/ComboBox.stories.tsx
@@ -61,99 +61,105 @@ const usStates = [
 ]
 
 export const Default: Story = () => {
-  const { handleSelectChange } = useLadleState<string>('ComboBox onChange')
+  const { value, handleChange } = useLadleState<string>('ComboBox onChange')
 
   return (
     <ComboBox
       label="Select an option"
       name="combobox"
       options={usStates}
-      onChange={handleSelectChange}
+      onChange={handleChange}
+      value={value}
     />
   )
 }
 
 export const WithPlaceholder: Story = () => {
-  const { handleSelectChange } = useLadleState<string>('ComboBox onChange')
+  const { value, handleChange } = useLadleState<string>('ComboBox onChange')
 
   return (
     <ComboBox
       label="Select an option"
       name="combobox"
       options={usStates}
-      onChange={handleSelectChange}
+      onChange={handleChange}
       placeholder="Search or select an option"
+      value={value}
     />
   )
 }
 
 export const WithDescription: Story = () => {
-  const { handleSelectChange } = useLadleState<string>('ComboBox onChange')
+  const { value, handleChange } = useLadleState<string>('ComboBox onChange')
 
   return (
     <ComboBox
       label="Select an option"
       name="combobox"
       options={usStates}
-      onChange={handleSelectChange}
+      onChange={handleChange}
       description="Please search or select one of the available options"
+      value={value}
     />
   )
 }
 
 export const WithError: Story = () => {
-  const { handleSelectChange } = useLadleState<string>('ComboBox onChange')
+  const { value, handleChange } = useLadleState<string>('ComboBox onChange')
 
   return (
     <ComboBox
       label="Select an option"
       name="combobox"
       options={usStates}
-      onChange={handleSelectChange}
+      onChange={handleChange}
       isInvalid
       errorMessage="Please select a valid option"
+      value={value}
     />
   )
 }
 
 export const Disabled: Story = () => {
-  const { handleSelectChange } = useLadleState<string>('ComboBox onChange')
+  const { value, handleChange } = useLadleState<string>('ComboBox onChange')
 
   return (
     <ComboBox
       label="Select an option"
       name="combobox"
       options={usStates}
-      onChange={handleSelectChange}
+      onChange={handleChange}
       isDisabled
+      value={value}
     />
   )
 }
 
 export const Required: Story = () => {
-  const { handleSelectChange } = useLadleState<string>('ComboBox onChange')
+  const { handleChange } = useLadleState<string>('ComboBox onChange')
 
   return (
     <ComboBox
       label="Select an option"
       name="combobox"
       options={usStates}
-      onChange={handleSelectChange}
+      onChange={handleChange}
       isRequired={true}
     />
   )
 }
 
 export const WithOnBlur: Story = () => {
-  const { handleSelectChange, handleBlur } = useLadleState<string>('ComboBox onChange')
+  const { value, handleChange, handleBlur } = useLadleState<string>('ComboBox onChange')
 
   return (
     <ComboBox
       label="Select an option"
       name="combobox"
       options={usStates}
-      onChange={handleSelectChange}
+      onChange={handleChange}
       onBlur={handleBlur}
+      value={value}
     />
   )
 }

--- a/src/components/Common/UI/DatePicker/DatePicker.stories.tsx
+++ b/src/components/Common/UI/DatePicker/DatePicker.stories.tsx
@@ -8,41 +8,41 @@ export default {
 }
 
 export const Default: Story = () => {
-  const { value, handleSelectChange } = useLadleState<Date | null>('DatePicker onChange', undefined)
+  const { value, handleChange } = useLadleState<Date | null>('DatePicker onChange', undefined)
 
   return (
     <DatePicker
       label="Select a date"
       name="datepicker"
       value={value || undefined}
-      onChange={handleSelectChange}
+      onChange={handleChange}
     />
   )
 }
 
 export const WithDescription: Story = () => {
-  const { value, handleSelectChange } = useLadleState<Date | null>('DatePicker onChange', undefined)
+  const { value, handleChange } = useLadleState<Date | null>('DatePicker onChange', undefined)
 
   return (
     <DatePicker
       label="Select a date"
       name="datepicker"
       value={value || undefined}
-      onChange={handleSelectChange}
+      onChange={handleChange}
       description="Please select a date for your appointment"
     />
   )
 }
 
 export const WithError: Story = () => {
-  const { value, handleSelectChange } = useLadleState<Date | null>('DatePicker onChange', undefined)
+  const { value, handleChange } = useLadleState<Date | null>('DatePicker onChange', undefined)
 
   return (
     <DatePicker
       label="Select a date"
       name="datepicker"
       value={value || undefined}
-      onChange={handleSelectChange}
+      onChange={handleChange}
       isInvalid
       errorMessage="Please select a valid date"
     />
@@ -50,35 +50,35 @@ export const WithError: Story = () => {
 }
 
 export const Disabled: Story = () => {
-  const { value, handleSelectChange } = useLadleState<Date | null>('DatePicker onChange', undefined)
+  const { value, handleChange } = useLadleState<Date | null>('DatePicker onChange', undefined)
 
   return (
     <DatePicker
       label="Select a date"
       name="datepicker"
       value={value || undefined}
-      onChange={handleSelectChange}
+      onChange={handleChange}
       isDisabled
     />
   )
 }
 
 export const Required: Story = () => {
-  const { value, handleSelectChange } = useLadleState<Date | null>('DatePicker onChange', undefined)
+  const { value, handleChange } = useLadleState<Date | null>('DatePicker onChange', undefined)
 
   return (
     <DatePicker
       label="Select a date"
       name="datepicker"
       value={value || undefined}
-      onChange={handleSelectChange}
+      onChange={handleChange}
       isRequired={true}
     />
   )
 }
 
 export const WithOnBlur: Story = () => {
-  const { value, handleSelectChange, handleBlur } = useLadleState<Date | null>(
+  const { value, handleChange, handleBlur } = useLadleState<Date | null>(
     'DatePicker onChange',
     undefined,
   )
@@ -88,7 +88,7 @@ export const WithOnBlur: Story = () => {
       label="Select a date"
       name="datepicker"
       value={value || undefined}
-      onChange={handleSelectChange}
+      onChange={handleChange}
       onBlur={handleBlur}
     />
   )
@@ -97,17 +97,14 @@ export const WithOnBlur: Story = () => {
 export const WithDefaultValue: Story = () => {
   // Using JavaScript's native Date
   const christmasDate = new Date(2023, 11, 25) // December 25, 2023
-  const { value, handleSelectChange } = useLadleState<Date | null>(
-    'DatePicker onChange',
-    christmasDate,
-  )
+  const { value, handleChange } = useLadleState<Date | null>('DatePicker onChange', christmasDate)
 
   return (
     <DatePicker
       label="Select a date"
       name="datepicker"
       value={value || undefined}
-      onChange={handleSelectChange}
+      onChange={handleChange}
     />
   )
 }

--- a/src/components/Common/UI/DatePicker/DatePickerTypes.ts
+++ b/src/components/Common/UI/DatePicker/DatePickerTypes.ts
@@ -10,6 +10,6 @@ export interface DatePickerProps
   onChange?: (value: Date | null) => void
   onBlur?: (e: FocusEvent) => void
   label: string
-  value?: Date
+  value?: Date | null
   placeholder?: string
 }

--- a/src/components/Common/UI/NumberInput/NumberInput.stories.tsx
+++ b/src/components/Common/UI/NumberInput/NumberInput.stories.tsx
@@ -9,17 +9,17 @@ export default {
 }
 
 export const Default: Story = () => {
-  const { value, handleAction } = useLadleState<number>('NumberInputChange', 0)
+  const { value, handleChange } = useLadleState<number>('NumberInputChange', 0)
 
   return (
     <LocaleProvider locale="en-US" currency="USD">
-      <NumberInput label="Amount" name="amount" value={value} onChange={handleAction} />
+      <NumberInput label="Amount" name="amount" value={value} onChange={handleChange} />
     </LocaleProvider>
   )
 }
 
 export const Currency: Story = () => {
-  const { value, handleAction } = useLadleState<number>('NumberInputChange', 0)
+  const { value, handleChange } = useLadleState<number>('NumberInputChange', 0)
 
   return (
     <LocaleProvider locale="en-US" currency="USD">
@@ -27,7 +27,7 @@ export const Currency: Story = () => {
         label="Price"
         name="price"
         value={value}
-        onChange={handleAction}
+        onChange={handleChange}
         format="currency"
         currencyDisplay="symbol"
       />
@@ -36,7 +36,7 @@ export const Currency: Story = () => {
 }
 
 export const Percent: Story = () => {
-  const { value, handleAction } = useLadleState<number>('NumberInputChange', 0)
+  const { value, handleChange } = useLadleState<number>('NumberInputChange', 0)
 
   return (
     <LocaleProvider locale="en-US" currency="USD">
@@ -44,7 +44,7 @@ export const Percent: Story = () => {
         label="Discount"
         name="discount"
         value={value}
-        onChange={handleAction}
+        onChange={handleChange}
         format="percent"
         description="Enter discount percentage"
       />
@@ -53,7 +53,7 @@ export const Percent: Story = () => {
 }
 
 export const Decimal: Story = () => {
-  const { value, handleAction } = useLadleState<number>('NumberInputChange', 0)
+  const { value, handleChange } = useLadleState<number>('NumberInputChange', 0)
 
   return (
     <LocaleProvider locale="en-US" currency="USD">
@@ -61,7 +61,7 @@ export const Decimal: Story = () => {
         label="Quantity"
         name="quantity"
         value={value}
-        onChange={handleAction}
+        onChange={handleChange}
         format="decimal"
       />
     </LocaleProvider>
@@ -69,7 +69,7 @@ export const Decimal: Story = () => {
 }
 
 export const WithDescription: Story = () => {
-  const { value, handleAction } = useLadleState<number>('NumberInputChange', 0)
+  const { value, handleChange } = useLadleState<number>('NumberInputChange', 0)
 
   return (
     <LocaleProvider locale="en-US" currency="USD">
@@ -77,7 +77,7 @@ export const WithDescription: Story = () => {
         label="Quantity"
         name="quantity"
         value={value}
-        onChange={handleAction}
+        onChange={handleChange}
         description="Enter the number of items"
       />
     </LocaleProvider>
@@ -85,7 +85,7 @@ export const WithDescription: Story = () => {
 }
 
 export const WithError: Story = () => {
-  const { value, handleAction } = useLadleState<number>('NumberInputChange', 0)
+  const { value, handleChange } = useLadleState<number>('NumberInputChange', 0)
 
   return (
     <LocaleProvider locale="en-US" currency="USD">
@@ -93,7 +93,7 @@ export const WithError: Story = () => {
         label="Age"
         name="age"
         value={value}
-        onChange={handleAction}
+        onChange={handleChange}
         isInvalid
         errorMessage="Please enter a valid age"
       />

--- a/src/components/Common/UI/NumberInput/NumberInput.tsx
+++ b/src/components/Common/UI/NumberInput/NumberInput.tsx
@@ -21,7 +21,6 @@ export function NumberInput({
   isDisabled,
   onChange,
   onBlur,
-  inputProps,
   label,
   min,
   max,
@@ -81,7 +80,6 @@ export function NumberInput({
             onBlur={onBlur}
             placeholder={placeholder}
             aria-describedby={ariaDescribedBy}
-            {...inputProps}
           />
           {format === 'percent' ? <span>%</span> : null}
         </Group>

--- a/src/components/Common/UI/NumberInput/NumberInputTypes.ts
+++ b/src/components/Common/UI/NumberInput/NumberInputTypes.ts
@@ -15,5 +15,4 @@ export interface NumberInputProps
   isDisabled?: boolean
   onChange?: (value: number) => void
   onBlur?: FocusEventHandler<HTMLElement>
-  inputProps?: InputHTMLAttributes<HTMLInputElement>
 }

--- a/src/components/Common/UI/Radio/Radio.stories.tsx
+++ b/src/components/Common/UI/Radio/Radio.stories.tsx
@@ -7,34 +7,27 @@ export default {
 }
 
 export const Default: Story = () => {
-  const { value, handleRadioChange } = useLadleState<boolean>('RadioChange', false)
+  const { value, handleChange } = useLadleState<boolean>('RadioChange', false)
   return (
-    <Radio
-      label="Select this option"
-      name="radio-option"
-      checked={value}
-      onChange={handleRadioChange}
-      value="option1"
-    />
+    <Radio label="Select this option" name="radio-option" onChange={handleChange} value={value} />
   )
 }
 
 export const WithDescription: Story = () => {
-  const { value, handleRadioChange } = useLadleState<boolean>('RadioChange', false)
+  const { value, handleChange } = useLadleState<boolean>('RadioChange', false)
   return (
     <Radio
       label="Subscribe to newsletter"
       name="newsletter"
       description="Receive updates about new features and promotions"
-      checked={value}
-      onChange={handleRadioChange}
-      value="newsletter"
+      onChange={handleChange}
+      value={value}
     />
   )
 }
 
 export const WithError: Story = () => {
-  const { value, handleRadioChange } = useLadleState<boolean>('RadioChange', false)
+  const { value, handleChange } = useLadleState<boolean>('RadioChange', false)
   return (
     <Radio
       label="Select this option"
@@ -42,25 +35,18 @@ export const WithError: Story = () => {
       isInvalid
       errorMessage="This field is required"
       description="Please select an option to continue"
-      checked={value}
-      onChange={handleRadioChange}
-      value="option1"
+      onChange={handleChange}
+      value={value}
     />
   )
 }
 
 export const Disabled: Story = () => {
-  return <Radio label="This option is not available" name="disabled" isDisabled value="disabled" />
+  return <Radio label="This option is not available" name="disabled" isDisabled value={false} />
 }
 
 export const DisabledChecked: Story = () => {
   return (
-    <Radio
-      label="This option is not available"
-      name="disabled-checked"
-      isDisabled
-      checked={true}
-      value="disabled-checked"
-    />
+    <Radio label="This option is not available" name="disabled-checked" isDisabled value={true} />
   )
 }

--- a/src/components/Common/UI/Radio/Radio.test.tsx
+++ b/src/components/Common/UI/Radio/Radio.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import type { ChangeEvent } from 'react'
 import { Radio } from './Radio'
 
 describe('Radio', () => {
@@ -32,20 +31,12 @@ describe('Radio', () => {
     expect(screen.getByText(description)).toHaveAttribute('id', descriptionId)
   })
 
-  it('calls both onChange handlers when clicked', async () => {
+  it('calls onChange handler when clicked', async () => {
     const user = userEvent.setup()
 
-    const onChangeFromProps = vi.fn<(event: ChangeEvent<HTMLInputElement>) => void>()
-    const onChangeFromInputProps = vi.fn<(event: ChangeEvent<HTMLInputElement>) => void>()
+    const onChange = vi.fn<(checked: boolean) => void>()
 
-    render(
-      <Radio
-        label="Test label"
-        onChange={onChangeFromProps}
-        inputProps={{ onChange: onChangeFromInputProps }}
-        value="test-value"
-      />,
-    )
+    render(<Radio label="Test label" onChange={onChange} />)
 
     const input = screen.getByRole('radio')
 
@@ -54,19 +45,8 @@ describe('Radio', () => {
     await user.click(input)
 
     expect(input).toBeChecked()
-    expect(onChangeFromProps).toHaveBeenCalledTimes(1)
-    expect(onChangeFromInputProps).toHaveBeenCalledTimes(1)
-
-    expect(onChangeFromProps).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: expect.objectContaining({ checked: true }),
-      }),
-    )
-    expect(onChangeFromInputProps).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: expect.objectContaining({ checked: true }),
-      }),
-    )
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(true)
   })
 
   it('applies disabled attribute when isDisabled is true', () => {
@@ -75,16 +55,9 @@ describe('Radio', () => {
     expect(input).toBeDisabled()
   })
 
-  it('renders with checked state when checked prop is true', () => {
-    render(<Radio label="Test Radio" checked={true} value="test-value" />)
+  it('renders with checked state when value prop is true', () => {
+    render(<Radio label="Test Radio" value={true} />)
     const input = screen.getByRole('radio')
     expect(input).toBeChecked()
-  })
-
-  it('passes value attribute to input element', () => {
-    const value = 'option-value'
-    render(<Radio label="Test Radio" value={value} />)
-    const input = screen.getByRole('radio')
-    expect(input).toHaveAttribute('value', value)
   })
 })

--- a/src/components/Common/UI/Radio/Radio.tsx
+++ b/src/components/Common/UI/Radio/Radio.tsx
@@ -4,6 +4,7 @@ import { useFieldIds } from '../hooks/useFieldIds'
 import { HorizontalFieldLayout } from '../HorizontalFieldLayout'
 import styles from './Radio.module.scss'
 import type { RadioProps } from './RadioTypes'
+
 export const Radio = ({
   name,
   label,
@@ -11,14 +12,13 @@ export const Radio = ({
   errorMessage,
   isRequired,
   inputRef,
-  checked,
   value,
   isInvalid = false,
   isDisabled = false,
   id,
-  onChange: onChangeFromRadioProps,
+  onChange,
   onBlur,
-  inputProps,
+  shouldVisuallyHideLabel,
   className,
   ...props
 }: RadioProps) => {
@@ -28,11 +28,8 @@ export const Radio = ({
     description,
   })
 
-  const { onChange: onChangeFromInputProps, ...restInputProps } = inputProps ?? {}
-
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onChangeFromRadioProps?.(event)
-    onChangeFromInputProps?.(event)
+    onChange?.(event.target.checked)
   }
 
   return (
@@ -44,6 +41,7 @@ export const Radio = ({
       htmlFor={inputId}
       errorMessageId={errorMessageId}
       descriptionId={descriptionId}
+      shouldVisuallyHideLabel={shouldVisuallyHideLabel}
       className={className}
       {...props}
     >
@@ -53,17 +51,15 @@ export const Radio = ({
           name={name}
           disabled={isDisabled}
           aria-describedby={ariaDescribedBy}
-          checked={checked}
+          checked={value}
           id={inputId}
           ref={inputRef}
           onBlur={onBlur}
           onChange={handleChange}
-          value={value}
           className={styles.radioInput}
-          {...restInputProps}
         />
-        <div className={classNames(styles.radio, { [styles.checked as string]: checked })}>
-          {checked && <div className={styles.radioDot} />}
+        <div className={classNames(styles.radio, { [styles.checked as string]: value })}>
+          {value && <div className={styles.radioDot} />}
         </div>
       </div>
     </HorizontalFieldLayout>

--- a/src/components/Common/UI/Radio/RadioTypes.ts
+++ b/src/components/Common/UI/Radio/RadioTypes.ts
@@ -3,12 +3,10 @@ import type { SharedHorizontalFieldLayoutProps } from '../HorizontalFieldLayout/
 
 export interface RadioProps
   extends SharedHorizontalFieldLayoutProps,
-    Pick<
-      InputHTMLAttributes<HTMLInputElement>,
-      'name' | 'id' | 'className' | 'onChange' | 'onBlur' | 'checked' | 'value'
-    > {
+    Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id' | 'className' | 'onBlur'> {
+  value?: boolean
+  onChange?: (checked: boolean) => void
   inputRef?: Ref<HTMLInputElement>
   isInvalid?: boolean
   isDisabled?: boolean
-  inputProps?: InputHTMLAttributes<HTMLInputElement>
 }

--- a/src/components/Common/UI/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/Common/UI/RadioGroup/RadioGroup.stories.tsx
@@ -15,32 +15,24 @@ const options = [
 ]
 
 function useRadioGroupState(initialValue?: string) {
-  const { value, handleRadioGroupChange } = useLadleState<string>(
-    'RadioGroupChange',
-    initialValue || '',
-  )
-  return { value, handleRadioGroupChange }
+  const { value, handleChange } = useLadleState<string>('RadioGroupChange', initialValue || '')
+  return { value, handleChange }
 }
 
 export const Default: Story = () => {
-  const { value, handleRadioGroupChange } = useRadioGroupState()
+  const { value, handleChange } = useRadioGroupState()
   return (
-    <RadioGroup
-      label="Select option"
-      options={options}
-      value={value}
-      onChange={handleRadioGroupChange}
-    />
+    <RadioGroup label="Select option" options={options} value={value} onChange={handleChange} />
   )
 }
 
 export const WithDescription: Story = () => {
-  const { value, handleRadioGroupChange } = useRadioGroupState()
+  const { value, handleChange } = useRadioGroupState()
   return (
     <RadioGroup
       label="Select your favorite fruit"
       options={options}
-      onChange={handleRadioGroupChange}
+      onChange={handleChange}
       description="Please select one option"
       value={value}
     />
@@ -48,12 +40,12 @@ export const WithDescription: Story = () => {
 }
 
 export const WithError: Story = () => {
-  const { value, handleRadioGroupChange } = useRadioGroupState()
+  const { value, handleChange } = useRadioGroupState()
   return (
     <RadioGroup
       label="Select your favorite fruit"
       options={options}
-      onChange={handleRadioGroupChange}
+      onChange={handleChange}
       value={value}
       isInvalid
       errorMessage="Please select a fruit"
@@ -62,12 +54,12 @@ export const WithError: Story = () => {
 }
 
 export const Disabled: Story = () => {
-  const { value, handleRadioGroupChange } = useRadioGroupState()
+  const { value, handleChange } = useRadioGroupState()
   return (
     <RadioGroup
       label="Select your favorite fruit"
       options={options}
-      onChange={handleRadioGroupChange}
+      onChange={handleChange}
       value={value}
       isDisabled
     />
@@ -75,12 +67,12 @@ export const Disabled: Story = () => {
 }
 
 export const Required: Story = () => {
-  const { value, handleRadioGroupChange } = useRadioGroupState()
+  const { value, handleChange } = useRadioGroupState()
   return (
     <RadioGroup
       label="Select your favorite fruit"
       options={options}
-      onChange={handleRadioGroupChange}
+      onChange={handleChange}
       value={value}
       isRequired
     />
@@ -88,7 +80,7 @@ export const Required: Story = () => {
 }
 
 export const WithDisabledOptions: Story = () => {
-  const { value, handleRadioGroupChange } = useRadioGroupState('apple')
+  const { value, handleChange } = useRadioGroupState('apple')
 
   const optionsWithDisabled = [
     { label: 'Apple', value: 'apple' },
@@ -102,26 +94,26 @@ export const WithDisabledOptions: Story = () => {
     <RadioGroup
       label="Select your favorite fruit"
       options={optionsWithDisabled}
-      onChange={handleRadioGroupChange}
+      onChange={handleChange}
       value={value}
     />
   )
 }
 
 export const WithPreselectedValue: Story = () => {
-  const { value, handleRadioGroupChange } = useLadleState<string>('RadioGroupChange', 'apple')
+  const { value, handleChange } = useLadleState<string>('RadioGroupChange', 'apple')
   return (
     <RadioGroup
       label="Select your favorite fruit"
       options={options}
-      onChange={handleRadioGroupChange}
+      onChange={handleChange}
       value={value}
     />
   )
 }
 
 export const WithOptionDescriptions: Story = () => {
-  const { value, handleRadioGroupChange } = useRadioGroupState()
+  const { value, handleChange } = useRadioGroupState()
 
   const optionsWithDescriptions = [
     {
@@ -155,7 +147,7 @@ export const WithOptionDescriptions: Story = () => {
     <RadioGroup
       label="Select your favorite fruit"
       options={optionsWithDescriptions}
-      onChange={handleRadioGroupChange}
+      onChange={handleChange}
       value={value}
       description="Each option includes a description to help you make your choice"
     />

--- a/src/components/Common/UI/RadioGroup/RadioGroup.tsx
+++ b/src/components/Common/UI/RadioGroup/RadioGroup.tsx
@@ -49,15 +49,20 @@ function ReactAriaRadio({
     inputRef,
   )
 
+  const handleChange = (checked: boolean) => {
+    if (checked) {
+      groupState.setSelectedValue(value)
+    }
+  }
+
   return (
     <Radio
       label={label}
       inputRef={handleInputRef}
-      checked={isSelected}
       isDisabled={isDisabled}
       description={description}
-      onChange={inputProps.onChange}
-      value={inputProps.value}
+      onChange={handleChange}
+      value={isSelected}
       name={inputProps.name}
     />
   )

--- a/src/components/Common/UI/Select/Select.stories.tsx
+++ b/src/components/Common/UI/Select/Select.stories.tsx
@@ -16,26 +16,28 @@ const options = [
 ]
 
 export const Default: Story = () => {
-  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
+  const { value, handleChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleSelectChange}
+      onChange={handleChange}
+      value={value}
       onBlur={handleBlur}
     />
   )
 }
 
 export const WithPlaceholder: Story = () => {
-  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
+  const { value, handleChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleSelectChange}
+      onChange={handleChange}
+      value={value}
       onBlur={handleBlur}
       placeholder="Choose an option"
     />
@@ -43,13 +45,14 @@ export const WithPlaceholder: Story = () => {
 }
 
 export const WithDescription: Story = () => {
-  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
+  const { value, handleChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleSelectChange}
+      onChange={handleChange}
+      value={value}
       onBlur={handleBlur}
       description="Please select one of the available options"
     />
@@ -57,13 +60,14 @@ export const WithDescription: Story = () => {
 }
 
 export const WithError: Story = () => {
-  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
+  const { value, handleChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleSelectChange}
+      onChange={handleChange}
+      value={value}
       onBlur={handleBlur}
       isInvalid
       errorMessage="Please select a valid option"
@@ -72,13 +76,14 @@ export const WithError: Story = () => {
 }
 
 export const Disabled: Story = () => {
-  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
+  const { value, handleChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleSelectChange}
+      onChange={handleChange}
+      value={value}
       onBlur={handleBlur}
       isDisabled
     />
@@ -86,13 +91,14 @@ export const Disabled: Story = () => {
 }
 
 export const Required: Story = () => {
-  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
+  const { value, handleChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleSelectChange}
+      onChange={handleChange}
+      value={value}
       onBlur={handleBlur}
       isRequired={true}
     />
@@ -100,13 +106,14 @@ export const Required: Story = () => {
 }
 
 export const WithOnBlur: Story = () => {
-  const { handleSelectChange, handleBlur } = useLadleState<string>('SelectChange')
+  const { value, handleChange, handleBlur } = useLadleState<string>('SelectChange')
   return (
     <Select
       label="Select an option"
       name="select"
       options={options}
-      onChange={handleSelectChange}
+      onChange={handleChange}
+      value={value}
       onBlur={handleBlur}
     />
   )

--- a/src/components/Common/UI/Select/Select.tsx
+++ b/src/components/Common/UI/Select/Select.tsx
@@ -66,7 +66,7 @@ export const Select = ({
         isDisabled={isDisabled}
         isInvalid={isInvalid}
         onSelectionChange={key => {
-          onChange(key.toString())
+          onChange?.(key.toString())
         }}
         onBlur={onBlur}
         id={inputId}

--- a/src/components/Common/UI/Select/SelectTypes.ts
+++ b/src/components/Common/UI/Select/SelectTypes.ts
@@ -12,7 +12,7 @@ export interface SelectProps
   isDisabled?: boolean
   isInvalid?: boolean
   label: string
-  onChange: (value: string) => void
+  onChange?: (value: string) => void
   onBlur?: (e: FocusEvent) => void
   options: SelectItem[]
   placeholder?: string

--- a/src/components/Common/UI/Switch/Switch.stories.tsx
+++ b/src/components/Common/UI/Switch/Switch.stories.tsx
@@ -8,37 +8,39 @@ export default {
 }
 
 export const Default: Story = () => {
-  const { value, handleSwitchChange } = useLadleState<boolean>('SwitchChange', false)
+  const { value, handleChange } = useLadleState<boolean>('SwitchChange', false)
   return (
     <Switch
       label="Enable notifications"
       name="notifications"
-      checked={value}
-      onChange={handleSwitchChange}
+      value={value}
+      onChange={handleChange}
     />
   )
 }
 
 export const WithDefaults: Story = () => {
-  const { value, handleSwitchChange } = useLadleState<boolean>('SwitchDefaultOn', true)
+  const { value, handleChange } = useLadleState<boolean>('SwitchDefaultOn', true)
   return (
     <Switch
       label="Feature enabled by default"
       name="featureEnabled"
-      checked={value}
-      onChange={handleSwitchChange}
+      value={value}
+      onChange={handleChange}
     />
   )
 }
 
 export const WithMultipleDefaults: Story = () => {
-  const { value: darkMode, handleSwitchChange: handleDarkModeChange } = useLadleState<boolean>(
+  const { value: darkMode, handleChange: handleDarkModeChange } = useLadleState<boolean>(
     'DarkMode',
     true,
   )
-  const { value: notifications, handleSwitchChange: handleNotificationsChange } =
-    useLadleState<boolean>('Notifications', false)
-  const { value: marketing, handleSwitchChange: handleMarketingChange } = useLadleState<boolean>(
+  const { value: notifications, handleChange: handleNotificationsChange } = useLadleState<boolean>(
+    'Notifications',
+    false,
+  )
+  const { value: marketing, handleChange: handleMarketingChange } = useLadleState<boolean>(
     'Marketing',
     true,
   )
@@ -48,19 +50,19 @@ export const WithMultipleDefaults: Story = () => {
       <Switch
         label="Dark mode (on by default)"
         name="darkMode"
-        checked={darkMode}
+        value={darkMode}
         onChange={handleDarkModeChange}
       />
       <Switch
         label="Notifications (off by default)"
         name="notifications"
-        checked={notifications}
+        value={notifications}
         onChange={handleNotificationsChange}
       />
       <Switch
         label="Marketing emails (on by default)"
         name="marketing"
-        checked={marketing}
+        value={marketing}
         onChange={handleMarketingChange}
       />
     </div>
@@ -68,20 +70,20 @@ export const WithMultipleDefaults: Story = () => {
 }
 
 export const WithDescription: Story = () => {
-  const { value, handleSwitchChange } = useLadleState<boolean>('SwitchWithDescription', false)
+  const { value, handleChange } = useLadleState<boolean>('SwitchWithDescription', false)
   return (
     <Switch
       label="Dark mode"
       name="darkMode"
       description="Switch to dark theme for better night-time viewing"
-      checked={value}
-      onChange={handleSwitchChange}
+      value={value}
+      onChange={handleChange}
     />
   )
 }
 
 export const WithError: Story = () => {
-  const { value, handleSwitchChange } = useLadleState<boolean>('SwitchWithError', false)
+  const { value, handleChange } = useLadleState<boolean>('SwitchWithError', false)
   return (
     <Switch
       label="Accept terms"
@@ -89,8 +91,8 @@ export const WithError: Story = () => {
       isInvalid
       errorMessage="You must accept the terms to continue"
       description="By enabling this, you agree to our terms of service"
-      checked={value}
-      onChange={handleSwitchChange}
+      value={value}
+      onChange={handleChange}
     />
   )
 }

--- a/src/components/Common/UI/Switch/Switch.test.tsx
+++ b/src/components/Common/UI/Switch/Switch.test.tsx
@@ -54,15 +54,15 @@ describe('Switch', () => {
     expect(onChange).toHaveBeenCalledWith(true)
   })
 
-  it('shows as selected when checked is true', () => {
-    render(<Switch {...defaultProps} checked={true} />)
+  it('shows as selected when value is true', () => {
+    render(<Switch {...defaultProps} value={true} />)
 
     const switchInput = screen.getByRole('switch')
     expect(switchInput).toHaveAttribute('checked')
   })
 
-  it('shows as not selected when checked is false', () => {
-    render(<Switch {...defaultProps} checked={false} />)
+  it('shows as not selected when value is false', () => {
+    render(<Switch {...defaultProps} value={false} />)
 
     const switchInput = screen.getByRole('switch')
     expect(switchInput).not.toHaveAttribute('checked')

--- a/src/components/Common/UI/Switch/Switch.tsx
+++ b/src/components/Common/UI/Switch/Switch.tsx
@@ -13,12 +13,12 @@ export function Switch({
   errorMessage,
   inputRef,
   isRequired,
-  checked,
   onChange,
   isInvalid = false,
   isDisabled = false,
   id,
   className,
+  value,
   ...props
 }: SwitchProps) {
   const { inputId, errorMessageId, descriptionId, ariaDescribedBy } = useFieldIds({
@@ -52,7 +52,7 @@ export function Switch({
     >
       <_Switch
         isDisabled={isDisabled}
-        isSelected={checked}
+        isSelected={value}
         onChange={onChange}
         name={name}
         id={inputId}

--- a/src/components/Common/UI/Switch/SwitchTypes.ts
+++ b/src/components/Common/UI/Switch/SwitchTypes.ts
@@ -3,13 +3,13 @@ import type { SharedHorizontalFieldLayoutProps } from '../HorizontalFieldLayout/
 
 export interface SwitchProps
   extends SharedHorizontalFieldLayoutProps,
-    Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id' | 'checked'> {
+    Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id'> {
   onBlur?: (e: FocusEvent) => void
   onChange?: (checked: boolean) => void
+  value?: boolean
   inputRef?: Ref<HTMLInputElement>
   isInvalid?: boolean
   isDisabled?: boolean
   className?: string
   label: string
-  value?: string
 }

--- a/src/components/Common/UI/TextInput/TextInput.stories.tsx
+++ b/src/components/Common/UI/TextInput/TextInput.stories.tsx
@@ -8,14 +8,12 @@ export default {
 }
 
 export const Default: Story = () => {
-  const { value, handleInputChange } = useLadleState<string>('TextInputChange', '')
-  return (
-    <TextInput label="Email" name="email" type="email" value={value} onChange={handleInputChange} />
-  )
+  const { value, handleChange } = useLadleState<string>('TextInputChange', '')
+  return <TextInput label="Email" name="email" type="email" value={value} onChange={handleChange} />
 }
 
 export const Description: Story = () => {
-  const { value, handleInputChange } = useLadleState<string>('TextInputChange', '')
+  const { value, handleChange } = useLadleState<string>('TextInputChange', '')
   return (
     <TextInput
       label="Email"
@@ -23,13 +21,13 @@ export const Description: Story = () => {
       type="email"
       value={value}
       description="Please enter your email address"
-      onChange={handleInputChange}
+      onChange={handleChange}
     />
   )
 }
 
 export const Error: Story = () => {
-  const { value, handleInputChange } = useLadleState<string>('TextInputChange', '')
+  const { value, handleChange } = useLadleState<string>('TextInputChange', '')
   return (
     <TextInput
       label="Email"
@@ -38,7 +36,7 @@ export const Error: Story = () => {
       value={value}
       isInvalid
       errorMessage="Please enter a valid email address"
-      onChange={handleInputChange}
+      onChange={handleChange}
     />
   )
 }

--- a/src/components/Common/UI/TextInput/TextInput.test.tsx
+++ b/src/components/Common/UI/TextInput/TextInput.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import type { ChangeEvent } from 'react'
 import { TextInput } from './TextInput'
 
 describe('TextInput', () => {
@@ -31,35 +30,17 @@ describe('TextInput', () => {
     expect(labelElement).toHaveAttribute('for', input.id)
   })
 
-  it('calls both onChange handlers when input changes', () => {
-    const onChangeFromProps = vi.fn<(event: ChangeEvent<HTMLInputElement>) => void>()
-    const onChangeFromInputProps = vi.fn<(event: ChangeEvent<HTMLInputElement>) => void>()
+  it('calls onChange handler when input changes', () => {
+    const onChange = vi.fn()
 
     const testValue = 'test value'
 
-    render(
-      <TextInput
-        label="Test label"
-        onChange={onChangeFromProps}
-        inputProps={{ onChange: onChangeFromInputProps }}
-      />,
-    )
+    render(<TextInput label="Test label" onChange={onChange} />)
 
     const input = screen.getByRole('textbox')
     fireEvent.change(input, { target: { value: testValue } })
 
-    expect(onChangeFromProps).toHaveBeenCalledTimes(1)
-    expect(onChangeFromInputProps).toHaveBeenCalledTimes(1)
-
-    expect(onChangeFromProps).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: expect.objectContaining({ value: testValue }),
-      }),
-    )
-    expect(onChangeFromInputProps).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: expect.objectContaining({ value: testValue }),
-      }),
-    )
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(testValue)
   })
 })

--- a/src/components/Common/UI/TextInput/TextInput.tsx
+++ b/src/components/Common/UI/TextInput/TextInput.tsx
@@ -19,9 +19,8 @@ export function TextInput({
   id,
   value,
   placeholder,
-  onChange: onChangeFromTextInputProps,
+  onChange,
   onBlur,
-  inputProps,
   className,
   shouldVisuallyHideLabel,
   ...props
@@ -32,11 +31,8 @@ export function TextInput({
     description,
   })
 
-  const { onChange: onChangeFromInputProps, ...restInputProps } = inputProps ?? {}
-
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onChangeFromTextInputProps?.(event)
-    onChangeFromInputProps?.(event)
+    onChange?.(event.target.value)
   }
 
   return (
@@ -64,7 +60,6 @@ export function TextInput({
         aria-describedby={ariaDescribedBy}
         aria-invalid={isInvalid}
         disabled={isDisabled}
-        {...restInputProps}
       />
     </FieldLayout>
   )

--- a/src/components/Common/UI/TextInput/TextInputTypes.ts
+++ b/src/components/Common/UI/TextInput/TextInputTypes.ts
@@ -5,11 +5,11 @@ export interface TextInputProps
   extends SharedFieldLayoutProps,
     Pick<
       InputHTMLAttributes<HTMLInputElement>,
-      'name' | 'id' | 'placeholder' | 'className' | 'type' | 'onChange' | 'onBlur'
+      'name' | 'id' | 'placeholder' | 'className' | 'type' | 'onBlur'
     > {
   inputRef?: Ref<HTMLInputElement>
   value?: string
+  onChange?: (value: string) => void
   isInvalid?: boolean
   isDisabled?: boolean
-  inputProps?: InputHTMLAttributes<HTMLInputElement>
 }

--- a/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatoryForm.tsx
+++ b/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatoryForm.tsx
@@ -83,14 +83,14 @@ export const CreateSignatoryForm = () => {
             label={t('signatoryDetails.phone')}
             isRequired
             errorMessage={t('validations.phone')}
-            transform={e => normalizePhone(e.target.value)}
+            transform={normalizePhone}
           />
           <TextInputField
             name="ssn"
             label={t('signatoryDetails.ssn')}
             errorMessage={t('validations.ssn', { ns: 'common' })}
             isRequired={!currentSignatory?.hasSsn}
-            transform={e => normalizeSSN(e.target.value)}
+            transform={normalizeSSN}
             placeholder={placeholderSSN}
           />
           <DatePickerField

--- a/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatoryForm.tsx
+++ b/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatoryForm.tsx
@@ -1,5 +1,4 @@
 import * as v from 'valibot'
-import { type ChangeEvent } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { TextInputField, Grid, Flex } from '@/components/Common'
@@ -38,9 +37,8 @@ export const InviteSignatoryForm = () => {
   // sets and clears the confirm_email field error state
   const confirmEmail = watch('confirmEmail')
 
-  const handleEmailChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const handleEmailChange = (value: string) => {
     if (isSubmitted) {
-      const value = event.target.value
       if (value === confirmEmail) {
         clearErrors('confirmEmail')
       }

--- a/src/components/Company/FederalTaxes/Form.tsx
+++ b/src/components/Company/FederalTaxes/Form.tsx
@@ -54,7 +54,7 @@ export function Form() {
           />
         }
         isRequired
-        transform={e => normalizeEin(e.target.value)}
+        transform={normalizeEin}
         placeholder={placeholderEin}
       />
       <SelectField

--- a/src/components/Employee/Profile/PersonalDetailsInputs.tsx
+++ b/src/components/Employee/Profile/PersonalDetailsInputs.tsx
@@ -110,7 +110,7 @@ type SocialSecurityNumberSchemaType = v.InferInput<typeof SocialSecurityNumberSc
 
 interface SocialSecurityNumberInputProps {
   employee?: Employee
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onChange?: (updatedValue: string) => void
 }
 
 export function SocialSecurityNumberInput({ employee, onChange }: SocialSecurityNumberInputProps) {
@@ -124,10 +124,10 @@ export function SocialSecurityNumberInput({ employee, onChange }: SocialSecurity
       label={t('ssnLabel')}
       errorMessage={t('validations.ssn', { ns: 'common' })}
       placeholder={placeholderSSN}
-      transform={e => normalizeSSN(e.target.value)}
-      onChange={event => {
+      transform={normalizeSSN}
+      onChange={updatedValue => {
         setValue('enableSsn', true)
-        onChange?.(event)
+        onChange?.(updatedValue)
       }}
     />
   )


### PR DESCRIPTION
This PR standardizes change handlers and values for all form components.

All form input components in the UI directory now have a `value` prop which sets the value, and an `onChange` handler that passes `value` of the same type. This allows for consistency and simplification. Ex. Look at reduced complexity in useField which now has a single value type. Also in the ladle helper for managing state which can now have a universal handler. This should be a more straightforward contract to maintain with consumers.

Updates to adopt this approach throughout the codebase including stories and test files.