### PR TITLE
chore: seperate rc publish and unpublish from main

### DIFF
--- a/.github/workflows/publish-rc.yaml
+++ b/.github/workflows/publish-rc.yaml
@@ -1,0 +1,129 @@
+name: Publish RC to NPM
+on:
+  workflow_dispatch:
+    inputs:
+      rc_number:
+        description: 'RC number (optional, will auto-increment if version exists)'
+        required: false
+        type: string
+        default: '1'
+      branch:
+        description: 'Branch to release from'
+        required: false
+        type: choice
+        options:
+          - 'main'
+          - 'develop'
+          - 'staging'
+        default: 'main'
+      commit:
+        description: 'Specific commit to release from (overrides branch if provided)'
+        required: false
+        type: string
+jobs:
+  publish:
+    runs-on:
+      group: gusto-ubuntu-default
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Determine checkout ref
+        id: checkout-ref
+        run: |
+          if [ -n "${{ github.event.inputs.commit }}" ]; then
+            echo "Using commit: ${{ github.event.inputs.commit }}"
+            echo "ref=${{ github.event.inputs.commit }}" >> $GITHUB_OUTPUT
+            echo "ref_type=commit" >> $GITHUB_OUTPUT
+            echo "ref_name=${{ github.event.inputs.commit }}" >> $GITHUB_OUTPUT
+          else
+            echo "Using branch: ${{ github.event.inputs.branch }}"
+            echo "ref=${{ github.event.inputs.branch }}" >> $GITHUB_OUTPUT
+            echo "ref_type=branch" >> $GITHUB_OUTPUT
+            echo "ref_name=${{ github.event.inputs.branch }}" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.checkout-ref.outputs.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+
+      - name: Show release info
+        run: |
+          echo "🚀 RC Release Information:"
+          echo "Source: ${{ steps.checkout-ref.outputs.ref_type }} -> ${{ steps.checkout-ref.outputs.ref_name }}"
+          echo "Full Commit: $(git rev-parse HEAD)"
+          echo "Short Commit: $(git rev-parse --short HEAD)"
+          echo "Current Version: $(node -p "require('./package.json').version")"
+
+          # Show commit details
+          echo ""
+          echo "📝 Commit Details:"
+          git log -1 --pretty=format:"  Author: %an <%ae>%n  Date: %ad%n  Message: %s" --date=short
+
+      - name: Prepare RC version
+        run: |
+          # Get current version from package.json
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME="@gusto/embedded-react-sdk"
+          REF_TYPE="${{ steps.checkout-ref.outputs.ref_type }}"
+          REF_NAME="${{ steps.checkout-ref.outputs.ref_name }}"
+
+          # Starting RC number (from input or default to 1)
+          RC_NUMBER="${{ github.event.inputs.rc_number || '1' }}"
+
+          # Function to check if version exists on npm
+          check_version_exists() {
+            local version=$1
+            npm view "${PACKAGE_NAME}@${version}" version 2>/dev/null
+          }
+
+          # Find the next available RC number
+          while true; do
+            RC_VERSION="${CURRENT_VERSION}-rc.${RC_NUMBER}"
+            
+            echo "Checking if version $RC_VERSION exists..."
+            
+            if check_version_exists "$RC_VERSION"; then
+              echo "Version $RC_VERSION already exists, incrementing to rc.$((RC_NUMBER + 1))"
+              RC_NUMBER=$((RC_NUMBER + 1))
+            else
+              echo "Version $RC_VERSION is available!"
+              break
+            fi
+            
+            # Safety check to prevent infinite loops
+            if [ $RC_NUMBER -gt 100 ]; then
+              echo "❌ Error: RC number exceeded 100, something might be wrong"
+              exit 1
+            fi
+          done
+
+          echo "Publishing RC version: $RC_VERSION from $REF_TYPE: $REF_NAME"
+
+          # Update package.json with RC version
+          npm version $RC_VERSION --no-git-tag-version
+
+          # Set environment variable for later steps
+          echo "RC_VERSION=$RC_VERSION" >> $GITHUB_ENV
+          echo "REF_TYPE=$REF_TYPE" >> $GITHUB_ENV
+          echo "REF_NAME=$REF_NAME" >> $GITHUB_ENV
+
+      - name: Publish RC version
+        run: npm publish --access public --tag rc
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Output published version
+        run: |
+          echo "✅ Published RC version: $RC_VERSION"
+          echo "📦 Install with: npm install @gusto/embedded-react-sdk@rc"
+          echo "🔗 Or specific version: npm install @gusto/embedded-react-sdk@$RC_VERSION"
+          echo "🌿 Released from $REF_TYPE: $REF_NAME"
+          echo "📋 Full commit: $(git rev-parse HEAD)"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,28 +1,5 @@
 name: Publish to NPM
