### PR TITLE
Add documentation to adapter interfaces

### DIFF
--- a/src/components/Common/FieldLayout/FieldLayoutTypes.ts
+++ b/src/components/Common/FieldLayout/FieldLayoutTypes.ts
@@ -2,19 +2,52 @@ import type { ReactNode } from 'react'
 import type { DataAttributes } from '@/types/Helpers'
 
 export interface SharedFieldLayoutProps extends DataAttributes {
+  /**
+   * Optional description text for the field
+   */
   description?: ReactNode
+  /**
+   * Error message to display when the field is invalid
+   */
   errorMessage?: string
+  /**
+   * Indicates if the field is required
+   */
   isRequired?: boolean
+  /**
+   * Label text for the field
+   */
   label: ReactNode
+  /**
+   * Hides the label visually while keeping it accessible to screen readers
+   */
   shouldVisuallyHideLabel?: boolean
 }
 
 export interface InternalFieldLayoutProps {
+  /**
+   * Content to be rendered inside the field layout
+   */
   children: React.ReactNode
+  /**
+   * ID of the form control that this label is associated with
+   */
   htmlFor: string
+  /**
+   * ID of the error message element
+   */
   errorMessageId: string
+  /**
+   * ID of the description element
+   */
   descriptionId: string
+  /**
+   * Additional CSS class name
+   */
   className?: string
+  /**
+   * Whether to show the error icon
+   */
   withErrorIcon?: boolean
 }
 

--- a/src/components/Common/UI/Alert/Alert.tsx
+++ b/src/components/Common/UI/Alert/Alert.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef } from 'react'
+import classNames from 'classnames'
 import { type AlertProps } from './AlertTypes'
 import styles from './Alert.module.scss'
 import InfoIcon from '@/assets/icons/info.svg?react'
@@ -6,7 +7,7 @@ import SuccessIcon from '@/assets/icons/success_check.svg?react'
 import WarningIcon from '@/assets/icons/warning.svg?react'
 import ErrorIcon from '@/assets/icons/error.svg?react'
 
