### PR TITLE
fix: update pay preview

### DIFF
--- a/src/components/Company/Locations/LocationsList/List.tsx
+++ b/src/components/Company/Locations/LocationsList/List.tsx
@@ -33,9 +33,11 @@ export const List = () => {
           return (
             <>
               <address>
-                {getStreet(location)}
+                <Components.Text as="span">{getStreet(location)}</Components.Text>
                 <br />
-                <small>{getCityStateZip(location)}</small>
+                <Components.Text as="span" size="sm">
+                  {getCityStateZip(location)}
+                </Components.Text>
               </address>
             </>
           )

--- a/src/components/Company/PaySchedule/PaySchedule.tsx
+++ b/src/components/Company/PaySchedule/PaySchedule.tsx
@@ -63,21 +63,6 @@ const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
     payPeriodPreviewRange: 0,
   }
 
-  const [payScheduleDraft, setPayScheduleDraft] = useState<PayScheduleType | null>(null)
-  const { data: payPreviewData, isLoading } = usePaySchedulesGetPreview(
-    {
-      companyId,
-      frequency: payScheduleDraft?.frequency as Frequency,
-      anchorPayDate: payScheduleDraft?.anchorPayDate ?? '',
-      anchorEndOfPayPeriod: payScheduleDraft?.anchorEndOfPayPeriod ?? '',
-      day1: payScheduleDraft?.day1 ?? undefined,
-      day2: payScheduleDraft?.day2 ?? undefined,
-    },
-    {
-      enabled: true,
-    }, // Casting to non-null because we know it's not null from the enabled prop
-  )
-
   const { data: paySchedules } = usePaySchedulesGetAllSuspense({
     companyId,
   })
@@ -102,6 +87,28 @@ const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
 
   const allValues = watch()
 
+  const { data: payPreviewData, isLoading } = usePaySchedulesGetPreview(
+    {
+      companyId,
+      frequency: allValues.frequency,
+      anchorPayDate: allValues.anchorPayDate
+        ? formatDateToStringDate(allValues.anchorPayDate) || ''
+        : '',
+      anchorEndOfPayPeriod: allValues.anchorEndOfPayPeriod
+        ? formatDateToStringDate(allValues.anchorEndOfPayPeriod) || ''
+        : '',
+      day1: allValues.day1 ?? undefined,
+      day2: allValues.day2 ?? undefined,
+    },
+    {
+      enabled: Boolean(
+        allValues.anchorPayDate &&
+          allValues.anchorEndOfPayPeriod &&
+          (mode === 'ADD_PAY_SCHEDULE' || mode === 'EDIT_PAY_SCHEDULE'),
+      ),
+    },
+  )
+
   // Set the custom_twice_per_month value based on the frequency and day_1 and day_2 values as it is not set by the API call
   useEffect(() => {
     if (
@@ -119,33 +126,6 @@ const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
     }
   }, [allValues.frequency, allValues.day1, allValues.day2, setValue, allValues.customTwicePerMonth])
 
