### PR TITLE
fix: only update onboarding status for admin

### DIFF
--- a/src/components/Employee/Profile/Profile.tsx
+++ b/src/components/Employee/Profile/Profile.tsx
@@ -265,12 +265,13 @@ const Root = ({
       } else {
         // Updating self-onboarding status
         if (
-          (selfOnboarding &&
+          isAdmin &&
+          ((selfOnboarding &&
             mergedData.current.employee.onboardingStatus ===
               EmployeeOnboardingStatus.ADMIN_ONBOARDING_INCOMPLETE) ||
-          (!selfOnboarding &&
-            mergedData.current.employee.onboardingStatus ===
-              EmployeeOnboardingStatus.SELF_ONBOARDING_PENDING_INVITE)
+            (!selfOnboarding &&
+              mergedData.current.employee.onboardingStatus ===
+                EmployeeOnboardingStatus.SELF_ONBOARDING_PENDING_INVITE))
         ) {
           const { employeeOnboardingStatus } = await updateEmployeeOnboardingStatus({
             request: {


### PR DESCRIPTION
Onboarding status is being updated for admins after profile completion to either reflect an invite to self onboarding or that admin onboarding is incomplete.

However, this update should be scoped to admins. There was a bug where the onboarding status was getting updated for employees self onboarding. This behavior should be scoped to admins. This PR implements that fix.