-export function Alert({ label, children, status = 'info', icon }: AlertProps) {
+export function Alert({ label, children, status = 'info', icon, className }: AlertProps) {
   const id = useId()
   const alertRef = useRef<HTMLDivElement>(null)
   const defaultIcon =
@@ -25,7 +26,7 @@ export function Alert({ label, children, status = 'info', icon }: AlertProps) {
   }, [])
 
   return (
-    <div className={styles.root}>
+    <div className={classNames(styles.root, className)}>
       <div
         className={styles.alert}
         role="alert"

--- a/src/components/Common/UI/Alert/AlertTypes.ts
+++ b/src/components/Common/UI/Alert/AlertTypes.ts
@@ -1,12 +1,24 @@
 import type { ReactNode } from 'react'
 
 export interface AlertProps {
-  /** The variant of the alert */
+  /**
+   * The visual status that the alert should convey
+   */
   status?: 'info' | 'success' | 'warning' | 'error'
-  /** The label text for the alert */
+  /**
+   * The label text for the alert
+   */
   label: string
-  /** Optional children to be rendered inside the alert */
+  /**
+   * Optional children to be rendered inside the alert
+   */
   children?: ReactNode
-  /** Optional custom icon component to override the default icon */
+  /**
+   * Optional custom icon component to override the default icon
+   */
   icon?: ReactNode
+  /**
+   * CSS className to be applied
+   */
+  className?: string
 }

--- a/src/components/Common/UI/Badge/BadgeTypes.ts
+++ b/src/components/Common/UI/Badge/BadgeTypes.ts
@@ -2,6 +2,12 @@ import type { HTMLAttributes, ReactNode } from 'react'
 
 export interface BadgeProps
   extends Pick<HTMLAttributes<HTMLSpanElement>, 'className' | 'id' | 'aria-label'> {
+  /**
+   * Content to be displayed inside the badge
+   */
   children: ReactNode
+  /**
+   * Visual style variant of the badge
+   */
   status?: 'success' | 'warning' | 'error' | 'info'
 }

--- a/src/components/Common/UI/Button/ButtonTypes.ts
+++ b/src/components/Common/UI/Button/ButtonTypes.ts
@@ -20,16 +20,43 @@ export interface ButtonProps
     | 'title'
     | 'tabIndex'
   > {
+  /**
+   * React ref for the button element
+   */
   ref?: Ref<HTMLButtonElement>
+  /**
+   * Visual style variant of the button
+   */
   variant?: 'primary' | 'secondary' | 'tertiary' | 'icon'
+  /**
+   * Indicates if the button is in an error state
+   */
   isError?: boolean
+  /**
+   * Shows a loading spinner and disables the button
+   */
   isLoading?: boolean
+  /**
+   * Disables the button and prevents interaction
+   */
   isDisabled?: boolean
+  /**
+   * Content to be rendered inside the button
+   */
   children?: ReactNode
+  /**
+   * Handler for blur events
+   */
   onBlur?: ButtonFocusHandler
+  /**
+   * Handler for focus events
+   */
   onFocus?: ButtonFocusHandler
 }
 
 export type ButtonIconProps = Omit<ButtonProps, 'variant'> & {
+  /**
+   * Required aria-label for icon buttons to ensure accessibility
+   */
   'aria-label': string
 }

--- a/src/components/Common/UI/CalendarPreview/CalendarPreviewTypes.ts
+++ b/src/components/Common/UI/CalendarPreview/CalendarPreviewTypes.ts
@@ -1,12 +1,36 @@
 export type CalendarPreviewProps = {
+  /**
+   * Array of dates to highlight with custom colors and labels
+   */
   highlightDates?: Array<{
+    /**
+     * Date to highlight
+     */
     date: Date
+    /**
+     * Color to use for highlighting
+     */
     highlightColor: 'primary' | 'secondary'
+    /**
+     * Label text for the highlighted date
+     */
     label: string
   }>
+  /**
+   * Date range to display in the calendar preview
+   */
   dateRange: {
+    /**
+     * Start date of the range
+     */
     start: Date
+    /**
+     * End date of the range
+     */
     end: Date
+    /**
+     * Label text for the date range
+     */
     label: string
   }
 }

--- a/src/components/Common/UI/Card/CardTypes.ts
+++ b/src/components/Common/UI/Card/CardTypes.ts
@@ -1,12 +1,20 @@
 import type { ReactNode } from 'react'
 
 export interface CardProps {
-  /** Callback function when the card is selected */
+  /**
+   * Callback function when the card is selected
+   */
   onSelect?: (checked: boolean) => void
-  /** Content to be displayed inside the card */
+  /**
+   * Content to be displayed inside the card
+   */
   children: ReactNode
-  /** Optional menu component to be displayed on the right side of the card */
+  /**
+   * Optional menu component to be displayed on the right side of the card
+   */
   menu?: ReactNode
-  /** Additional CSS class name */
+  /**
+   * CSS className to be applied
+   */
   className?: string
 }

--- a/src/components/Common/UI/Checkbox/CheckboxTypes.ts
+++ b/src/components/Common/UI/Checkbox/CheckboxTypes.ts
@@ -4,9 +4,24 @@ import type { SharedHorizontalFieldLayoutProps } from '@/components/Common/Horiz
 export interface CheckboxProps
   extends SharedHorizontalFieldLayoutProps,
     Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id' | 'className' | 'onBlur'> {
+  /**
+   * Current checked state of the checkbox
+   */
   value?: boolean
+  /**
+   * Callback when checkbox state changes
+   */
   onChange?: (value: boolean) => void
+  /**
+   * React ref for the checkbox input element
+   */
   inputRef?: Ref<HTMLInputElement>
+  /**
+   * Indicates if the checkbox is in an invalid state
+   */
   isInvalid?: boolean
+  /**
+   * Disables the checkbox and prevents interaction
+   */
   isDisabled?: boolean
 }

--- a/src/components/Common/UI/CheckboxGroup/CheckboxGroupTypes.ts
+++ b/src/components/Common/UI/CheckboxGroup/CheckboxGroupTypes.ts
@@ -2,19 +2,49 @@ import type { FieldsetHTMLAttributes, Ref } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
 export type CheckboxGroupOption = {
+  /**
+   * Label text or content for the checkbox option
+   */
   label: React.ReactNode
+  /**
+   * Value of the option that will be passed to onChange
+   */
   value: string
+  /**
+   * Disables this specific checkbox option
+   */
   isDisabled?: boolean
+  /**
+   * Optional description text for the checkbox option
+   */
   description?: React.ReactNode
 }
 
 export interface CheckboxGroupProps
   extends SharedFieldLayoutProps,
     Pick<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'className'> {
+  /**
+   * Indicates if the checkbox group is in an invalid state
+   */
   isInvalid?: boolean
+  /**
+   * Disables all checkbox options in the group
+   */
   isDisabled?: boolean
+  /**
+   * Array of checkbox options to display
+   */
   options: Array<CheckboxGroupOption>
+  /**
+   * Array of currently selected values
+   */
   value?: string[]
+  /**
+   * Callback when selection changes
+   */
   onChange?: (value: string[]) => void
+  /**
+   * React ref for the first checkbox input element
+   */
   inputRef?: Ref<HTMLInputElement>
 }

--- a/src/components/Common/UI/ComboBox/ComboBoxTypes.ts
+++ b/src/components/Common/UI/ComboBox/ComboBoxTypes.ts
@@ -2,19 +2,49 @@ import type { InputHTMLAttributes, Ref, FocusEvent } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
 export interface ComboBoxOption {
+  /**
+   * Display text for the option
+   */
   label: string
+  /**
+   * Value of the option that will be passed to onChange
+   */
   value: string
 }
 
 export interface ComboBoxProps
   extends SharedFieldLayoutProps,
     Pick<InputHTMLAttributes<HTMLInputElement>, 'className' | 'id' | 'name' | 'placeholder'> {
+  /**
+   * Disables the combo box and prevents interaction
+   */
   isDisabled?: boolean
+  /**
+   * Indicates that the field has an error
+   */
   isInvalid?: boolean
+  /**
+   * Label text for the combo box field
+   */
   label: string
+  /**
+   * Callback when selection changes
+   */
   onChange?: (value: string) => void
+  /**
+   * Handler for blur events
+   */
   onBlur?: (e: FocusEvent) => void
+  /**
+   * Array of options to display in the dropdown
+   */
   options: ComboBoxOption[]
+  /**
+   * Currently selected value
+   */
   value?: string
+  /**
+   * React ref for the combo box input element
+   */
   inputRef?: Ref<HTMLInputElement>
 }

--- a/src/components/Common/UI/DatePicker/DatePickerTypes.ts
+++ b/src/components/Common/UI/DatePicker/DatePickerTypes.ts
@@ -4,12 +4,36 @@ import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/Fie
 export interface DatePickerProps
   extends SharedFieldLayoutProps,
     Pick<InputHTMLAttributes<HTMLInputElement>, 'className' | 'id' | 'name'> {
+  /**
+   * React ref for the date input element
+   */
   inputRef?: Ref<HTMLInputElement>
+  /**
+   * Disables the date picker and prevents interaction
+   */
   isDisabled?: boolean
+  /**
+   * Indicates that the field has an error
+   */
   isInvalid?: boolean
+  /**
+   * Callback when selected date changes
+   */
   onChange?: (value: Date | null) => void
+  /**
+   * Handler for blur events
+   */
   onBlur?: (e: FocusEvent) => void
+  /**
+   * Label text for the date picker field
+   */
   label: string
+  /**
+   * Currently selected date value
+   */
   value?: Date | null
+  /**
+   * Placeholder text when no date is selected
+   */
   placeholder?: string
 }

--- a/src/components/Common/UI/Heading/HeadingTypes.ts
+++ b/src/components/Common/UI/Heading/HeadingTypes.ts
@@ -1,8 +1,20 @@
 import type { HTMLAttributes, ReactNode } from 'react'
 
 export interface HeadingProps extends Pick<HTMLAttributes<HTMLHeadingElement>, 'className'> {
+  /**
+   * The HTML heading element to render (h1-h6)
+   */
   as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  /**
+   * Optional visual style to apply, independent of the semantic heading level
+   */
   styledAs?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  /**
+   * Text alignment within the heading
+   */
   textAlign?: 'start' | 'center' | 'end'
+  /**
+   * Content to be displayed inside the heading
+   */
   children?: ReactNode
 }

--- a/src/components/Common/UI/Link/LinkTypes.ts
+++ b/src/components/Common/UI/Link/LinkTypes.ts
@@ -2,17 +2,56 @@ import type { AnchorHTMLAttributes } from 'react'
 
 export type LinkProps = Pick<
   AnchorHTMLAttributes<HTMLAnchorElement>,
+  /**
+   * URL that the link points to
+   */
   | 'href'
+  /**
+   * Specifies where to open the linked document
+   */
   | 'target'
+  /**
+   * Specifies the relationship between the current document and the linked document
+   */
   | 'rel'
+  /**
+   * Indicates that the link is for downloading a resource
+   */
   | 'download'
+  /**
+   * Content to be displayed inside the link
+   */
   | 'children'
+  /**
+   * Additional CSS class name
+   */
   | 'className'
+  /**
+   * Unique identifier for the link
+   */
   | 'id'
+  /**
+   * Handler for key down events
+   */
   | 'onKeyDown'
+  /**
+   * Handler for key up events
+   */
   | 'onKeyUp'
+  /**
+   * Accessible label for the link
+   */
   | 'aria-label'
+  /**
+   * ID of an element that labels this link
+   */
   | 'aria-labelledby'
+  /**
+   * ID of an element that describes this link
+   */
   | 'aria-describedby'
+  /**
+   * Title text shown on hover
+   */
   | 'title'
 >

--- a/src/components/Common/UI/Menu/MenuTypes.ts
+++ b/src/components/Common/UI/Menu/MenuTypes.ts
@@ -2,17 +2,47 @@ import type { ReactNode, RefObject } from 'react'
 import type { DataAttributes } from '@/types/Helpers'
 
 export interface MenuItem extends DataAttributes {
+  /**
+   * Text label for the menu item
+   */
   label: string
+  /**
+   * Optional icon to display before the label
+   */
   icon?: ReactNode
+  /**
+   * Callback function when the menu item is clicked
+   */
   onClick: () => void
+  /**
+   * Disables the menu item and prevents interaction
+   */
   isDisabled?: boolean
+  /**
+   * Optional URL to navigate to when clicked
+   */
   href?: string
 }
 
 export interface MenuProps extends DataAttributes {
+  /**
+   * Reference to the element that triggers the menu
+   */
   triggerRef?: RefObject<Element | null>
+  /**
+   * Array of menu items to display
+   */
   items?: MenuItem[]
+  /**
+   * Controls whether the menu is currently open
+   */
   isOpen?: boolean
+  /**
+   * Callback when the menu is closed
+   */
   onClose?: () => void
+  /**
+   * Accessible label describing the menu's purpose
+   */
   'aria-label': string
 }

--- a/src/components/Common/UI/NumberInput/NumberInputTypes.ts
+++ b/src/components/Common/UI/NumberInput/NumberInputTypes.ts
@@ -8,15 +8,48 @@ export interface NumberInputProps
       InputHTMLAttributes<HTMLInputElement>,
       'min' | 'max' | 'name' | 'id' | 'placeholder' | 'className'
     > {
+  /**
+   * Format type for the number input
+   */
   format?: 'currency' | 'decimal' | 'percent'
+  /**
+   * React ref for the number input element
+   */
   inputRef?: Ref<HTMLInputElement>
+  /**
+   * Current value of the number input
+   */
   value?: number
+  /**
+   * Indicates that the field has an error
+   */
   isInvalid?: boolean
+  /**
+   * Disables the number input and prevents interaction
+   */
   isDisabled?: boolean
+  /**
+   * Callback when number input value changes
+   */
   onChange?: (value: number) => void
+  /**
+   * Handler for blur events
+   */
   onBlur?: FocusEventHandler<HTMLElement>
+  /**
+   * Element to display at the start of the input
+   */
   adornmentStart?: InputProps['adornmentStart']
+  /**
+   * Element to display at the end of the input
+   */
   adornmentEnd?: InputProps['adornmentEnd']
+  /**
+   * Minimum number of decimal places to display
+   */
   minimumFractionDigits?: number
+  /**
+   * Maximum number of decimal places to display
+   */
   maximumFractionDigits?: number
 }

--- a/src/components/Common/UI/ProgressBar/ProgressBarTypes.ts
+++ b/src/components/Common/UI/ProgressBar/ProgressBarTypes.ts
@@ -1,6 +1,18 @@
 export interface ProgressBarProps {
+  /**
+   * Total number of steps in the progress sequence
+   */
   totalSteps: number
+  /**
+   * Current step in the progress sequence
+   */
   currentStep: number
+  /**
+   * Additional CSS class name for the progress bar container
+   */
   className?: string
+  /**
+   * Accessible label describing the progress bar's purpose
+   */
   label: string
 }

--- a/src/components/Common/UI/Radio/RadioTypes.ts
+++ b/src/components/Common/UI/Radio/RadioTypes.ts
@@ -4,9 +4,24 @@ import type { SharedHorizontalFieldLayoutProps } from '@/components/Common/Horiz
 export interface RadioProps
   extends SharedHorizontalFieldLayoutProps,
     Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id' | 'className' | 'onBlur'> {
+  /**
+   * Current checked state of the radio button
+   */
   value?: boolean
+  /**
+   * Callback when radio button state changes
+   */
   onChange?: (checked: boolean) => void
+  /**
+   * React ref for the radio input element
+   */
   inputRef?: Ref<HTMLInputElement>
+  /**
+   * Indicates that the field has an error
+   */
   isInvalid?: boolean
+  /**
+   * Disables the radio button and prevents interaction
+   */
   isDisabled?: boolean
 }