-on:
-  workflow_dispatch:
-    inputs:
-      release_type:
-        description: 'Type of release'
-        required: true
-        type: choice
-        options:
-          - 'regular'
-          - 'rc'
-        default: 'regular'
-      rc_number:
-        description: 'RC number (optional, will auto-increment if version exists)'
-        required: false
-        type: string
-        default: '1'
-      branch:
-        description: 'Branch to release from (leave empty for current branch)'
-        required: false
-        type: string
-      commit:
-        description: 'Specific commit to release from (overrides branch if provided)'
-        required: false
-        type: string
+on: workflow_dispatch
 jobs:
   publish:
     runs-on:
@@ -31,127 +8,13 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - name: Determine checkout ref
-        id: checkout-ref
-        run: |
-          if [ -n "${{ github.event.inputs.commit }}" ]; then
-            echo "Using commit: ${{ github.event.inputs.commit }}"
-            echo "ref=${{ github.event.inputs.commit }}" >> $GITHUB_OUTPUT
-            echo "ref_type=commit" >> $GITHUB_OUTPUT
-            echo "ref_name=${{ github.event.inputs.commit }}" >> $GITHUB_OUTPUT
-          elif [ -n "${{ github.event.inputs.branch }}" ]; then
-            echo "Using branch: ${{ github.event.inputs.branch }}"
-            echo "ref=${{ github.event.inputs.branch }}" >> $GITHUB_OUTPUT
-            echo "ref_type=branch" >> $GITHUB_OUTPUT
-            echo "ref_name=${{ github.event.inputs.branch }}" >> $GITHUB_OUTPUT
-          else
-            echo "Using current ref: ${{ github.ref }}"
-            echo "ref=${{ github.ref }}" >> $GITHUB_OUTPUT
-            echo "ref_type=default" >> $GITHUB_OUTPUT
-            echo "ref_name=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          fi
-
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.checkout-ref.outputs.ref }}
-
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
-
-      - name: Show release info
-        run: |
-          echo "🚀 Release Information:"
-          echo "Release Type: ${{ github.event.inputs.release_type }}"
-          echo "Source: ${{ steps.checkout-ref.outputs.ref_type }} -> ${{ steps.checkout-ref.outputs.ref_name }}"
-          echo "Full Commit: $(git rev-parse HEAD)"
-          echo "Short Commit: $(git rev-parse --short HEAD)"
-          echo "Current Version: $(node -p "require('./package.json').version")"
-
-          # Show commit details
-          echo ""
-          echo "📝 Commit Details:"
-          git log -1 --pretty=format:"  Author: %an <%ae>%n  Date: %ad%n  Message: %s" --date=short
-
-      - name: Prepare RC version
-        if: ${{ github.event.inputs.release_type == 'rc' }}
-        run: |
-          # Get current version from package.json
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          PACKAGE_NAME="@gusto/embedded-react-sdk"
-          REF_TYPE="${{ steps.checkout-ref.outputs.ref_type }}"
-          REF_NAME="${{ steps.checkout-ref.outputs.ref_name }}"
-
-          # Starting RC number (from input or default to 1)
-          RC_NUMBER="${{ github.event.inputs.rc_number || '1' }}"
-
-          # Function to check if version exists on npm
-          check_version_exists() {
-            local version=$1
-            npm view "${PACKAGE_NAME}@${version}" version 2>/dev/null
-          }
-
-          # Find the next available RC number
-          while true; do
-            RC_VERSION="${CURRENT_VERSION}-rc.${RC_NUMBER}"
-            
-            echo "Checking if version $RC_VERSION exists..."
-            
-            if check_version_exists "$RC_VERSION"; then
-              echo "Version $RC_VERSION already exists, incrementing to rc.$((RC_NUMBER + 1))"
-              RC_NUMBER=$((RC_NUMBER + 1))
-            else
-              echo "Version $RC_VERSION is available!"
-              break
-            fi
-            
-            # Safety check to prevent infinite loops
-            if [ $RC_NUMBER -gt 100 ]; then
-              echo "❌ Error: RC number exceeded 100, something might be wrong"
-              exit 1
-            fi
-          done
-
-          echo "Publishing RC version: $RC_VERSION from $REF_TYPE: $REF_NAME"
-
-          # Update package.json with RC version
-          npm version $RC_VERSION --no-git-tag-version
-
-          # Set environment variable for later steps
-          echo "RC_VERSION=$RC_VERSION" >> $GITHUB_ENV
-          echo "IS_RC=true" >> $GITHUB_ENV
-          echo "REF_TYPE=$REF_TYPE" >> $GITHUB_ENV
-          echo "REF_NAME=$REF_NAME" >> $GITHUB_ENV
-
-      - name: Publish regular version
-        if: ${{ github.event.inputs.release_type == 'regular' }}
-        run: npm publish --access public
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish RC version
-        if: ${{ github.event.inputs.release_type == 'rc' }}
-        run: npm publish --access public --tag rc
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Output published version
-        run: |
-          if [ "${{ github.event.inputs.release_type }}" == "rc" ]; then
-            echo "✅ Published RC version: $RC_VERSION"
-            echo "📦 Install with: npm install @gusto/embedded-react-sdk@rc"
-            echo "🔗 Or specific version: npm install @gusto/embedded-react-sdk@$RC_VERSION"
-            echo "🌿 Released from $REF_TYPE: $REF_NAME"
-            echo "📋 Full commit: $(git rev-parse HEAD)"
-          else
-            CURRENT_VERSION=$(node -p "require('./package.json').version")
-            REF_TYPE="${{ steps.checkout-ref.outputs.ref_type }}"
-            REF_NAME="${{ steps.checkout-ref.outputs.ref_name }}"
-            echo "✅ Published regular version: $CURRENT_VERSION"
-            echo "📦 Install with: npm install @gusto/embedded-react-sdk@latest"
-            echo "🌿 Released from $REF_TYPE: $REF_NAME"
-            echo "📋 Full commit: $(git rev-parse HEAD)"
-          fi

