### PR TITLE
feat: remove exports for all compound components

### DIFF
--- a/src/components/Company/AssignSignatory/AssignSignatory.tsx
+++ b/src/components/Company/AssignSignatory/AssignSignatory.tsx
@@ -96,7 +96,3 @@ function Root({
     </section>
   )
 }
-
-AssignSignatory.Head = Head
-AssignSignatory.Selection = AssignSignatorySelection
-AssignSignatory.Form = SignatoryForm

--- a/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatory.tsx
+++ b/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatory.tsx
@@ -169,6 +169,3 @@ function Root({
     </section>
   )
 }
-
-CreateSignatory.Form = CreateSignatoryForm
-CreateSignatory.Actions = Actions

--- a/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatory.tsx
+++ b/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatory.tsx
@@ -110,6 +110,3 @@ function Root({ companyId, defaultValues, className, children }: InviteSignatory
     </section>
   )
 }
-
-InviteSignatory.Form = InviteSignatoryForm
-InviteSignatory.Actions = Actions

--- a/src/components/Company/AssignSignatory/index.ts
+++ b/src/components/Company/AssignSignatory/index.ts
@@ -1,6 +1,5 @@
 export { AssignSignatory } from './AssignSignatory'
 export { SignatoryAssignmentMode } from './useAssignSignatory'
-export { Head } from './Head'
 export { AssignSignatorySelection } from './AssignSignatorySelection'
 export { CreateSignatory } from './CreateSignatory'
 export { InviteSignatory } from './InviteSignatory'

--- a/src/components/Company/BankAccount/BankAccount.tsx
+++ b/src/components/Company/BankAccount/BankAccount.tsx
@@ -6,9 +6,6 @@ import {
 } from './BankAccountComponents'
 import { bankAccountStateMachine } from './stateMachine'
 import { BankAccountListContextual } from './BankAccountComponents'
-import { BankAccountList } from './BankAccountList/BankAccountList'
-import { BankAccountForm } from './BankAccountForm/BankAccountForm'
-import { BankAccountVerify } from './BankAccountVerify/BankAccountVerify'
 import { Flow } from '@/components/Flow/Flow'
 import { BaseComponent, type BaseComponentInterface } from '@/components/Base'
 import { useComponentDictionary } from '@/i18n/I18n'
@@ -45,7 +42,3 @@ export function BankAccount(props: BankAccountProps) {
     </BaseComponent>
   )
 }
-
-BankAccount.BankAccountList = BankAccountList
-BankAccount.BankAccountForm = BankAccountForm
-BankAccount.BankAccountVerify = BankAccountVerify

--- a/src/components/Company/BankAccount/BankAccountForm/BankAccountForm.tsx
+++ b/src/components/Company/BankAccount/BankAccountForm/BankAccountForm.tsx
@@ -70,6 +70,3 @@ function Root({ companyId, className, children, isEditing = false }: BankAccount
     </section>
   )
 }
-BankAccountForm.Head = Head
-BankAccountForm.Form = Form
-BankAccountForm.Actions = Actions

--- a/src/components/Company/BankAccount/BankAccountList/BankAccountList.tsx
+++ b/src/components/Company/BankAccount/BankAccountList/BankAccountList.tsx
@@ -73,6 +73,3 @@ function Root({
     </section>
   )
 }
-BankAccountList.Head = Head
-BankAccountList.AccountView = AccountView
-BankAccountList.Actions = Actions

--- a/src/components/Company/BankAccount/BankAccountVerify/BankAccountVerify.tsx
+++ b/src/components/Company/BankAccount/BankAccountVerify/BankAccountVerify.tsx
@@ -75,6 +75,3 @@ function Root({ companyId, bankAccountId, className, children }: BankAccountVeri
     </section>
   )
 }
-BankAccountVerify.Head = Head
-BankAccountVerify.Form = Form
-BankAccountVerify.Actions = Actions

--- a/src/components/Company/DocumentSigner/DocumentList/DocumentList.tsx
+++ b/src/components/Company/DocumentSigner/DocumentList/DocumentList.tsx
@@ -90,8 +90,3 @@ function Root({ companyId, signatoryId, className, children }: DocumentListProps
     </section>
   )
 }
