### PR TITLE
fix: payschedule error doesnt clear on cancel

### DIFF
--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -95,6 +95,14 @@ export const BaseComponent = <TResourceKey extends keyof Resources = keyof Resou
 
   const LoaderComponent = LoadingIndicatorFromProps ?? LoadingIndicatorFromContext
 
+  // Enhanced setError that also clears fieldErrors when error is cleared
+  const setErrorWithFieldsClear = useCallback((error: KnownErrors | null) => {
+    setError(error)
+    if (!error) {
+      setFieldErrors(null)
+    }
+  }, [])
+
   const processError = (error: KnownErrors) => {
     setError(error)
     //422	application/json - content relaited error
@@ -126,7 +134,7 @@ export const BaseComponent = <TResourceKey extends keyof Resources = keyof Resou
     <BaseContext.Provider
       value={{
         fieldErrors,
-        setError,
+        setError: setErrorWithFieldsClear,
         onEvent,
         throwError,
         baseSubmitHandler,

--- a/src/components/Base/useBase.tsx
+++ b/src/components/Base/useBase.tsx
@@ -15,7 +15,7 @@ export type FieldError = {
 
 interface BaseContextProps {
   fieldErrors: FieldError[] | null
-  setError: (err: KnownErrors) => void
+  setError: (err: KnownErrors | null) => void
   onEvent: OnEventType<EventType, unknown>
   throwError: (e: unknown) => void
   baseSubmitHandler: <T>(

--- a/src/components/Company/PaySchedule/PaySchedule.tsx
+++ b/src/components/Company/PaySchedule/PaySchedule.tsx
@@ -47,7 +47,7 @@ export const PaySchedule = ({
 }
 
 const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
-  const { baseSubmitHandler, onEvent, fieldErrors } = useBase()
+  const { baseSubmitHandler, onEvent, fieldErrors, setError: setBaseError } = useBase()
   const [mode, setMode] = useState<MODE>('LIST_PAY_SCHEDULES')
   const [currentPaySchedule, setCurrentPaySchedule] = useState<PayScheduleType | null>(null)
   const transformedDefaultValues: PayScheduleInputs = {
@@ -74,7 +74,7 @@ const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
     resolver: zodResolver(PayScheduleSchema),
     defaultValues: transformedDefaultValues,
   })
-  const { watch, setValue, reset, setError } = formMethods
+  const { watch, setValue, reset, clearErrors, setError } = formMethods
 
   useEffect(() => {
     if (fieldErrors) {
@@ -136,6 +136,8 @@ const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
   const handleCancel = () => {
     setMode('LIST_PAY_SCHEDULES')
     reset({})
+    clearErrors()
+    setBaseError(null)
   }
   const handleEdit = (schedule: PayScheduleType) => {
     reset({


### PR DESCRIPTION
This PR handles clearing our field errors when our errors are set to null. 