### PR TITLE
fix: allow for non active fallback address in profile for self onboard

### DIFF
--- a/src/components/Employee/Profile/Profile.tsx
+++ b/src/components/Employee/Profile/Profile.tsx
@@ -30,6 +30,7 @@ import { Actions } from './Actions'
 import { HomeAddress, HomeAddressSchema, type HomeAddressInputs } from './HomeAddress'
 import { WorkAddress } from './WorkAddress'
 import { ProfileProvider } from './useProfile'
+import { getEmployeeAddressForProfile } from './getEmployeeAddressForProfile'
 import {
   useBase,
   BaseComponent,
@@ -157,9 +158,8 @@ const Root = ({
 
   const existingData = { employee, workAddresses, homeAddresses }
 
-  const currentHomeAddress = homeAddresses
-    ? homeAddresses.find(address => address.active)
-    : undefined
+  const currentHomeAddress = getEmployeeAddressForProfile(homeAddresses)
+
   const currentWorkAddress = existingData.workAddresses?.find(address => address.active)
   const mergedData = useRef({
     employee: existingData.employee,

--- a/src/components/Employee/Profile/getEmployeeAddressForProfile.test.ts
+++ b/src/components/Employee/Profile/getEmployeeAddressForProfile.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { getEmployeeAddressForProfile } from './getEmployeeAddressForProfile'
+import { type EmployeeAddress } from '@gusto/embedded-api/models/components/employeeaddress'
+
+describe('getEmployeeAddressForProfile', () => {
+  it('should return undefined when no addresses are provided', () => {
+    expect(getEmployeeAddressForProfile([])).toBeUndefined()
+  })
+
+  it('should return the only address when there is exactly one', () => {
+    const address: EmployeeAddress = {
+      active: false,
+      uuid: '1',
+      employeeUuid: '1',
+      street1: '123 Main St',
+    }
+
+    expect(getEmployeeAddressForProfile([address])).toBe(address)
+  })
+
+  it('should return the active address when multiple addresses exist', () => {
+    const inactiveAddress: EmployeeAddress = {
+      active: false,
+      uuid: '1',
+      employeeUuid: '1',
+      street1: '123 Main St',
+    }
+    const anotherInactiveAddress: EmployeeAddress = {
+      active: false,
+      uuid: '2',
+      employeeUuid: '1',
+      street1: '123 Main St',
+    }
+    const activeAddress: EmployeeAddress = {
+      active: true,
+      uuid: '3',
+      employeeUuid: '1',
+      street1: '123 Main St',
+    }
+
+    expect(
+      getEmployeeAddressForProfile([inactiveAddress, anotherInactiveAddress, activeAddress]),
+    ).toBe(activeAddress)
+  })
+
+  it('should return the first address when multiple inactive addresses exist', () => {
+    const firstAddress: EmployeeAddress = {
+      active: false,
+      uuid: '1',
+      employeeUuid: '1',
+      street1: '123 Main St',
+    }
+    const secondAddress: EmployeeAddress = {
+      active: false,
+      uuid: '2',
+      employeeUuid: '1',
+      street1: '123 Main St',
+    }
+
+    expect(getEmployeeAddressForProfile([firstAddress, secondAddress])).toBe(firstAddress)
+  })
+})

--- a/src/components/Employee/Profile/getEmployeeAddressForProfile.ts
+++ b/src/components/Employee/Profile/getEmployeeAddressForProfile.ts
@@ -1,0 +1,12 @@
+import { type EmployeeAddress } from '@gusto/embedded-api/models/components/employeeaddress'
+
+export const getEmployeeAddressForProfile = (homeAddresses?: EmployeeAddress[]) => {
+  if (!homeAddresses || homeAddresses.length === 0) {
+    return undefined
+  }
+
+  // Either return the active address or the first address if there is no active address
+  // The first address will either be the only address or the one with the earliest effective date
+  // since the backend returns them sorted by effective date
+  return homeAddresses.find(address => address.active) ?? homeAddresses[0]
+}


### PR DESCRIPTION
For self onboarding, we were experiencing an "Effective date is required" issue for users under the following circumstances
* They are invited to self onboard
* Their admin has filled out the compensation step
* They have submitted their profile with their address
* They refresh the flow and start from the beginning

Under the above circumstances, users were getting an error for "Effective date is required" when attempting to submit a profile update and were blocked from continuing the flow.

This PR provides a fix by ensuring an address is supplied when present even if it is not necessarily active. This ensures that the address is updated properly.

## Further context

* This issue was occurring because we were filtering all addresses out by active
* Address being active is determined by if the effective date is today or in the past ([See ZP code reference here](https://github.com/Gusto/zenpayroll/blob/ef341da922644fb5cd75b1dfb39ea2965c4d6ae5/packs/technical_services/addresses/addresses/app/public/addresses/employees/home_address.rb#L77-L79))
* You are able to create an address once without explicitly setting an effective date
* When you create an address without an effective date, it defaults to the work start date (this is desired behavior for external payroll reasons and correct taxation)
* If you attempt to create _an additional address_ after this, you are required to manually specify a start date

### What was happening in our case?
* We were filtering out home addresses if they are not active
* Home address is only active when it is today or in the past
* When the user submitted the profile the first time in self onboarding under the above circumstances, the effective date was in the future, which meant that the address was not set to active
* When the user attempted to submit the profile the second time, instead of updating the address (desired behavior) we were creating an address since the component filtered out all addresses since there's no active one
* Since we were creating an address, we were getting the error for effective date, since effective date is required when you have already created an address once without an effective date

### How do we fix it?
One option was to set the effective_date to today. We were advised to not do that though for external payrolls reasons and correct taxation. Instead, we allow for referencing addresses beyond just active. We give preference to the active address, but if it is not present we can fallback to the first entry in the work address array. This will either be the only entry (corresponding to the one they have already provided in onboarding) or it will be an entry with the soonest effective date present (since these are sorted on the backend)

## Proof of functionality

### Before
Observe how this user in self onboarding has no address information present. They previously already filled out address information, but it is getting filtered out because the effective date is in the future so it is not active. This means that it attempts to create an additional new address which fails with the error:

https://github.com/user-attachments/assets/998f510e-ffb5-4501-89e7-7ba40cb68f2f

### After
Observe the self onboarding user submit the profile once, refresh, reenter the flow, and resubmit the profile successfully without issues

https://github.com/user-attachments/assets/3124e9f2-7522-489c-adb3-c3cf314406db