-  useEffect(() => {
-    // Don't update if dates are not set
-    if (!allValues.anchorPayDate || !allValues.anchorEndOfPayPeriod) {
-      return
-    }
-
-    setPayScheduleDraft({
-      frequency: allValues.frequency,
-      anchorPayDate: allValues.anchorPayDate.toString(),
-      anchorEndOfPayPeriod: allValues.anchorEndOfPayPeriod.toString(),
-      day1: allValues.day1 || undefined,
-      day2: allValues.day2 || undefined,
-      uuid: '',
-      version: currentPaySchedule?.version || '', //TODO: This needs to be set to something
-    })
-  }, [
-    allValues.anchorEndOfPayPeriod,
-    allValues.anchorPayDate,
-    allValues.day1,
-    allValues.day2,
-    allValues.frequency,
-    currentPaySchedule?.version,
-    setPayScheduleDraft,
-  ])
-
-  // Custom effect to show/hide pay schedule preview errors
-
   const handleAdd = () => {
     setMode('ADD_PAY_SCHEDULE')
     reset({})
@@ -153,7 +133,6 @@ const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
   const handleCancel = () => {
     setMode('LIST_PAY_SCHEDULES')
     reset({})
-    setPayScheduleDraft(null)
   }
   const handleEdit = (schedule: PayScheduleType) => {
     reset({
@@ -181,7 +160,7 @@ const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
       if (mode === 'ADD_PAY_SCHEDULE') {
         const createPayScheduleResponse = await createPayScheduleMutation.mutateAsync({
           request: {
-            companyId: companyId,
+            companyId,
             requestBody: {
               frequency: payload.frequency,
               anchorPayDate: formatPayloadDate(payload.anchorPayDate),
@@ -194,13 +173,12 @@ const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
         })
         onEvent(componentEvents.PAY_SCHEDULE_CREATED, createPayScheduleResponse)
         reset()
-        setPayScheduleDraft(null)
       } else if (mode === 'EDIT_PAY_SCHEDULE') {
         const version = currentPaySchedule?.version
         const updatePayScheduleResponse = await updatePayScheduleMutation.mutateAsync({
           request: {
             payScheduleId: currentPaySchedule?.uuid as string,
-            companyId: companyId,
+            companyId,
             requestBody: {
               frequency: payload.frequency,
               anchorPayDate: formatPayloadDate(payload.anchorPayDate),
@@ -214,7 +192,6 @@ const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
         })
         onEvent(componentEvents.PAY_SCHEDULE_UPDATED, updatePayScheduleResponse)
         reset()
-        setPayScheduleDraft(null)
       }
       setMode('LIST_PAY_SCHEDULES')
     })

--- a/src/components/Company/PaySchedule/_parts/Edit.tsx
+++ b/src/components/Company/PaySchedule/_parts/Edit.tsx
@@ -55,7 +55,7 @@ export const Edit = () => {
       <Grid gap={32} gridTemplateColumns={{ base: '1fr', small: '1fr 1fr' }}>
         <div className={style.payScheduleForm}>
           <Flex flexDirection={'column'}>
-            <TextInputField name="customName" label="Name" />
+            <TextInputField name="customName" label="Name" isRequired />
             <SelectField
               name="frequency"
               label={t('labels.frequency')}
@@ -65,6 +65,7 @@ export const Edit = () => {
                 { value: 'Twice per month', label: t('frequencies.twicePerMonth') },
                 { value: 'Monthly', label: t('frequencies.monthly') },
               ]}
+              isRequired
             />
             {frequency === 'Twice per month' && (
               <RadioGroupField
@@ -81,22 +82,24 @@ export const Edit = () => {
               name="anchorPayDate"
               label={t('labels.firstPayDate')}
               description={t('descriptions.anchorPayDateDescription')}
+              isRequired
             />
             <DatePickerField
               name="anchorEndOfPayPeriod"
               label={t('labels.firstPayPeriodEndDate')}
               description={t('descriptions.anchorEndOfPayPeriodDescription')}
+              isRequired
             />
             <div className={shouldShowDay1 ? '' : style.visuallyHidden}>
-              <NumberInputField name="day1" label={t('labels.firstPayDayOfTheMonth')} />
+              <NumberInputField name="day1" label={t('labels.firstPayDayOfTheMonth')} isRequired />
             </div>
             <div className={shouldShowDay2 ? '' : style.visuallyHidden}>
-              <NumberInputField name="day2" label={t('labels.lastPayDayOfTheMonth')} />
+              <NumberInputField name="day2" label={t('labels.lastPayDayOfTheMonth')} isRequired />
             </div>
           </Flex>
         </div>
         <Flex flexDirection="column" gap={4} justifyContent="center" alignItems="center">
-          {payPeriodPreview && payPeriodPreview[selectedPayPeriodIndex] && (
+          {payPeriodPreview && payPeriodPreview[selectedPayPeriodIndex] ? (
             <div className={style.calendarContainer}>
               {!payPreviewLoading && (
                 <SelectField
@@ -137,6 +140,20 @@ export const Edit = () => {
                   },
                 ]}
               />
+            </div>
+          ) : (
+            <div className={style.calendarContainer}>
+              <Components.Alert
+                status="info"
+                label={t('previewAlert.title', 'Pay Schedule Preview')}
+              >
+                <Components.Text>
+                  {t(
+                    'previewAlert.description',
+                    'Complete all the required fields on the left to see a preview of your pay schedule.',
+                  )}
+                </Components.Text>
+              </Components.Alert>
             </div>
           )}
         </Flex>

--- a/src/i18n/en/Company.PaySchedule.json
+++ b/src/i18n/en/Company.PaySchedule.json
@@ -53,5 +53,9 @@
   "frequencyOptions": {
     "15thAndLast": "15th and Last day of the month",
     "custom": "Custom"
+  },
+  "previewAlert": {
+    "title": "Pay Schedule Preview",
+    "description": "Complete all the required fields to see a preview of your pay schedule."
   }
 }

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -312,6 +312,10 @@ export interface CompanyPaySchedule{
 "15thAndLast":string;
 "custom":string;
 };
+"previewAlert":{
+"title":string;
+"description":string;
+};
 };
 export interface CompanySignatureForm{
 "signatureFormTitle":string;


### PR DESCRIPTION
Update Pay Preview bugs

# Fixes
- Removed small from table and use <Text> with size prop instead
- Fixed issue where monthly payschedule doesn't show preview when editing
- Fixed an issue where alert where PaySchedule is located was suppressed

# Proof of Functionality
<img width="1104" height="700" alt="Screenshot 2025-07-10 at 1 56 29 PM" src="https://github.com/user-attachments/assets/15dca5a7-1720-4cd3-9a28-5b84f054f813" />
<img width="1309" height="539" alt="Screenshot 2025-07-10 at 1 56 11 PM" src="https://github.com/user-attachments/assets/bbae7ad5-9ba5-430d-9b41-3eeb134ffd20" />
