### PR TITLE
fix: update rate to not be labeled optional when it is required

### DIFF
--- a/src/components/Employee/Compensation/useCompensation.ts
+++ b/src/components/Employee/Compensation/useCompensation.ts
@@ -5,6 +5,9 @@ import { createCompoundContext } from '@/components/Base/createCompoundContext'
 import { FLSA_OVERTIME_SALARY_LIMIT, FlsaStatus } from '@/shared/constants'
 import { yearlyRate } from '@/helpers/payRateCalculator'
 
+export const rateMinimumError = 'rate_minimum_error'
+export const rateExemptThresholdError = 'rate_exempt_threshold_error'
+
 export const CompensationSchema = z
   .object({
     jobTitle: z.string().min(1),
@@ -53,13 +56,6 @@ export const CompensationSchema = z
       flsaStatus === FlsaStatus.SALARIED_NONEXEMPT ||
       flsaStatus === FlsaStatus.NONEXEMPT
     ) {
-      if (rate === undefined || rate < 1) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['rate'],
-          message: 'rate must be at least 1 for this FLSA status',
-        })
-      }
       // For EXEMPT, check salary threshold
       if (
         flsaStatus === FlsaStatus.EXEMPT &&
@@ -69,7 +65,15 @@ export const CompensationSchema = z
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['rate'],
-          message: 'FLSA Exempt employees must meet salary threshold',
+          message: rateExemptThresholdError,
+        })
+      }
+
+      if (rate === undefined || rate < 1) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['rate'],
+          message: rateMinimumError,
         })
       }
     } else if (flsaStatus === FlsaStatus.OWNER) {
@@ -84,7 +88,7 @@ export const CompensationSchema = z
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['rate'],
-          message: 'rate must be at least 1 for OWNER',
+          message: rateMinimumError,
         })
       }
     } else if (
@@ -101,7 +105,7 @@ export const CompensationSchema = z
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['rate'],
-          message: 'rate must be exactly 0 for commission-only FLSA statuses',
+          message: rateMinimumError,
         })
       }
     }

--- a/src/i18n/en/Employee.Compensation.json
+++ b/src/i18n/en/Employee.Compensation.json
@@ -48,6 +48,8 @@
     "exemptThreshold": "Most employees who make under {{limit}}/year should be eligible for overtime.",
     "paymentUnit": "Payment unit must be one of Hour, Week, Month, or Year",
     "rate": "Amount is a required field",
+    "nonZeroRate": "Amount must be at least $1.00",
+    "rateExemptThreshold": "FLSA Exempt employees must meet salary threshold of {{limit}}/year",
     "title": "Title is a required field",
     "minimumWage": "Please select minimum wage for adjustment",
     "stateWcClassCode": "Please select a risk class code"

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -440,6 +440,8 @@ export interface EmployeeCompensation{
 "exemptThreshold":string;
 "paymentUnit":string;
 "rate":string;
+"nonZeroRate":string;
+"rateExemptThreshold":string;
 "title":string;
 "minimumWage":string;
 "stateWcClassCode":string;


### PR DESCRIPTION
This PR updates compensation amount (rate) to no longer be labeled as optional since it is required by most employee types. It also updates the validation messages to correctly reflect the underlying validation logic in the schema (ex. provides an explanation if it is required, if the rate amount does not satisfy the min threshold etc)

## Proof of functionality

### Before

Compensation amount is labeled as "optional" when it is actually required. Error message also simply says that the amount is required, it does not provide helpful context. Ex. in the video you can observe that the entered amount does not meet the min salary threshold. The validation message is just around the required field which is frustrating UX.

https://github.com/user-attachments/assets/eb02a468-c8cd-4618-8352-c8fdce03d958

### After

Observe that
* Compensation amount is no longer labeled as optional
* Validation messages are descriptive about the issue the field is actually experiencing

https://github.com/user-attachments/assets/7b7e0fc3-c17f-4be5-ada6-a5df086433a5






