### PR TITLE
refactor: remove manual invalidation in favor of automatic invalidation after mutation

### DIFF
--- a/src/components/Company/BankAccount/BankAccountForm/BankAccountForm.tsx
+++ b/src/components/Company/BankAccount/BankAccountForm/BankAccountForm.tsx
@@ -1,8 +1,6 @@
 import { useBankAccountsCreateMutation } from '@gusto/embedded-api/react-query/bankAccountsCreate'
 import { FormProvider, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { invalidateAllBankAccountsGet } from '@gusto/embedded-api/react-query/bankAccountsGet'
-import { useQueryClient } from '@tanstack/react-query'
 import { Head } from './Head'
 import type { BankAccountFormInputs } from './Form'
 import { BankAccountFormSchema, Form } from './Form'
@@ -31,7 +29,6 @@ export function BankAccountForm(props: BankAccountFormProps & BaseComponentInter
 function Root({ companyId, className, children, isEditing = false }: BankAccountFormProps) {
   useI18n('Company.BankAccount')
   const { onEvent, baseSubmitHandler } = useBase()
-  const queryClient = useQueryClient()
 
   const { mutateAsync: createBankAccount, isPending: isPendingCreate } =
     useBankAccountsCreateMutation()
@@ -47,8 +44,6 @@ function Root({ companyId, className, children, isEditing = false }: BankAccount
         //Account type is always checking for company bank accounts
         request: { companyId, requestBody: { ...payload, accountType: 'Checking' } },
       })
-
-      await invalidateAllBankAccountsGet(queryClient)
 
       onEvent(componentEvents.COMPANY_BANK_ACCOUNT_CREATED, companyBankAccount)
     })

--- a/src/components/Company/DocumentSigner/SignatureForm/SignatureForm.tsx
+++ b/src/components/Company/DocumentSigner/SignatureForm/SignatureForm.tsx
@@ -1,13 +1,6 @@
-import {
-  useCompanyFormsGetSuspense,
-  invalidateAllCompanyFormsGet,
-} from '@gusto/embedded-api/react-query/companyFormsGet'
+import { useCompanyFormsGetSuspense } from '@gusto/embedded-api/react-query/companyFormsGet'
 import { useCompanyFormsSignMutation } from '@gusto/embedded-api/react-query/companyFormsSign'
-import {
-  useCompanyFormsGetPdfSuspense,
-  invalidateAllCompanyFormsGetPdf,
-} from '@gusto/embedded-api/react-query/companyFormsGetPdf'
-import { useQueryClient } from '@tanstack/react-query'
+import { useCompanyFormsGetPdfSuspense } from '@gusto/embedded-api/react-query/companyFormsGetPdf'
 import { Head } from './Head'
 import { Preview } from './Preview'
 import { Form } from './Form'
@@ -41,7 +34,6 @@ export function Root({ formId, children, dictionary }: SignatureFormProps) {
   useComponentDictionary('Company.SignatureForm', dictionary)
   useI18n('Company.SignatureForm')
   const { onEvent, baseSubmitHandler } = useBase()
-  const queryClient = useQueryClient()
 
   const {
     data: { form: formNullable },
@@ -70,8 +62,6 @@ export function Root({ formId, children, dictionary }: SignatureFormProps) {
           },
         },
       })
-      await invalidateAllCompanyFormsGet(queryClient)
-      await invalidateAllCompanyFormsGetPdf(queryClient)
 
       onEvent(companyEvents.COMPANY_SIGN_FORM, signFormResponse.form)
 

--- a/src/components/Company/Industry/Industry.tsx
+++ b/src/components/Company/Industry/Industry.tsx
@@ -1,10 +1,6 @@
 import { useCallback, type HTMLAttributes } from 'react'
-import {
-  useIndustrySelectionGetSuspense,
-  invalidateAllIndustrySelectionGet,
-} from '@gusto/embedded-api/react-query/industrySelectionGet'
+import { useIndustrySelectionGetSuspense } from '@gusto/embedded-api/react-query/industrySelectionGet'
 import { useIndustrySelectionUpdateMutation } from '@gusto/embedded-api/react-query/industrySelectionUpdate'
-import { useQueryClient } from '@tanstack/react-query'
 import { Actions } from './Actions'
 import { Head } from './Head'
 import type { IndustryFormFields } from './Edit'
