### PR TITLE
chore: surface component adapter interfaces

### DIFF
--- a/src/components/Common/DataView/DataView.stories.tsx
+++ b/src/components/Common/DataView/DataView.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from '@ladle/react'
 import { DataView } from '@/components/Common/DataView/DataView'
 import { useDataView } from '@/components/Common/DataView/useDataView'
-import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
 import PencilSvg from '@/assets/icons/pencil.svg?react'
 
@@ -157,8 +157,6 @@ export const DataViewSelectable = () => {
 }
 
 export const DataViewWithMenu = () => {
-  const Components = useComponentContext()
-
   const { ...dataProps } = useDataView({
     data: compensationData,
     columns: [
@@ -169,7 +167,7 @@ export const DataViewWithMenu = () => {
     ],
     itemMenu: item => {
       return (
-        <Components.HamburgerMenu
+        <HamburgerMenu
           items={[
             { label: 'Edit', icon: <PencilSvg aria-hidden />, onClick: () => {} },
             { label: 'Delete', icon: <TrashCanSvg aria-hidden />, onClick: () => {} },
@@ -183,8 +181,6 @@ export const DataViewWithMenu = () => {
 }
 
 export const DataViewSelectableWithMenu = () => {
-  const Components = useComponentContext()
-
   const { ...dataProps } = useDataView({
     data: compensationData,
     columns: [
@@ -195,7 +191,7 @@ export const DataViewSelectableWithMenu = () => {
     ],
     itemMenu: item => {
       return (
-        <Components.HamburgerMenu
+        <HamburgerMenu
           items={[
             { label: 'Edit', icon: <PencilSvg aria-hidden />, onClick: () => {} },
             { label: 'Delete', icon: <TrashCanSvg aria-hidden />, onClick: () => {} },

--- a/src/components/Common/UI/Card/Card.stories.tsx
+++ b/src/components/Common/UI/Card/Card.stories.tsx
@@ -3,7 +3,7 @@ import type { Story } from '@ladle/react'
 import type { CardProps } from './CardTypes'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
-
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 export default {
   title: 'UI/Components/Card',
 }
@@ -58,9 +58,8 @@ const CardContent = () => (
 )
 
 const CardMenu = () => {
-  const Components = useComponentContext()
   return (
-    <Components.HamburgerMenu
+    <HamburgerMenu
       items={[
         { label: 'View', onClick: () => {} },
         { label: 'Edit', onClick: () => {} },

--- a/src/components/Common/UI/Table/Table.stories.tsx
+++ b/src/components/Common/UI/Table/Table.stories.tsx
@@ -2,6 +2,7 @@ import type { Story } from '@ladle/react'
 import { action } from '@ladle/react'
 import { Badge } from '../Badge/Badge'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
 import PencilSvg from '@/assets/icons/pencil.svg?react'
 
@@ -47,7 +48,6 @@ export const Default: Story = () => {
 
 export const WithSelectAndItemMenu: Story = () => {
   const { Table } = useComponentContext()
-  const Components = useComponentContext()
 
   const data: User[] = [
     { id: 1, name: 'John Doe', email: 'john@example.com', role: 'Admin' },
@@ -67,7 +67,7 @@ export const WithSelectAndItemMenu: Story = () => {
   }
 
   const itemMenu = (item: User) => (
-    <Components.HamburgerMenu
+    <HamburgerMenu
       items={[
         {
           label: 'Edit',
@@ -100,7 +100,6 @@ export const WithSelectAndItemMenu: Story = () => {
 
 export const WithItemMenu: Story = () => {
   const { Table } = useComponentContext()
-  const Components = useComponentContext()
 
   const data: User[] = [
     { id: 1, name: 'John Doe', email: 'john@example.com', role: 'Admin' },
@@ -116,7 +115,7 @@ export const WithItemMenu: Story = () => {
   ]
 
   const itemMenu = (item: User) => (
-    <Components.HamburgerMenu
+    <HamburgerMenu
       items={[
         {
           label: 'Edit',
@@ -189,7 +188,6 @@ export const EmptyState: Story = () => {
 
 export const ComplexTable: Story = () => {
   const { Table } = useComponentContext()
-  const Components = useComponentContext()
 
   const payrollData: EmployeePayroll[] = [
     {
@@ -277,7 +275,7 @@ export const ComplexTable: Story = () => {
   ]
 
   const itemMenu = (item: EmployeePayroll) => (
-    <Components.HamburgerMenu
+    <HamburgerMenu
       items={[
         {
           label: 'Edit',

--- a/src/components/Company/Locations/LocationsList/List.tsx
+++ b/src/components/Company/Locations/LocationsList/List.tsx
@@ -4,6 +4,7 @@ import { useLocationsList } from './useLocationsList'
 import PencilSvg from '@/assets/icons/pencil.svg?react'
 import { DataView, EmptyData, useDataView } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import { getCityStateZip, getStreet } from '@/helpers/formattedStrings'
 
 /**List of employees slot for EmployeeList component */
@@ -60,7 +61,7 @@ export const List = () => {
     ],
     itemMenu: location => {
       return (
-        <Components.HamburgerMenu
+        <HamburgerMenu
           items={[
             {
               label: t('editCta'),

--- a/src/components/Company/PaySchedule/_parts/List.tsx
+++ b/src/components/Company/PaySchedule/_parts/List.tsx
@@ -4,6 +4,7 @@ import { usePaySchedule } from '../usePaySchedule'
 import { useDataView, DataView, Flex } from '@/components/Common'
 import PencilSvg from '@/assets/icons/pencil.svg?react'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 
 export const List = () => {
   const { t } = useTranslation('Company.PaySchedule')
@@ -51,7 +52,7 @@ export const List = () => {
         key: 'actions',
         render: schedule => {
           return (
-            <Components.HamburgerMenu
+            <HamburgerMenu
               triggerLabel="Actions"
               items={[
                 {

--- a/src/components/Employee/Compensation/List.tsx
+++ b/src/components/Employee/Compensation/List.tsx
@@ -4,6 +4,7 @@ import { useCompensation } from './useCompensation'
 import PencilSvg from '@/assets/icons/pencil.svg?react'
 import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 
 export const List = () => {
   const { employeeJobs, mode, isPending, handleEdit, handleDelete } = useCompensation()
@@ -42,7 +43,7 @@ export const List = () => {
       key: 'actions',
       title: <VisuallyHidden>{t('allCompensations.actionColumn')}</VisuallyHidden>,
       render: (job: (typeof employeeJobs)[0]) => (
-        <Components.HamburgerMenu
+        <HamburgerMenu
           triggerLabel={t('hamburgerTitle')}
           items={[
             {

--- a/src/components/Employee/Deductions/DeductionsList.tsx
+++ b/src/components/Employee/Deductions/DeductionsList.tsx
@@ -5,14 +5,13 @@ import { useDataView, DataView } from '@/components/Common'
 import useNumberFormatter from '@/components/Common/hooks/useNumberFormatter'
 import PencilSvg from '@/assets/icons/pencil.svg?react'
 import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
-import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 
 export const DeductionsList: React.FC = () => {
   const { mode, deductions, handleDelete, handleEdit, isPending } = useDeductions()
   const { t } = useTranslation('Employee.Deductions')
   const formatCurrency = useNumberFormatter('currency')
   const formatPercent = useNumberFormatter('percent')
-  const Components = useComponentContext()
 
   const activeDeductions = deductions.filter(deduction => deduction.active)
 
@@ -42,7 +41,7 @@ export const DeductionsList: React.FC = () => {
     ],
     itemMenu: deduction => {
       return (
-        <Components.HamburgerMenu
+        <HamburgerMenu
           isLoading={isPending}
           items={[
             {

--- a/src/components/Employee/EmployeeList/List.tsx
+++ b/src/components/Employee/EmployeeList/List.tsx
@@ -4,6 +4,7 @@ import style from './List.module.scss'
 import { useEmployeeList } from './useEmployeeList'
 import { DataView, EmptyData, ActionsLayout, useDataView } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import PencilSvg from '@/assets/icons/pencil.svg?react'
 import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
 import { EmployeeOnboardingStatus, EmployeeSelfOnboardingStatuses } from '@/shared/constants'
@@ -121,7 +122,7 @@ export const List = () => {
       }
 
       return (
-        <Components.HamburgerMenu
+        <HamburgerMenu
           items={menuItems}
           triggerLabel={t('hamburgerTitle')}
           isLoading={deleting.has(employee.uuid)}

--- a/src/components/Employee/PaymentMethod/BankAccountsList.tsx
+++ b/src/components/Employee/PaymentMethod/BankAccountsList.tsx
@@ -3,13 +3,12 @@ import { usePaymentMethod } from './usePaymentMethod'
 import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
 import { DataView, useDataView } from '@/components/Common'
 import useNumberFormatter from '@/components/Common/hooks/useNumberFormatter'
-import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 
 export function BankAccountsList() {
   const { bankAccounts, paymentMethod, mode, handleDelete, isPending } = usePaymentMethod()
   const { t } = useTranslation('Employee.PaymentMethod')
   const format = useNumberFormatter(paymentMethod.splitBy === 'Amount' ? 'currency' : 'percent')
-  const Components = useComponentContext()
 
   const { ...dataViewProps } = useDataView({
     data: bankAccounts,
@@ -29,7 +28,7 @@ export function BankAccountsList() {
     ],
     itemMenu: bankAccount => {
       return (
-        <Components.HamburgerMenu
+        <HamburgerMenu
           items={[
             {
               label: t('deleteBankAccountCTA'),

--- a/src/contexts/ComponentAdapter/ComponentsProvider.tsx
+++ b/src/contexts/ComponentAdapter/ComponentsProvider.tsx
@@ -2,11 +2,10 @@ import type React from 'react'
 import { useMemo } from 'react'
 import type { ComponentsContextType } from './useComponentContext'
 import { ComponentsContext } from './useComponentContext'
-import { internalComponents } from './adapters/internalComponentAdapter'
 
 interface ComponentsProviderProps {
   children: React.ReactNode
-  value: ComponentsContextType
+  value: ComponentsContextType | undefined
 }
 
 export const ComponentsProvider = ({ children, value }: ComponentsProviderProps) => {
@@ -15,8 +14,6 @@ export const ComponentsProvider = ({ children, value }: ComponentsProviderProps)
   }, [value]) // This is intentional to make the component context immutable
 
   return (
-    <ComponentsContext.Provider value={{ ...contextValue, ...internalComponents }}>
-      {children}
-    </ComponentsContext.Provider>
+    <ComponentsContext.Provider value={contextValue ?? null}>{children}</ComponentsContext.Provider>
   )
 }

--- a/src/contexts/ComponentAdapter/adapters/internalComponentAdapter.tsx
+++ b/src/contexts/ComponentAdapter/adapters/internalComponentAdapter.tsx
@@ -1,7 +1,0 @@
-import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
-import type { HamburgerMenuProps } from '@/components/Common/HamburgerMenu/HamburgerMenuTypes'
-import type { InternalComponentsContextType } from '@/contexts/ComponentAdapter/useComponentContext'
-
-export const internalComponents: InternalComponentsContextType = {
-  HamburgerMenu: (props: HamburgerMenuProps) => <HamburgerMenu {...props} />,
-}

--- a/src/contexts/ComponentAdapter/componentAdapterTypes.ts
+++ b/src/contexts/ComponentAdapter/componentAdapterTypes.ts
@@ -1,0 +1,32 @@
+export type { BreadcrumbsProps, Crumb } from '@/components/Common/UI/Breadcrumb/BreadcrumbTypes'
+export type { ButtonProps, ButtonIconProps } from '@/components/Common/UI/Button/ButtonTypes'
+export type { CardProps } from '@/components/Common/UI/Card/CardTypes'
+export type { CheckboxProps } from '@/components/Common/UI/Checkbox/CheckboxTypes'
+export type {
+  CheckboxGroupProps,
+  CheckboxGroupOption,
+} from '@/components/Common/UI/CheckboxGroup/CheckboxGroupTypes'
+export type { ComboBoxProps, ComboBoxOption } from '@/components/Common/UI/ComboBox/ComboBoxTypes'
+export type { DatePickerProps } from '@/components/Common/UI/DatePicker/DatePickerTypes'
+export type { LinkProps } from '@/components/Common/UI/Link/LinkTypes'
+export type { MenuProps, MenuItem } from '@/components/Common/UI/Menu/MenuTypes'
+export type { NumberInputProps } from '@/components/Common/UI/NumberInput/NumberInputTypes'
+export type { RadioProps } from '@/components/Common/UI/Radio/RadioTypes'
+export type {
+  RadioGroupProps,
+  RadioGroupOption,
+} from '@/components/Common/UI/RadioGroup/RadioGroupTypes'
+export type { SelectProps, SelectOption } from '@/components/Common/UI/Select/SelectTypes'
+export type { SwitchProps } from '@/components/Common/UI/Switch/SwitchTypes'
+export type {
+  TableProps,
+  TableColumn,
+  TableHeadProps,
+  TableBodyProps,
+  TableRowProps,
+  TableHeaderProps,
+  TableCellProps,
+} from '@/components/Common/UI/Table/TableTypes'
+export type { TextInputProps } from '@/components/Common/UI/TextInput/TextInputTypes'
+export type { AlertProps } from '@/components/Common/UI/Alert/AlertTypes'
+export type { BadgeProps } from '@/components/Common/UI/Badge/BadgeTypes'

--- a/src/contexts/ComponentAdapter/useComponentContext.ts
+++ b/src/contexts/ComponentAdapter/useComponentContext.ts
@@ -17,7 +17,6 @@ import type { CardProps } from '@/components/Common/UI/Card/CardTypes'
 import type { LinkProps } from '@/components/Common/UI/Link/LinkTypes'
 import type { BadgeProps } from '@/components/Common/UI/Badge/BadgeTypes'
 import type { MenuProps } from '@/components/Common/UI/Menu/MenuTypes'
-import type { HamburgerMenuProps } from '@/components/Common/HamburgerMenu/HamburgerMenuTypes'
 import type { TableProps } from '@/components/Common/UI/Table'
 
 export interface ComponentsContextType {
@@ -42,13 +41,7 @@ export interface ComponentsContextType {
   Table: <T>(props: TableProps<T>) => JSX.Element | null
 }
 
-export interface InternalComponentsContextType {
-  HamburgerMenu: (props: HamburgerMenuProps) => JSX.Element | null
-}
-
-interface AllComponentsContextType extends ComponentsContextType, InternalComponentsContextType {}
-
-export const ComponentsContext = createContext<AllComponentsContextType | null>(null)
+export const ComponentsContext = createContext<ComponentsContextType | null>(null)
 
 export const useComponentContext = () => {
   const context = useContext(ComponentsContext)

--- a/src/contexts/GustoProvider/GustoProvider.tsx
+++ b/src/contexts/GustoProvider/GustoProvider.tsx
@@ -1,16 +1,18 @@
 import type React from 'react'
 import { defaultComponents } from '../ComponentAdapter/adapters/defaultComponentAdapter'
+import type { ComponentsContextType } from '../ComponentAdapter/useComponentContext'
 import {
   GustoProviderCustomUIAdapter,
   type GustoProviderProps,
 } from './GustoProviderCustomUIAdapter'
 
-export interface GustoApiProps extends GustoProviderProps {
+export interface GustoApiProps extends Omit<GustoProviderProps, 'components'> {
+  components?: Partial<ComponentsContextType>
   children?: React.ReactNode
 }
 
 const GustoProvider: React.FC<GustoApiProps> = props => {
-  const { children, components, ...remainingProps } = props
+  const { children, components = {}, ...remainingProps } = props
 
   const mergedComponents = {
     ...defaultComponents,

--- a/src/contexts/GustoProvider/GustoProviderCustomUIAdapter.tsx
+++ b/src/contexts/GustoProvider/GustoProviderCustomUIAdapter.tsx
@@ -34,7 +34,7 @@ export interface GustoProviderProps {
   currency?: string
   theme?: DeepPartial<GTheme>
   queryClient?: QueryClient
-  components?: Partial<ComponentsContextType>
+  components: ComponentsContextType
 }
 
 export interface GustoProviderCustomUIAdapterProps extends GustoProviderProps {
@@ -80,7 +80,7 @@ const GustoProviderCustomUIAdapter: React.FC<GustoProviderCustomUIAdapterProps> 
   }, [lng])
 
   return (
-    <ComponentsProvider value={components as ComponentsContextType}>
+    <ComponentsProvider value={components}>
       <ErrorBoundary FallbackComponent={InternalError}>
         <ThemeProvider theme={theme}>
           <LocaleProvider locale={locale} currency={currency}>

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,0 +1,4 @@
+export { GustoApiProvider } from './GustoApiProvider'
+export { GustoProvider, GustoProviderCustomUIAdapter } from './GustoProvider'
+export type { ComponentsContextType } from './ComponentAdapter/useComponentContext'
+export * from './ComponentAdapter/componentAdapterTypes'

--- a/src/contexts/index.tsx
+++ b/src/contexts/index.tsx
@@ -1,1 +1,0 @@
-export { GustoApiProvider } from './GustoApiProvider'


### PR DESCRIPTION
This PR updates to surface exports needed to implement the adapter pattern locally. This includes exposing exports for
* ComponentContextType
* All UI component types
* GustoProvider and GustoProviderCustomUIAdapter

This also takes care of updating HamburgerMenu to just get imported from the common directory instead of implementing it as an internal component for component context. This internal component implementation was not necessary since we can just import these components from the common directory instead of getting them from context.