### PR TITLE
fix: clear out error list before base submit handler fires to prevent errors from persisting

### DIFF
--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -132,6 +132,7 @@ export const BaseComponent: FC<BaseComponentInterface> = ({
   const baseSubmitHandler = useCallback(
     async <T,>(data: T, componentHandler: SubmitHandler<T>) => {
       setError(null)
+      setFieldErrors(null)
       try {
         await componentHandler(data)
       } catch (err) {


### PR DESCRIPTION
This PR aims to fix GWS-4366 which shows that errors do not clear from our `fieldErrors` list upon a successful submission. Simply clearing the list before the 2nd submit will handle this issue. 