### PR TITLE
feat: update field components to support generic values

### DIFF
--- a/src/components/Common/Fields/CheckboxGroupField/CheckboxGroupField.stories.tsx
+++ b/src/components/Common/Fields/CheckboxGroupField/CheckboxGroupField.stories.tsx
@@ -77,3 +77,46 @@ export const WithDefaultValues: Story = () => (
     <CheckboxGroupField name="notifications" label="Notifications" options={notifications} />
   </FormWrapper>
 )
+
+export const WithCustomValue: Story = () => {
+  const numericOptions = [
+    { value: 1, label: 'Option 1' },
+    { value: 2, label: 'Option 2' },
+    { value: 3, label: 'Option 3' },
+    { value: 4, label: 'Option 4' },
+  ]
+
+  const objectOptions = [
+    { value: { id: 101, type: 'premium' }, label: 'Premium Plan' },
+    { value: { id: 102, type: 'standard' }, label: 'Standard Plan' },
+    { value: { id: 103, type: 'basic' }, label: 'Basic Plan' },
+  ]
+
+  const booleanOptions = [
+    { value: true, label: 'Yes' },
+    { value: false, label: 'No' },
+  ]
+
+  const objectValueToString = (value: { id: number; type: string }) => `${value.id}-${value.type}`
+
+  return (
+    <FormWrapper>
+      <CheckboxGroupField<number>
+        name="numericValues"
+        label="Numeric Values"
+        options={numericOptions}
+      />
+      <CheckboxGroupField<{ id: number; type: string }>
+        name="objectValues"
+        label="Object Values"
+        options={objectOptions}
+        convertValueToString={objectValueToString}
+      />
+      <CheckboxGroupField<boolean>
+        name="booleanValues"
+        label="Boolean Values"
+        options={booleanOptions}
+      />
+    </FormWrapper>
+  )
+}

--- a/src/components/Common/Fields/CheckboxGroupField/CheckboxGroupField.tsx
+++ b/src/components/Common/Fields/CheckboxGroupField/CheckboxGroupField.tsx
@@ -1,30 +1,50 @@
 import { useField, type UseFieldProps } from '@/components/Common/Fields/hooks/useField'
 import type { CheckboxGroupProps } from '@/components/Common/UI/CheckboxGroup/CheckboxGroupTypes'
 import { useComponentContext } from '@/contexts/ComponentAdapter/ComponentsProvider'
-export interface CheckboxGroupFieldProps
-  extends Omit<CheckboxGroupProps, 'value'>,
-    UseFieldProps<string[]> {}
+import type { CheckboxGroupOption } from '@/components/Common/UI/CheckboxGroup/CheckboxGroupTypes'
+import {
+  useStringifyGenericFieldValueArray,
+  type OptionWithGenericValue,
+} from '@/components/Common/Fields/hooks/useStringifyGenericFieldValue'
 
