### PR TITLE
fix: update state taxes to allow for API based validation messages

### DIFF
--- a/src/components/Employee/Taxes/StateForm.tsx
+++ b/src/components/Employee/Taxes/StateForm.tsx
@@ -8,7 +8,7 @@ import { QuestionInput } from '@/components/Common/TaxInputs/TaxInputs'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export const StateFormSchema = z.object({
-  states: z.record(z.string(), z.record(z.string(), z.unknown())),
+  states: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
 })
 
 export type StateFormPayload = z.output<typeof StateFormSchema>

--- a/src/components/Employee/Taxes/Taxes.tsx
+++ b/src/components/Employee/Taxes/Taxes.tsx
@@ -139,7 +139,7 @@ const Root = (props: TaxesProps) => {
                 key: question.key,
                 answers: [
                   {
-                    validFrom: question.answers[0]?.validFrom ?? '2010-01-01',
+                    validFrom: question.answers[0]?.validFrom ?? DEFAULT_TAX_VALID_FROM,
                     validUpTo: question.answers[0]?.validUpTo ?? null,
                     value:
                       formValue == null || (typeof formValue === 'number' && isNaN(formValue))

--- a/src/components/Employee/Taxes/Taxes.tsx
+++ b/src/components/Employee/Taxes/Taxes.tsx
@@ -30,6 +30,8 @@ import { snakeCaseToCamelCase } from '@/helpers/formattedStrings'
 import { Form } from '@/components/Common/Form'
 import { useComponentDictionary } from '@/i18n/I18n'
 
+const DEFAULT_TAX_VALID_FROM = '2010-01-01'
+
 interface TaxesProps extends CommonComponentInterface<'Employee.Taxes'> {
   employeeId: string
   isAdmin?: boolean
@@ -125,10 +127,7 @@ const Root = (props: TaxesProps) => {
       onEvent(componentEvents.EMPLOYEE_FEDERAL_TAXES_UPDATED, federalTaxesResponse)
 
       //State Taxes - only process if statesPayload exists
-      if (
-        statesPayload &&
-        Object.keys(statesPayload).length > 0
-      ) {
+      if (statesPayload && Object.keys(statesPayload).length > 0) {
         const body = {
           states: employeeStateTaxes.map(state => ({
             state: state.state,

--- a/src/components/Employee/Taxes/Taxes.tsx
+++ b/src/components/Employee/Taxes/Taxes.tsx
@@ -127,7 +127,6 @@ const Root = (props: TaxesProps) => {
       //State Taxes - only process if statesPayload exists
       if (
         statesPayload &&
-        typeof statesPayload === 'object' &&
         Object.keys(statesPayload).length > 0
       ) {
         const body = {


### PR DESCRIPTION
This fix ensures Zod validation allows state taxes to be submitted, enabling us to receive more detailed error responses from the API.

The payload must pass initial validation before state tax data can be sent, which allows the API to return 422 responses with specific, descriptive errors related to state tax issues.