--- a/src/components/Common/UI/RadioGroup/RadioGroupTypes.ts
+++ b/src/components/Common/UI/RadioGroup/RadioGroupTypes.ts
@@ -2,19 +2,49 @@ import type { FieldsetHTMLAttributes, Ref } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
 export type RadioGroupOption = {
+  /**
+   * Label text or content for the radio option
+   */
   label: React.ReactNode
+  /**
+   * Value of the option that will be passed to onChange
+   */
   value: string
+  /**
+   * Disables this specific radio option
+   */
   isDisabled?: boolean
+  /**
+   * Optional description text for the radio option
+   */
   description?: React.ReactNode
 }
 
 export interface RadioGroupProps
   extends SharedFieldLayoutProps,
     Pick<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'className'> {
+  /**
+   * Indicates that the field has an error
+   */
   isInvalid?: boolean
+  /**
+   * Disables all radio options in the group
+   */
   isDisabled?: boolean
+  /**
+   * Array of radio options to display
+   */
   options: Array<RadioGroupOption>
+  /**
+   * Currently selected value
+   */
   value?: string
+  /**
+   * Callback when selection changes
+   */
   onChange?: (value: string) => void
+  /**
+   * React ref for the first radio input element
+   */
   inputRef?: Ref<HTMLInputElement>
 }

