### PR TITLE
refactor: extract `useInvalidateOnSuccess` pattern

### DIFF
--- a/src/components/Employee/Profile/Profile.tsx
+++ b/src/components/Employee/Profile/Profile.tsx
@@ -10,14 +10,12 @@ import { useEmployeeAddressesGetSuspense } from '@gusto/embedded-api/react-query
 import { type EmployeeAddress } from '@gusto/embedded-api/models/components/employeeaddress'
 import { useEmployeeAddressesCreateMutation } from '@gusto/embedded-api/react-query/employeeAddressesCreate'
 import { useEmployeeAddressesUpdateMutation } from '@gusto/embedded-api/react-query/employeeAddressesUpdate'
-import { useEmployeeAddressesUpdateWorkAddressMutation } from '@gusto/embedded-api/react-query/employeeAddressesUpdateWorkAddress'
 import { useEmployeesUpdateMutation } from '@gusto/embedded-api/react-query/employeesUpdate'
 import {
   invalidateAllEmployeeAddressesGetWorkAddresses,
   useEmployeeAddressesGetWorkAddressesSuspense,
 } from '@gusto/embedded-api/react-query/employeeAddressesGetWorkAddresses'
 import type { EmployeeWorkAddress } from '@gusto/embedded-api/models/components/employeeworkaddress'
-import { useEmployeeAddressesCreateWorkAddressMutation } from '@gusto/embedded-api/react-query/employeeAddressesCreateWorkAddress'
 import { RFCDate } from '@gusto/embedded-api/types/rfcdate'
 import { useEmployeesUpdateOnboardingStatusMutation } from '@gusto/embedded-api/react-query/employeesUpdateOnboardingStatus'
 import { invalidateEmployeesList } from '@gusto/embedded-api/react-query/employeesList'
@@ -36,6 +34,7 @@ import { HomeAddress, HomeAddressSchema, type HomeAddressInputs } from './HomeAd
 import { WorkAddress } from './WorkAddress'
 import { ProfileProvider } from './useProfile'
 import { getEmployeeAddressForProfile } from './getEmployeeAddressForProfile'
+import { useCreateEmployeeWorkAddress, useUpdateEmployeeWorkAddress } from './hooks'
 import { Form } from '@/components/Common/Form'
 import {
   useBase,
@@ -153,9 +152,9 @@ const Root = ({
     useEmployeesUpdateMutation()
 
   const { mutateAsync: createEmployeeWorkAddress, isPending: isPendingCreateWA } =
-    useEmployeeAddressesCreateWorkAddressMutation()
+    useCreateEmployeeWorkAddress()
   const { mutateAsync: mutateEmployeeWorkAddress, isPending: isPendingWorkAddressUpdate } =
-    useEmployeeAddressesUpdateWorkAddressMutation()
+    useUpdateEmployeeWorkAddress()
 
   const { mutateAsync: createEmployeeHomeAddress, isPending: isPendingAddHA } =
     useEmployeeAddressesCreateMutation()

--- a/src/components/Employee/Profile/hooks.ts
+++ b/src/components/Employee/Profile/hooks.ts
@@ -1,0 +1,18 @@
+import { useEmployeeAddressesCreateWorkAddressMutation } from '@gusto/embedded-api/react-query/employeeAddressesCreateWorkAddress'
+import { invalidateAllEmployeeAddressesGetWorkAddresses } from '@gusto/embedded-api/react-query/employeeAddressesGetWorkAddresses'
+import { useEmployeeAddressesUpdateWorkAddressMutation } from '@gusto/embedded-api/react-query/employeeAddressesUpdateWorkAddress'
+import { useInvalidateOnSuccess } from '@/hooks/useInvalidateOnSuccess'
+
+export const useCreateEmployeeWorkAddress = () => {
+  return useInvalidateOnSuccess({
+    invalidators: [invalidateAllEmployeeAddressesGetWorkAddresses],
+    mutator: useEmployeeAddressesCreateWorkAddressMutation,
+  })
+}
+
+export const useUpdateEmployeeWorkAddress = () => {
+  return useInvalidateOnSuccess({
+    invalidators: [invalidateAllEmployeeAddressesGetWorkAddresses],
+    mutator: useEmployeeAddressesUpdateWorkAddressMutation,
+  })
+}

--- a/src/hooks/useInvalidateOnSuccess/index.ts
+++ b/src/hooks/useInvalidateOnSuccess/index.ts
@@ -1,0 +1,26 @@
+import type { MutationHookOptions } from '@gusto/embedded-api/react-query/_types'
+import { useQueryClient, type QueryClient, type UseMutationResult } from '@tanstack/react-query'
+
+interface UseInvalidateOnSuccessArgs<TData, TVariables> {
+  invalidators: ((queryClient: QueryClient) => Promise<unknown>)[]
+  mutator: ({
+    onSuccess,
+  }: Pick<MutationHookOptions, 'onSuccess'>) => UseMutationResult<TData, Error, TVariables>
+}
+
+export const useInvalidateOnSuccess = <TData, TVariables>({
+  invalidators,
+  mutator,
+}: UseInvalidateOnSuccessArgs<TData, TVariables>) => {
+  const queryClient = useQueryClient()
+  const { mutateAsync, isPending } = mutator({
+    async onSuccess() {
+      await Promise.all(invalidators.map(invalidator => invalidator(queryClient)))
+    },
+  })
+
+  return {
+    isPending,
+    mutateAsync,
+  }
+}


### PR DESCRIPTION
Trying to help prevent a common mistake, which is mutating without invalidating the correct API responses from the cache.

This approach lifts up mutation another level into a hook that uses `useInvalidateOnSuccess`. `useInvalidateOnSuccess` accepts a list of invalidation functions to call once your mutation succeeds and then gives access to the mutator function and pending state to be used as usual in our forms.