### PR TITLE
feat: expose types for adapter and create a loading indicator provider

### DIFF
--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -11,10 +11,12 @@ import { QueryErrorResetBoundary } from '@tanstack/react-query'
 import { FadeIn } from '../Common/FadeIn/FadeIn'
 import { BaseContext, type FieldError, type KnownErrors, type OnEventType } from './useBase'
 import { componentEvents, type EventType } from '@/shared/constants'
-import { InternalError, Loading, useAsyncError } from '@/components/Common'
+import { InternalError, useAsyncError } from '@/components/Common'
 import { snakeCaseToCamelCase } from '@/helpers/formattedStrings'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import type { ResourceDictionary, Resources } from '@/types/Helpers'
+import { useLoadingIndicator } from '@/contexts/LoadingIndicatorProvider/useLoadingIndicator'
+import type { LoadingIndicatorContextProps } from '@/contexts/LoadingIndicatorProvider/useLoadingIndicator'
 
 export interface CommonComponentInterface<TResourceKey extends keyof Resources = keyof Resources> {
   children?: ReactNode
@@ -27,7 +29,7 @@ export interface CommonComponentInterface<TResourceKey extends keyof Resources =
 export interface BaseComponentInterface<TResourceKey extends keyof Resources = keyof Resources>
   extends CommonComponentInterface<TResourceKey> {
   FallbackComponent?: (props: FallbackProps) => JSX.Element
-  LoaderComponent?: () => JSX.Element
+  LoaderComponent?: LoadingIndicatorContextProps['LoadingIndicator']
   onEvent: OnEventType<EventType, unknown>
 }
 
@@ -80,7 +82,7 @@ type SubmitHandler<T> = (data: T) => Promise<void>
 export const BaseComponent = <TResourceKey extends keyof Resources = keyof Resources>({
   children,
   FallbackComponent = InternalError,
-  LoaderComponent = Loading,
+  LoaderComponent: LoadingIndicatorFromProps,
   onEvent,
 }: BaseComponentInterface<TResourceKey>) => {
   const [error, setError] = useState<KnownErrors | null>(null)
@@ -88,6 +90,10 @@ export const BaseComponent = <TResourceKey extends keyof Resources = keyof Resou
   const throwError = useAsyncError()
   const { t } = useTranslation()
   const Components = useComponentContext()
+
+  const { LoadingIndicator: LoadingIndicatorFromContext } = useLoadingIndicator()
+
+  const LoaderComponent = LoadingIndicatorFromProps ?? LoadingIndicatorFromContext
 
   const processError = (error: KnownErrors) => {
     setError(error)

--- a/src/components/Company/BankAccount/BankAccountList/AccountView.tsx
+++ b/src/components/Company/BankAccount/BankAccountList/AccountView.tsx
@@ -1,19 +1,29 @@
 import { useTranslation } from 'react-i18next'
 import { useBankAccount } from './context'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export function AccountView() {
   const { bankAccount } = useBankAccount()
   const { t } = useTranslation('Company.BankAccount')
+  const Components = useComponentContext()
 
   return (
     <dl>
       <div>
-        <dt>{t('routingNumberLabel')}</dt>
-        <dd>{bankAccount?.routingNumber}</dd>
+        <dt>
+          <Components.Text>{t('routingNumberLabel')}</Components.Text>
+        </dt>
+        <dd>
+          <Components.Text>{bankAccount?.routingNumber}</Components.Text>
+        </dd>
       </div>
       <div>
-        <dt>{t('accountNumberLabel')}</dt>
-        <dd>{bankAccount?.hiddenAccountNumber}</dd>
+        <dt>
+          <Components.Text>{t('accountNumberLabel')}</Components.Text>
+        </dt>
+        <dd>
+          <Components.Text>{bankAccount?.hiddenAccountNumber}</Components.Text>
+        </dd>
       </div>
     </dl>
   )

--- a/src/components/Company/Locations/LocationsList/List.tsx
+++ b/src/components/Company/Locations/LocationsList/List.tsx
@@ -51,7 +51,10 @@ export const List = () => {
                 <Components.Badge status={'info'}>{t('mailingAddress')}</Components.Badge>
               )}
               {location.filingAddress && (
-                <Components.Badge status={'info'}>{t('filingAddress')}</Components.Badge>
+                <>
+                  {' '}
+                  <Components.Badge status={'info'}>{t('filingAddress')}</Components.Badge>
+                </>
               )}
             </>
           )

--- a/src/components/Employee/Taxes/FederalForm.tsx
+++ b/src/components/Employee/Taxes/FederalForm.tsx
@@ -42,13 +42,15 @@ export function FederalForm() {
         label={t('multipleJobs2c')}
         errorMessage={t('validations.federalTwoJobs')}
         description={
-          <Trans
-            i18nKey={'includesSpouseExplanation'}
-            t={t}
-            components={{
-              irs_link: <Components.Link />,
-            }}
-          />
+          <Components.Text>
+            <Trans
+              i18nKey={'includesSpouseExplanation'}
+              t={t}
+              components={{
+                irs_link: <Components.Link />,
+              }}
+            />
+          </Components.Text>
         }
         options={[
           { value: 'true', label: t('twoJobYesLabel') },

--- a/src/contexts/ComponentAdapter/componentAdapterTypes.ts
+++ b/src/contexts/ComponentAdapter/componentAdapterTypes.ts
@@ -22,3 +22,8 @@ export type { TableProps, TableData, TableRow } from '@/components/Common/UI/Tab
 export type { TextInputProps } from '@/components/Common/UI/TextInput/TextInputTypes'
 export type { AlertProps } from '@/components/Common/UI/Alert/AlertTypes'
 export type { BadgeProps } from '@/components/Common/UI/Badge/BadgeTypes'
+export type { OrderedListProps, UnorderedListProps } from '@/components/Common/UI/List/ListTypes'
+export type { HeadingProps } from '@/components/Common/UI/Heading/HeadingTypes'
+export type { PaginationControlProps } from '@/components/Common/PaginationControl/PaginationControlTypes'
+export type { TextProps } from '@/components/Common/UI/Text/TextTypes'
+export type { CalendarPreviewProps } from '@/components/Common/UI/CalendarPreview/CalendarPreviewTypes'

--- a/src/contexts/GustoProvider/GustoProviderCustomUIAdapter.tsx
+++ b/src/contexts/GustoProvider/GustoProviderCustomUIAdapter.tsx
@@ -6,6 +6,8 @@ import { useEffect } from 'react'
 import { ComponentsProvider } from '../ComponentAdapter/ComponentsProvider'
 import type { ComponentsContextType } from '../ComponentAdapter/useComponentContext'
 import { ApiProvider } from '../ApiProvider/ApiProvider'
+import { LoadingIndicatorProvider } from '../LoadingIndicatorProvider/LoadingIndicatorProvider'
+import type { LoadingIndicatorContextProps } from '../LoadingIndicatorProvider/useLoadingIndicator'
 import { SDKI18next } from './SDKI18next'
 import { InternalError } from '@/components/Common'
 import { LocaleProvider } from '@/contexts/LocaleProvider'
@@ -27,6 +29,7 @@ export interface GustoProviderProps {
   theme?: DeepPartial<GTheme>
   queryClient?: QueryClient
   components: ComponentsContextType
+  LoaderComponent?: LoadingIndicatorContextProps['LoadingIndicator']
 }
 
 export interface GustoProviderCustomUIAdapterProps extends GustoProviderProps {
@@ -46,6 +49,7 @@ const GustoProviderCustomUIAdapter: React.FC<GustoProviderCustomUIAdapterProps> 
     currency = 'USD',
     theme,
     components,
+    LoaderComponent,
   } = props
 
   // Handle dictionary resources
@@ -74,17 +78,19 @@ const GustoProviderCustomUIAdapter: React.FC<GustoProviderCustomUIAdapterProps> 
 
   return (
     <ComponentsProvider value={components}>
-      <ErrorBoundary FallbackComponent={InternalError}>
-        <ThemeProvider theme={theme}>
-          <LocaleProvider locale={locale} currency={currency}>
-            <I18nextProvider i18n={SDKI18next} key={lng}>
-              <ApiProvider url={config.baseUrl} headers={config.headers}>
-                {children}
-              </ApiProvider>
-            </I18nextProvider>
-          </LocaleProvider>
-        </ThemeProvider>
-      </ErrorBoundary>
+      <LoadingIndicatorProvider value={LoaderComponent}>
+        <ErrorBoundary FallbackComponent={InternalError}>
+          <ThemeProvider theme={theme}>
+            <LocaleProvider locale={locale} currency={currency}>
+              <I18nextProvider i18n={SDKI18next} key={lng}>
+                <ApiProvider url={config.baseUrl} headers={config.headers}>
+                  {children}
+                </ApiProvider>
+              </I18nextProvider>
+            </LocaleProvider>
+          </ThemeProvider>
+        </ErrorBoundary>
+      </LoadingIndicatorProvider>
     </ComponentsProvider>
   )
 }

--- a/src/contexts/LoadingIndicatorProvider/LoadingIndicatorProvider.tsx
+++ b/src/contexts/LoadingIndicatorProvider/LoadingIndicatorProvider.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react'
+import { LoadingIndicatorContext, type LoadingIndicatorContextProps } from './useLoadingIndicator'
+import { Loading } from '@/components/Common/Loading/Loading'
+
+export interface LoadingIndicatorProviderProps {
+  children: ReactNode
+  value?: LoadingIndicatorContextProps['LoadingIndicator']
+}
+
+export function LoadingIndicatorProvider({ children, value }: LoadingIndicatorProviderProps) {
+  return (
+    <LoadingIndicatorContext.Provider value={{ LoadingIndicator: value ?? Loading }}>
+      {children}
+    </LoadingIndicatorContext.Provider>
+  )
+}

--- a/src/contexts/LoadingIndicatorProvider/useLoadingIndicator.tsx
+++ b/src/contexts/LoadingIndicatorProvider/useLoadingIndicator.tsx
@@ -1,0 +1,12 @@
+import type { JSX } from 'react'
+import { createContext, useContext } from 'react'
+import { Loading } from '@/components/Common/Loading/Loading'
+
+export interface LoadingIndicatorContextProps {
+  LoadingIndicator: () => JSX.Element
+}
+export const LoadingIndicatorContext = createContext<LoadingIndicatorContextProps>({
+  LoadingIndicator: () => <Loading />,
+})
+
+export const useLoadingIndicator = () => useContext(LoadingIndicatorContext)


### PR DESCRIPTION
This PR adds some updates that were needed while creating the latest partner adapter demo. This includes
* Exposing adapter types
* Updating to allow for setting the loading indicator on the provider globally so it doesn't have to be set on each individual component. it still defaults to the component level indicator if set, but allows consumers to set a global baseline