--- a/src/components/Common/UI/Select/SelectTypes.ts
+++ b/src/components/Common/UI/Select/SelectTypes.ts
@@ -2,20 +2,53 @@ import type { FocusEvent, Ref, SelectHTMLAttributes } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
 export interface SelectOption {
+  /**
+   * Value of the option that will be passed to onChange
+   */
   value: string
+  /**
+   * Display text for the option
+   */
   label: string
 }
 
 export interface SelectProps
   extends SharedFieldLayoutProps,
     Pick<SelectHTMLAttributes<HTMLSelectElement>, 'id' | 'name' | 'className'> {
+  /**
+   * Disables the select and prevents interaction
+   */
   isDisabled?: boolean
+  /**
+   * Indicates that the field has an error
+   */
   isInvalid?: boolean
+  /**
+   * Label text for the select field
+   */
   label: string
+  /**
+   * Callback when selection changes
+   */
   onChange?: (value: string) => void
+  /**
+   * Handler for blur events
+   */
   onBlur?: (e: FocusEvent) => void
+  /**
+   * Array of options to display in the select dropdown
+   */
   options: SelectOption[]
+  /**
+   * Placeholder text when no option is selected
+   */
   placeholder?: string
+  /**
+   * Currently selected value
+   */
   value?: string
+  /**
+   * React ref for the select button element
+   */
   inputRef?: Ref<HTMLButtonElement>
 }

