### PR TITLE
feat: moving ApiProvider into SDK from speakeasy client

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "vitest": "^2.1.9"
   },
   "peerDependencies": {
+    "@tanstack/react-query": "^5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.8.3"
@@ -103,7 +104,6 @@
     "@hookform/resolvers": "^3.10.0",
     "@internationalized/date": "^3.8.0",
     "@internationalized/number": "^3.6.1",
-    "@tanstack/react-query": "^5",
     "classnames": "^2.5.1",
     "deepmerge": "^4.3.1",
     "dompurify": "^3.2.5",

--- a/src/components/Company/DocumentSignerFlow/SignatureForm/SignatureForm.tsx
+++ b/src/components/Company/DocumentSignerFlow/SignatureForm/SignatureForm.tsx
@@ -8,7 +8,7 @@ import {
   useCompanyFormsGetPdfSuspense,
   invalidateAllCompanyFormsGetPdf,
 } from '@gusto/embedded-api/react-query/companyFormsGetPdf'
-import { useQueryClient } from '@gusto/embedded-api/ReactSDKProvider'
+import { useQueryClient } from '@tanstack/react-query'
 import { Head } from './Head'
 import { Preview } from './Preview'
 import { Form } from './Form'

--- a/src/components/Company/Industry/Industry.tsx
+++ b/src/components/Company/Industry/Industry.tsx
@@ -4,7 +4,7 @@ import {
   invalidateAllIndustrySelectionGet,
 } from '@gusto/embedded-api/react-query/industrySelectionGet'
 import { useIndustrySelectionUpdateMutation } from '@gusto/embedded-api/react-query/industrySelectionUpdate'
-import { useQueryClient } from '@gusto/embedded-api/ReactSDKProvider'
+import { useQueryClient } from '@tanstack/react-query'
 import { Actions } from './Actions'
 import { Head } from './Head'
 import type { IndustryFormFields } from './Edit'

--- a/src/components/Company/Locations/LocationForm/LocationForm.tsx
+++ b/src/components/Company/Locations/LocationForm/LocationForm.tsx
@@ -5,7 +5,7 @@ import { useLocationsRetrieveSuspense } from '@gusto/embedded-api/react-query/lo
 import { invalidateAllLocationsGet } from '@gusto/embedded-api/react-query/locationsGet'
 import { useLocationsCreateMutation } from '@gusto/embedded-api/react-query/locationsCreate'
 import { type Location } from '@gusto/embedded-api/models/components/location'
-import { useQueryClient } from '@gusto/embedded-api/ReactSDKProvider'
+import { useQueryClient } from '@tanstack/react-query'
 import { Head } from './Head'
 import type { LocationFormInputs } from './Form'
 import { Form, LocationFormSchema } from './Form'

--- a/src/components/Company/PaySchedule/PaySchedule.tsx
+++ b/src/components/Company/PaySchedule/PaySchedule.tsx
@@ -10,7 +10,7 @@ import {
 } from '@gusto/embedded-api/react-query/paySchedulesGetAll'
 import { usePaySchedulesCreateMutation } from '@gusto/embedded-api/react-query/paySchedulesCreate'
 import type { PayScheduleObject as PayScheduleType } from '@gusto/embedded-api/models/components/payscheduleobject'
-import { useQueryClient } from '@gusto/embedded-api/ReactSDKProvider'
+import { useQueryClient } from '@tanstack/react-query'
 import type { Frequency } from '@gusto/embedded-api/models/operations/postv1companiescompanyidpayschedules'
 import type { MODE, PayScheduleInputs, PayScheduleOutputs } from './usePaySchedule'
 import {

--- a/src/components/Employee/Compensation/Compensation.tsx
+++ b/src/components/Employee/Compensation/Compensation.tsx
@@ -13,7 +13,7 @@ import { useJobsAndCompensationsUpdateCompensationMutation } from '@gusto/embedd
 import { useLocationsGetMinimumWagesSuspense } from '@gusto/embedded-api/react-query/locationsGetMinimumWages'
 import { useEmployeeAddressesGetWorkAddressesSuspense } from '@gusto/embedded-api/react-query/employeeAddressesGetWorkAddresses'
 import { type Job } from '@gusto/embedded-api/models/components/job'
-import { useQueryClient } from '@gusto/embedded-api/ReactSDKProvider'
+import { useQueryClient } from '@tanstack/react-query'
 import type { FlsaStatusType } from '@gusto/embedded-api/models/components/flsastatustype'
 import { useFederalTaxDetailsGetSuspense } from '@gusto/embedded-api/react-query/federalTaxDetailsGet'
 import { useEmployeesGetSuspense } from '@gusto/embedded-api/react-query/employeesGet'

--- a/src/components/Employee/Deductions/Deductions.tsx
+++ b/src/components/Employee/Deductions/Deductions.tsx
@@ -10,7 +10,7 @@ import {
 import { type Garnishment } from '@gusto/embedded-api/models/components/garnishment'
 import { useGarnishmentsCreateMutation } from '@gusto/embedded-api/react-query/garnishmentsCreate'
 import { useGarnishmentsUpdateMutation } from '@gusto/embedded-api/react-query/garnishmentsUpdate'
-import { useQueryClient } from '@gusto/embedded-api/ReactSDKProvider'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   type DeductionInputs,
   type DeductionPayload,

--- a/src/components/Employee/DocumentSigner/SignatureForm/SignatureForm.tsx
+++ b/src/components/Employee/DocumentSigner/SignatureForm/SignatureForm.tsx
@@ -2,7 +2,7 @@ import { invalidateEmployeeFormsList } from '@gusto/embedded-api/react-query/emp
 import { useEmployeeFormsGetPdfSuspense } from '@gusto/embedded-api/react-query/employeeFormsGetPdf'
 import { useEmployeeFormsSignMutation } from '@gusto/embedded-api/react-query/employeeFormsSign'
 import { useEmployeeFormsGetSuspense } from '@gusto/embedded-api/react-query/employeeFormsGet'
-import { useQueryClient } from '@gusto/embedded-api/ReactSDKProvider'
+import { useQueryClient } from '@tanstack/react-query'
 import { Form as FormComponent } from './Form'
 import { Head } from './Head'
 import { Actions } from './Actions'

--- a/src/components/Employee/EmployeeList/EmployeeList.tsx
+++ b/src/components/Employee/EmployeeList/EmployeeList.tsx
@@ -5,7 +5,7 @@ import {
 } from '@gusto/embedded-api/react-query/employeesList'
 import { useEmployeesDeleteMutation } from '@gusto/embedded-api/react-query/employeesDelete'
 import { useEmployeesUpdateOnboardingStatusMutation } from '@gusto/embedded-api/react-query/employeesUpdateOnboardingStatus'
-import { useQueryClient } from '@gusto/embedded-api/ReactSDKProvider'
+import { useQueryClient } from '@tanstack/react-query'
 import { EmployeeListProvider } from './useEmployeeList'
 import { Actions } from './Actions'
 import {

--- a/src/components/Employee/PaymentMethod/PaymentMethod.tsx
+++ b/src/components/Employee/PaymentMethod/PaymentMethod.tsx
@@ -11,7 +11,7 @@ import {
 } from '@gusto/embedded-api/react-query/employeePaymentMethodGet'
 import { useEmployeePaymentMethodUpdateBankAccountMutation } from '@gusto/embedded-api/react-query/employeePaymentMethodUpdateBankAccount'
 import { useEmployeePaymentMethodUpdateMutation } from '@gusto/embedded-api/react-query/employeePaymentMethodUpdate'
-import { useQueryClient } from '@gusto/embedded-api/ReactSDKProvider'
+import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FormProvider, useForm, type DefaultValues, type SubmitHandler } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'

--- a/src/components/Employee/Profile/Profile.tsx
+++ b/src/components/Employee/Profile/Profile.tsx
@@ -18,7 +18,7 @@ import { useEmployeeAddressesCreateWorkAddressMutation } from '@gusto/embedded-a
 import { RFCDate } from '@gusto/embedded-api/types/rfcdate'
 import { useEmployeesUpdateOnboardingStatusMutation } from '@gusto/embedded-api/react-query/employeesUpdateOnboardingStatus'
 import { invalidateEmployeesList } from '@gusto/embedded-api/react-query/employeesList'
-import { useQueryClient } from '@gusto/embedded-api/ReactSDKProvider'
+import { useQueryClient } from '@tanstack/react-query'
 import { AdminPersonalDetails, AdminPersonalDetailsSchema } from './AdminPersonalDetails'
 import { SelfPersonalDetails, SelfPersonalDetailsSchema } from './SelfPersonalDetails'
 import { type PersonalDetailsPayload, type PersonalDetailsInputs } from './PersonalDetailsInputs'

--- a/src/contexts/ApiProvider/ApiProvider.tsx
+++ b/src/contexts/ApiProvider/ApiProvider.tsx
@@ -1,0 +1,41 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { GustoEmbeddedProvider } from '@gusto/embedded-api/react-query/_context'
+import { GustoEmbeddedCore } from '@gusto/embedded-api/core'
+import { HTTPClient } from '@gusto/embedded-api/lib/http'
+
+export function ApiProvider({
+  url,
+  headers,
+  children,
+}: {
+  url: string
+  headers?: Headers
+  children: React.ReactNode
+}) {
+  const httpClientWithHeaders = new HTTPClient({
+    fetcher: async request => {
+      if (request instanceof Request && headers) {
+        headers.forEach((headerValue, headerName) => {
+          if (headerValue) {
+            request.headers.set(headerName, headerValue)
+          }
+        })
+      }
+
+      return fetch(request)
+    },
+  })
+
+  const queryClient = new QueryClient()
+  const gustoClient = new GustoEmbeddedCore({
+    serverURL: url,
+    httpClient: httpClientWithHeaders,
+  })
+  queryClient.setQueryDefaults(['@gusto/embedded-api'], { retry: false })
+  queryClient.setMutationDefaults(['@gusto/embedded-api'], { retry: false })
+  return (
+    <QueryClientProvider client={queryClient}>
+      <GustoEmbeddedProvider client={gustoClient}>{children}</GustoEmbeddedProvider>
+    </QueryClientProvider>
+  )
+}

--- a/src/contexts/GustoProvider/GustoProviderCustomUIAdapter.tsx
+++ b/src/contexts/GustoProvider/GustoProviderCustomUIAdapter.tsx
@@ -1,12 +1,12 @@
 import type React from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { I18nextProvider } from 'react-i18next'
-import { ReactSDKProvider } from '@gusto/embedded-api/ReactSDKProvider'
 import type { CustomTypeOptions } from 'i18next'
 import type { QueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import { ComponentsProvider } from '../ComponentAdapter/ComponentsProvider'
 import type { ComponentsContextType } from '../ComponentAdapter/useComponentContext'
+import { ApiProvider } from '../ApiProvider/ApiProvider'
 import { SDKI18next } from './SDKI18next'
 import { InternalError } from '@/components/Common'
 import { LocaleProvider } from '@/contexts/LocaleProvider'
@@ -85,7 +85,7 @@ const GustoProviderCustomUIAdapter: React.FC<GustoProviderCustomUIAdapterProps> 
         <ThemeProvider theme={theme}>
           <LocaleProvider locale={locale} currency={currency}>
             <I18nextProvider i18n={SDKI18next} key={lng}>
-              <ReactSDKProvider url={config.baseUrl}>{children}</ReactSDKProvider>
+              <ApiProvider url={config.baseUrl}>{children}</ApiProvider>
             </I18nextProvider>
           </LocaleProvider>
         </ThemeProvider>


### PR DESCRIPTION
Since speakeasy marks react-query as a peerDependency and we have to include it in our bundle, this change moves custom provider from speakeasy to sdk. 