### PR TITLE
feat: add Heading component and implement adapter

### DIFF
--- a/.ladle/adapters/PlainComponentAdapter.tsx
+++ b/.ladle/adapters/PlainComponentAdapter.tsx
@@ -22,6 +22,7 @@ import type { ComponentsContextType } from '@/contexts/ComponentAdapter/useCompo
 import type { MenuProps } from '@/components/Common/UI/Menu/MenuTypes'
 import type { BreadcrumbsProps } from '@/components/Common/UI/Breadcrumb'
 import type { TableProps } from '@/components/Common/UI/Table'
+import type { HeadingProps } from '@/components/Common/UI/Heading/HeadingTypes'
 
 export const PlainComponentAdapter: ComponentsContextType = {
   Alert: ({ label, children, status = 'info', icon }: AlertProps) => {
@@ -981,5 +982,25 @@ export const PlainComponentAdapter: ComponentsContextType = {
         ))}
       </ul>
     )
+  },
+
+  Heading: ({ as: Component, styledAs, textAlign, children }: HeadingProps) => {
+    const levelStyles = styledAs ?? Component
+
+    const fontSizes = {
+      h1: '2rem',
+      h2: '1.5rem',
+      h3: '1.25rem',
+      h4: '1rem',
+      h5: '0.875rem',
+      h6: '0.75rem',
+    }
+
+    const headingStyles = {
+      textAlign: textAlign,
+      fontSize: fontSizes[levelStyles],
+    }
+
+    return <Component style={headingStyles}>{children}</Component>
   },
 }

--- a/src/components/Common/DataView/DataCards/DataCards.module.scss
+++ b/src/components/Common/DataView/DataCards/DataCards.module.scss
@@ -2,5 +2,5 @@ h5.columnTitle {
   font-size: var(--g-card-columnTitleFontSize);
   font-weight: var(--g-typography-fontWeight-medium);
   color: var(--g-card-columnTitleColor);
-  margin-top: 0;
+  margin: 0;
 }

--- a/src/components/Common/DataView/DataCards/DataCards.tsx
+++ b/src/components/Common/DataView/DataCards/DataCards.tsx
@@ -1,4 +1,3 @@
-import { Heading } from 'react-aria-components'
 import styles from './DataCards.module.scss'
 import type { useDataViewPropReturn } from '@/components/Common/DataView/useDataView'
 import { Flex } from '@/components/Common/Flex/Flex'