@@ -26,7 +22,6 @@ export type IndustryProps<T> = Pick<
 function Root<T>({ children, className, companyId, dictionary }: IndustryProps<T>) {
   useComponentDictionary('Company.Industry', dictionary)
   const { baseSubmitHandler, onEvent } = useBase()
-  const queryClient = useQueryClient()
 
   const {
     data: { industry },
@@ -40,11 +35,10 @@ function Root<T>({ children, className, companyId, dictionary }: IndustryProps<T
         const response = await mutateIndustry({
           request: { companyId, requestBody: { naicsCode: naics_code } },
         })
-        await invalidateAllIndustrySelectionGet(queryClient)
         onEvent(componentEvents.COMPANY_INDUSTRY_SELECTED, response.industry)
       })
     },
-    [baseSubmitHandler, companyId, mutateIndustry, onEvent, queryClient],
+    [baseSubmitHandler, companyId, mutateIndustry, onEvent],
   )
 
   return (

--- a/src/components/Company/Locations/LocationForm/LocationForm.tsx
+++ b/src/components/Company/Locations/LocationForm/LocationForm.tsx
@@ -2,10 +2,8 @@ import { FormProvider, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useLocationsUpdateMutation } from '@gusto/embedded-api/react-query/locationsUpdate'
 import { useLocationsRetrieveSuspense } from '@gusto/embedded-api/react-query/locationsRetrieve'
-import { invalidateAllLocationsGet } from '@gusto/embedded-api/react-query/locationsGet'
 import { useLocationsCreateMutation } from '@gusto/embedded-api/react-query/locationsCreate'
 import { type Location } from '@gusto/embedded-api/models/components/location'
-import { useQueryClient } from '@tanstack/react-query'
 import { Head } from './Head'
 import type { LocationFormInputs } from './Form'
 import { Form, LocationFormSchema } from './Form'
@@ -43,7 +41,6 @@ function Root({
 
   const { mutateAsync: createLocation, isPending: isPendingCreate } = useLocationsCreateMutation()
   const { mutateAsync: updateLocation, isPending: isPendingUpdate } = useLocationsUpdateMutation()
-  const queryClient = useQueryClient()
   const addressType = ['mailingAddress', 'filingAddress'] as const
 
   const { control, ...methods } = useForm<LocationFormInputs>({
@@ -91,9 +88,6 @@ function Root({
         })
         onEvent(componentEvents.COMPANY_LOCATION_CREATED, responseData)
       }
-
-      // Invalidate cache after mutation
-      await invalidateAllLocationsGet(queryClient)
     })
   }
 

--- a/src/components/Company/PaySchedule/PaySchedule.tsx
+++ b/src/components/Company/PaySchedule/PaySchedule.tsx
@@ -4,13 +4,9 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useEffect, useState } from 'react'
 import { usePaySchedulesGetPreview } from '@gusto/embedded-api/react-query/paySchedulesGetPreview'
 import { usePaySchedulesUpdateMutation } from '@gusto/embedded-api/react-query/paySchedulesUpdate'
-import {
-  usePaySchedulesGetAllSuspense,
-  invalidateAllPaySchedulesGetAll,
-} from '@gusto/embedded-api/react-query/paySchedulesGetAll'
+import { usePaySchedulesGetAllSuspense } from '@gusto/embedded-api/react-query/paySchedulesGetAll'
 import { usePaySchedulesCreateMutation } from '@gusto/embedded-api/react-query/paySchedulesCreate'
 import type { PayScheduleObject as PayScheduleType } from '@gusto/embedded-api/models/components/payscheduleobject'
-import { useQueryClient } from '@tanstack/react-query'
 import type { Frequency } from '@gusto/embedded-api/models/operations/postv1companiescompanyidpayschedules'
 import type { MODE, PayScheduleInputs, PayScheduleOutputs } from './usePaySchedule'
 import {
@@ -51,7 +47,6 @@ export const PaySchedule = ({
 }
 
 const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
-  const queryClient = useQueryClient()
   const { baseSubmitHandler, onEvent, fieldErrors } = useBase()
   const [mode, setMode] = useState<MODE>('LIST_PAY_SCHEDULES')
   const [currentPaySchedule, setCurrentPaySchedule] = useState<PayScheduleType | null>(null)
@@ -221,7 +216,6 @@ const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
         reset()
         setPayScheduleDraft(null)
       }
-      await invalidateAllPaySchedulesGetAll(queryClient)
       setMode('LIST_PAY_SCHEDULES')
     })
   }