--- a/.github/workflows/unpublish-rc.yaml
+++ b/.github/workflows/unpublish-rc.yaml
@@ -1,0 +1,190 @@
+name: Unpublish RC NPM Package
+on:
+  workflow_dispatch:
+    inputs:
+      unpublish_type:
+        description: 'What to unpublish'
+        required: true
+        type: choice
+        options:
+          - 'specific_version'
+          - 'latest_rc'
+          - 'all_rc_for_version'
+        default: 'specific_version'
+      version:
+        description: 'Specific version to unpublish (e.g., 0.10.3-rc.1 or 0.10.3)'
+        required: false
+        type: string
+      base_version:
+        description: 'Base version for RC cleanup (e.g., 0.10.3 - only for "all_rc_for_version")'
+        required: false
+        type: string
+      confirm:
+        description: 'Type "CONFIRM" to proceed with unpublishing'
+        required: true
+        type: string
+jobs:
+  unpublish:
+    runs-on:
+      group: gusto-ubuntu-default
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Validate confirmation
+        run: |
+          if [ "${{ github.event.inputs.confirm }}" != "CONFIRM" ]; then
+            echo "❌ Error: You must type 'CONFIRM' to proceed with unpublishing"
+            echo "   This is a safety measure to prevent accidental unpublishing"
+            exit 1
+          fi
+          echo "✅ Confirmation received"
+
+      - name: Validate inputs
+        run: |
+          UNPUBLISH_TYPE="${{ github.event.inputs.unpublish_type }}"
+          VERSION="${{ github.event.inputs.version }}"
+          BASE_VERSION="${{ github.event.inputs.base_version }}"
+
+          case "$UNPUBLISH_TYPE" in
+            "specific_version")
+              if [ -z "$VERSION" ]; then
+                echo "❌ Error: Version is required for specific_version unpublish type"
+                exit 1
+              fi
+              ;;
+            "all_rc_for_version")
+              if [ -z "$BASE_VERSION" ]; then
+                echo "❌ Error: Base version is required for all_rc_for_version unpublish type"
+                exit 1
+              fi
+              ;;
+          esac
+
+          echo "✅ Input validation passed"
+
+      - name: Show available versions
+        run: |
+          PACKAGE_NAME="@gusto/embedded-react-sdk"
+          echo "📦 Available versions for $PACKAGE_NAME:"
+          echo ""
+
+          # Get all versions
+          ALL_VERSIONS=$(npm view $PACKAGE_NAME versions --json | jq -r '.[]' | sort -V)
+
+          # Show regular versions
+          echo "🏷️  Regular versions:"
+          echo "$ALL_VERSIONS" | grep -v "\-rc\." | tail -5 | sed 's/^/  /'
+
+          # Show RC versions  
+          echo ""
+          echo "🧪 RC versions:"
+          RC_VERSIONS=$(echo "$ALL_VERSIONS" | grep "\-rc\." | tail -10)
+          if [ -n "$RC_VERSIONS" ]; then
+            echo "$RC_VERSIONS" | sed 's/^/  /'
+          else
+            echo "  No RC versions found"
+          fi
+
+          echo ""
+          echo "💡 Tip: Use 'npm view $PACKAGE_NAME versions --json' to see all versions"
+
+      - name: Determine versions to unpublish
+        id: determine-versions
+        run: |
+          PACKAGE_NAME="@gusto/embedded-react-sdk"
+          UNPUBLISH_TYPE="${{ github.event.inputs.unpublish_type }}"
+          VERSION="${{ github.event.inputs.version }}"
+          BASE_VERSION="${{ github.event.inputs.base_version }}"
+
+          case "$UNPUBLISH_TYPE" in
+            "specific_version")
+              # Check if version exists
+              if npm view "${PACKAGE_NAME}@${VERSION}" version 2>/dev/null; then
+                echo "versions_to_unpublish=$VERSION" >> $GITHUB_OUTPUT
+                echo "✅ Version $VERSION exists and will be unpublished"
+              else
+                echo "❌ Error: Version $VERSION does not exist"
+                exit 1
+              fi
+              ;;
+              
+            "latest_rc")
+              # Find the latest RC version
+              LATEST_RC=$(npm view $PACKAGE_NAME versions --json | jq -r '.[]' | grep "\-rc\." | sort -V | tail -1)
+              if [ -n "$LATEST_RC" ]; then
+                echo "versions_to_unpublish=$LATEST_RC" >> $GITHUB_OUTPUT
+                echo "✅ Latest RC version $LATEST_RC will be unpublished"
+              else
+                echo "❌ Error: No RC versions found"
+                exit 1
+              fi
+              ;;
+              
+            "all_rc_for_version")
+              # Find all RC versions for the base version
+              ALL_RC_FOR_VERSION=$(npm view $PACKAGE_NAME versions --json | jq -r '.[]' | grep "^${BASE_VERSION}-rc\." | sort -V)
+              if [ -n "$ALL_RC_FOR_VERSION" ]; then
+                echo "versions_to_unpublish<<EOF" >> $GITHUB_OUTPUT
+                echo "$ALL_RC_FOR_VERSION" >> $GITHUB_OUTPUT
+                echo "EOF" >> $GITHUB_OUTPUT
+                echo "✅ Found RC versions for $BASE_VERSION:"
+                echo "$ALL_RC_FOR_VERSION" | sed 's/^/  /'
+              else
+                echo "❌ Error: No RC versions found for base version $BASE_VERSION"
+                exit 1
+              fi
+              ;;
+          esac
+
+      - name: Unpublish versions
+        run: |
+          PACKAGE_NAME="@gusto/embedded-react-sdk"
+          VERSIONS_TO_UNPUBLISH="${{ steps.determine-versions.outputs.versions_to_unpublish }}"
+
+          echo "🗑️  Starting unpublish process..."
+          echo ""
+
+          # Convert to array if multiple versions
+          if echo "$VERSIONS_TO_UNPUBLISH" | grep -q $'\n'; then
+            # Multiple versions (newline separated)
+            echo "$VERSIONS_TO_UNPUBLISH" | while read -r version; do
+              if [ -n "$version" ]; then
+                echo "🗑️  Unpublishing $PACKAGE_NAME@$version..."
+                if npm unpublish "$PACKAGE_NAME@$version"; then
+                  echo "✅ Successfully unpublished $version"
+                else
+                  echo "❌ Failed to unpublish $version"
+                  exit 1
+                fi
+                echo ""
+              fi
+            done
+          else
+            # Single version
+            echo "🗑️  Unpublishing $PACKAGE_NAME@$VERSIONS_TO_UNPUBLISH..."
+            if npm unpublish "$PACKAGE_NAME@$VERSIONS_TO_UNPUBLISH"; then
+              echo "✅ Successfully unpublished $VERSIONS_TO_UNPUBLISH"
+            else
+              echo "❌ Failed to unpublish $VERSIONS_TO_UNPUBLISH"
+              exit 1
+            fi
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "📋 Unpublish Summary:"
+          echo "Type: ${{ github.event.inputs.unpublish_type }}"
+          echo "Versions unpublished:"
+          echo "${{ steps.determine-versions.outputs.versions_to_unpublish }}" | sed 's/^/  ✅ /'
+          echo ""
+          echo "🔗 Check remaining versions:"
+          echo "   npm view @gusto/embedded-react-sdk versions --json"

