### PR TITLE
feat: add contractor address form

### DIFF
--- a/src/components/Contractor/Address/Actions.tsx
+++ b/src/components/Contractor/Address/Actions.tsx
@@ -1,0 +1,18 @@
+import { useTranslation } from 'react-i18next'
+import { useAddress } from './useAddress'
+import { ActionsLayout } from '@/components/Common/ActionsLayout/ActionsLayout'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+export function Actions() {
+  const { t } = useTranslation('Contractor.Address')
+  const Components = useComponentContext()
+  const { isPending } = useAddress()
+
+  return (
+    <ActionsLayout>
+      <Components.Button type="submit" isLoading={isPending}>
+        {t('submit')}
+      </Components.Button>
+    </ActionsLayout>
+  )
+}

--- a/src/components/Contractor/Address/Address.tsx
+++ b/src/components/Contractor/Address/Address.tsx
@@ -1,0 +1,126 @@
+import type { ReactNode } from 'react'
+import { useContractorsGetSuspense } from '@gusto/embedded-api/react-query/contractorsGet'
+import {
+  useContractorsGetAddressSuspense,
+  invalidateContractorsGetAddress,
+} from '@gusto/embedded-api/react-query/contractorsGetAddress'
+import { useContractorsUpdateAddressMutation } from '@gusto/embedded-api/react-query/contractorsUpdateAddress'
+import { useQueryClient } from '@tanstack/react-query'
+import { FormProvider, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { AddressFormSchema, AddressProvider } from './useAddress'
+import { Head } from './Head'
+import { Form } from './Form'
+import { Actions } from './Actions'
+import type { AddressDefaultValues, AddressFormValues } from './useAddress'
+import { Form as HtmlForm } from '@/components/Common/Form/Form'
+import { useI18n, useComponentDictionary } from '@/i18n'
+import { Flex } from '@/components/Common'
+import type { BaseComponentInterface } from '@/components/Base/Base'
+import { BaseComponent } from '@/components/Base/Base'
+import { useBase } from '@/components/Base/useBase'
+import { contractorEvents } from '@/shared/constants'
+
+export interface AddressProps extends BaseComponentInterface<'Contractor.Address'> {
+  contractorId: string
+  defaultValues?: AddressDefaultValues
+  children?: ReactNode
+  className?: string
+}
+
+export function Address(props: AddressProps) {
+  return (
+    <BaseComponent {...props}>
+      <Root {...props}>{props.children}</Root>
+    </BaseComponent>
+  )
+}
+
+function Root({ contractorId, defaultValues, children, className, dictionary }: AddressProps) {
+  useComponentDictionary('Contractor.Address', dictionary)
+  useI18n('Contractor.Address')
+  const queryClient = useQueryClient()
+
+  const { onEvent, baseSubmitHandler } = useBase()
+
+  const { data: contractorData } = useContractorsGetSuspense({ contractorUuid: contractorId })
+  const { data: addressData } = useContractorsGetAddressSuspense({ contractorUuid: contractorId })
+
+  const { mutateAsync: updateAddress, isPending: isUpdatingAddressPending } =
+    useContractorsUpdateAddressMutation()
+
+  const contractor = contractorData.contractor
+  const contractorType = contractorData.contractor?.type
+  const address = addressData.contractorAddress
+
+  const formDefaultValues = {
+    street1: address?.street1 || defaultValues?.street1 || '',
+    street2: address?.street2 || defaultValues?.street2 || '',
+    city: address?.city || defaultValues?.city || '',
+    state: address?.state || defaultValues?.state || '',
+    zip: address?.zip || defaultValues?.zip || '',
+  }
+
+  const formMethods = useForm<AddressFormValues>({
+    resolver: zodResolver(AddressFormSchema),
+    defaultValues: formDefaultValues,
+  })
+
+  const onSubmit = async (data: AddressFormValues) => {
+    await baseSubmitHandler(data, async payload => {
+      const { contractorAddress } = await updateAddress({
+        request: {
+          contractorUuid: contractorId,
+          requestBody: {
+            version: address?.version as string,
+            street1: payload.street1,
+            street2: payload.street2,
+            city: payload.city,
+            state: payload.state,
+            zip: payload.zip,
+          },
+        },
+      })
+
+      await invalidateContractorsGetAddress(queryClient, [contractorId])
+
+      onEvent(contractorEvents.CONTRACTOR_ADDRESS_UPDATED, contractorAddress)
+      onEvent(contractorEvents.CONTRACTOR_ADDRESS_DONE)
+    })
+  }
+
+  return (
+    <section className={className}>
+      <AddressProvider
+        value={{
+          contractor,
+          contractorType,
+          address,
+          isPending: isUpdatingAddressPending,
+        }}
+      >
+        <FormProvider {...formMethods}>
+          <HtmlForm onSubmit={formMethods.handleSubmit(onSubmit)}>
+            <Flex flexDirection="column" gap={32}>
+              {children ? (
+                children
+              ) : (
+                <>
+                  <Head />
+                  <Form />
+                  <Actions />
+                </>
+              )}
+            </Flex>
+          </HtmlForm>
+        </FormProvider>
+      </AddressProvider>
+    </section>
+  )
+}
+
+Address.Head = Head
+Address.Form = Form
+Address.Actions = Actions
+
+export default Address

--- a/src/components/Contractor/Address/Form.tsx
+++ b/src/components/Contractor/Address/Form.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next'
+import { TextInputField, SelectField, Grid } from '@/components/Common'
+import { STATES_ABBR } from '@/shared/constants'
+
+export function Form() {
+  const { t } = useTranslation('Contractor.Address')
+
+  return (
+    <Grid gridTemplateColumns={{ base: '1fr', small: ['1fr', '1fr'] }} gap={20}>
+      <TextInputField
+        name="street1"
+        label={t('street1')}
+        isRequired
+        errorMessage={t('validations.street1')}
+      />
+      <TextInputField name="street2" label={t('street2', 'Street 2')} />
+      <TextInputField
+        name="city"
+        label={t('city', 'City')}
+        isRequired
+        errorMessage={t('validations.city')}
+      />
+      <SelectField
+        name="state"
+        options={STATES_ABBR.map(stateAbbr => ({
+          label: t(`statesHash.${stateAbbr}`, { ns: 'common', defaultValue: stateAbbr }),
+          value: stateAbbr,
+        }))}
+        label={t('state', 'State')}
+        placeholder={t('statePlaceholder')}
+        errorMessage={t('validations.state')}
+        isRequired
+      />
+      <TextInputField
+        name="zip"
+        label={t('zip', 'Zip')}
+        isRequired
+        errorMessage={t('validations.zip')}
+      />
+    </Grid>
+  )
+}

--- a/src/components/Contractor/Address/Head.tsx
+++ b/src/components/Contractor/Address/Head.tsx
@@ -1,0 +1,22 @@
+import { useTranslation } from 'react-i18next'
+import { useAddress } from './useAddress'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+export function Head() {
+  const { t } = useTranslation('Contractor.Address')
+  const { contractorType } = useAddress()
+  const Components = useComponentContext()
+
+  return (
+    <header>
+      <Components.Heading as="h2">
+        {contractorType === 'Business' ? t('businessAddressTitle') : t('homeAddressTitle')}
+      </Components.Heading>
+      <Components.Text>
+        {contractorType === 'Business'
+          ? t('businessAddressDescription')
+          : t('homeAddressDescription')}
+      </Components.Text>
+    </header>
+  )
+}

--- a/src/components/Contractor/Address/index.ts
+++ b/src/components/Contractor/Address/index.ts
@@ -1,0 +1,1 @@
+export { Address } from './Address'

--- a/src/components/Contractor/Address/useAddress.ts
+++ b/src/components/Contractor/Address/useAddress.ts
@@ -1,0 +1,32 @@
+import type { Contractor, ContractorType } from '@gusto/embedded-api/models/components/contractor'
+import type { ContractorAddress } from '@gusto/embedded-api/models/components/contractoraddress'
+import { z } from 'zod'
+import { createCompoundContext } from '@/components/Base'
+import type { RequireAtLeastOne } from '@/types/Helpers'
+
+export interface AddressContextType {
+  contractor?: Contractor
+  contractorType?: ContractorType
+  address?: ContractorAddress
+  isPending: boolean
+}
+
+export type AddressDefaultValues = RequireAtLeastOne<
+  Pick<ContractorAddress, 'street1' | 'street2' | 'city' | 'state' | 'zip'>
+>
+
+export const AddressFormSchema = z.object({
+  street1: z.string().min(1),
+  street2: z.string().optional(),
+  city: z.string().min(1),
+  state: z.string().min(1),
+  zip: z.string().min(1),
+})
+
+export type AddressFormValues = z.infer<typeof AddressFormSchema>
+
+const [useAddress, AddressProvider] = createCompoundContext<AddressContextType>(
+  'ContractorAddressContext',
+)
+
+export { useAddress, AddressProvider }

--- a/src/components/Contractor/index.ts
+++ b/src/components/Contractor/index.ts
@@ -1,0 +1,1 @@
+export { Address } from './Address'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 // Explicit exports available to partners
 export * as Company from './Company'
 export * as Employee from './Employee'
+export * as Contractor from './Contractor'

--- a/src/i18n/en/Contractor.Address.json
+++ b/src/i18n/en/Contractor.Address.json
@@ -1,0 +1,19 @@
+{
+  "businessAddressTitle": "Business address",
+  "businessAddressDescription": "Contractor's business address, within the United States.",
+  "homeAddressTitle": "Home address",
+  "homeAddressDescription": "Contractor's home mailing address, within the United States.",
+  "street1": "Street 1",
+  "street2": "Street 2",
+  "city": "City",
+  "state": "State",
+  "statePlaceholder": "Select state...",
+  "zip": "Zip",
+  "submit": "Continue",
+  "validations": {
+    "street1": "Street address is required",
+    "city": "Please provide valid city name",
+    "state": "Please select a state",
+    "zip": "Please provide valid zip code"
+  }
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -81,6 +81,11 @@ export const companyEvents = {
   COMPANY_OVERVIEW_CONTINUE: 'company/overview/continue',
 } as const
 
+export const contractorEvents = {
+  CONTRACTOR_ADDRESS_UPDATED: 'contractor/address/updated',
+  CONTRACTOR_ADDRESS_DONE: 'contractor/address/done',
+} as const
+
 export const payScheduleEvents = {
   PAY_SCHEDULE_CREATE: 'paySchedule/create',
   PAY_SCHEDULE_CREATED: 'paySchedule/created',
@@ -98,6 +103,7 @@ export const componentEvents = {
   ...employeeEvents,
   ...companyEvents,
   ...payScheduleEvents,
+  ...contractorEvents,
 } as const
 
 export type EventType = (typeof componentEvents)[keyof typeof componentEvents]

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -353,6 +353,25 @@ export interface CompanyStateTaxes{
 };
 };
 };
+export interface ContractorAddress{
+"businessAddressTitle":string;
+"businessAddressDescription":string;
+"homeAddressTitle":string;
+"homeAddressDescription":string;
+"street1":string;
+"street2":string;
+"city":string;
+"state":string;
+"statePlaceholder":string;
+"zip":string;
+"submit":string;
+"validations":{
+"street1":string;
+"city":string;
+"state":string;
+"zip":string;
+};
+};
 export interface EmployeeBankAccount{
 "accountNumberLabel":string;
 "accountTypeChecking":string;
@@ -915,6 +934,6 @@ export interface common{
 
     interface CustomTypeOptions {
         defaultNS: 'common';
-        resources: { 'Company.AddBank': CompanyAddBank, 'Company.Addresses': CompanyAddresses, 'Company.AssignSignatory': CompanyAssignSignatory, 'Company.BankAccount': CompanyBankAccount, 'Company.DocumentList': CompanyDocumentList, 'Company.FederalTaxes': CompanyFederalTaxes, 'Company.Industry': CompanyIndustry, 'Company.Locations': CompanyLocations, 'Company.OnboardingOverview': CompanyOnboardingOverview, 'Company.PaySchedule': CompanyPaySchedule, 'Company.SignatureForm': CompanySignatureForm, 'Company.StateTaxes': CompanyStateTaxes, 'Employee.BankAccount': EmployeeBankAccount, 'Employee.Compensation': EmployeeCompensation, 'Employee.Deductions': EmployeeDeductions, 'Employee.DocumentSigner': EmployeeDocumentSigner, 'Employee.EmployeeList': EmployeeEmployeeList, 'Employee.HomeAddress': EmployeeHomeAddress, 'Employee.Landing': EmployeeLanding, 'Employee.OnboardingSummary': EmployeeOnboardingSummary, 'Employee.PaySchedules': EmployeePaySchedules, 'Employee.PaymentMethod': EmployeePaymentMethod, 'Employee.Profile': EmployeeProfile, 'Employee.SplitPaycheck': EmployeeSplitPaycheck, 'Employee.StateTaxes': EmployeeStateTaxes, 'Employee.Taxes': EmployeeTaxes, 'Payroll.PayrollHistoryList': PayrollPayrollHistoryList, 'Payroll.PayrollSchedule': PayrollPayrollSchedule, 'common': common,  }
+        resources: { 'Company.AddBank': CompanyAddBank, 'Company.Addresses': CompanyAddresses, 'Company.AssignSignatory': CompanyAssignSignatory, 'Company.BankAccount': CompanyBankAccount, 'Company.DocumentList': CompanyDocumentList, 'Company.FederalTaxes': CompanyFederalTaxes, 'Company.Industry': CompanyIndustry, 'Company.Locations': CompanyLocations, 'Company.OnboardingOverview': CompanyOnboardingOverview, 'Company.PaySchedule': CompanyPaySchedule, 'Company.SignatureForm': CompanySignatureForm, 'Company.StateTaxes': CompanyStateTaxes, 'Contractor.Address': ContractorAddress, 'Employee.BankAccount': EmployeeBankAccount, 'Employee.Compensation': EmployeeCompensation, 'Employee.Deductions': EmployeeDeductions, 'Employee.DocumentSigner': EmployeeDocumentSigner, 'Employee.EmployeeList': EmployeeEmployeeList, 'Employee.HomeAddress': EmployeeHomeAddress, 'Employee.Landing': EmployeeLanding, 'Employee.OnboardingSummary': EmployeeOnboardingSummary, 'Employee.PaySchedules': EmployeePaySchedules, 'Employee.PaymentMethod': EmployeePaymentMethod, 'Employee.Profile': EmployeeProfile, 'Employee.SplitPaycheck': EmployeeSplitPaycheck, 'Employee.StateTaxes': EmployeeStateTaxes, 'Employee.Taxes': EmployeeTaxes, 'Payroll.PayrollHistoryList': PayrollPayrollHistoryList, 'Payroll.PayrollSchedule': PayrollPayrollSchedule, 'common': common,  }
     };
 }


### PR DESCRIPTION
Adds the address form for contractors. See Figma here https://www.figma.com/design/6dxOSiONDiJoa9zY1wOwbs/Frontend-SDK-Partner-Design-File?node-id=8224-17639&t=O6iUevayceAZJvHb-4

## Proof of functionality

### Individual contractor

https://github.com/user-attachments/assets/5ad81b0d-1948-409a-8ef4-7f629ffe4fe3

### Business contractor

https://github.com/user-attachments/assets/d68da9db-d85e-4f9a-b05b-42663b6e0f21

### Editing with an existing address

https://github.com/user-attachments/assets/eb188534-e6fc-4fae-83f8-bd46f57dfd93

### Default values

https://github.com/user-attachments/assets/97d9b079-419e-4cd1-b691-5c41cd37273c