-
-DocumentList.Head = Head
-DocumentList.ManageSignatories = ManageSignatories
-DocumentList.List = List
-DocumentList.Actions = Actions

--- a/src/components/Company/DocumentSigner/DocumentSigner.tsx
+++ b/src/components/Company/DocumentSigner/DocumentSigner.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react'
 import { AssignSignatory, DocumentList } from './documentSignerStateMachine'
 import { documentSignerMachine } from './stateMachine'
 import type { DocumentSignerContextInterface } from './useDocumentSigner'
-import { SignatureForm } from './SignatureForm'
 import { Flow } from '@/components/Flow/Flow'
 import { BaseComponent, type BaseComponentInterface } from '@/components/Base'
 import { useComponentDictionary } from '@/i18n/I18n'
@@ -49,6 +48,3 @@ export function DocumentSigner(props: DocumentSignerProps) {
     </BaseComponent>
   )
 }
-
-DocumentSigner.DocumentList = DocumentList
-DocumentSigner.SignatureForm = SignatureForm

--- a/src/components/Company/DocumentSigner/SignatureForm/SignatureForm.tsx
+++ b/src/components/Company/DocumentSigner/SignatureForm/SignatureForm.tsx
@@ -99,8 +99,3 @@ export function Root({ formId, children, dictionary }: SignatureFormProps) {
     </SignatureFormProvider>
   )
 }
-
-SignatureForm.Head = Head
-SignatureForm.Preview = Preview
-SignatureForm.Form = Form
-SignatureForm.Actions = Actions

--- a/src/components/Company/Industry/Industry.stories.tsx
+++ b/src/components/Company/Industry/Industry.stories.tsx
@@ -1,6 +1,8 @@
 import { action } from '@ladle/react'
 import { IndustrySelect } from './IndustrySelect'
-import { Industry } from './Industry'
+import { Actions } from './Actions'
+import { Head } from './Head'
+import { Edit } from './Edit'
 
 // Adding a meta object for title
 export default {
@@ -14,9 +16,9 @@ export const Select = () => {
 export const WithCustomization = () => {
   return (
     <IndustrySelect onValid={action('industrySelect/submit') as () => Promise<void>}>
-      <Industry.Actions />
-      <Industry.Head />
-      <Industry.Edit />
+      <Actions />
+      <Head />
+      <Edit />
     </IndustrySelect>
   )
 }

--- a/src/components/Company/Industry/Industry.tsx
+++ b/src/components/Company/Industry/Industry.tsx
@@ -1,10 +1,7 @@
 import { useCallback, type HTMLAttributes } from 'react'
 import { useIndustrySelectionGetSuspense } from '@gusto/embedded-api/react-query/industrySelectionGet'
 import { useIndustrySelectionUpdateMutation } from '@gusto/embedded-api/react-query/industrySelectionUpdate'
-import { Actions } from './Actions'
-import { Head } from './Head'
 import type { IndustryFormFields } from './Edit'
-import { Edit } from './Edit'
 import { IndustryApiStateProvider } from './Context'
 import { IndustrySelect } from './IndustrySelect'
 import { componentEvents } from '@/shared/constants'
@@ -61,7 +58,3 @@ export function Industry<T>(props: IndustryProps<T>) {
     </BaseComponent>
   )
 }
-
-Industry.Actions = Actions
-Industry.Edit = Edit
-Industry.Head = Head

--- a/src/components/Company/Locations/LocationForm/LocationForm.tsx
+++ b/src/components/Company/Locations/LocationForm/LocationForm.tsx
@@ -137,7 +137,3 @@ export function LocationForm({
     </BaseComponent>
   )
 }
-
-LocationForm.Head = Head
-LocationForm.Form = Form
-LocationForm.Actions = Actions

--- a/src/components/Company/Locations/Locations.tsx
+++ b/src/components/Company/Locations/Locations.tsx
@@ -2,8 +2,6 @@ import { createMachine } from 'robot3'
 import { type LocationsContextInterface } from './locationsStateMachine'
 import { locationsStateMachine } from './stateMachine'
 import { LocationsListContextual } from './locationsStateMachine'
-import { LocationsList } from './LocationsList'
-import { LocationForm } from './LocationForm/LocationForm'
 import { Flow } from '@/components/Flow/Flow'
 import type { BaseComponentInterface } from '@/components/Base'
 import { useComponentDictionary } from '@/i18n/I18n'
@@ -26,6 +24,3 @@ export function Locations({ companyId, onEvent, dictionary }: LocationsProps) {
   )
   return <Flow machine={manageLocations} onEvent={onEvent} />
 }