--- a/.github/workflows/unpublish.yaml
+++ b/.github/workflows/unpublish.yaml
@@ -1,30 +1,12 @@
-name: Unpublish NPM Package
+name: Unpublish an old NPM package
 on:
   workflow_dispatch:
     inputs:
-      unpublish_type:
-        description: 'What to unpublish'
-        required: true
-        type: choice
-        options:
-          - 'specific_version'
-          - 'latest_rc'
-          - 'all_rc_for_version'
-        default: 'specific_version'
       version:
-        description: 'Specific version to unpublish (e.g., 0.10.3-rc.1 or 0.10.3)'
-        required: false
-        type: string
-      base_version:
-        description: 'Base version for RC cleanup (e.g., 0.10.3 - only for "all_rc_for_version")'
-        required: false
-        type: string
-      confirm:
-        description: 'Type "CONFIRM" to proceed with unpublishing'
+        description: 'Version to unpublish'
         required: true
-        type: string
 jobs:
-  unpublish:
+  publish:
     runs-on:
       group: gusto-ubuntu-default
     permissions:
@@ -36,155 +18,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Validate confirmation
-        run: |
-          if [ "${{ github.event.inputs.confirm }}" != "CONFIRM" ]; then
-            echo "❌ Error: You must type 'CONFIRM' to proceed with unpublishing"
-            echo "   This is a safety measure to prevent accidental unpublishing"
-            exit 1
-          fi
-          echo "✅ Confirmation received"
-
-      - name: Validate inputs
-        run: |
-          UNPUBLISH_TYPE="${{ github.event.inputs.unpublish_type }}"
-          VERSION="${{ github.event.inputs.version }}"
-          BASE_VERSION="${{ github.event.inputs.base_version }}"
-
-          case "$UNPUBLISH_TYPE" in
-            "specific_version")
-              if [ -z "$VERSION" ]; then
-                echo "❌ Error: Version is required for specific_version unpublish type"
-                exit 1
-              fi
-              ;;
-            "all_rc_for_version")
-              if [ -z "$BASE_VERSION" ]; then
-                echo "❌ Error: Base version is required for all_rc_for_version unpublish type"
-                exit 1
-              fi
-              ;;
-          esac
-
-          echo "✅ Input validation passed"
-
-      - name: Show available versions
-        run: |
-          PACKAGE_NAME="@gusto/embedded-react-sdk"
-          echo "📦 Available versions for $PACKAGE_NAME:"
-          echo ""
-
-          # Get all versions
-          ALL_VERSIONS=$(npm view $PACKAGE_NAME versions --json | jq -r '.[]' | sort -V)
-
-          # Show regular versions
-          echo "🏷️  Regular versions:"
-          echo "$ALL_VERSIONS" | grep -v "\-rc\." | tail -5 | sed 's/^/  /'
-
-          # Show RC versions  
-          echo ""
-          echo "🧪 RC versions:"
-          RC_VERSIONS=$(echo "$ALL_VERSIONS" | grep "\-rc\." | tail -10)
-          if [ -n "$RC_VERSIONS" ]; then
-            echo "$RC_VERSIONS" | sed 's/^/  /'
-          else
-            echo "  No RC versions found"
-          fi
-
-          echo ""
-          echo "💡 Tip: Use 'npm view $PACKAGE_NAME versions --json' to see all versions"
-
-      - name: Determine versions to unpublish
-        id: determine-versions
-        run: |
-          PACKAGE_NAME="@gusto/embedded-react-sdk"
-          UNPUBLISH_TYPE="${{ github.event.inputs.unpublish_type }}"
-          VERSION="${{ github.event.inputs.version }}"
-          BASE_VERSION="${{ github.event.inputs.base_version }}"
-
-          case "$UNPUBLISH_TYPE" in
-            "specific_version")
-              # Check if version exists
-              if npm view "${PACKAGE_NAME}@${VERSION}" version 2>/dev/null; then
-                echo "versions_to_unpublish=$VERSION" >> $GITHUB_OUTPUT
-                echo "✅ Version $VERSION exists and will be unpublished"
-              else
-                echo "❌ Error: Version $VERSION does not exist"
-                exit 1
-              fi
-              ;;
-              
-            "latest_rc")
-              # Find the latest RC version
-              LATEST_RC=$(npm view $PACKAGE_NAME versions --json | jq -r '.[]' | grep "\-rc\." | sort -V | tail -1)
-              if [ -n "$LATEST_RC" ]; then
-                echo "versions_to_unpublish=$LATEST_RC" >> $GITHUB_OUTPUT
-                echo "✅ Latest RC version $LATEST_RC will be unpublished"
-              else
-                echo "❌ Error: No RC versions found"
-                exit 1
-              fi
-              ;;
-              
-            "all_rc_for_version")
-              # Find all RC versions for the base version
-              ALL_RC_FOR_VERSION=$(npm view $PACKAGE_NAME versions --json | jq -r '.[]' | grep "^${BASE_VERSION}-rc\." | sort -V)
-              if [ -n "$ALL_RC_FOR_VERSION" ]; then
-                echo "versions_to_unpublish<<EOF" >> $GITHUB_OUTPUT
-                echo "$ALL_RC_FOR_VERSION" >> $GITHUB_OUTPUT
-                echo "EOF" >> $GITHUB_OUTPUT
-                echo "✅ Found RC versions for $BASE_VERSION:"
-                echo "$ALL_RC_FOR_VERSION" | sed 's/^/  /'
-              else
-                echo "❌ Error: No RC versions found for base version $BASE_VERSION"
-                exit 1
-              fi
-              ;;
-          esac
-
-      - name: Unpublish versions
-        run: |
-          PACKAGE_NAME="@gusto/embedded-react-sdk"
-          VERSIONS_TO_UNPUBLISH="${{ steps.determine-versions.outputs.versions_to_unpublish }}"
-
-          echo "🗑️  Starting unpublish process..."
-          echo ""
-
-          # Convert to array if multiple versions
-          if echo "$VERSIONS_TO_UNPUBLISH" | grep -q $'\n'; then
-            # Multiple versions (newline separated)
-            echo "$VERSIONS_TO_UNPUBLISH" | while read -r version; do
-              if [ -n "$version" ]; then
-                echo "🗑️  Unpublishing $PACKAGE_NAME@$version..."
-                if npm unpublish "$PACKAGE_NAME@$version"; then
-                  echo "✅ Successfully unpublished $version"
-                else
-                  echo "❌ Failed to unpublish $version"
-                  exit 1
-                fi
-                echo ""
-              fi
-            done
-          else
-            # Single version
-            echo "🗑️  Unpublishing $PACKAGE_NAME@$VERSIONS_TO_UNPUBLISH..."
-            if npm unpublish "$PACKAGE_NAME@$VERSIONS_TO_UNPUBLISH"; then
-              echo "✅ Successfully unpublished $VERSIONS_TO_UNPUBLISH"
-            else
-              echo "❌ Failed to unpublish $VERSIONS_TO_UNPUBLISH"
-              exit 1
-            fi
-          fi
+      - run: npm unpublish @gusto/embedded-react-sdk@${{ github.event.inputs.version }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Summary
-        run: |
-          echo "📋 Unpublish Summary:"
-          echo "Type: ${{ github.event.inputs.unpublish_type }}"
-          echo "Versions unpublished:"
-          echo "${{ steps.determine-versions.outputs.versions_to_unpublish }}" | sed 's/^/  ✅ /'
-          echo ""
-          echo "🔗 Check remaining versions:"
-          echo "   npm view @gusto/embedded-react-sdk versions --json"


### PR DESCRIPTION
Decided to separate how we publish an RC versus a normal package. 

Now RC will have its own publish/unpublish commands