### PR TITLE
fix: state tax fixes for tax_rate fields not submitting

### DIFF
--- a/src/components/Common/TaxInputs/TaxInputs.tsx
+++ b/src/components/Common/TaxInputs/TaxInputs.tsx
@@ -25,6 +25,8 @@ interface CompR {
 
 type NumberFieldProps = { isCurrency?: boolean; isPercent?: boolean }
 
+type TextInputProps = { type?: string; isPercent?: boolean }
+
 export function QuestionInput({
   questionType,
   ...props
@@ -85,7 +87,13 @@ export function SelectInput({ question, requirement, isDisabled = false }: EmpQ 
   )
 }
 
-export function TextInput({ question, requirement, isDisabled = false }: EmpQ | CompR) {
+export function TextInput({
+  question,
+  requirement,
+  isDisabled = false,
+  type = 'text',
+  isPercent = false,
+}: (EmpQ | CompR) & TextInputProps) {
   const { key, label, description } = question ? question : requirement
   const value = question ? question.answers[0]?.value : requirement.value
   const mask = requirement?.metadata?.mask ?? null
@@ -103,6 +111,8 @@ export function TextInput({ question, requirement, isDisabled = false }: EmpQ | 
       isDisabled={isDisabled}
       transform={mask ? transform : undefined}
       placeholder={mask ? mask : undefined}
+      type={type}
+      adornmentEnd={isPercent ? '%' : undefined}
     />
   )
 }
@@ -225,9 +235,9 @@ export function TaxRateInput({ requirement, question, ...props }: EmpQ | CompR) 
         }
       />
     ) : (
-      <NumberInput requirement={requirement} {...props} isPercent />
+      <TextInput requirement={requirement} {...props} type="number" isPercent />
     )
   }
 
-  return <NumberInput question={question} {...props} isPercent />
+  return <TextInput question={question} {...props} type="number" isPercent />
 }

--- a/src/i18n/en/Company.StateTaxes.json
+++ b/src/i18n/en/Company.StateTaxes.json
@@ -21,7 +21,8 @@
     "validations": {
       "minValue": "Minimum value is {{min}}",
       "maxValue": "Maximum value is {{max}}",
-      "oneOf": "Value must be one of: {{values}}"
+      "oneOf": "Value must be one of: {{values}}",
+      "required": "This field is required"
     }
   }
 }

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -354,6 +354,7 @@ export interface CompanyStateTaxes{
 "minValue":string;
 "maxValue":string;
 "oneOf":string;
+"required":string;
 };
 };
 };


### PR DESCRIPTION
This PR makes the following updates for company state taxes:
* Updates tax_rate inputs to be of type TextInput instead of NumberInput. This is because the api can accept strings universally for these numeric values for tax rates but it can only accept numbers occasionally. There was no way to make the distinction with the api output so using strings was safer. We add `type="number"` to the text input component which prevents non numeric characters. Verified that the validation was working for a sampling of states and properly outputting an error message
* Updates validation messages to consistently output a more human readable required message (before they were saying things like "expected null but got boolean" etc
* Updates default values to correctly not set as strings for radios

## Proof of functionality

https://github.com/user-attachments/assets/01c6b222-c974-4ce8-a4f4-a60e57a03182