--- a/src/components/Contractor/Address/Address.tsx
+++ b/src/components/Contractor/Address/Address.tsx
@@ -1,11 +1,7 @@
 import type { ReactNode } from 'react'
 import { useContractorsGetSuspense } from '@gusto/embedded-api/react-query/contractorsGet'
-import {
-  useContractorsGetAddressSuspense,
-  invalidateContractorsGetAddress,
-} from '@gusto/embedded-api/react-query/contractorsGetAddress'
+import { useContractorsGetAddressSuspense } from '@gusto/embedded-api/react-query/contractorsGetAddress'
 import { useContractorsUpdateAddressMutation } from '@gusto/embedded-api/react-query/contractorsUpdateAddress'
-import { useQueryClient } from '@tanstack/react-query'
 import { FormProvider, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { AddressFormSchema, AddressProvider } from './useAddress'
@@ -39,7 +35,6 @@ export function Address(props: AddressProps) {
 function Root({ contractorId, defaultValues, children, className, dictionary }: AddressProps) {
   useComponentDictionary('Contractor.Address', dictionary)
   useI18n('Contractor.Address')
-  const queryClient = useQueryClient()
 
   const { onEvent, baseSubmitHandler } = useBase()
 
@@ -81,8 +76,6 @@ function Root({ contractorId, defaultValues, children, className, dictionary }: 
           },
         },
       })
-
-      await invalidateContractorsGetAddress(queryClient, [contractorId])
 
       onEvent(contractorEvents.CONTRACTOR_ADDRESS_UPDATED, contractorAddress)
       onEvent(contractorEvents.CONTRACTOR_ADDRESS_DONE)

--- a/src/components/Contractor/NewHireReport/NewHireReport.tsx
+++ b/src/components/Contractor/NewHireReport/NewHireReport.tsx
@@ -4,12 +4,8 @@ import { FormProvider, useForm, useWatch } from 'react-hook-form'
 import { useMemo } from 'react'
 import z from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import {
-  invalidateContractorsGet,
-  useContractorsGetSuspense,
-} from '@gusto/embedded-api/react-query/contractorsGet'
+import { useContractorsGetSuspense } from '@gusto/embedded-api/react-query/contractorsGet'
 import { useContractorsUpdateMutation } from '@gusto/embedded-api/react-query/contractorsUpdate'
-import { useQueryClient } from '@tanstack/react-query'
 import type { NewHireReportProps } from './types'
 import { useI18n } from '@/i18n'
 import { BaseComponent, useBase } from '@/components/Base'
@@ -46,7 +42,6 @@ function Root({ contractorId, className, dictionary }: NewHireReportProps) {
   const { t } = useTranslation('Contractor.NewHireReport')
   const { onEvent, baseSubmitHandler } = useBase()
   const Components = useComponentContext()
-  const queryClient = useQueryClient()
 
   const {
     data: { contractor },
@@ -82,7 +77,6 @@ function Root({ contractorId, className, dictionary }: NewHireReportProps) {
           },
         },
       })
-      await invalidateContractorsGet(queryClient, [contractorId])
       onEvent(componentEvents.CONTRACTOR_NEW_HIRE_REPORT_UPDATED, contractorResponse)
       onEvent(componentEvents.CONTRACTOR_NEW_HIRE_REPORT_DONE)
     })

--- a/src/components/Employee/Compensation/Compensation.tsx
+++ b/src/components/Employee/Compensation/Compensation.tsx
@@ -2,10 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useEffect, useMemo, useState } from 'react'
 import { FormProvider, useForm, type SubmitHandler } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import {
-  useJobsAndCompensationsGetJobsSuspense,
-  invalidateJobsAndCompensationsGetJobs,
-} from '@gusto/embedded-api/react-query/jobsAndCompensationsGetJobs'
+import { useJobsAndCompensationsGetJobsSuspense } from '@gusto/embedded-api/react-query/jobsAndCompensationsGetJobs'
 import { useJobsAndCompensationsCreateJobMutation } from '@gusto/embedded-api/react-query/jobsAndCompensationsCreateJob'
 import { useJobsAndCompensationsUpdateMutation } from '@gusto/embedded-api/react-query/jobsAndCompensationsUpdate'
 import { useJobsAndCompensationsDeleteMutation } from '@gusto/embedded-api/react-query/jobsAndCompensationsDelete'
