### PR TITLE
feat: add cancel button for company bank account when editing

### DIFF
--- a/src/components/Company/BankAccount/BankAccountComponents.tsx
+++ b/src/components/Company/BankAccount/BankAccountComponents.tsx
@@ -29,8 +29,14 @@ export function BankAccountListContextual() {
   )
 }
 export function BankAccountFormContextual() {
-  const { companyId, onEvent } = useFlow<BankAccountContextInterface>()
-  return <BankAccountForm companyId={ensureRequired(companyId)} onEvent={onEvent} />
+  const { companyId, onEvent, bankAccount } = useFlow<BankAccountContextInterface>()
+  return (
+    <BankAccountForm
+      companyId={ensureRequired(companyId)}
+      onEvent={onEvent}
+      isEditing={!!bankAccount}
+    />
+  )
 }
 export function BankAccountVerifyContextual() {
   const { bankAccount, companyId, onEvent } = useFlow<BankAccountContextInterface>()

--- a/src/components/Company/BankAccount/BankAccountForm/Actions.tsx
+++ b/src/components/Company/BankAccount/BankAccountForm/Actions.tsx
@@ -2,14 +2,26 @@ import { useTranslation } from 'react-i18next'
 import { useBankAccountForm } from './context'
 import { ActionsLayout } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { componentEvents } from '@/shared/constants'
 
 export function Actions() {
   const { t } = useTranslation('Company.BankAccount')
-  const { isPending } = useBankAccountForm()
+  const { isPending, isEditing, onEvent } = useBankAccountForm()
   const Components = useComponentContext()
 
   return (
     <ActionsLayout>
+      {isEditing && (
+        <Components.Button
+          type="button"
+          variant="secondary"
+          onClick={() => {
+            onEvent(componentEvents.COMPANY_BANK_ACCOUNT_CANCEL)
+          }}
+        >
+          {t('cancelCta')}
+        </Components.Button>
+      )}
       <Components.Button type="submit" isLoading={isPending} data-testid="bank-account-submit">
         {t('continueCta')}
       </Components.Button>

--- a/src/components/Company/BankAccount/BankAccountForm/BankAccountForm.test.tsx
+++ b/src/components/Company/BankAccount/BankAccountForm/BankAccountForm.test.tsx
@@ -11,19 +11,23 @@ import { renderWithProviders } from '@/test-utils/renderWithProviders'
 describe('Company BankAccounts Form', () => {
   const onEvent = vi.fn()
   const user = userEvent.setup()
+
   beforeEach(() => {
     setupApiTestMocks()
     server.use(postCompanyBankAccount)
-    renderWithProviders(<BankAccountForm companyId="company-123" onEvent={onEvent} />)
   })
 
   it('renders empty form', async () => {
+    renderWithProviders(<BankAccountForm companyId="company-123" onEvent={onEvent} />)
+
     await waitFor(() => {
       expect(screen.getByTestId('bank-account-submit')).toBeInTheDocument()
     })
   })
 
   it('fires submission with correct payload', async () => {
+    renderWithProviders(<BankAccountForm companyId="company-123" onEvent={onEvent} />)
+
     const submitButton = await screen.findByTestId('bank-account-submit')
     expect(submitButton).toBeInTheDocument()
     await user.type(screen.getByLabelText('Routing number'), '123123123')
@@ -36,5 +40,14 @@ describe('Company BankAccounts Form', () => {
         expect.anything(),
       )
     })
+  })
+
+  it('shows cancel button when editing and calls the onEvent with the correct event', async () => {
+    renderWithProviders(<BankAccountForm companyId="company-123" onEvent={onEvent} isEditing />)
+
+    const cancelButton = await screen.findByText('Cancel')
+    expect(cancelButton).toBeInTheDocument()
+    await user.click(cancelButton)
+    expect(onEvent).toHaveBeenCalledWith(companyEvents.COMPANY_BANK_ACCOUNT_CANCEL)
   })
 })

--- a/src/components/Company/BankAccount/BankAccountForm/BankAccountForm.tsx
+++ b/src/components/Company/BankAccount/BankAccountForm/BankAccountForm.tsx
@@ -18,6 +18,7 @@ import { componentEvents } from '@/shared/constants'
 
 interface BankAccountFormProps extends CommonComponentInterface {
   companyId: string
+  isEditing?: boolean
 }
 
 export function BankAccountForm(props: BankAccountFormProps & BaseComponentInterface) {
@@ -27,7 +28,7 @@ export function BankAccountForm(props: BankAccountFormProps & BaseComponentInter
     </BaseComponent>
   )
 }
-function Root({ companyId, className, children }: BankAccountFormProps) {
+function Root({ companyId, className, children, isEditing = false }: BankAccountFormProps) {
   useI18n('Company.BankAccount')
   const { onEvent, baseSubmitHandler } = useBase()
   const queryClient = useQueryClient()
@@ -56,7 +57,7 @@ function Root({ companyId, className, children }: BankAccountFormProps) {
     <section className={className}>
       <FormProvider {...methods} control={control}>
         <HtmlForm onSubmit={methods.handleSubmit(onSubmit)}>
-          <BankAccountFormProvider value={{ isPending: isPendingCreate }}>
+          <BankAccountFormProvider value={{ isPending: isPendingCreate, isEditing, onEvent }}>
             <Flex flexDirection="column" gap={32}>
               {children ? (
                 children

--- a/src/components/Company/BankAccount/BankAccountForm/context.ts
+++ b/src/components/Company/BankAccount/BankAccountForm/context.ts
@@ -1,7 +1,11 @@
 import { createCompoundContext } from '@/components/Base'
+import { type OnEventType } from '@/components/Base/useBase'
+import { type EventType } from '@/shared/constants'
 
 type BankAccountFormContextType = {
   isPending: boolean
+  isEditing: boolean
+  onEvent: OnEventType<EventType, unknown>
 }
 
 const [useBankAccountForm, BankAccountFormProvider] =

--- a/src/components/Company/BankAccount/stateMachine.ts
+++ b/src/components/Company/BankAccount/stateMachine.ts
@@ -45,6 +45,14 @@ export const bankAccountStateMachine = {
         }),
       ),
     ),
+    transition(
+      componentEvents.COMPANY_BANK_ACCOUNT_CANCEL,
+      'viewBankAccount',
+      reduce((ctx: BankAccountContextInterface) => ({
+        ...ctx,
+        component: BankAccountListContextual,
+      })),
+    ),
   ),
   verifyBankAccount: state(
     transition(

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -70,6 +70,7 @@ export const companyEvents = {
   COMPANY_LOCATION_UPDATED: 'company/location/edit/done',
   COMPANY_LOCATION_DONE: 'company/location/done',
   COMPANY_BANK_ACCOUNT_CHANGE: 'company/bankAccount/change',
+  COMPANY_BANK_ACCOUNT_CANCEL: 'company/bankAccount/cancel',
   COMPANY_BANK_ACCOUNT_CREATED: 'company/bankAccount/created',
   COMPANY_BANK_ACCOUNT_VERIFY: 'company/bankAccount/verify',
   COMPANY_BANK_ACCOUNT_DONE: 'company/bankAccount/done',


### PR DESCRIPTION
This updates to add a cancel button for company bank account when you are navigating to the form from the list. Note that if you are hitting the form for the first time in the flow, the cancel doesn't show.

## Proof of functionality

### When navigating to the form from the list

https://github.com/user-attachments/assets/5af50e32-46b0-4ad6-97da-0969907d8bcf

### When navigating to the form for the first time in the flow without an account\

<img width="852" alt="Screenshot 2025-06-30 at 3 14 31 PM" src="https://github.com/user-attachments/assets/be7c6fcb-1585-486b-8fec-38d2a8c81de0" />
