### PR TITLE
chore: loosen peer deps for react to include 18 and 19

### DIFF
--- a/.ladle/adapters/PlainComponentAdapter.tsx
+++ b/.ladle/adapters/PlainComponentAdapter.tsx
@@ -63,7 +63,7 @@ export const PlainComponentAdapter: ComponentsContextType = {
     isError = false,
     isLoading = false,
     isDisabled = false,
-    ref,
+    buttonRef,
     onClick,
     children,
     ...props
@@ -71,7 +71,7 @@ export const PlainComponentAdapter: ComponentsContextType = {
     // Implement a simple button without the complex event translations
     return (
       <button
-        ref={ref}
+        ref={buttonRef}
         disabled={isDisabled || isLoading}
         onClick={onClick}
         className={`button button-primary ${isError ? 'button-error' : ''} ${isLoading ? 'button-loading' : ''}`}
@@ -86,14 +86,14 @@ export const PlainComponentAdapter: ComponentsContextType = {
     isError = false,
     isLoading = false,
     isDisabled = false,
-    ref,
+    buttonRef,
     onClick,
     children,
     ...props
   }: ButtonIconProps) => {
     return (
       <button
-        ref={ref}
+        ref={buttonRef}
         disabled={isDisabled || isLoading}
         onClick={onClick}
         className={`button button-icon ${isError ? 'button-error' : ''} ${isLoading ? 'button-loading' : ''}`}

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,8 +76,8 @@
       },
       "peerDependencies": {
         "@tanstack/react-query": "^5",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
         "typescript": "^5.8.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "typescript": "^5.8.3"
   },
   "dependencies": {

--- a/src/components/Common/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/components/Common/HamburgerMenu/HamburgerMenu.tsx
@@ -16,12 +16,15 @@ export function HamburgerMenu({
   const Components = useComponentContext()
   const { triggerProps, menuProps } = useMenu()
 
+  const { ref, ...restTriggerProps } = triggerProps
+
   return (
     <>
       <Components.ButtonIcon
         isLoading={isLoading}
         aria-label={triggerLabel || t('labels.openMenu')}
-        {...triggerProps}
+        buttonRef={ref}
+        {...restTriggerProps}
       >
         <HamburgerIcon />
       </Components.ButtonIcon>

--- a/src/components/Common/ReorderableList/ReorderableItem.tsx
+++ b/src/components/Common/ReorderableList/ReorderableItem.tsx
@@ -218,7 +218,7 @@ export const ReorderableItem = memo(function ReorderableItem({
             aria-roledescription={t('reorderableList.draggableItem')}
             aria-grabbed={isDragging}
             onKeyDown={handleKeyDown}
-            ref={node => {
+            buttonRef={node => {
               if (node) {
                 buttonRef.current = node
                 drag(node)

--- a/src/components/Common/UI/Button/Button.tsx
+++ b/src/components/Common/UI/Button/Button.tsx
@@ -8,7 +8,7 @@ export function Button({
   isLoading = false,
   isDisabled = false,
   variant = 'primary',
-  ref,
+  buttonRef,
   className,
   children,
   onBlur,
@@ -26,7 +26,7 @@ export function Button({
     <AriaButton
       {...props}
       className={({ defaultClassName }) => classNames(styles.root, defaultClassName, className)}
-      ref={ref}
+      ref={buttonRef}
       onBlur={onBlur}
       onFocus={onFocus}
       isDisabled={isDisabled || isLoading}

--- a/src/components/Common/UI/Button/ButtonTypes.ts
+++ b/src/components/Common/UI/Button/ButtonTypes.ts
@@ -20,7 +20,7 @@ export interface ButtonProps
   /**
    * React ref for the button element
    */
-  ref?: Ref<HTMLButtonElement>
+  buttonRef?: Ref<HTMLButtonElement>
   /**
    * Visual style variant of the button
    */


### PR DESCRIPTION
This updates to allow for React 18 or 19 as a peer dependency.

In order to make the SDK React 19 compatible, we had to move away from passing `ref` as a function argument. We opted to avoid a replacement with forwardRef for this case because we wanted it to be more straightforward for consumers to wire up adapters. The only instance where we passed ref like this was Button which we updated to have a `buttonRef` prop which can be wired up.

## Proof of functionality

I updated the SDK workshop app to point to the RC version of the react sdk with the adjusted peer deps and tested it both with React 18 and 19 to verify no regressions.

### App working with React 18

https://github.com/user-attachments/assets/f7cf0cfd-b5f2-4c68-b0b5-3765049c80e0

### App working with React 19

https://github.com/user-attachments/assets/115b6ed4-687f-4a58-bf9c-304e201b366e