-export const CheckboxGroupField: React.FC<CheckboxGroupFieldProps> = ({
+type GenericCheckboxGroupOption<TValue> = OptionWithGenericValue<TValue, CheckboxGroupOption>
+
+export interface CheckboxGroupFieldProps<TValue>
+  extends Omit<CheckboxGroupProps, 'value' | 'onChange' | 'options'>,
+    UseFieldProps<TValue[]> {
+  options: GenericCheckboxGroupOption<TValue>[]
+  convertValueToString?: (value: TValue) => string
+}
+
+export const CheckboxGroupField = <TValue = string,>({
   rules,
   defaultValue,
   name,
   errorMessage,
   isRequired,
-  onChange,
+  onChange: onChangeFromProps,
   transform,
+  options,
+  convertValueToString,
   ...checkboxGroupProps
-}: CheckboxGroupFieldProps) => {
+}: CheckboxGroupFieldProps<TValue>) => {
   const Components = useComponentContext()
-  const fieldProps = useField({
+  const { value, onChange, ...fieldProps } = useField({
     name,
     rules,
     defaultValue,
     errorMessage,
     isRequired,
-    onChange,
+    onChange: onChangeFromProps,
     transform,
   })
 
-  return <Components.CheckboxGroup {...fieldProps} {...checkboxGroupProps} />
+  const stringFieldProps = useStringifyGenericFieldValueArray<TValue, CheckboxGroupOption>({
+    options,
+    value,
+    onChange,
+    convertValueToString,
+  })
+
+  return <Components.CheckboxGroup {...fieldProps} {...checkboxGroupProps} {...stringFieldProps} />
 }

--- a/src/components/Common/Fields/ComboBoxField/ComboBoxField.stories.tsx
+++ b/src/components/Common/Fields/ComboBoxField/ComboBoxField.stories.tsx
@@ -143,3 +143,55 @@ export const WithDescription: Story = () => {
     </FormWrapper>
   )
 }
+
+export const WithCustomValue: Story = () => {
+  const numericOptions = [
+    { value: 1, label: 'Option 1' },
+    { value: 2, label: 'Option 2' },
+    { value: 3, label: 'Option 3' },
+    { value: 4, label: 'Option 4' },
+  ]
+
+  const objectOptions = [
+    { value: { id: 101, type: 'premium' }, label: 'Premium Plan' },
+    { value: { id: 102, type: 'standard' }, label: 'Standard Plan' },
+    { value: { id: 103, type: 'basic' }, label: 'Basic Plan' },
+  ]
+
+  const booleanOptions = [
+    { value: true, label: 'Yes' },
+    { value: false, label: 'No' },
+  ]
+
+  const objectValueToString = (value: { id: number; type: string }) => `${value.id}-${value.type}`
+
+  return (
+    <FormWrapper
+      defaultValues={{
+        numericValue: 3,
+        objectValue: { id: 101, type: 'premium' },
+        booleanValue: true,
+      }}
+    >
+      <ComboBoxField<number>
+        name="numericValue"
+        label="Numeric Value"
+        options={numericOptions}
+        placeholder="Select a numeric value"
+      />
+      <ComboBoxField<{ id: number; type: string }>
+        name="objectValue"
+        label="Object Value"
+        options={objectOptions}
+        placeholder="Select a plan"
+        convertValueToString={objectValueToString}
+      />
+      <ComboBoxField<boolean>
+        name="booleanValue"
+        label="Boolean Value"
+        options={booleanOptions}
+        placeholder="Select yes or no"
+      />
+    </FormWrapper>
+  )
+}

--- a/src/components/Common/Fields/ComboBoxField/ComboBoxField.tsx
+++ b/src/components/Common/Fields/ComboBoxField/ComboBoxField.tsx
@@ -1,30 +1,49 @@
 import { useField, type UseFieldProps } from '@/components/Common/Fields/hooks/useField'
-import type { ComboBoxProps } from '@/components/Common/UI/ComboBox/ComboBoxTypes'
+import type { ComboBoxProps, ComboBoxOption } from '@/components/Common/UI/ComboBox/ComboBoxTypes'
 import { useComponentContext } from '@/contexts/ComponentAdapter/ComponentsProvider'
-interface ComboBoxFieldProps
-  extends Omit<ComboBoxProps, 'name' | 'onChange' | 'onBlur'>,
-    UseFieldProps {}
+import {
+  useStringifyGenericFieldValue,
+  type OptionWithGenericValue,
+} from '@/components/Common/Fields/hooks/useStringifyGenericFieldValue'
 
-export const ComboBoxField: React.FC<ComboBoxFieldProps> = ({
+type GenericComboBoxOption<TValue> = OptionWithGenericValue<TValue, ComboBoxOption>
+
+export interface ComboBoxFieldProps<TValue>
+  extends Omit<ComboBoxProps, 'name' | 'value' | 'onChange' | 'onBlur' | 'options'>,
+    UseFieldProps<TValue> {
+  options: GenericComboBoxOption<TValue>[]
+  convertValueToString?: (value: TValue) => string
+}
+
+export const ComboBoxField = <TValue = string,>({
   rules,
   defaultValue,
   name,
   errorMessage,
   isRequired,
-  onChange,
+  onChange: onChangeFromProps,
   transform,
+  options,
+  convertValueToString,
   ...comboBoxProps
-}: ComboBoxFieldProps) => {
+}: ComboBoxFieldProps<TValue>) => {
   const Components = useComponentContext()
-  const fieldProps = useField({
+  const { value, onChange, ...fieldProps } = useField<TValue>({
     name,
     rules,
     defaultValue,
     errorMessage,
     isRequired,
-    onChange,
+    onChange: onChangeFromProps,
     transform,
   })
 
-  return <Components.ComboBox {...fieldProps} {...comboBoxProps} />
+  const stringFieldProps = useStringifyGenericFieldValue<TValue, ComboBoxOption>({
+    options,
+    value,
+    onChange,
+    convertValueToString,
+  })
+
+  return <Components.ComboBox {...comboBoxProps} {...fieldProps} {...stringFieldProps} />
 }

--- a/src/components/Common/Fields/ComboBoxField/index.ts
+++ b/src/components/Common/Fields/ComboBoxField/index.ts
@@ -1,1 +1,2 @@
 export { ComboBoxField } from './ComboBoxField'
+export type { ComboBoxFieldProps } from './ComboBoxField'

--- a/src/components/Common/Fields/RadioGroupField/RadioGroupField.stories.tsx
+++ b/src/components/Common/Fields/RadioGroupField/RadioGroupField.stories.tsx
@@ -76,3 +76,48 @@ export const WithDefaultValues: Story = () => (
     <RadioGroupField name="notifications" label="Notifications" options={notifications} />
   </FormWrapper>
 )
+
+export const WithCustomValue: Story = () => {
+  const numericOptions = [
+    { value: 1, label: 'Option 1' },
+    { value: 2, label: 'Option 2' },
+    { value: 3, label: 'Option 3' },
+    { value: 4, label: 'Option 4' },
+  ]
+
+  const objectOptions = [
+    { value: { id: 101, type: 'premium' }, label: 'Premium Plan' },
+    { value: { id: 102, type: 'standard' }, label: 'Standard Plan' },
+    { value: { id: 103, type: 'basic' }, label: 'Basic Plan' },
+  ]
+
+  const booleanOptions = [
+    { value: true, label: 'Yes' },
+    { value: false, label: 'No' },
+  ]
+
+  const objectValueToString = (value: { id: number; type: string }) => `${value.id}-${value.type}`
+
+  return (
+    <FormWrapper
+      defaultValues={{
+        numericValue: 3,
+        objectValue: { id: 101, type: 'premium' },
+        booleanValue: true,
+      }}
+    >
+      <RadioGroupField<number> name="numericValue" label="Numeric Value" options={numericOptions} />
+      <RadioGroupField<{ id: number; type: string }>
+        name="objectValue"
+        label="Object Value"
+        options={objectOptions}
+        convertValueToString={objectValueToString}
+      />
+      <RadioGroupField<boolean>
+        name="booleanValue"
+        label="Boolean Value"
+        options={booleanOptions}
+      />
+    </FormWrapper>
+  )
+}

--- a/src/components/Common/Fields/RadioGroupField/RadioGroupField.tsx
+++ b/src/components/Common/Fields/RadioGroupField/RadioGroupField.tsx
@@ -1,28 +1,52 @@
 import { useField, type UseFieldProps } from '@/components/Common/Fields/hooks/useField'
-import type { RadioGroupProps } from '@/components/Common/UI/RadioGroup/RadioGroupTypes'
+import type {
+  RadioGroupProps,
+  RadioGroupOption,
+} from '@/components/Common/UI/RadioGroup/RadioGroupTypes'
 import { useComponentContext } from '@/contexts/ComponentAdapter/ComponentsProvider'
-export interface RadioGroupFieldProps extends Omit<RadioGroupProps, 'value'>, UseFieldProps {}
+import {
+  useStringifyGenericFieldValue,
+  type OptionWithGenericValue,
+} from '@/components/Common/Fields/hooks/useStringifyGenericFieldValue'
 
-export const RadioGroupField: React.FC<RadioGroupFieldProps> = ({
+type GenericRadioGroupOption<TValue> = OptionWithGenericValue<TValue, RadioGroupOption>
+
+export interface RadioGroupFieldProps<TValue>
+  extends Omit<RadioGroupProps, 'value' | 'onChange' | 'options'>,
+    UseFieldProps<TValue> {
+  options: GenericRadioGroupOption<TValue>[]
+  convertValueToString?: (value: TValue) => string
+}
+
+export const RadioGroupField = <TValue = string,>({
   rules,
   defaultValue,
   name,
   errorMessage,
   isRequired,
-  onChange,
+  onChange: onChangeFromProps,
   transform,
+  options,
+  convertValueToString,
   ...radioGroupProps
-}: RadioGroupFieldProps) => {
+}: RadioGroupFieldProps<TValue>) => {
   const Components = useComponentContext()
-  const fieldProps = useField({
+  const { value, onChange, ...fieldProps } = useField<TValue>({
     name,
     rules,
     defaultValue,
     errorMessage,
     isRequired,
-    onChange,
+    onChange: onChangeFromProps,
     transform,
   })
 
-  return <Components.RadioGroup {...fieldProps} {...radioGroupProps} />
+  const stringFieldProps = useStringifyGenericFieldValue<TValue, RadioGroupOption>({
+    options,
+    value,
+    onChange,
+    convertValueToString,
+  })
+
+  return <Components.RadioGroup {...radioGroupProps} {...fieldProps} {...stringFieldProps} />
 }

--- a/src/components/Common/Fields/SelectField/SelectField.stories.tsx
+++ b/src/components/Common/Fields/SelectField/SelectField.stories.tsx
@@ -126,3 +126,55 @@ export const WithDescription: Story = () => (
     />
   </FormWrapper>
 )
+
+export const WithCustomValue: Story = () => {
+  const numericOptions = [
+    { value: 1, label: 'Option 1' },
+    { value: 2, label: 'Option 2' },
+    { value: 3, label: 'Option 3' },
+    { value: 4, label: 'Option 4' },
+  ]
+
+  const objectOptions = [
+    { value: { id: 101, type: 'premium' }, label: 'Premium Plan' },
+    { value: { id: 102, type: 'standard' }, label: 'Standard Plan' },
+    { value: { id: 103, type: 'basic' }, label: 'Basic Plan' },
+  ]
+
+  const booleanOptions = [
+    { value: true, label: 'Yes' },
+    { value: false, label: 'No' },
+  ]
+
+  const objectValueToString = (value: { id: number; type: string }) => `${value.id}-${value.type}`
+
+  return (
+    <FormWrapper
+      defaultValues={{
+        numericValue: 3,
+        objectValue: { id: 101, type: 'premium' },
+        booleanValue: true,
+      }}
+    >
+      <SelectField<number>
+        name="numericValue"
+        label="Numeric Value"
+        options={numericOptions}
+        placeholder="Select a numeric value"
+      />
+      <SelectField<{ id: number; type: string }>
+        name="objectValue"
+        label="Object Value"
+        options={objectOptions}
+        placeholder="Select a plan"
+        convertValueToString={objectValueToString}
+      />
+      <SelectField<boolean>
+        name="booleanValue"
+        label="Boolean Value"
+        options={booleanOptions}
+        placeholder="Select yes or no"
+      />
+    </FormWrapper>
+  )
+}

--- a/src/components/Common/Fields/SelectField/SelectField.tsx
+++ b/src/components/Common/Fields/SelectField/SelectField.tsx
@@ -1,30 +1,49 @@
 import { useField, type UseFieldProps } from '@/components/Common/Fields/hooks/useField'
-import type { SelectProps } from '@/components/Common/UI/Select/SelectTypes'
+import type { SelectOption, SelectProps } from '@/components/Common/UI/Select/SelectTypes'
 import { useComponentContext } from '@/contexts/ComponentAdapter/ComponentsProvider'
-interface SelectFieldProps
-  extends Omit<SelectProps, 'name' | 'value' | 'onChange' | 'onBlur'>,
-    UseFieldProps {}
+import {
+  useStringifyGenericFieldValue,
+  type OptionWithGenericValue,
+} from '@/components/Common/Fields/hooks/useStringifyGenericFieldValue'
 
-export const SelectField: React.FC<SelectFieldProps> = ({
+type GenericSelectOption<TValue> = OptionWithGenericValue<TValue, SelectOption>
+
+export interface SelectFieldProps<TValue>
+  extends Omit<SelectProps, 'name' | 'value' | 'onChange' | 'onBlur' | 'options'>,
+    UseFieldProps<TValue> {
+  options: GenericSelectOption<TValue>[]
+  convertValueToString?: (value: TValue) => string
+}
+
+export const SelectField = <TValue = string,>({
   rules,
   defaultValue,
   name,
   errorMessage,
   isRequired,
-  onChange,
+  onChange: onChangeFromProps,
   transform,
+  options,
+  convertValueToString,
   ...selectProps
-}: SelectFieldProps) => {
+}: SelectFieldProps<TValue>) => {
   const Components = useComponentContext()
-  const fieldProps = useField({
+  const { value, onChange, ...fieldProps } = useField<TValue>({
     name,
     rules,
     defaultValue,
     errorMessage,
     isRequired,
-    onChange,
+    onChange: onChangeFromProps,
     transform,
   })
 
-  return <Components.Select {...fieldProps} {...selectProps} />
+  const stringFieldProps = useStringifyGenericFieldValue<TValue, SelectOption>({
+    options,
+    value,
+    onChange,
+    convertValueToString,
+  })
+
+  return <Components.Select {...selectProps} {...fieldProps} {...stringFieldProps} />
 }

--- a/src/components/Common/Fields/SelectField/index.ts
+++ b/src/components/Common/Fields/SelectField/index.ts
@@ -1,1 +1,2 @@
 export { SelectField } from './SelectField'
+export type { SelectFieldProps } from './SelectField'

--- a/src/components/Common/Fields/hooks/useStringifyGenericFieldValue.test.tsx
+++ b/src/components/Common/Fields/hooks/useStringifyGenericFieldValue.test.tsx
@@ -1,0 +1,198 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, test, expect, vi } from 'vitest'
+import {
+  useStringifyGenericFieldValue,
+  useStringifyGenericFieldValueArray,
+} from './useStringifyGenericFieldValue'
+import type { ConvertValueToString } from './useStringifyGenericFieldValue'
+
+interface TestOption<TValue> {
+  label: string
+  value: TValue
+}
+
+interface ComplexValue {
+  id: number
+  name: string
+}
+
+describe('useStringifyGenericFieldValue', () => {
+  test('should convert option values to strings and handle selection', () => {
+    const options = [
+      { label: 'Option 1', value: 1 },
+      { label: 'Option 2', value: 2 },
+      { label: 'Option 3', value: 3 },
+    ]
+    const onChange = vi.fn()
+
+    const { result } = renderHook(() =>
+      useStringifyGenericFieldValue<number, TestOption<number>>({
+        options,
+        value: 2,
+        onChange,
+      }),
+    )
+
+    expect(result.current.options).toEqual([
+      { label: 'Option 1', value: '1' },
+      { label: 'Option 2', value: '2' },
+      { label: 'Option 3', value: '3' },
+    ])
+    expect(result.current.value).toBe('2')
+
+    act(() => {
+      result.current.onChange('1')
+    })
+    expect(onChange).toHaveBeenCalledWith(1)
+  })
+
+  test('should handle undefined values', () => {
+    const options = [
+      { label: 'Option 1', value: 1 },
+      { label: 'Option 2', value: 2 },
+    ]
+    const onChange = vi.fn()
+
+    const { result } = renderHook(() =>
+      useStringifyGenericFieldValue<number, TestOption<number>>({
+        options,
+        value: undefined,
+        onChange,
+      }),
+    )
+
+    expect(result.current.value).toBeUndefined()
+  })
+
+  test('should use custom convertValueToString function', () => {
+    const options = [
+      { label: 'Option 1', value: { id: 1, name: 'One' } },
+      { label: 'Option 2', value: { id: 2, name: 'Two' } },
+    ]
+    const onChange = vi.fn()
+    const convertValueToString: ConvertValueToString<ComplexValue> = value =>
+      `${value.id}-${value.name}`
+
+    const { result } = renderHook(() =>
+      useStringifyGenericFieldValue<ComplexValue, TestOption<ComplexValue>>({
+        options,
+        value: { id: 1, name: 'One' },
+        onChange,
+        convertValueToString,
+      }),
+    )
+
+    expect(result.current.value).toBe('1-One')
+
+    act(() => {
+      result.current.onChange('2-Two')
+    })
+
+    expect(onChange).toHaveBeenCalledWith({ id: 2, name: 'Two' })
+  })
+})
+
+describe('useStringifyGenericFieldValueArray', () => {
+  test('should handle array values and convert them to strings', () => {
+    const options = [
+      { label: 'Option 1', value: 1 },
+      { label: 'Option 2', value: 2 },
+      { label: 'Option 3', value: 3 },
+    ]
+    const onChange = vi.fn()
+
+    const { result } = renderHook(() =>
+      useStringifyGenericFieldValueArray<number, TestOption<number>>({
+        options,
+        value: [1, 3],
+        onChange,
+      }),
+    )
+
+    expect(result.current.options).toEqual([
+      { label: 'Option 1', value: '1' },
+      { label: 'Option 2', value: '2' },
+      { label: 'Option 3', value: '3' },
+    ])
+    expect(result.current.value).toEqual(['1', '3'])
+
+    act(() => {
+      result.current.onChange(['1', '2'])
+    })
+    expect(onChange).toHaveBeenCalledWith([1, 2])
+  })
+
+  test('should handle undefined array values', () => {
+    const options = [
+      { label: 'Option 1', value: 1 },
+      { label: 'Option 2', value: 2 },
+    ]
+    const onChange = vi.fn()
+
+    const { result } = renderHook(() =>
+      useStringifyGenericFieldValueArray<number, TestOption<number>>({
+        options,
+        value: undefined,
+        onChange,
+      }),
+    )
+
+    expect(result.current.value).toBeUndefined()
+  })
+
+  test('should use custom convertValueToString function with arrays', () => {
+    const options = [
+      { label: 'Option 1', value: { id: 1, name: 'One' } },
+      { label: 'Option 2', value: { id: 2, name: 'Two' } },
+      { label: 'Option 3', value: { id: 3, name: 'Three' } },
+    ]
+    const onChange = vi.fn()
+    const convertValueToString: ConvertValueToString<ComplexValue> = value =>
+      `${value.id}-${value.name}`
+
+    const { result } = renderHook(() =>
+      useStringifyGenericFieldValueArray<ComplexValue, TestOption<ComplexValue>>({
+        options,
+        value: [
+          { id: 1, name: 'One' },
+          { id: 3, name: 'Three' },
+        ],
+        onChange,
+        convertValueToString,
+      }),
+    )
+
+    expect(result.current.value).toEqual(['1-One', '3-Three'])
+
+    act(() => {
+      result.current.onChange(['1-One', '2-Two'])
+    })
+
+    expect(onChange).toHaveBeenCalledWith([
+      { id: 1, name: 'One' },
+      { id: 2, name: 'Two' },
+    ])
+  })
+
+  test('should filter out invalid values when converting back from strings', () => {
+    const options = [
+      { label: 'Option 1', value: 1 },
+      { label: 'Option 2', value: 2 },
+    ]
+    const onChange = vi.fn()
+
+    const { result } = renderHook(() =>
+      useStringifyGenericFieldValueArray<number, TestOption<number>>({
+        options,
+        value: [1],
+        onChange,
+      }),
+    )
+
+    act(() => {
+      result.current.onChange(['1', '3'])
+    })
+
+    expect(onChange).toHaveBeenCalledWith([1])
+  })
+})

--- a/src/components/Common/Fields/hooks/useStringifyGenericFieldValue.ts
+++ b/src/components/Common/Fields/hooks/useStringifyGenericFieldValue.ts
@@ -1,0 +1,119 @@
+import { useCallback, useMemo } from 'react'
+
+export type ConvertValueToString<TValue> = (value: TValue) => string
+
+export type OptionWithGenericValue<TValue, TOption> = Omit<TOption, 'value'> & {
+  value: TValue
+}
+
+interface UseStringifyOptionValuesProps<TValue, TOption> {
+  options: OptionWithGenericValue<TValue, TOption>[]
+  convertValueToString?: ConvertValueToString<TValue>
+}
+
+const defaultConvertValueToString = (value: unknown) => String(value)
+
+function useStringifyOptionValues<TValue, TOption>({
+  options,
+  convertValueToString = defaultConvertValueToString,
+}: UseStringifyOptionValuesProps<TValue, TOption>) {
+  return useMemo(() => {
+    const optionValuesMap: Record<string, OptionWithGenericValue<TValue, TOption>> = {}
+    const optionsWithStringValues = []
+
+    for (const option of options) {
+      const stringValue = convertValueToString(option.value)
+      optionValuesMap[stringValue] = option
+      const { value, ...restOptionsProps } = option
+
+      optionsWithStringValues.push({
+        value: stringValue,
+        ...restOptionsProps,
+      })
+    }
+
+    return { optionValuesMap, options: optionsWithStringValues }
+  }, [options, convertValueToString])
+}
+
+interface UseStringifyGenericFieldValueProps<TValue, TOption> {
+  options: OptionWithGenericValue<TValue, TOption>[]
+  value?: TValue
+  onChange: (value: TValue) => void
+  convertValueToString?: ConvertValueToString<TValue>
+}
+
+export function useStringifyGenericFieldValue<TValue, TOption>({
+  options,
+  value,
+  onChange,
+  convertValueToString = defaultConvertValueToString,
+}: UseStringifyGenericFieldValueProps<TValue, TOption>) {
+  const { optionValuesMap, options: optionsWithStringValues } = useStringifyOptionValues({
+    options,
+    convertValueToString,
+  })
+
+  const handleChange = useCallback(
+    (value: string) => {
+      const originalValue = optionValuesMap[value]?.value
+      if (typeof originalValue !== 'undefined') {
+        onChange(originalValue)
+      }
+    },
+    [optionValuesMap, onChange],
+  )
+
+  const stringValue =
+    value === null || typeof value === 'undefined' ? undefined : convertValueToString(value)
+
+  return {
+    options: optionsWithStringValues,
+    value: stringValue,
+    onChange: handleChange,
+  }
+}
+
+interface UseStringifyGenericFieldValueArrayProps<TValue, TOption> {
+  options: OptionWithGenericValue<TValue, TOption>[]
+  value?: TValue[]
+  onChange: (value: TValue[]) => void
+  convertValueToString?: ConvertValueToString<TValue>
+}
+
+export function useStringifyGenericFieldValueArray<TValue, TOption>({
+  options,
+  value,
+  onChange,
+  convertValueToString = defaultConvertValueToString,
+}: UseStringifyGenericFieldValueArrayProps<TValue, TOption>) {
+  const { optionValuesMap, options: optionsWithStringValues } = useStringifyOptionValues({
+    options,
+    convertValueToString,
+  })
+
+  const handleChange = useCallback(
+    (updatedStringValue: string[]) => {
+      const updatedValues = []
+
+      for (const stringValue of updatedStringValue) {
+        const value = optionValuesMap[stringValue]?.value
+
+        if (typeof value !== 'undefined') {
+          updatedValues.push(value)
+        }
+      }
+
+      onChange(updatedValues)
+    },
+    [optionValuesMap, onChange],
+  )
+
+  const stringValue = value ? value.map(convertValueToString) : value
+
+  return {
+    options: optionsWithStringValues,
+    value: stringValue,
+    onChange: handleChange,
+  }
+}

--- a/src/components/Common/TaxInputs/TaxInputs.tsx
+++ b/src/components/Common/TaxInputs/TaxInputs.tsx
@@ -1,6 +1,5 @@
 import DOMPurify from 'dompurify'
 import { Text } from 'react-aria-components'
-import { type Control } from 'react-hook-form'
 import type { EmployeeStateTaxQuestion } from '@gusto/embedded-api/models/components/employeestatetaxquestion'
 import { type TaxRequirement } from '@gusto/embedded-api/models/components/taxrequirement'
 import { SelectField } from '../Fields/SelectField/SelectField'
@@ -14,43 +13,47 @@ const dompurifyConfig = { ALLOWED_TAGS: ['a', 'b', 'strong'], ALLOWED_ATTR: ['ta
 interface EmpQ {
   question: NonNullable<EmployeeStateTaxQuestion>
   requirement?: never
-  control: Control
 }
 interface CompR {
   requirement: TaxRequirement
   question?: never
-  control: Control
 }
 
 type NumberFieldProps = { isCurrency?: boolean }
 
-export function SelectInput({ question, requirement, control }: EmpQ | CompR) {
+export function SelectInput({ question, requirement }: EmpQ | CompR) {
   const { key, label, description } = question ? question : requirement
   const value = question ? question.answers[0]?.value : requirement.value
 
   const meta = question ? question.inputQuestionFormat : requirement.metadata
   if (!meta?.options) throw new Error('Select input must have options')
+
+  if (!key) return null
+
   return (
     <SelectField
-      name={key as string}
-      defaultValue={(value as string) || ''}
+      name={key}
+      defaultValue={value}
       label={label as string}
       description={description}
+      isDisabled={key.includes('fileNewHireReport') ? (value === undefined ? false : true) : false}
       options={meta.options.map((item, _) => ({
-        value: String(item.value || ''),
+        value: item.value,
         label: item.label,
       }))}
     />
   )
 }
 
-export function TextInput({ question, requirement, control }: EmpQ | CompR) {
+export function TextInput({ question, requirement }: EmpQ | CompR) {
   const { key, label, description } = question ? question : requirement
   const value = question ? question.answers[0]?.value : requirement.value
 
+  if (!key) return null
+
   return (
     <TextInputField
-      name={key as string}
+      name={key}
       label={label}
       // @ts-expect-error HACK value is insufficiently narrowed here
       defaultValue={value}
@@ -66,9 +69,11 @@ export function NumberInput({
   const { key, label, description } = question ? question : requirement
   const value = question ? question.answers[0]?.value : requirement.value
 
+  if (!key) return null
+
   return (
     <NumberInputField
-      name={key as string}
+      name={key}
       label={label}
       description={description}
       defaultValue={Number(value)}
@@ -84,11 +89,14 @@ export function RadioInput({ question, requirement }: EmpQ | CompR) {
 
   const meta = question ? question.inputQuestionFormat : requirement.metadata
   if (!meta?.options) throw new Error(`RadioInput must have options:${JSON.stringify(question)}`)
+
+  if (!key) return null
+
   return (
     <RadioGroupField
-      name={key as string}
+      name={key}
       //File new hire report setting cannot be changed after it has been configured.
-      isDisabled={key?.includes('fileNewHireReport') ? (value === undefined ? false : true) : false}
+      isDisabled={key.includes('fileNewHireReport') ? (value === undefined ? false : true) : false}
       description={
         description && (
           <Text
@@ -99,21 +107,23 @@ export function RadioInput({ question, requirement }: EmpQ | CompR) {
       }
       label={label as string}
       options={meta.options.map(item => ({
-        value: item.value as string,
+        value: item.value,
         label: item.label,
       }))}
     />
   )
 }
 //TODO: This type is untested as of yet
-export function DateField({ question, requirement, control }: (EmpQ | CompR) & NumberFieldProps) {
+export function DateField({ question, requirement }: (EmpQ | CompR) & NumberFieldProps) {
   const { key, label, description } = question ? question : requirement
   const value = question ? question.answers[0]?.value : requirement.value
   if (typeof value !== 'string') throw new Error('Expecting value to be string for DateInput')
 
+  if (!key) return null
+
   return (
     <DatePickerField
-      name={key as string}
+      name={key}
       defaultValue={value ? new Date(value) : null}
       label={label as string}
       description={description}

--- a/src/components/Common/UI/CheckboxGroup/CheckboxGroupTypes.ts
+++ b/src/components/Common/UI/CheckboxGroup/CheckboxGroupTypes.ts
@@ -1,7 +1,7 @@
 import type { FieldsetHTMLAttributes, Ref } from 'react'
 import type { SharedFieldLayoutProps } from '../FieldLayout/FieldLayoutTypes'
 
-export type CheckboxGroupOptions = {
+export type CheckboxGroupOption = {
   label: React.ReactNode
   value: string
   isDisabled?: boolean
@@ -13,7 +13,7 @@ export interface CheckboxGroupProps
     Pick<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'className'> {
   isInvalid?: boolean
   isDisabled?: boolean
-  options: Array<CheckboxGroupOptions>
+  options: Array<CheckboxGroupOption>
   value?: string[]
   onChange?: (value: string[]) => void
   inputRef?: Ref<HTMLInputElement>

--- a/src/components/Common/UI/RadioGroup/RadioGroupTypes.ts
+++ b/src/components/Common/UI/RadioGroup/RadioGroupTypes.ts
@@ -1,7 +1,7 @@
 import type { FieldsetHTMLAttributes, Ref } from 'react'
 import type { SharedFieldLayoutProps } from '../FieldLayout/FieldLayoutTypes'
 
-export type RadioGroupOptions = {
+export type RadioGroupOption = {
   label: React.ReactNode
   value: string
   isDisabled?: boolean
@@ -13,7 +13,7 @@ export interface RadioGroupProps
     Pick<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'className'> {
   isInvalid?: boolean
   isDisabled?: boolean
-  options: Array<RadioGroupOptions>
+  options: Array<RadioGroupOption>
   value?: string
   onChange?: (value: string) => void
   inputRef?: Ref<HTMLInputElement>

--- a/src/components/Common/UI/Select/Select.module.scss
+++ b/src/components/Common/UI/Select/Select.module.scss
@@ -28,10 +28,6 @@
     }
   }
 
-  :global(.input-text-stack) {
-    @include inputTextStack;
-  }
-
   :global(.react-aria-Button) {
     border: var(--g-input-borderWidth) solid var(--g-input-borderColor);
     border-radius: var(--g-radius);
@@ -55,6 +51,12 @@
     &[data-pressed] {
       background-color: var(--g-colors-gray-100);
       color: var(--g-colors-gray-1000);
+    }
+
+    &[data-disabled] {
+      border-color: var(--g-input-disabled-border);
+      color: var(--g-input-disabled-color);
+      background-color: var(--g-input-disabled-bg);
     }
   }
 

--- a/src/components/Common/UI/Select/SelectTypes.ts
+++ b/src/components/Common/UI/Select/SelectTypes.ts
@@ -1,7 +1,7 @@
 import type { FocusEvent, Ref, SelectHTMLAttributes } from 'react'
 import type { SharedFieldLayoutProps } from '../FieldLayout/FieldLayoutTypes'
 
-export interface SelectItem {
+export interface SelectOption {
   value: string
   label: string
 }
@@ -14,7 +14,7 @@ export interface SelectProps
   label: string
   onChange?: (value: string) => void
   onBlur?: (e: FocusEvent) => void
-  options: SelectItem[]
+  options: SelectOption[]
   placeholder?: string
   value?: string
   inputRef?: Ref<HTMLButtonElement>

--- a/src/components/Common/UI/Switch/Switch.tsx
+++ b/src/components/Common/UI/Switch/Switch.tsx
@@ -17,6 +17,7 @@ export function Switch({
   isInvalid = false,
   isDisabled = false,
   id,
+  shouldVisuallyHideLabel,
   className,
   value,
   ...props
@@ -48,6 +49,7 @@ export function Switch({
       htmlFor={inputId}
       errorMessageId={errorMessageId}
       descriptionId={descriptionId}
+      shouldVisuallyHideLabel={shouldVisuallyHideLabel}
       className={classNames(styles.root, className)}
     >
       <_Switch

--- a/src/components/Employee/PaymentMethod/Split.tsx
+++ b/src/components/Employee/PaymentMethod/Split.tsx
@@ -122,10 +122,10 @@ export function Split() {
         label={t('splitByLabel')}
         onChange={value => {
           switch (value) {
-            case 'Percentage':
+            case SPLIT_BY.percentage:
               setValue('splitAmount', percentageValues)
               break
-            case 'Amount':
+            case SPLIT_BY.amount:
               setValue('splitAmount', amountValues)
               break
             default:

--- a/src/components/Employee/Taxes/StateForm.tsx
+++ b/src/components/Employee/Taxes/StateForm.tsx
@@ -1,5 +1,4 @@
 import { Fragment } from 'react/jsx-runtime'
-import { useFormContext, type Control } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import * as v from 'valibot'
 import type { EmployeeStateTaxQuestion } from '@gusto/embedded-api/models/components/employeestatetaxquestion'
@@ -16,27 +15,25 @@ export type StateFormPayload = v.InferOutput<typeof StateFormSchema>
 
 function QuestionInput({
   question,
-  control,
   questionType,
 }: {
   question: EmployeeStateTaxQuestion
-  control: Control
   questionType: string
 }) {
   switch (questionType) {
     case 'Date':
-      return <TaxInputs.DateField question={question} control={control} />
+      return <TaxInputs.DateField question={question} />
     case 'Radio':
-      return <TaxInputs.RadioInput question={question} control={control} />
+      return <TaxInputs.RadioInput question={question} />
     case 'Autocomplete': //TODO: Need an example Autocomplete response to implement this component. For now falling back to Text
     case 'Text':
-      return <TaxInputs.TextInput question={question} control={control} />
+      return <TaxInputs.TextInput question={question} />
     case 'Select':
-      return <TaxInputs.SelectInput question={question} control={control} />
+      return <TaxInputs.SelectInput question={question} />
     case 'Number':
-      return <TaxInputs.NumberInput question={question} control={control} />
+      return <TaxInputs.NumberInput question={question} />
     case 'Currency':
-      return <TaxInputs.NumberInput question={question} isCurrency control={control} />
+      return <TaxInputs.NumberInput question={question} isCurrency />
     default:
       return null
   }
@@ -44,7 +41,6 @@ function QuestionInput({
 
 export const StateForm = () => {
   const { employeeStateTaxes, isAdmin } = useTaxes()
-  const { control } = useFormContext()
   const { t } = useTranslation('Employee.Taxes')
   const { t: statesHash } = useTranslation('common', { keyPrefix: 'statesHash' })
 
@@ -64,7 +60,6 @@ export const StateForm = () => {
               question.key === 'fileNewHireReport' ? 'Radio' : question.inputQuestionFormat.type
             }
             key={question.key}
-            control={control}
           />
         )
       })}


### PR DESCRIPTION
This PR updates our field components to support generic values. This was necessary for our field components to work with the state tax forms.

This change takes place in the field components instead of the UI components directly. This is because we want to make the contract between us and consumers as simple as possible. This makes it so that for components with options, they just support a consistent case with a string value and options that will have a string value inside corresponding. We take on all the complexity of managing generic types and ensuring that they map to string values.

This PR centralizes that logic inside of a hook and applies it to each component where generic values make sense including
* RadioGroupField
* CheckboxGroupField
* ComboBoxField
* SelectField

This also restores logic to disable the file new hire report when it has already been set for an employee

## Proof of functionality

### File new hire report disabled
<img width="1007" alt="Screenshot 2025-04-21 at 3 52 01 PM" src="https://github.com/user-attachments/assets/793f9df9-a2d8-4f90-837d-c624a99ded8e" />

### File new hire report select input working
This is a good test case since this is set as a boolean value

https://github.com/user-attachments/assets/0b206bb2-6328-401d-8afc-ddc7508906fa

### Ladle instances examples with generic typed values

https://github.com/user-attachments/assets/7897dc62-6bf0-4e6d-acb7-465118fafff3

Uploading Screen Recording 2025-04-21 at 3.51.28 PM.mov…
