### PR TITLE
fix: mark required fields as required to prevent optional label display

### DIFF
--- a/src/components/Contractor/PaymentMethod/BankAccountForm.tsx
+++ b/src/components/Contractor/PaymentMethod/BankAccountForm.tsx
@@ -31,6 +31,7 @@ export function BankAccountForm({ bankAccount }: BankAccountFormProps) {
 
       <RadioGroupField
         name="accountType"
+        isRequired
         label={t('accountTypeLabel')}
         options={[
           { value: 'Checking', label: t('accountTypeChecking') },

--- a/src/components/Contractor/Profile/ContractorProfileForm.tsx
+++ b/src/components/Contractor/Profile/ContractorProfileForm.tsx
@@ -72,6 +72,7 @@ export function ContractorProfileForm({
             {/* Contractor Type */}
             <RadioGroupField
               name="contractorType"
+              isRequired
               label={t('fields.contractorType.label')}
               options={contractorTypeOptions}
             />
@@ -115,6 +116,7 @@ export function ContractorProfileForm({
             {/* Wage Type */}
             <RadioGroupField
               name="wageType"
+              isRequired
               label={t('fields.wageType.label')}
               options={wageTypeOptions}
             />

--- a/src/components/Employee/Compensation/Edit.tsx
+++ b/src/components/Employee/Compensation/Edit.tsx
@@ -169,6 +169,7 @@ export const Edit = () => {
         description={t('paymentUnitDescription')}
         options={paymentUnitOptions}
         errorMessage={t('validations.paymentUnit')}
+        isRequired
         isDisabled={
           watchedFlsaStatus === FlsaStatus.OWNER ||
           watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_NONEXEMPT ||

--- a/src/components/Employee/Deductions/IncludeDeductionsForm.tsx
+++ b/src/components/Employee/Deductions/IncludeDeductionsForm.tsx
@@ -9,6 +9,7 @@ export const IncludeDeductionsForm = () => {
   return (
     <RadioGroupField
       name="includeDeductions"
+      isRequired
       label={t('includeDeductionsFormLabel')}
       description={t('includeDeductionsDescription')}
       options={[

--- a/src/components/Employee/PaymentMethod/BankAccountEdit.tsx
+++ b/src/components/Employee/PaymentMethod/BankAccountEdit.tsx
@@ -42,6 +42,7 @@ export const BankAccountForm = () => {
 
       <RadioGroupField
         name="accountType"
+        isRequired
         label={t('accountTypeLabel')}
         options={[
           { value: 'Checking', label: t('accountTypeChecking') },

--- a/src/components/Employee/Profile/PersonalDetailsInputs.tsx
+++ b/src/components/Employee/Profile/PersonalDetailsInputs.tsx
@@ -74,6 +74,7 @@ export function AdminInputs({ companyLocations }: AdminInputsProps) {
         name="startDate"
         label={t('startDateLabel')}
         description={t('startDateDescription')}
+        isRequired
         errorMessage={
           errors.startDate?.type === 'custom'
             ? t('validations.startDateOutOfRange')
@@ -137,6 +138,7 @@ export function DateOfBirthInput() {
     <DatePickerField
       name="dateOfBirth"
       label={t('dobLabel')}
+      isRequired
       errorMessage={t('validations.dob', { ns: 'common' })}
     />
   )

--- a/src/components/Employee/Taxes/FederalForm.tsx
+++ b/src/components/Employee/Taxes/FederalForm.tsx
@@ -39,6 +39,7 @@ export function FederalForm() {
       />
       <RadioGroupField
         name="twoJobs"
+        isRequired
         label={t('multipleJobs2c')}
         errorMessage={t('validations.federalTwoJobs')}
         description={


### PR DESCRIPTION
## Summary

This PR fixes an issue where required form fields were incorrectly displaying as 'optional' in the UI. By properly marking fields as required, we ensure the correct label is shown to users.

## Changes

- Updated form fields across multiple components to properly mark required fields
- This prevents fields from incorrectly showing as 'optional' when they are actually required
- Affects Contractor and Employee components including payment methods, profiles, and forms

## Testing

- Verified that required fields now properly display as required instead of optional
- No breaking changes to existing functionality