-
-Locations.LocationsList = LocationsList
-Locations.LocationForm = LocationForm

--- a/src/components/Company/Locations/LocationsList/LocationsList.tsx
+++ b/src/components/Company/Locations/LocationsList/LocationsList.tsx
@@ -93,7 +93,3 @@ function Root({ companyId, className, children }: LocationsListProps) {
     </section>
   )
 }
-
-LocationsList.Head = Head
-LocationsList.List = List
-LocationsList.Actions = Actions

--- a/src/components/Company/PaySchedule/PaySchedule.tsx
+++ b/src/components/Company/PaySchedule/PaySchedule.tsx
@@ -236,8 +236,3 @@ const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
     </PayScheduleProvider>
   )
 }
-
-PaySchedule.Head = Head
-PaySchedule.List = List
-PaySchedule.Edit = Edit
-PaySchedule.Actions = Actions

--- a/src/components/Company/StateTaxes/StateTaxes.tsx
+++ b/src/components/Company/StateTaxes/StateTaxes.tsx
@@ -2,8 +2,6 @@ import { createMachine } from 'robot3'
 import { stateTaxesStateMachine } from './stateTaxesStateMachine'
 import type { StateTaxesContextInterface } from './StateTaxesComponents'
 import { StateTaxesListContextual } from './StateTaxesComponents'
-import { StateTaxesList } from './StateTaxesList/StateTaxesList'
-import { StateTaxesForm } from './StateTaxesForm/StateTaxesForm'
 import { Flow } from '@/components/Flow/Flow'
 import type { BaseComponentInterface } from '@/components/Base'
 import { useComponentDictionary } from '@/i18n/I18n'
@@ -25,6 +23,3 @@ export function StateTaxes({ companyId, onEvent, dictionary }: StateTaxesProps) 
   )
   return <Flow machine={manageStateTaxes} onEvent={onEvent} />
 }
-
-StateTaxes.StateTaxesList = StateTaxesList
-StateTaxes.StateTaxesForm = StateTaxesForm

--- a/src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.tsx
@@ -195,7 +195,3 @@ function Root({ companyId, state, className, children }: StateTaxesFormProps) {
     </section>
   )
 }
-
-StateTaxesForm.Head = Head
-StateTaxesForm.Form = Form
-StateTaxesForm.Actions = Actions

--- a/src/components/Company/StateTaxes/StateTaxesList/StateTaxesList.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesList/StateTaxesList.tsx
@@ -61,7 +61,3 @@ function Root({ className, children, companyId }: StateTaxesListProps) {
     </section>
   )
 }
-
-StateTaxesList.Head = Head
-StateTaxesList.List = List
-StateTaxesList.Actions = Actions

--- a/src/components/Contractor/Address/Address.tsx
+++ b/src/components/Contractor/Address/Address.tsx
@@ -112,8 +112,4 @@ function Root({ contractorId, defaultValues, children, className, dictionary }: 
   )
 }
 
-Address.Head = Head
-Address.Form = Form
-Address.Actions = Actions
-
 export default Address

--- a/src/components/Employee/Compensation/Compensation.tsx
+++ b/src/components/Employee/Compensation/Compensation.tsx
@@ -343,11 +343,6 @@ const Root = ({ employeeId, startDate, className, children, ...props }: Compensa
   )
 }
 