--- a/src/components/Common/UI/Switch/SwitchTypes.ts
+++ b/src/components/Common/UI/Switch/SwitchTypes.ts
@@ -4,12 +4,36 @@ import type { SharedHorizontalFieldLayoutProps } from '@/components/Common/Horiz
 export interface SwitchProps
   extends SharedHorizontalFieldLayoutProps,
     Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id'> {
+  /**
+   * Handler for blur events
+   */
   onBlur?: (e: FocusEvent) => void
+  /**
+   * Callback when switch state changes
+   */
   onChange?: (checked: boolean) => void
+  /**
+   * Current checked state of the switch
+   */
   value?: boolean
+  /**
+   * React ref for the switch input element
+   */
   inputRef?: Ref<HTMLInputElement>
+  /**
+   * Indicates that the field has an error
+   */
   isInvalid?: boolean
+  /**
+   * Disables the switch and prevents interaction
+   */
   isDisabled?: boolean
+  /**
+   * Additional CSS class name for the switch container
+   */
   className?: string
+  /**
+   * Label text for the switch
+   */
   label: string
 }

--- a/src/components/Common/UI/Table/TableTypes.ts
+++ b/src/components/Common/UI/Table/TableTypes.ts
@@ -1,12 +1,24 @@
 import type { ReactNode, TableHTMLAttributes } from 'react'
 
 export interface TableData {
+  /**
+   * Unique identifier for the table cell
+   */
   key: string
+  /**
+   * Content to be displayed in the table cell
+   */
   content: ReactNode
 }
 
 export interface TableRow {
+  /**
+   * Unique identifier for the table row
+   */
   key: string
+  /**
+   * Array of cells to be displayed in the row
+   */
   data: TableData[]
 }
 
