### PR TITLE
chore: release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.1
+
+- Replaced Valibot with Zod for bundle size reduxtion. Also included zod as a dependency
+- Updated package.json to fix an issue with types being unavaiable for consumers
+- Misc style corrections and consisteny fixes
+
 ## 0.8.0
 
 - Company Onboarding flow improvements and fixes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-react-sdk",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@gusto/embedded-api": "^0.5.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "homepage": "https://github.com/Gusto/embedded-react-sdk",
   "bugs": {
     "url": "https://github.com/Gusto/embedded-react-sdk/issues"


### PR DESCRIPTION
This PR is for our 0.8.1 release. See CHANGELOG for detailed changes.