@@ -37,9 +36,7 @@ export const DataCards = <T,>({
           >
             {columns.map((column, index) => (
               <Flex key={index} flexDirection="column" gap={0}>
-                <Heading className={styles.columnTitle} level={5}>
-                  {column.title}
-                </Heading>
+                <h5 className={styles.columnTitle}>{column.title}</h5>
                 <div className={styles.columnData}>
                   {' '}
                   {column.render ? column.render(item) : String(item[column.key as keyof T])}

--- a/src/components/Common/InternalError/InternalError.module.scss
+++ b/src/components/Common/InternalError/InternalError.module.scss
@@ -1,5 +1,4 @@
-h1 {
-  font-size: toRem(21) !important;
+.internalErrorCardTitle {
   color: var(--g-colors-gray-1000);
 }
 

--- a/src/components/Common/InternalError/InternalError.stories.tsx
+++ b/src/components/Common/InternalError/InternalError.stories.tsx
@@ -1,0 +1,13 @@
+import type { Story } from '@ladle/react'
+import { InternalError } from './InternalError'
+
+export default {
+  title: 'Common/InternalError',
+}
+
+const mockError = new Error('This is a mock error message')
+const mockResetHandler = () => {}
+
+export const DefaultError: Story = () => {
+  return <InternalError error={mockError} resetErrorBoundary={mockResetHandler} />
+}

--- a/src/components/Common/InternalError/InternalError.tsx
+++ b/src/components/Common/InternalError/InternalError.tsx
@@ -17,7 +17,9 @@ export const InternalError = ({ error, resetErrorBoundary }: FallbackProps) => {
   return (
     <div className={styles.internalErrorCard} role="alert" data-testid="internal-error-card">
       <div>
-        <h1 className={styles.internalErrorCardTitle}>{t('errors.errorHeading')}</h1>
+        <Components.Heading className={styles.internalErrorCardTitle} as="h1" styledAs="h3">
+          {t('errors.errorHeading')}
+        </Components.Heading>
         <p className={styles.errorMessage}>
           <Trans
             t={t}

--- a/src/components/Common/UI/Card/Card.stories.tsx
+++ b/src/components/Common/UI/Card/Card.stories.tsx
@@ -1,4 +1,3 @@
-import { Heading } from 'react-aria-components'
 import type { Story } from '@ladle/react'
 import type { CardProps } from './CardTypes'
 import { Flex } from '@/components/Common/Flex/Flex'
@@ -8,54 +7,37 @@ export default {
   title: 'UI/Components/Card',
 }
 
-const CardContent = () => (
-  <>
-    <Flex flexDirection="column" gap={4}>
-      <Heading
-        level={5}
-        style={{
-          marginTop: 0,
-        }}
-      >
-        Job title
-      </Heading>
-      <div>Administrator</div>
-    </Flex>
-    <Flex flexDirection="column" gap={4}>
-      <Heading
-        level={5}
-        style={{
-          marginTop: 0,
-        }}
-      >
-        Pay type
-      </Heading>
-      <div>By the hour</div>
-    </Flex>
-    <Flex flexDirection="column" gap={4}>
-      <Heading
-        level={5}
-        style={{
-          marginTop: 0,
-        }}
-      >
-        Amount
-      </Heading>
-      <div>$32.00</div>
-    </Flex>
-    <Flex flexDirection="column" gap={4}>
-      <Heading
-        level={5}
-        style={{
-          marginTop: 0,
-        }}
-      >
-        Pay time period
-      </Heading>
-      <div>Annually</div>
-    </Flex>
-  </>
-)
+function CardContent() {
+  const Components = useComponentContext()
+  return (
+    <>
+      <Flex flexDirection="column" gap={4}>
+        <Components.Heading as="h5" styledAs="h6">
+          Job title
+        </Components.Heading>
+        <div>Administrator</div>
+      </Flex>
+      <Flex flexDirection="column" gap={4}>
+        <Components.Heading as="h5" styledAs="h6">
+          Pay type
+        </Components.Heading>
+        <div>By the hour</div>
+      </Flex>
+      <Flex flexDirection="column" gap={4}>
+        <Components.Heading as="h5" styledAs="h6">
+          Amount
+        </Components.Heading>
+        <div>$32.00</div>
+      </Flex>
+      <Flex flexDirection="column" gap={4}>
+        <Components.Heading as="h5" styledAs="h6">
+          Pay time period
+        </Components.Heading>
+        <div>Annually</div>
+      </Flex>
+    </>
+  )
+}
 
 const CardMenu = () => {
   return (

--- a/src/components/Common/UI/DatePicker/DatePicker.module.scss
+++ b/src/components/Common/UI/DatePicker/DatePicker.module.scss
@@ -258,6 +258,7 @@
     color: var(--g-colors-gray-1000);
     font-weight: 400;
     font-size: var(--g-typography-fontSize-small);
+    overflow-x: hidden;
 
     header {
       display: flex;

--- a/src/components/Common/UI/Heading/Heading.module.scss
+++ b/src/components/Common/UI/Heading/Heading.module.scss
@@ -1,0 +1,45 @@
+:global(.GSDK) {
+  .root {
+    text-wrap: balance;
+    margin: 0;
+    font-weight: var(--g-typography-fontWeight-medium);
+    line-height: 1.2;
+  }
+
+  .h1 {
+    font-size: var(--g-typography-headings-1);
+    line-height: 1.125;
+  }
+
+  .h2 {
+    font-size: var(--g-typography-headings-2);
+  }
+
+  .h3 {
+    font-size: var(--g-typography-headings-3);
+  }
+
+  .h4 {
+    font-size: var(--g-typography-headings-4);
+  }
+
+  .h5 {
+    font-size: var(--g-typography-headings-5);
+  }
+
+  .h6 {
+    font-size: var(--g-typography-headings-6);
+  }
+
+  .textAlign-start {
+    text-align: start;
+  }
+
+  .textAlign-center {
+    text-align: center;
+  }
+
+  .textAlign-end {
+    text-align: end;
+  }
+}

--- a/src/components/Common/UI/Heading/Heading.stories.tsx
+++ b/src/components/Common/UI/Heading/Heading.stories.tsx
@@ -1,0 +1,75 @@
+import type { Story } from '@ladle/react'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+export default {
+  title: 'UI/Typography/Heading',
+}
+
+export const AllHeadings: Story = () => {
+  const Components = useComponentContext()
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <Components.Heading as="h1">This is an H1 Heading</Components.Heading>
+      <Components.Heading as="h2">This is an H2 Heading</Components.Heading>
+      <Components.Heading as="h3">This is an H3 Heading</Components.Heading>
+      <Components.Heading as="h4">This is an H4 Heading</Components.Heading>
+      <Components.Heading as="h5">This is an H5 Heading</Components.Heading>
+      <Components.Heading as="h6">This is an H6 Heading</Components.Heading>
+    </div>
+  )
+}
+
+export const StyledDifferently: Story = () => {
+  const Components = useComponentContext()
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <Components.Heading as="h2" styledAs="h4">
+        This is an H2 styled as H4
+      </Components.Heading>
+      <Components.Heading as="h1" styledAs="h3">
+        This is an H1 styled as H3
+      </Components.Heading>
+      <Components.Heading as="h3" styledAs="h1">
+        This is an H3 styled as H1
+      </Components.Heading>
+      <Components.Heading as="h4" styledAs="h6">
+        This is an H4 styled as H6
+      </Components.Heading>
+      <Components.Heading as="h6" styledAs="h2">
+        This is an H6 styled as H2
+      </Components.Heading>
+    </div>
+  )
+}
+
+export const TextAlignStart: Story = () => {
+  const Components = useComponentContext()
+
+  return (
+    <Components.Heading as="h3" textAlign="start">
+      This heading is aligned to the start
+    </Components.Heading>
+  )
+}
+
+export const TextAlignCenter: Story = () => {
+  const Components = useComponentContext()
+
+  return (
+    <Components.Heading as="h3" textAlign="center">
+      This heading is centered
+    </Components.Heading>
+  )
+}
+
+export const TextAlignEnd: Story = () => {
+  const Components = useComponentContext()
+
+  return (
+    <Components.Heading as="h3" textAlign="end">
+      This heading is aligned to the end
+    </Components.Heading>
+  )
+}

--- a/src/components/Common/UI/Heading/Heading.tsx
+++ b/src/components/Common/UI/Heading/Heading.tsx
@@ -1,0 +1,26 @@
+import classNames from 'classnames'
+import type { HeadingProps } from './HeadingTypes'
+import styles from './Heading.module.scss'
+
+export const Heading = ({
+  as: Component,
+  styledAs,
+  textAlign,
+  className,
+  children,
+}: HeadingProps) => {
+  const levelStyles = styledAs ?? Component
+
+  return (
+    <Component
+      className={classNames(
+        className,
+        styles.root,
+        styles[levelStyles as string],
+        styles[`textAlign-${textAlign}`],
+      )}
+    >
+      {children}
+    </Component>
+  )
+}

--- a/src/components/Common/UI/Heading/HeadingTypes.ts
+++ b/src/components/Common/UI/Heading/HeadingTypes.ts
@@ -1,0 +1,8 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+
+export interface HeadingProps extends Pick<HTMLAttributes<HTMLHeadingElement>, 'className'> {
+  as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  styledAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  textAlign?: 'start' | 'center' | 'end'
+  children?: ReactNode
+}

--- a/src/components/Common/UI/Heading/index.ts
+++ b/src/components/Common/UI/Heading/index.ts
@@ -1,0 +1,2 @@
+export { Heading } from './Heading'
+export type { HeadingProps } from './HeadingTypes'

--- a/src/components/Common/UI/Select/Select.module.scss
+++ b/src/components/Common/UI/Select/Select.module.scss
@@ -51,7 +51,7 @@
     line-height: toRem(24);
 
     &[data-focus-visible] {
-      @include formFocusOutline;
+      @include formFocusOutline($offset: calc(var(--g-input-borderWidth) * -1));
     }
 
     &[data-hovered],

--- a/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatoryForm.tsx
+++ b/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatoryForm.tsx
@@ -7,10 +7,12 @@ import { STATES_ABBR } from '@/shared/constants'
 import { normalizeSSN, usePlaceholderSSN } from '@/helpers/ssn'
 import { TitleSelect } from '@/components/Company/AssignSignatory/TitleSelect'
 import { commonMasks, useMaskedTransform } from '@/helpers/mask'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export type CreateSignatoryInputs = InferInput<ReturnType<typeof generateCreateSignatorySchema>>
 
 export const CreateSignatoryForm = () => {
+  const Components = useComponentContext()
   const { currentSignatory } = useCreateSignatory()
   const { t } = useTranslation('Company.AssignSignatory')
   const placeholderSSN = usePlaceholderSSN(currentSignatory?.hasSsn)
@@ -20,7 +22,7 @@ export const CreateSignatoryForm = () => {
     <Flex flexDirection="column" gap={32}>
       <Flex flexDirection="column" gap={12}>
         <header>
-          <h2>{t('signatoryDetails.title')}</h2>
+          <Components.Heading as="h2">{t('signatoryDetails.title')}</Components.Heading>
           <p>{t('signatoryDetails.description')}</p>
         </header>
 
@@ -71,7 +73,7 @@ export const CreateSignatoryForm = () => {
 
       <Flex flexDirection="column" gap={12}>
         <header>
-          <h2>{t('address.title')}</h2>
+          <Components.Heading as="h2">{t('address.title')}</Components.Heading>
           <p>{t('address.description')}</p>
         </header>
 

--- a/src/components/Company/AssignSignatory/Head.tsx
+++ b/src/components/Company/AssignSignatory/Head.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from 'react-i18next'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export const Head = () => {
   const { t } = useTranslation('Company.AssignSignatory')
+  const Components = useComponentContext()
 
   return (
     <header>
-      <h1>{t('title')}</h1>
+      <Components.Heading as="h1">{t('title')}</Components.Heading>
       <p>{t('description')}</p>
     </header>
   )

--- a/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatoryForm.tsx
+++ b/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatoryForm.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { TextInputField, Grid, Flex } from '@/components/Common'
 import { nameValidation } from '@/helpers/validations'
 import { TitleSelect } from '@/components/Company/AssignSignatory/TitleSelect'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 const emailMismatchError = 'email_mismatch'
 
@@ -25,6 +26,7 @@ export type InviteSignatoryInputs = v.InferInput<typeof InviteSignatorySchema>
 
 export const InviteSignatoryForm = () => {
   const { t } = useTranslation('Company.AssignSignatory')
+  const Components = useComponentContext()
 
   const {
     setError,
@@ -52,7 +54,7 @@ export const InviteSignatoryForm = () => {
   return (
     <Flex flexDirection="column" gap={12}>
       <header>
-        <h2>{t('inviteSignatory.title')}</h2>
+        <Components.Heading as="h2">{t('inviteSignatory.title')}</Components.Heading>
         <p>{t('inviteSignatory.description')}</p>
       </header>
 

--- a/src/components/Company/BankAccount/BankAccountForm/Head.tsx
+++ b/src/components/Company/BankAccount/BankAccountForm/Head.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from 'react-i18next'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export function Head() {
   const { t } = useTranslation('Company.BankAccount')
+  const Components = useComponentContext()
 
   return (
     <header>
-      <h2>{t('addBankAccountTitle')}</h2>
+      <Components.Heading as="h2">{t('addBankAccountTitle')}</Components.Heading>
       <p>{t('addBankAccountDescription')}</p>
     </header>
   )

--- a/src/components/Company/BankAccount/BankAccountList/Head.tsx
+++ b/src/components/Company/BankAccount/BankAccountList/Head.tsx
@@ -10,7 +10,7 @@ export function Head() {
 
   return (
     <header>
-      <h2>{t('addBankAccountTitle')}</h2>
+      <Components.Heading as="h2">{t('addBankAccountTitle')}</Components.Heading>
       <p>{t('addBankAccountDescription')}</p>
       {bankAccount?.verificationStatus != 'verified' && (
         <Components.Alert

--- a/src/components/Company/BankAccount/BankAccountVerify/Head.tsx
+++ b/src/components/Company/BankAccount/BankAccountVerify/Head.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from 'react-i18next'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export function Head() {
   const { t } = useTranslation('Company.BankAccount')
+  const Components = useComponentContext()
 
   return (
     <header>
-      <h2>{t('verifyBankAccountTitle')}</h2>
+      <Components.Heading as="h2">{t('verifyBankAccountTitle')}</Components.Heading>
       <p>{t('verifyBankAccountDescription')}</p>
     </header>
   )

--- a/src/components/Company/DocumentSignerFlow/DocumentList/Head.tsx
+++ b/src/components/Company/DocumentSignerFlow/DocumentList/Head.tsx
@@ -1,7 +1,9 @@
 import { useTranslation } from 'react-i18next'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export function Head() {
   const { t } = useTranslation('Company.DocumentList')
+  const Components = useComponentContext()
 
-  return <h2>{t('documentListTitle')}</h2>
+  return <Components.Heading as="h2">{t('documentListTitle')}</Components.Heading>
 }

--- a/src/components/Company/DocumentSignerFlow/SignatureForm/Head.tsx
+++ b/src/components/Company/DocumentSignerFlow/SignatureForm/Head.tsx
@@ -9,7 +9,9 @@ export function Head() {
 
   return (
     <section>
-      <h2>{t('signatureFormTitle', { formTitle: form.title })}</h2>
+      <Components.Heading as="h2">
+        {t('signatureFormTitle', { formTitle: form.title })}
+      </Components.Heading>
       {pdfUrl && (
         <p>
           <Trans

--- a/src/components/Company/FederalTaxes/Head.tsx
+++ b/src/components/Company/FederalTaxes/Head.tsx
@@ -7,7 +7,7 @@ export function Head() {
 
   return (
     <header>
-      <h2>{t('pageTitle')}</h2>
+      <Components.Heading as="h2">{t('pageTitle')}</Components.Heading>
       <p>
         <Trans
           t={t}

--- a/src/components/Company/Industry/Head.tsx
+++ b/src/components/Company/Industry/Head.tsx
@@ -1,10 +1,13 @@
 import { useTranslation } from 'react-i18next'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export const Head = () => {
   const { t } = useTranslation('Company.Industry')
+  const Components = useComponentContext()
+
   return (
     <div>
-      <h2>{t('title')}</h2>
+      <Components.Heading as="h2">{t('title')}</Components.Heading>
       <p>{t('description')}</p>
     </div>
   )

--- a/src/components/Company/Locations/LocationForm/Head.tsx
+++ b/src/components/Company/Locations/LocationForm/Head.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from 'react-i18next'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export function Head() {
   const { t } = useTranslation('Company.Locations')
+  const Components = useComponentContext()
 
   return (
     <header>
-      <h2>{t('locationsListTitle')}</h2>
+      <Components.Heading as="h2">{t('locationsListTitle')}</Components.Heading>
       <p>{t('locationsListDescription')}</p>
     </header>
   )

--- a/src/components/Company/Locations/LocationsList/Head.tsx
+++ b/src/components/Company/Locations/LocationsList/Head.tsx
@@ -1,11 +1,13 @@
 import { useTranslation } from 'react-i18next'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export function Head() {
   const { t } = useTranslation('Company.Locations')
+  const Components = useComponentContext()
 
   return (
     <header>
-      <h2>{t('locationsListTitle')}</h2>
+      <Components.Heading as="h2">{t('locationsListTitle')}</Components.Heading>
       <p>{t('locationsListDescription')}</p>
     </header>
   )

--- a/src/components/Company/PaySchedule/_parts/Head.tsx
+++ b/src/components/Company/PaySchedule/_parts/Head.tsx
@@ -15,7 +15,7 @@ export const Head = () => {
     case 'LIST_PAY_SCHEDULES':
       headingOutput = (
         <>
-          <h2>{t('headings.pageTitle')}</h2>
+          <Components.Heading as="h2">{t('headings.pageTitle')}</Components.Heading>
           <p>
             <Trans
               i18nKey={'listDescription'}
@@ -38,10 +38,14 @@ export const Head = () => {
       )
       break
     case 'ADD_PAY_SCHEDULE':
-      headingOutput = <h2>{t('headings.addPaySchedule')}</h2>
+      headingOutput = (
+        <Components.Heading as="h2">{t('headings.addPaySchedule')}</Components.Heading>
+      )
       break
     case 'EDIT_PAY_SCHEDULE':
-      headingOutput = <h2>{t('headings.editPaySchedule')}</h2>
+      headingOutput = (
+        <Components.Heading as="h2">{t('headings.editPaySchedule')}</Components.Heading>
+      )
       break
     default:
   }

--- a/src/components/Company/StateTaxes/StateTaxesForm/Form.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesForm/Form.tsx
@@ -4,6 +4,7 @@ import { Fragment } from 'react/jsx-runtime'
 import { useStateTaxesForm } from './context'
 import { QuestionInput } from '@/components/Common/TaxInputs/TaxInputs'
 import { useLocaleDateFormatter } from '@/contexts/LocaleProvider/useLocale'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export const StateFormSchema = v.record(v.string(), v.record(v.string(), v.unknown()))
 
@@ -13,11 +14,13 @@ export function Form() {
   const { t } = useTranslation('Company.StateTaxes', { keyPrefix: 'form' })
   const dateFormatter = useLocaleDateFormatter()
   const { stateTaxRequirements } = useStateTaxesForm()
+  const Components = useComponentContext()
+
   return stateTaxRequirements.requirementSets?.map(
     ({ requirements, label, effectiveFrom, key }) => (
       <Fragment key={key}>
         <div>
-          <h4>{label}</h4>
+          <Components.Heading as="h4">{label}</Components.Heading>
           {effectiveFrom && (
             <p className="lightText">
               {t('effectiveFromLabel', { date: dateFormatter.format(new Date(effectiveFrom)) })}

--- a/src/components/Company/StateTaxes/StateTaxesForm/Head.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesForm/Head.tsx
@@ -1,16 +1,20 @@
 import { useTranslation } from 'react-i18next'
 import { useStateTaxesForm } from './context'
 import type { STATES_ABBR } from '@/shared/constants'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export function Head() {
   const { t } = useTranslation('Company.StateTaxes', { keyPrefix: 'form' })
   const { t: statesHash } = useTranslation('common', { keyPrefix: 'statesHash' })
+  const Components = useComponentContext()
 
   const { state } = useStateTaxesForm()
 
   return (
     <header>
-      <h2>{t('title', { state: statesHash(state as (typeof STATES_ABBR)[number]) })}</h2>
+      <Components.Heading as="h2">
+        {t('title', { state: statesHash(state as (typeof STATES_ABBR)[number]) })}
+      </Components.Heading>
     </header>
   )
 }

--- a/src/components/Employee/Compensation/Head.tsx
+++ b/src/components/Employee/Compensation/Head.tsx
@@ -19,7 +19,7 @@ export const Head = () => {
 
   return (
     <>
-      <h2>{title}</h2>
+      <Components.Heading as="h2">{title}</Components.Heading>
       {showFlsaChangeWarning && (
         <Components.Alert
           label={t('validations.classificationChangeNotification')}

--- a/src/components/Employee/Deductions/DeductionForm.tsx
+++ b/src/components/Employee/Deductions/DeductionForm.tsx
@@ -8,12 +8,14 @@ import {
   TextInputField,
 } from '@/components/Common'
 import { useI18n } from '@/i18n'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export const DeductionForm = () => {
   const { mode } = useDeductions()
   const { control } = useFormContext<DeductionInputs>()
   useI18n('Employee.Deductions')
   const { t } = useTranslation('Employee.Deductions')
+  const Components = useComponentContext()
 
   const watchedRecurring = useWatch({ control, name: 'recurring' })
   const watchedDeductAsPercentage = useWatch({ control, name: 'deductAsPercentage' })
@@ -22,7 +24,9 @@ export const DeductionForm = () => {
 
   return (
     <>
-      <h2>{mode === 'EDIT' ? t('editDeductionTitle') : t('addDeductionTitle')}</h2>
+      <Components.Heading as="h2">
+        {mode === 'EDIT' ? t('editDeductionTitle') : t('addDeductionTitle')}
+      </Components.Heading>
       <p>{t('addDeuctionDescription')}</p>
       <TextInputField
         name="description"

--- a/src/components/Employee/Deductions/Head.tsx
+++ b/src/components/Employee/Deductions/Head.tsx
@@ -1,13 +1,16 @@
 import { useTranslation } from 'react-i18next'
 import { useDeductions } from './useDeductions'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export function Head() {
   const { t } = useTranslation('Employee.Deductions')
   const { mode } = useDeductions()
+  const Components = useComponentContext()
+
   if (mode !== 'INITIAL' && mode !== 'LIST') return
   return (
     <>
-      <h2>{t('pageTitle')}</h2>
+      <Components.Heading as="h2">{t('pageTitle')}</Components.Heading>
     </>
   )
 }

--- a/src/components/Employee/DocumentSigner/DocumentList/Head.tsx
+++ b/src/components/Employee/DocumentSigner/DocumentList/Head.tsx
@@ -1,9 +1,11 @@
 import { useTranslation } from 'react-i18next'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 function Head() {
   const { t } = useTranslation('Employee.DocumentSigner')
+  const Components = useComponentContext()
 
-  return <h2>{t('documentListTitle')}</h2>
+  return <Components.Heading as="h2">{t('documentListTitle')}</Components.Heading>
 }
 
 export { Head }

--- a/src/components/Employee/DocumentSigner/SignatureForm/Head.tsx
+++ b/src/components/Employee/DocumentSigner/SignatureForm/Head.tsx
@@ -9,7 +9,9 @@ export function Head() {
 
   return (
     <section>
-      <h2>{t('signatureFormTitle', { formTitle: form.title })}</h2>
+      <Components.Heading as="h2">
+        {t('signatureFormTitle', { formTitle: form.title })}
+      </Components.Heading>
       {pdfUrl && (
         <p>
           <Trans

--- a/src/components/Employee/EmployeeList/Head.tsx
+++ b/src/components/Employee/EmployeeList/Head.tsx
@@ -1,12 +1,15 @@
 import { useTranslation } from 'react-i18next'
 import { Flex } from '@/components/Common'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 // Head slot for EmployeeList component
 export const Head = () => {
   const { t } = useTranslation('Employee.EmployeeList')
+  const Components = useComponentContext()
+
   return (
     <Flex justifyContent="space-between" alignItems="center">
-      <h2>{t('title')}</h2>
+      <Components.Heading as="h2">{t('title')}</Components.Heading>
     </Flex>
   )
 }

--- a/src/components/Employee/Landing/Landing.module.scss
+++ b/src/components/Employee/Landing/Landing.module.scss
@@ -1,7 +1,3 @@
-.subtitle {
-  text-align: center;
-}
-
 .description {
   text-align: center;
 }

--- a/src/components/Employee/Landing/Landing.tsx
+++ b/src/components/Employee/Landing/Landing.tsx
@@ -48,11 +48,13 @@ const Root = ({ employeeId, companyId, className }: SummaryProps) => {
     <section className={className}>
       <Flex alignItems="center" flexDirection="column" gap={32}>
         <Flex alignItems="center" flexDirection="column" gap={8}>
-          <h2 className={styles.subtitle}>{t('landingSubtitle', { firstName, companyName })}</h2>
+          <Components.Heading as="h2" textAlign="center">
+            {t('landingSubtitle', { firstName, companyName })}
+          </Components.Heading>
           <p className={styles.description}>{t('landingDescription')}</p>
         </Flex>
         <Flex flexDirection="column" gap={8}>
-          <h3>{t('stepsSubtitle')}</h3>
+          <Components.Heading as="h3">{t('stepsSubtitle')}</Components.Heading>
           <ul>
             <li>{t('steps.personalInfo')}</li>
             <li>{t('steps.taxInfo')}</li>

--- a/src/components/Employee/OnboardingSummary/OnboardingSummary.module.scss
+++ b/src/components/Employee/OnboardingSummary/OnboardingSummary.module.scss
@@ -1,8 +1,4 @@
 :global(.GSDK) {
-  .subtitle {
-    text-align: center;
-  }
-
   .description {
     text-align: center;
   }

--- a/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
+++ b/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
@@ -62,14 +62,14 @@ const Root = ({ employeeId, className, isAdmin = false }: SummaryProps) => {
           {isAdmin ? (
             isOnboardingCompleted ? (
               <>
-                <h2 className={styles.subtitle}>
+                <Components.Heading as="h2" textAlign="center">
                   {t('onboardedAdminSubtitle', { name: `${firstName} ${lastName}` })}
-                </h2>
+                </Components.Heading>
                 <p className={styles.description}>{t('onboardedAdminDescription')}</p>
               </>
             ) : (
               <Flex flexDirection="column" alignItems="flex-start" gap={8}>
-                <h2>{t('missingRequirementsSubtitle')}</h2>
+                <Components.Heading as="h2">{t('missingRequirementsSubtitle')}</Components.Heading>
                 <p>{t('missingRequirementsDescription')}</p>
                 <ul className={styles.list}>
                   {onboardingSteps
@@ -86,8 +86,10 @@ const Root = ({ employeeId, className, isAdmin = false }: SummaryProps) => {
                               className={classNames(styles.listItemIcon, styles.incomplete)}
                             />
                           )}
-                          {/* @ts-expect-error: id has typeof keyof steps */}
-                          <h4>{t(`steps.${step.id}`, step.title)}</h4>
+                          <Components.Heading as="h4">
+                            {/* @ts-expect-error: id has typeof keyof steps */}
+                            {t(`steps.${step.id}`, step.title)}
+                          </Components.Heading>
                         </li>
                       )
                     })}
@@ -96,7 +98,9 @@ const Root = ({ employeeId, className, isAdmin = false }: SummaryProps) => {
             )
           ) : (
             <>
-              <h2 className={styles.subtitle}>{t('onboardedSelfSubtitle')}</h2>
+              <Components.Heading as="h2" textAlign="center">
+                {t('onboardedSelfSubtitle')}
+              </Components.Heading>
               <p className={styles.description}>{t('onboardedSelfDescription')}</p>
             </>
           )}

--- a/src/components/Employee/PaymentMethod/Head.tsx
+++ b/src/components/Employee/PaymentMethod/Head.tsx
@@ -1,13 +1,16 @@
 import { useTranslation } from 'react-i18next'
 import { usePaymentMethod } from './usePaymentMethod'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export function Head() {
   const { t } = useTranslation('Employee.PaymentMethod')
   const { mode } = usePaymentMethod()
+  const Components = useComponentContext()
+
   if (mode !== 'INITIAL' && mode !== 'LIST') return
   return (
     <>
-      <h2>{t('title')}</h2>
+      <Components.Heading as="h2">{t('title')}</Components.Heading>
     </>
   )
 }

--- a/src/components/Employee/PaymentMethod/Split.tsx
+++ b/src/components/Employee/PaymentMethod/Split.tsx
@@ -114,7 +114,7 @@ export function Split() {
         name="split_amount.root"
         render={() => <Components.Alert status="error" label={t('validations.percentageError')} />}
       />
-      <h2>{t('title')}</h2>
+      <Components.Heading as="h2">{t('title')}</Components.Heading>
       <Trans t={t} i18nKey="splitDescription" components={{ p: <p /> }} />
       <RadioGroupField
         name="splitBy"

--- a/src/components/Employee/Profile/Head.tsx
+++ b/src/components/Employee/Profile/Head.tsx
@@ -1,10 +1,13 @@
 import { useTranslation } from 'react-i18next'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export const Head = () => {
   const { t } = useTranslation('Employee.Profile')
+  const Components = useComponentContext()
+
   return (
     <div>
-      <h2>{t('title')}</h2>
+      <Components.Heading as="h2">{t('title')}</Components.Heading>
       <p>{t('description')}</p>
     </div>
   )

--- a/src/components/Employee/Profile/HomeAddress.tsx
+++ b/src/components/Employee/Profile/HomeAddress.tsx
@@ -39,7 +39,7 @@ export const HomeAddress = () => {
   return (
     <>
       <div>
-        <h2>{t('formTitle')}</h2>
+        <Components.Heading as="h2">{t('formTitle')}</Components.Heading>
         <p>{t('desc')}</p>
       </div>
       <Grid

--- a/src/components/Employee/Profile/WorkAddress.tsx
+++ b/src/components/Employee/Profile/WorkAddress.tsx
@@ -2,10 +2,12 @@ import { useTranslation } from 'react-i18next'
 import styles from './WorkAddress.module.scss'
 import { useProfile } from './useProfile'
 import { getStreet, getCityStateZip } from '@/helpers/formattedStrings'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export function WorkAddress() {
   const { t } = useTranslation('Employee.Profile')
   const { isAdmin, workAddresses } = useProfile()
+  const Components = useComponentContext()
 
   const activeWorkAddress = workAddresses?.find(address => address.active)
 
@@ -15,7 +17,7 @@ export function WorkAddress() {
 
   return (
     <section>
-      <h2>{t('workAddressSectionTitle')}</h2>
+      <Components.Heading as="h2">{t('workAddressSectionTitle')}</Components.Heading>
       <p>{t('workAddressSectionDescription')}</p>
       <address className={styles.address}>
         <p>{getStreet(activeWorkAddress)}</p>

--- a/src/components/Employee/Taxes/FederalHead.tsx
+++ b/src/components/Employee/Taxes/FederalHead.tsx
@@ -7,7 +7,7 @@ export function FederalHead() {
 
   return (
     <>
-      <h2>{t('federalTaxesTitle')}</h2>
+      <Components.Heading as="h2">{t('federalTaxesTitle')}</Components.Heading>
       <p>
         <Trans
           i18nKey={'irs_calculator'}

--- a/src/components/Employee/Taxes/StateForm.tsx
+++ b/src/components/Employee/Taxes/StateForm.tsx
@@ -5,6 +5,7 @@ import { useTaxes } from './useTaxes'
 import type { STATES_ABBR } from '@/shared/constants'
 import { snakeCaseToCamelCase } from '@/helpers/formattedStrings'
 import { QuestionInput } from '@/components/Common/TaxInputs/TaxInputs'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export const StateFormSchema = v.object({
   states: v.record(v.string(), v.record(v.string(), v.unknown())),
@@ -13,13 +14,16 @@ export const StateFormSchema = v.object({
 export type StateFormPayload = v.InferOutput<typeof StateFormSchema>
 
 export const StateForm = () => {
+  const Components = useComponentContext()
   const { employeeStateTaxes, isAdmin } = useTaxes()
   const { t } = useTranslation('Employee.Taxes')
   const { t: statesHash } = useTranslation('common', { keyPrefix: 'statesHash' })
 
   return employeeStateTaxes.map(({ state, questions }) => (
     <Fragment key={state}>
-      <h2>{t('stateTaxesTitle', { state: statesHash(state as (typeof STATES_ABBR)[number]) })}</h2>
+      <Components.Heading as="h2">
+        {t('stateTaxesTitle', { state: statesHash(state as (typeof STATES_ABBR)[number]) })}
+      </Components.Heading>
       {questions.map(question => {
         // @ts-expect-error TODO: This is an issue with the schema, the isQuestionForAdminOnly field is not defined
         if (question.isQuestionForAdminOnly && !isAdmin) return null

--- a/src/contexts/ComponentAdapter/adapters/defaultComponentAdapter.tsx
+++ b/src/contexts/ComponentAdapter/adapters/defaultComponentAdapter.tsx
@@ -38,6 +38,8 @@ import type { TableProps } from '@/components/Common/UI/Table'
 import { Table } from '@/components/Common/UI/Table'
 import type { OrderedListProps, UnorderedListProps } from '@/components/Common/UI/List'
 import { OrderedList, UnorderedList } from '@/components/Common/UI/List'
+import { Heading } from '@/components/Common/UI/Heading'
+import type { HeadingProps } from '@/components/Common/UI/Heading/HeadingTypes'
 
 export const defaultComponents: ComponentsContextType = {
   Alert: (props: AlertProps) => <Alert {...props} />,
@@ -61,4 +63,5 @@ export const defaultComponents: ComponentsContextType = {
   Link: (props: LinkProps) => <Link {...props} />,
   Menu: (props: MenuProps) => <Menu {...props} />,
   Table: <T,>(props: TableProps<T>) => <Table {...props} />,
+  Heading: (props: HeadingProps) => <Heading {...props} />,
 }

--- a/src/contexts/ComponentAdapter/useComponentContext.ts
+++ b/src/contexts/ComponentAdapter/useComponentContext.ts
@@ -19,6 +19,7 @@ import type { BadgeProps } from '@/components/Common/UI/Badge/BadgeTypes'
 import type { MenuProps } from '@/components/Common/UI/Menu/MenuTypes'
 import type { TableProps } from '@/components/Common/UI/Table'
 import type { OrderedListProps, UnorderedListProps } from '@/components/Common/UI/List'
+import type { HeadingProps } from '@/components/Common/UI/Heading/HeadingTypes'
 
 export interface ComponentsContextType {
   Alert: (props: AlertProps) => JSX.Element | null
@@ -42,6 +43,7 @@ export interface ComponentsContextType {
   Link: (props: LinkProps) => JSX.Element | null
   Menu: (props: MenuProps) => JSX.Element | null
   Table: <T>(props: TableProps<T>) => JSX.Element | null
+  Heading: (props: HeadingProps) => JSX.Element | null
 }
 
 export const ComponentsContext = createContext<ComponentsContextType | null>(null)

--- a/src/styles/_Base.scss
+++ b/src/styles/_Base.scss
@@ -13,17 +13,6 @@
     box-sizing: border-box;
   }
 
-  // Balance text wrapping on headings
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    text-wrap: balance;
-    // margin-bottom: var(--g-spacing-20);
-    margin-bottom: 0;
-  }
   dl {
     width: 100%;
     div:not(:last-child) {
@@ -39,12 +28,6 @@
     color: var(--g-colors-gray-900);
     font-weight: var(--g-typography-fontWeight-regular);
     font-size: var(--g-typography-fontSize-small);
-  }
-
-  @for $i from 1 through 6 {
-    h#{$i} {
-      font-size: var(--g-typography-headings-#{$i});
-    }
   }
 
   /* Make images easier to work with */


### PR DESCRIPTION
This PR adds a new `Heading` component. The `Heading` component centralizes our heading styles and allows for decoupling of the semantic heading html from the heading styles. For example, you can now render an h2 styled as an h4 if that meets the demands of the heading level .

This also implements an adapter for the heading components, and updates heading instances throughout the codebase (both React Aria `Heading` component and `h1`-`h6`) to use that adapter.

Note: it didn't always make sense to update to use the `Heading` component. For example, for headings that live within a table, table will have specific styling needs that likely diverge from the system. This would also introduce theming issues where the core Heading component styles would conflict with the component level styles. In these cases, it's sufficient to just use the `h*` component directly and provide component specific theme variables.

## Proof of functionality 
### Heading styles

https://github.com/user-attachments/assets/b54625ac-b53f-4568-afd6-b736c799f513

### Smoke test of existing employee flows to use updated heading

https://github.com/user-attachments/assets/3b8d8bb4-371b-4ec8-ad63-14fdf32cb320