@@ -13,7 +10,6 @@ import { useJobsAndCompensationsUpdateCompensationMutation } from '@gusto/embedd
 import { useLocationsGetMinimumWagesSuspense } from '@gusto/embedded-api/react-query/locationsGetMinimumWages'
 import { useEmployeeAddressesGetWorkAddressesSuspense } from '@gusto/embedded-api/react-query/employeeAddressesGetWorkAddresses'
 import { type Job } from '@gusto/embedded-api/models/components/job'
-import { useQueryClient } from '@tanstack/react-query'
 import type { FlsaStatusType } from '@gusto/embedded-api/models/components/flsastatustype'
 import { useFederalTaxDetailsGetSuspense } from '@gusto/embedded-api/react-query/federalTaxDetailsGet'
 import { useEmployeesGetSuspense } from '@gusto/embedded-api/react-query/employeesGet'
@@ -71,7 +67,6 @@ const findCurrentCompensation = (employeeJob?: Job | null) => {
 const Root = ({ employeeId, startDate, className, children, ...props }: CompensationProps) => {
   useI18n('Employee.Compensation')
   const { baseSubmitHandler, onEvent } = useBase()
-  const queryClient = useQueryClient()
 
   const { data: jobsData } = useJobsAndCompensationsGetJobsSuspense({ employeeId })
   const employeeJobs = jobsData.jobList!
@@ -99,18 +94,10 @@ const Root = ({ employeeId, startDate, className, children, ...props }: Compensa
   const { data } = useFederalTaxDetailsGetSuspense({ companyId: employee.companyUuid! })
   const showTwoPercentStakeholder = data.federalTaxDetails!.taxPayerType === 'S-Corporation'
 
-  const updateCompensationMutation = useJobsAndCompensationsUpdateCompensationMutation({
-    onSettled: () => invalidateJobsAndCompensationsGetJobs(queryClient, [employeeId]),
-  })
-  const createEmployeeJobMutation = useJobsAndCompensationsCreateJobMutation({
-    onSettled: () => invalidateJobsAndCompensationsGetJobs(queryClient, [employeeId]),
-  })
-  const updateEmployeeJobMutation = useJobsAndCompensationsUpdateMutation({
-    onSettled: () => invalidateJobsAndCompensationsGetJobs(queryClient, [employeeId]),
-  })
-  const deleteEmployeeJobMutation = useJobsAndCompensationsDeleteMutation({
-    onSettled: () => invalidateJobsAndCompensationsGetJobs(queryClient, [employeeId]),
-  })
+  const updateCompensationMutation = useJobsAndCompensationsUpdateCompensationMutation()
+  const createEmployeeJobMutation = useJobsAndCompensationsCreateJobMutation()
+  const updateEmployeeJobMutation = useJobsAndCompensationsUpdateMutation()
+  const deleteEmployeeJobMutation = useJobsAndCompensationsDeleteMutation()
 
   //Job being edited/created
   const [currentJob, setCurrentJob] = useState<Job | null>(

--- a/src/components/Employee/Deductions/Deductions.tsx
+++ b/src/components/Employee/Deductions/Deductions.tsx
@@ -3,14 +3,10 @@ import { useEffect, useMemo, useState } from 'react'
 import { z } from 'zod'
 import { FormProvider, useForm, type SubmitHandler } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import {
-  useGarnishmentsListSuspense,
-  invalidateGarnishmentsList,
-} from '@gusto/embedded-api/react-query/garnishmentsList'
+import { useGarnishmentsListSuspense } from '@gusto/embedded-api/react-query/garnishmentsList'
 import { type Garnishment } from '@gusto/embedded-api/models/components/garnishment'
 import { useGarnishmentsCreateMutation } from '@gusto/embedded-api/react-query/garnishmentsCreate'
 import { useGarnishmentsUpdateMutation } from '@gusto/embedded-api/react-query/garnishmentsUpdate'
-import { useQueryClient } from '@tanstack/react-query'
 import type { OnboardingContextInterface } from '../OnboardingFlow/OnboardingFlow'
 import {
   type DeductionInputs,
@@ -52,7 +48,6 @@ export function Deductions(props: DeductionsProps & BaseComponentInterface) {
 }
 export const Root = ({ employeeId, className, dictionary }: DeductionsProps) => {
   const { onEvent, baseSubmitHandler } = useBase()
-  const queryClient = useQueryClient()
   useComponentDictionary('Employee.Deductions', dictionary)
 
   const { data } = useGarnishmentsListSuspense({ employeeId })
@@ -60,13 +55,9 @@ export const Root = ({ employeeId, className, dictionary }: DeductionsProps) => 
 
   // Used for deletion or edit of deduction
   const { mutateAsync: updateDeduction, isPending: isPendingUpdate } =
-    useGarnishmentsUpdateMutation({
-      onSettled: () => invalidateGarnishmentsList(queryClient, [employeeId]),
-    })
+    useGarnishmentsUpdateMutation()
   const { mutateAsync: createDeduction, isPending: isPendingCreate } =
-    useGarnishmentsCreateMutation({
-      onSettled: () => invalidateGarnishmentsList(queryClient, [employeeId]),
-    })
+    useGarnishmentsCreateMutation()
 
   const activeDeductions = deductions.filter(deduction => deduction.active)
   const [mode, setMode] = useState<MODE>(activeDeductions.length < 1 ? 'INITIAL' : 'LIST')

--- a/src/components/Employee/DocumentSigner/SignatureForm/SignatureForm.tsx
+++ b/src/components/Employee/DocumentSigner/SignatureForm/SignatureForm.tsx
@@ -1,8 +1,6 @@
-import { invalidateEmployeeFormsList } from '@gusto/embedded-api/react-query/employeeFormsList'
 import { useEmployeeFormsGetPdfSuspense } from '@gusto/embedded-api/react-query/employeeFormsGetPdf'
 import { useEmployeeFormsSignMutation } from '@gusto/embedded-api/react-query/employeeFormsSign'
 import { useEmployeeFormsGetSuspense } from '@gusto/embedded-api/react-query/employeeFormsGet'
-import { useQueryClient } from '@tanstack/react-query'
 import { Form as FormComponent } from './Form'
 import { Head } from './Head'
 import { Actions } from './Actions'
@@ -36,7 +34,6 @@ export function SignatureForm(props: SignatureFormProps & BaseComponentInterface
 function Root({ employeeId, formId, className, children }: SignatureFormProps) {
   useI18n('Employee.DocumentSigner')
   const { onEvent, baseSubmitHandler } = useBase()
-  const queryClient = useQueryClient()
 
   const { data } = useEmployeeFormsGetSuspense({ employeeId, formId })
   const form = data.form!
@@ -46,11 +43,7 @@ function Root({ employeeId, formId, className, children }: SignatureFormProps) {
   } = useEmployeeFormsGetPdfSuspense({ employeeId, formId: form.uuid })
   const pdfUrl = formPdf!.documentUrl
 
-  const { mutateAsync: signForm, isPending: isSignFormPending } = useEmployeeFormsSignMutation({
-    onSettled: async () => {
-      await invalidateEmployeeFormsList(queryClient, [employeeId])
-    },
-  })
+  const { mutateAsync: signForm, isPending: isSignFormPending } = useEmployeeFormsSignMutation()
 
   const handleBack = () => {
     onEvent(componentEvents.CANCEL)

--- a/src/components/Employee/EmployeeList/EmployeeList.tsx
+++ b/src/components/Employee/EmployeeList/EmployeeList.tsx
@@ -1,12 +1,8 @@
 import { useState } from 'react'
-import {
-  useEmployeesListSuspense,
-  invalidateEmployeesList,
-} from '@gusto/embedded-api/react-query/employeesList'
+import { useEmployeesListSuspense } from '@gusto/embedded-api/react-query/employeesList'
 import type { OnboardingStatus } from '@gusto/embedded-api/models/operations/putv1employeesemployeeidonboardingstatus'
 import { useEmployeesDeleteMutation } from '@gusto/embedded-api/react-query/employeesDelete'
 import { useEmployeesUpdateOnboardingStatusMutation } from '@gusto/embedded-api/react-query/employeesUpdateOnboardingStatus'
-import { useQueryClient } from '@tanstack/react-query'
 import type { OnboardingContextInterface } from '../OnboardingFlow/OnboardingFlow'
 import { EmployeeListProvider } from './useEmployeeList'
 import { Actions } from './Actions'
@@ -43,7 +39,6 @@ function Root({ companyId, className, children, dictionary }: EmployeeListProps)
   const { onEvent, baseSubmitHandler } = useBase()
   const [currentPage, setCurrentPage] = useState(1)
   const [itemsPerPage, setItemsPerPage] = useState(5)
-  const queryClient = useQueryClient()
 
   const { data } = useEmployeesListSuspense({ companyId, page: currentPage, per: itemsPerPage })
   const { httpMeta, employees: employeeList } = data
@@ -76,7 +71,6 @@ function Root({ companyId, className, children, dictionary }: EmployeeListProps)
         request: { employeeId: payload },
       })
 
-      await invalidateEmployeesList(queryClient, [companyId])
       onEvent(componentEvents.EMPLOYEE_DELETED, { employeeId: payload })
     })
   }

--- a/src/components/Employee/PaymentMethod/PaymentMethod.tsx
+++ b/src/components/Employee/PaymentMethod/PaymentMethod.tsx
@@ -1,18 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useEmployeePaymentMethodCreateMutation } from '@gusto/embedded-api/react-query/employeePaymentMethodCreate'
 import { useEmployeePaymentMethodDeleteBankAccountMutation } from '@gusto/embedded-api/react-query/employeePaymentMethodDeleteBankAccount'
-import {
-  useEmployeePaymentMethodsGetBankAccountsSuspense,
-  invalidateAllEmployeePaymentMethodsGetBankAccounts,
-} from '@gusto/embedded-api/react-query/employeePaymentMethodsGetBankAccounts'
-import {
-  useEmployeePaymentMethodGetSuspense,
-  invalidateAllEmployeePaymentMethodGet,
-} from '@gusto/embedded-api/react-query/employeePaymentMethodGet'
+import { useEmployeePaymentMethodsGetBankAccountsSuspense } from '@gusto/embedded-api/react-query/employeePaymentMethodsGetBankAccounts'
+import { useEmployeePaymentMethodGetSuspense } from '@gusto/embedded-api/react-query/employeePaymentMethodGet'
 import { useEmployeePaymentMethodUpdateBankAccountMutation } from '@gusto/embedded-api/react-query/employeePaymentMethodUpdateBankAccount'
 import { useEmployeePaymentMethodUpdateMutation } from '@gusto/embedded-api/react-query/employeePaymentMethodUpdate'
 import { useQueryClient } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { FormProvider, useForm, type DefaultValues, type SubmitHandler } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import type { OnboardingContextInterface } from '../OnboardingFlow/OnboardingFlow'
@@ -72,11 +66,6 @@ const Root = ({ employeeId, className, dictionary }: PaymentMethodProps) => {
   const deleteBankAccountMutation = useEmployeePaymentMethodDeleteBankAccountMutation()
   const addBankAccountMutation = useEmployeePaymentMethodCreateMutation()
   const updateBankAccountMutation = useEmployeePaymentMethodUpdateBankAccountMutation()
-
-  const invalidateAll = useCallback(async () => {
-    await invalidateAllEmployeePaymentMethodGet(queryClient)
-    await invalidateAllEmployeePaymentMethodsGetBankAccounts(queryClient)
-  }, [queryClient])
 
   const [mode, setMode] = useState<MODE>(bankAccounts.length < 1 ? 'INITIAL' : 'LIST')
   if (mode !== 'INITIAL' && bankAccounts.length < 1) {
@@ -149,10 +138,9 @@ const Root = ({ employeeId, className, dictionary }: PaymentMethodProps) => {
             },
           },
         })
-        await invalidateAll()
       }
     })()
