### PR TITLE
fix: restore proper SSN validation

### DIFF
--- a/src/components/Employee/Profile/AdminPersonalDetails.tsx
+++ b/src/components/Employee/Profile/AdminPersonalDetails.tsx
@@ -17,22 +17,21 @@ import { useProfile } from './useProfile'
 import { EmployeeOnboardingStatus } from '@/shared/constants'
 import { CheckboxField } from '@/components/Common'
 
-// Base schema with common fields
-const PersonalDetailsBaseSchema = NameInputsSchema.merge(AdminInputsSchema)
+export const AdminSelfOnboardingPersonalDetailsSchema = AdminInputsSchema.merge(
+  NameInputsSchema,
+).extend({
+  selfOnboarding: z.boolean(),
+})
 
-// Use Zod's discriminated union with proper composition
-export const AdminPersonalDetailsSchema = z.discriminatedUnion('selfOnboarding', [
-  // Case 1: Self onboarding is true - only base fields required
-  PersonalDetailsBaseSchema.extend({
-    selfOnboarding: z.literal(true),
-    enableSsn: z.boolean().optional(),
-  }),
-  // Case 2: Self onboarding is false - additional fields required
-  PersonalDetailsBaseSchema.merge(SocialSecurityNumberSchema)
+export const AdminPersonalDetailsSchema = z.discriminatedUnion('enableSsn', [
+  AdminSelfOnboardingPersonalDetailsSchema.merge(SocialSecurityNumberSchema)
     .merge(DateOfBirthSchema)
     .extend({
-      selfOnboarding: z.literal(false),
+      enableSsn: z.literal(true),
     }),
+  AdminSelfOnboardingPersonalDetailsSchema.merge(DateOfBirthSchema).extend({
+    enableSsn: z.literal(false),
+  }),
 ])
 
 export const AdminPersonalDetails = () => {


### PR DESCRIPTION
SSN validation was broken for employees that already had an SSN set. The field was failing validation when the user had an SSN but was editing the profile. In this case, SSN is undefined but we don't enable the validation so they can still proceed since they already have one set.

This PR fixes the validation. The root of the issue is that zod struggles to support nested discriminated unions. In this case we have enableSsn and selfOnboarding as different branches in the form validation. Attempting to nest discriminated unions results in a zod typing error. I was able to suppress the TS warnings using the typing solution [presented in this issue](https://github.com/colinhacks/zod/issues/1618#issuecomment-1511051340), however this still presented a failure for multiple keys with the same false value (since we need to configure selfOnboarding to false for both branches).

I went in circles trying to resolve this purely with zod, but eventually gave up. This approach is probably less than ideal, but it does work. We separate the admin schema into self onboarding and non self onboarding, and then watch the self onboarding checkbox and set the schema depending on that value.

Overall, this stems from complexities with conditional fields in forms with a lot of branching logic. We may still need to revisit this to see how we might simplify that pattern.

## Proof of functionality

### Filling out profile for a new employee

https://github.com/user-attachments/assets/6fee32ee-dd14-4c38-b77f-347cd8564dfc

### Editing the profile for an employee that already has an SSN

https://github.com/user-attachments/assets/d97afc49-e95c-4683-be9f-4ec3e402c7df

### Filling out profile for a new employee and selecting self onboarding

https://github.com/user-attachments/assets/69b930ea-e6bc-4a9a-bfe8-88195b0bd95b

### Editing the profile for an employee that has self onboarding selected

https://github.com/user-attachments/assets/de8b69ce-4109-4945-b00b-4f6fe34ff97c

### Self onboarding without profile fields filled out

https://github.com/user-attachments/assets/9ab3c1e6-ecb8-43d0-98d6-2081a8a51e01

### Editing self onboarding with ssn already set

https://github.com/user-attachments/assets/62d5e8a8-2704-466c-a533-1ccf3df5343f