-Compensation.Head = Head
-Compensation.List = List
-Compensation.Actions = Actions
-Compensation.Edit = Edit
-
 export const CompensationContextual = () => {
   const { employeeId, onEvent, startDate, defaultValues } = useFlow<OnboardingContextInterface>()
   const { t } = useTranslation('common')

--- a/src/components/Employee/DocumentSigner/DocumentList/DocumentList.tsx
+++ b/src/components/Employee/DocumentSigner/DocumentList/DocumentList.tsx
@@ -67,7 +67,3 @@ function Root({ employeeId, className, children }: DocumentListProps) {
     </section>
   )
 }
-
-DocumentList.Head = Head
-DocumentList.List = List
-DocumentList.Actions = Actions

--- a/src/components/Employee/DocumentSigner/DocumentSigner.tsx
+++ b/src/components/Employee/DocumentSigner/DocumentSigner.tsx
@@ -4,8 +4,6 @@ import {
   type DocumentSignerContextInterface,
 } from './documentSignerStateMachine'
 import { documentSignerMachine } from './stateMachine'
-import { DocumentList } from './DocumentList/DocumentList'
-import { SignatureForm } from './SignatureForm/SignatureForm'
 import { Flow } from '@/components/Flow/Flow'
 import type { BaseComponentInterface } from '@/components/Base'
 import { useComponentDictionary } from '@/i18n/I18n'
@@ -28,6 +26,3 @@ export const DocumentSigner = ({ employeeId, onEvent, dictionary }: DocumentSign
   )
   return <Flow machine={documentSigner} onEvent={onEvent} />
 }
-
-DocumentSigner.DocumentList = DocumentList
-DocumentSigner.SignatureForm = SignatureForm

--- a/src/components/Employee/DocumentSigner/SignatureForm/SignatureForm.tsx
+++ b/src/components/Employee/DocumentSigner/SignatureForm/SignatureForm.tsx
@@ -95,8 +95,3 @@ function Root({ employeeId, formId, className, children }: SignatureFormProps) {
     </section>
   )
 }
-
-SignatureForm.Head = Head
-SignatureForm.Preview = Preview
-SignatureForm.Form = FormComponent
-SignatureForm.Actions = Actions

--- a/src/components/Employee/EmployeeList/EmployeeList.tsx
+++ b/src/components/Employee/EmployeeList/EmployeeList.tsx
@@ -149,10 +149,6 @@ function Root({ companyId, className, children, dictionary }: EmployeeListProps)
   )
 }
 
-EmployeeList.Head = Head
-EmployeeList.List = List
-EmployeeList.Actions = Actions
-
 /**
  * Wrapper used inside Flows -> exposes flow context for required parameters
  */

--- a/src/components/Employee/Profile/Profile.tsx
+++ b/src/components/Employee/Profile/Profile.tsx
@@ -427,13 +427,6 @@ const Root = ({
   )
 }
 
-Profile.Head = Head
-Profile.Actions = Actions
-Profile.AdminPersonalDetails = AdminPersonalDetails
-Profile.SelfPersonalDetails = SelfPersonalDetails
-Profile.HomeAddress = HomeAddress
-Profile.WorkAddress = WorkAddress
-
 export const ProfileContextual = () => {
   const { companyId, employeeId, onEvent, isAdmin, defaultValues, isSelfOnboardingEnabled } =
     useFlow<OnboardingContextInterface>()

--- a/src/components/Employee/Taxes/Taxes.tsx
+++ b/src/components/Employee/Taxes/Taxes.tsx
@@ -200,10 +200,6 @@ const Root = (props: TaxesProps) => {
     </section>
   )
 }
-Taxes.FederalHead = FederalHead
-Taxes.FederalForm = FederalForm
-Taxes.StateForm = StateForm
-Taxes.Actions = Actions
 
 export const TaxesContextual = () => {
   const { employeeId, onEvent, isAdmin } = useFlow<OnboardingContextInterface>()


### PR DESCRIPTION
The team has chosen to deprecate this pattern, so this PR removes all exports of compound components.

There still could be some further work we could choose to do where we re-arrange what each former compound component contains since they no longer require to be exported in this way -- such as refactoring some components together or moving call sites to be more closely co-located.