### PR TITLE
chore: update to no longer have onClick with Link

### DIFF
--- a/src/components/Common/UI/Link/LinkTypes.ts
+++ b/src/components/Common/UI/Link/LinkTypes.ts
@@ -9,7 +9,6 @@ export type LinkProps = Pick<
   | 'children'
   | 'className'
   | 'id'
-  | 'onClick'
   | 'onKeyDown'
   | 'onKeyUp'
   | 'aria-label'


### PR DESCRIPTION
React Aria Link does not actually accept onClick even though it is supported by native `a` tags. Because we are still using React Aria Link, this updates to just remove it from the component API for now.

## Further notes
This wasn't getting caught for some reason due to using the spread operator. When destructuring onClick directly, it gets the error as expected. This merits more investigation into tsc on various machines and why we are seeing inconsistencies.

<img width="1285" alt="Screenshot 2025-04-28 at 8 55 48 AM" src="https://github.com/user-attachments/assets/d747172c-6ef4-48ff-9bc4-1acaefc07bd4" />
