### PR TITLE
fix: fix msc style regressions

### DIFF
--- a/src/components/Common/DataView/DataCards/DataCards.module.scss
+++ b/src/components/Common/DataView/DataCards/DataCards.module.scss
@@ -4,3 +4,7 @@ h5.columnTitle {
   color: var(--g-card-columnTitleColor);
   margin: 0;
 }
+
+.columnData {
+  width: 100%;
+}

--- a/src/components/Common/FadeIn/FadeIn.module.scss
+++ b/src/components/Common/FadeIn/FadeIn.module.scss
@@ -1,4 +1,5 @@
 .fade {
+  width: 100%;
   opacity: 0;
   transform: translateY(10px);
   transition:

--- a/src/components/Common/UI/Button/Button.module.scss
+++ b/src/components/Common/UI/Button/Button.module.scss
@@ -1,5 +1,5 @@
 .root {
-  :global(.react-aria-Button) {
+  &:global(.react-aria-Button) {
     --button-color: var(--g-button-primary-color);
     --button-bg: var(--g-button-primary-bg);
     --button-border-color: var(--g-button-primary-borderColor);

--- a/src/components/Common/UI/Button/Button.tsx
+++ b/src/components/Common/UI/Button/Button.tsx
@@ -1,4 +1,5 @@
 import { Button as AriaButton } from 'react-aria-components'
+import classNames from 'classnames'
 import { type ButtonProps } from './ButtonTypes'
 import styles from './Button.module.scss'
 
@@ -22,20 +23,19 @@ export function Button({
     : undefined
 
   return (
-    <span className={styles.root}>
-      <AriaButton
-        {...props}
-        ref={ref}
-        onBlur={onBlur}
-        onFocus={onFocus}
-        isDisabled={isDisabled || isLoading}
-        data-variant={variant}
-        data-loading={isLoading || undefined}
-        data-error={isError || undefined}
-        onPress={handlePress}
-      >
-        {children}
-      </AriaButton>
-    </span>
+    <AriaButton
+      {...props}
+      className={({ defaultClassName }) => classNames(styles.root, defaultClassName, className)}
+      ref={ref}
+      onBlur={onBlur}
+      onFocus={onFocus}
+      isDisabled={isDisabled || isLoading}
+      data-variant={variant}
+      data-loading={isLoading || undefined}
+      data-error={isError || undefined}
+      onPress={handlePress}
+    >
+      {children}
+    </AriaButton>
   )
 }

--- a/src/components/Common/UI/Card/Card.module.scss
+++ b/src/components/Common/UI/Card/Card.module.scss
@@ -1,5 +1,4 @@
 .cardContainer {
-  min-width: 20rem;
   border: 1px solid var(--g-card-borderColor);
   border-radius: 4px;
   padding: toRem(20);

--- a/src/components/Company/PaySchedule/_parts/List.module.scss
+++ b/src/components/Company/PaySchedule/_parts/List.module.scss
@@ -1,0 +1,3 @@
+.content {
+  width: 100%;
+}

--- a/src/components/Company/PaySchedule/_parts/List.tsx
+++ b/src/components/Company/PaySchedule/_parts/List.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { usePaySchedule } from '../usePaySchedule'
+import styles from './List.module.scss'
 import { useDataView, DataView, Flex, VisuallyHidden } from '@/components/Common'
 import PencilSvg from '@/assets/icons/pencil.svg?react'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
@@ -27,8 +28,10 @@ export const List = () => {
           const displayFrequency = schedule.customName
           return (
             <Flex flexDirection={'column'} gap={0}>
-              <div>{displayName}</div>
-              {hasName && <div>{displayFrequency}</div>}
+              <div className={styles.content}>
+                <div>{displayName}</div>
+                {hasName && <div>{displayFrequency}</div>}
+              </div>
             </Flex>
           )
         },
@@ -38,35 +41,33 @@ export const List = () => {
         key: 'active',
         render: schedule => (
           <Flex alignItems={'center'} justifyContent={'center'}>
-            {schedule.active ? (
-              <Components.Badge status="success">{t('payScheduleList.active')}</Components.Badge>
-            ) : (
-              <Components.Badge status="info">{t('payScheduleList.inactive')}</Components.Badge>
-            )}
+            <div className={styles.content}>
+              {schedule.active ? (
+                <Components.Badge status="success">{t('payScheduleList.active')}</Components.Badge>
+              ) : (
+                <Components.Badge status="info">{t('payScheduleList.inactive')}</Components.Badge>
+              )}
+            </div>
           </Flex>
         ),
       },
-      {
-        title: <VisuallyHidden>{t('payScheduleList.actions')}</VisuallyHidden>,
-        key: 'actions',
-        render: schedule => {
-          return (
-            <HamburgerMenu
-              triggerLabel="Actions"
-              items={[
-                {
-                  label: t('payScheduleList.edit'),
-                  onClick: () => {
-                    handleEdit(schedule)
-                  },
-                  icon: <PencilSvg aria-hidden />,
-                },
-              ]}
-            />
-          )
-        },
-      },
     ],
+    itemMenu: schedule => {
+      return (
+        <HamburgerMenu
+          triggerLabel="Actions"
+          items={[
+            {
+              label: t('payScheduleList.edit'),
+              onClick: () => {
+                handleEdit(schedule)
+              },
+              icon: <PencilSvg aria-hidden />,
+            },
+          ]}
+        />
+      )
+    },
   })
 
   if (mode !== 'LIST_PAY_SCHEDULES') {


### PR DESCRIPTION
This updates to fix the following style regressions
* Buttons not filling up full width of the container on mobile
* Assign signatory form not filling the width of the container and looking squished on the screen
* Company pay schedule table not having the menu correctly placed and not being responsive on mobile

## Proof of functionality

### Button styles applied as before

<img width="1239" alt="Screenshot 2025-05-27 at 1 41 03 PM" src="https://github.com/user-attachments/assets/e8b4dc71-6335-482d-a39c-9a28ab312574" />

### Pay schedule table and buttons correctly responsive

https://github.com/user-attachments/assets/2709aa69-6b15-448f-9dac-15a75cfc01f9

### Assign signatory form correctly filling container

<img width="872" alt="Screenshot 2025-05-27 at 1 46 23 PM" src="https://github.com/user-attachments/assets/67097891-1dd4-4a6d-b542-9a4c672da08d" />