@@ -15,7 +27,16 @@ export interface TableProps
     TableHTMLAttributes<HTMLTableElement>,
     'className' | 'aria-label' | 'id' | 'role' | 'aria-labelledby' | 'aria-describedby'
   > {
+  /**
+   * Array of header cells for the table
+   */
   headers: TableData[]
+  /**
+   * Array of rows to be displayed in the table
+   */
   rows: TableRow[]
+  /**
+   * Content to display when the table has no rows
+   */
   emptyState?: ReactNode
 }

--- a/src/components/Common/UI/Text/TextTypes.ts
+++ b/src/components/Common/UI/Text/TextTypes.ts
@@ -1,10 +1,28 @@
 import type { HTMLAttributes, ReactNode } from 'react'
 
 export interface TextProps extends Pick<HTMLAttributes<HTMLParagraphElement>, 'className' | 'id'> {
+  /**
+   * HTML element to render the text as
+   */
   as?: 'p' | 'span' | 'div'
+  /**
+   * Size variant of the text
+   */
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  /**
+   * Text alignment within the container
+   */
   textAlign?: 'start' | 'center' | 'end'
+  /**
+   * Font weight of the text
+   */
   weight?: 'regular' | 'medium' | 'semibold' | 'bold'
+  /**
+   * Content to be displayed
+   */
   children?: ReactNode
+  /**
+   * Visual style variant of the text
+   */
   variant?: 'supporting'
 }

--- a/src/components/Common/UI/TextInput/TextInputTypes.ts
+++ b/src/components/Common/UI/TextInput/TextInputTypes.ts
@@ -8,11 +8,32 @@ export interface TextInputProps
       InputHTMLAttributes<HTMLInputElement>,
       'name' | 'id' | 'placeholder' | 'className' | 'type' | 'onBlur'
     > {
+  /**
+   * React ref for the input element
+   */
   inputRef?: Ref<HTMLInputElement>
+  /**
+   * Current value of the input
+   */
   value?: string
+  /**
+   * Callback when input value changes
+   */
   onChange?: (value: string) => void
+  /**
+   * Indicates that the field has an error
+   */
   isInvalid?: boolean
+  /**
+   * Disables the input and prevents interaction
+   */
   isDisabled?: boolean
+  /**
+   * Element to display at the start of the input
+   */
   adornmentStart?: InputProps['adornmentStart']
+  /**
+   * Element to display at the end of the input
+   */
   adornmentEnd?: InputProps['adornmentEnd']
 }


### PR DESCRIPTION
This adds props documentation to all adapter interfaces.

Note: this one is based on https://github.com/Gusto/embedded-react-sdk/pull/316 and will be merged after that one.