-  }, [employeeId, invalidateAll, paymentMethod, queryClient, mutatePaymentMethod])
+  }, [employeeId, paymentMethod, queryClient, mutatePaymentMethod])
 
   useEffect(() => {
     resetForm(defaultValues)
@@ -177,7 +165,6 @@ const Root = ({ employeeId, className, dictionary }: PaymentMethodProps) => {
             },
           },
         })
-        await invalidateAll()
 
         onEvent(componentEvents.EMPLOYEE_BANK_ACCOUNT_CREATED, bankAccountResponse)
       } else {
@@ -203,7 +190,6 @@ const Root = ({ employeeId, className, dictionary }: PaymentMethodProps) => {
         const paymentMethodResponse = await paymentMethodMutation.mutateAsync({
           request: { employeeId, requestBody: { ...body, type } },
         })
-        await invalidateAll()
         onEvent(componentEvents.EMPLOYEE_PAYMENT_METHOD_UPDATED, paymentMethodResponse)
       }
       //Cleanup after submission bank/split submission
@@ -222,7 +208,6 @@ const Root = ({ employeeId, className, dictionary }: PaymentMethodProps) => {
     const data = await deleteBankAccountMutation.mutateAsync({
       request: { employeeId, bankAccountUuid: uuid },
     })
-    await invalidateAll()
     onEvent(componentEvents.EMPLOYEE_BANK_ACCOUNT_DELETED, data)
   }
   const handleAdd = () => {

--- a/src/components/Employee/Profile/Profile.tsx
+++ b/src/components/Employee/Profile/Profile.tsx
@@ -17,8 +17,6 @@ import type { EmployeeWorkAddress } from '@gusto/embedded-api/models/components/
 import { useEmployeeAddressesCreateWorkAddressMutation } from '@gusto/embedded-api/react-query/employeeAddressesCreateWorkAddress'
 import { RFCDate } from '@gusto/embedded-api/types/rfcdate'
 import { useEmployeesUpdateOnboardingStatusMutation } from '@gusto/embedded-api/react-query/employeesUpdateOnboardingStatus'
-import { invalidateEmployeesList } from '@gusto/embedded-api/react-query/employeesList'
-import { useQueryClient } from '@tanstack/react-query'
 import type { OnboardingContextInterface } from '../OnboardingFlow/OnboardingFlow'
 import {
   AdminPersonalDetails,
@@ -135,7 +133,6 @@ const Root = ({
     defaultValues,
   } = props
   const { onEvent, baseSubmitHandler } = useBase()
-  const queryClient = useQueryClient()
 
   const [AdminSchema, setAdminSchema] = useState<
     typeof AdminPersonalDetailsSchema | typeof AdminSelfOnboardingPersonalDetailsSchema
@@ -162,9 +159,7 @@ const Root = ({
   const {
     mutateAsync: updateEmployeeOnboardingStatus,
     isPending: isPendingUpdateOnboardingStatus,
-  } = useEmployeesUpdateOnboardingStatusMutation({
-    onSettled: () => invalidateEmployeesList(queryClient, [companyId]),
-  })
+  } = useEmployeesUpdateOnboardingStatusMutation()
 
   const existingData = { employee, workAddresses, homeAddresses }
 

--- a/src/components/Employee/Taxes/Taxes.tsx
+++ b/src/components/Employee/Taxes/Taxes.tsx
@@ -2,11 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { FormProvider, useForm, type SubmitHandler } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { useEffect } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
-import {
-  useEmployeeTaxSetupGetFederalTaxesSuspense,
-  invalidateEmployeeTaxSetupGetFederalTaxes,
-} from '@gusto/embedded-api/react-query/employeeTaxSetupGetFederalTaxes'
+import { useEmployeeTaxSetupGetFederalTaxesSuspense } from '@gusto/embedded-api/react-query/employeeTaxSetupGetFederalTaxes'
 import { useEmployeeTaxSetupUpdateFederalTaxesMutation } from '@gusto/embedded-api/react-query/employeeTaxSetupUpdateFederalTaxes'
 import { useEmployeeTaxSetupGetStateTaxesSuspense } from '@gusto/embedded-api/react-query/employeeTaxSetupGetStateTaxes'
 import { useEmployeeTaxSetupUpdateStateTaxesMutation } from '@gusto/embedded-api/react-query/employeeTaxSetupUpdateStateTaxes'
@@ -54,7 +50,6 @@ const Root = (props: TaxesProps) => {
   const { onEvent, fieldErrors, baseSubmitHandler } = useBase()
   useI18n('Employee.Taxes')
   useComponentDictionary('Employee.Taxes', dictionary)
-  const queryClient = useQueryClient()
 
   const { data: fedData } = useEmployeeTaxSetupGetFederalTaxesSuspense({
     employeeUuid: employeeId,
@@ -131,7 +126,6 @@ const Root = (props: TaxesProps) => {
           },
         },
       })
-      await invalidateEmployeeTaxSetupGetFederalTaxes(queryClient, [employeeId])
       onEvent(componentEvents.EMPLOYEE_FEDERAL_TAXES_UPDATED, federalTaxesResponse)
 
       //State Taxes - only process if statesPayload exists


### PR DESCRIPTION
Now that we automatically invalidate post mutation, we don't need to have all these manual invalidation call sites