### PR TITLE
fix: update zod schemas to not spread but use merge/extend instead

### DIFF
--- a/src/components/Employee/Compensation/useCompensation.ts
+++ b/src/components/Employee/Compensation/useCompensation.ts
@@ -55,7 +55,6 @@ export const CompensationSchema = z
       return true
     },
     {
-      message: 'Invalid compensation configuration',
       path: ['flsaStatus'],
     },
   )
@@ -67,7 +66,6 @@ export const CompensationSchema = z
       return true
     },
     {
-      message: 'Minimum wage ID is required when adjustForMinimumWage is true',
       path: ['minimumWageId'],
     },
   )
@@ -79,7 +77,6 @@ export const CompensationSchema = z
       return true
     },
     {
-      message: 'State WC class code is required when stateWcCovered is true',
       path: ['stateWcClassCode'],
     },
   )

--- a/src/components/Employee/PaymentMethod/BankAccount.ts
+++ b/src/components/Employee/PaymentMethod/BankAccount.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { accountNumberValidation, routingNumberValidation } from '@/helpers/validations'
 
 export const BankAccountSchema = z.object({
-  name: z.string().min(1, 'f'),
+  name: z.string().min(1),
   routingNumber: routingNumberValidation,
   accountNumber: accountNumberValidation,
   accountType: z.enum(['Checking', 'Savings']),

--- a/src/components/Employee/PaymentMethod/usePaymentMethod.ts
+++ b/src/components/Employee/PaymentMethod/usePaymentMethod.ts
@@ -5,10 +5,9 @@ import { BankAccountSchema } from './BankAccount'
 import { createCompoundContext } from '@/components/Base'
 
 export const CombinedSchema = z.union([
-  z.object({
+  BankAccountSchema.extend({
     type: z.literal('Direct Deposit'),
     isSplit: z.literal(false),
-    ...BankAccountSchema.shape,
   }),
   z.object({
     type: z.literal('Direct Deposit'),

--- a/src/components/Employee/Profile/PersonalDetailsInputs.tsx
+++ b/src/components/Employee/Profile/PersonalDetailsInputs.tsx
@@ -143,14 +143,13 @@ export function DateOfBirthInput() {
 }
 
 // All possible inputs for PersonalDetails forms
-const PersonalDetailsTotalSchema = z.object({
-  ...NameInputsSchema.shape,
-  ...AdminInputsSchema.shape,
-  ...SocialSecurityNumberSchema.shape,
-  ...DateOfBirthSchema.shape,
-  selfOnboarding: z.boolean(),
-  enableSsn: z.boolean(),
-})
+const PersonalDetailsTotalSchema = NameInputsSchema.merge(AdminInputsSchema)
+  .merge(SocialSecurityNumberSchema)
+  .merge(DateOfBirthSchema)
+  .extend({
+    selfOnboarding: z.boolean(),
+    enableSsn: z.boolean(),
+  })
 
 type NullableDatesMapper<Source> = {
   [Property in keyof Source]: Source[Property] extends Date

--- a/src/components/Employee/Profile/SelfPersonalDetails.tsx
+++ b/src/components/Employee/Profile/SelfPersonalDetails.tsx
@@ -9,18 +9,15 @@ import {
 } from './PersonalDetailsInputs'
 import { useProfile } from './useProfile'
 
-export const SelfPersonalDetailsSchema = z.union([
+export const SelfPersonalDetailsSchema = z.discriminatedUnion('enableSsn', [
   // Case 1: enableSsn is true
-  z.object({
-    ...NameInputsSchema.shape,
-    ...SocialSecurityNumberSchema.shape,
-    ...DateOfBirthSchema.shape,
-    enableSsn: z.literal(true),
-  }),
+  NameInputsSchema.merge(SocialSecurityNumberSchema)
+    .merge(DateOfBirthSchema)
+    .extend({
+      enableSsn: z.literal(true),
+    }),
   // Case 2: enableSsn is false
-  z.object({
-    ...NameInputsSchema.shape,
-    ...DateOfBirthSchema.shape,
+  NameInputsSchema.merge(DateOfBirthSchema).extend({
     enableSsn: z.literal(false),
   }),
 ])

--- a/src/components/Employee/Taxes/Taxes.tsx
+++ b/src/components/Employee/Taxes/Taxes.tsx
@@ -1,7 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { FormProvider, useForm, type SubmitHandler } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { z } from 'zod'
 import { useEffect } from 'react'
 import { useEmployeeTaxSetupGetFederalTaxesSuspense } from '@gusto/embedded-api/react-query/employeeTaxSetupGetFederalTaxes'
 import { useEmployeeTaxSetupUpdateFederalTaxesMutation } from '@gusto/embedded-api/react-query/employeeTaxSetupUpdateFederalTaxes'
@@ -91,7 +90,7 @@ const Root = (props: TaxesProps) => {
   }
 
   const formMethods = useForm<FederalFormInputs, unknown, FederalFormPayload & StateFormPayload>({
-    resolver: zodResolver(z.object({ ...FederalFormSchema.shape, ...StateFormSchema.shape })),
+    resolver: zodResolver(FederalFormSchema.merge(StateFormSchema)),
     defaultValues,
   })
   const { handleSubmit, setError: _setError } = formMethods

--- a/src/helpers/validations.ts
+++ b/src/helpers/validations.ts
@@ -4,7 +4,7 @@ import { removeNonDigits } from '@/helpers/formattedStrings'
 
 export const NAME_REGEX = /^([a-zA-Z\xC0-\uFFFF]+([ \-']{0,1}[a-zA-Z\xC0-\uFFFF]+)*[.]{0,1}){1,2}$/
 
-export const nameValidation = z.string().min(1, 'Should not be empty').regex(NAME_REGEX)
+export const nameValidation = z.string().min(1).regex(NAME_REGEX)
 
 export const zipValidation = z.string().refine(zip => /(^\d{5}$)|(^\d{5}-\d{4}$)/.test(zip))
 


### PR DESCRIPTION
This PR contains updates to our ZOD Schema

Overview
- Replaced spreads of Zod Shapes to use Merge/Extend which is provided by Zod and allows for better management of schemas
- Removed error messages which were added to Zod by AI but are already configured in other parts of the app. Zod schemas can run i18n yet (Nor could Valibot)