### PR TITLE
chore: add new theming infrastructure

### DIFF
--- a/build/generateAdapterPropDocs.ts
+++ b/build/generateAdapterPropDocs.ts
@@ -15,7 +15,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 const UI_COMPONENTS_DIR = join(__dirname, '../src/components/Common/UI')
-const DOCS_OUTPUT_DIR = join(__dirname, '../docs/06/01')
+const DOCS_OUTPUT_DIR = join(__dirname, '../docs/component-adapter')
 const DOCS_OUTPUT_FILE = join(DOCS_OUTPUT_DIR, 'component-inventory.md')
 
 // Types that should be excluded from documentation

--- a/docs/component-adapter/component-adapter-types.md
+++ b/docs/component-adapter/component-adapter-types.md
@@ -29,7 +29,7 @@ interface ButtonProps {
   children: ReactNode
   isDisabled?: boolean
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
-  variant?: 'primary' | 'secondary' | 'tertiary'
+  variant?: 'primary' | 'secondary'
   // ... additional props
 }
 ```

--- a/docs/component-adapter/component-inventory.md
+++ b/docs/component-adapter/component-inventory.md
@@ -1,7 +1,3 @@
----
-title: Component Inventory
----
-
 # Component Inventory
 
 - [AlertProps](#alertprops)
@@ -85,7 +81,7 @@ title: Component Inventory
 | **form**             | `string`                                          | No       | -                                                                     |
 | **title**            | `string`                                          | No       | -                                                                     |
 | **tabIndex**         | `number`                                          | No       | -                                                                     |
-| **ref**              | `Ref<HTMLButtonElement \| null>`                  | No       | React ref for the button element                                      |
+| **buttonRef**        | `Ref<HTMLButtonElement \| null>`                  | No       | React ref for the button element                                      |
 | **isError**          | `boolean`                                         | No       | Indicates if the button is in an error state                          |
 | **isLoading**        | `boolean`                                         | No       | Shows a loading spinner and disables the button                       |
 | **isDisabled**       | `boolean`                                         | No       | Disables the button and prevents interaction                          |
@@ -95,29 +91,29 @@ title: Component Inventory
 
 ## ButtonProps
 
-| Prop                 | Type                                               | Required | Description                                                           |
-| -------------------- | -------------------------------------------------- | -------- | --------------------------------------------------------------------- |
-| **ref**              | `Ref<HTMLButtonElement \| null>`                   | No       | React ref for the button element                                      |
-| **variant**          | `"primary" \| "secondary" \| "tertiary" \| "icon"` | No       | Visual style variant of the button                                    |
-| **isError**          | `boolean`                                          | No       | Indicates if the button is in an error state                          |
-| **isLoading**        | `boolean`                                          | No       | Shows a loading spinner and disables the button                       |
-| **isDisabled**       | `boolean`                                          | No       | Disables the button and prevents interaction                          |
-| **children**         | `React.ReactNode`                                  | No       | Content to be rendered inside the button                              |
-| **onBlur**           | `(e: React.FocusEvent<Element, Element>) => void`  | No       | Handler for blur events                                               |
-| **onFocus**          | `(e: React.FocusEvent<Element, Element>) => void`  | No       | Handler for focus events                                              |
-| **className**        | `string`                                           | No       | -                                                                     |
-| **id**               | `string`                                           | No       | -                                                                     |
-| **aria-label**       | `string`                                           | No       | Defines a string value that labels the current element.               |
-| **name**             | `string`                                           | No       | -                                                                     |
-| **type**             | `"submit" \| "reset" \| "button"`                  | No       | -                                                                     |
-| **onClick**          | `React.MouseEventHandler<HTMLButtonElement>`       | No       | -                                                                     |
-| **onKeyDown**        | `React.KeyboardEventHandler<HTMLButtonElement>`    | No       | -                                                                     |
-| **onKeyUp**          | `React.KeyboardEventHandler<HTMLButtonElement>`    | No       | -                                                                     |
-| **aria-labelledby**  | `string`                                           | No       | Identifies the element (or elements) that labels the current element. |
-| **aria-describedby** | `string`                                           | No       | Identifies the element (or elements) that describes the object.       |
-| **form**             | `string`                                           | No       | -                                                                     |
-| **title**            | `string`                                           | No       | -                                                                     |
-| **tabIndex**         | `number`                                           | No       | -                                                                     |
+| Prop                 | Type                                              | Required | Description                                                           |
+| -------------------- | ------------------------------------------------- | -------- | --------------------------------------------------------------------- |
+| **buttonRef**        | `Ref<HTMLButtonElement \| null>`                  | No       | React ref for the button element                                      |
+| **variant**          | `"primary" \| "secondary" \| "icon"`              | No       | Visual style variant of the button                                    |
+| **isError**          | `boolean`                                         | No       | Indicates if the button is in an error state                          |
+| **isLoading**        | `boolean`                                         | No       | Shows a loading spinner and disables the button                       |
+| **isDisabled**       | `boolean`                                         | No       | Disables the button and prevents interaction                          |
+| **children**         | `React.ReactNode`                                 | No       | Content to be rendered inside the button                              |
+| **onBlur**           | `(e: React.FocusEvent<Element, Element>) => void` | No       | Handler for blur events                                               |
+| **onFocus**          | `(e: React.FocusEvent<Element, Element>) => void` | No       | Handler for focus events                                              |
+| **className**        | `string`                                          | No       | -                                                                     |
+| **id**               | `string`                                          | No       | -                                                                     |
+| **aria-label**       | `string`                                          | No       | Defines a string value that labels the current element.               |
+| **name**             | `string`                                          | No       | -                                                                     |
+| **type**             | `"submit" \| "reset" \| "button"`                 | No       | -                                                                     |
+| **onClick**          | `React.MouseEventHandler<HTMLButtonElement>`      | No       | -                                                                     |
+| **onKeyDown**        | `React.KeyboardEventHandler<HTMLButtonElement>`   | No       | -                                                                     |
+| **onKeyUp**          | `React.KeyboardEventHandler<HTMLButtonElement>`   | No       | -                                                                     |
+| **aria-labelledby**  | `string`                                          | No       | Identifies the element (or elements) that labels the current element. |
+| **aria-describedby** | `string`                                          | No       | Identifies the element (or elements) that describes the object.       |
+| **form**             | `string`                                          | No       | -                                                                     |
+| **title**            | `string`                                          | No       | -                                                                     |
+| **tabIndex**         | `number`                                          | No       | -                                                                     |
 
 ## CalendarPreviewProps
 
@@ -491,7 +487,7 @@ The props for this component are defined in [BaseListProps](#baselistprops).
 
 | Prop          | Type                                            | Required | Description                         |
 | ------------- | ----------------------------------------------- | -------- | ----------------------------------- |
-| **as**        | `"p" \| "span" \| "div"`                        | No       | HTML element to render the text as  |
+| **as**        | `"p" \| "span" \| "div" \| "pre"`               | No       | HTML element to render the text as  |
 | **size**      | `"xs" \| "sm" \| "md" \| "lg" \| "xl"`          | No       | Size variant of the text            |
 | **textAlign** | `"start" \| "center" \| "end"`                  | No       | Text alignment within the container |
 | **weight**    | `"regular" \| "medium" \| "semibold" \| "bold"` | No       | Font weight of the text             |

--- a/src/components/Common/FieldCaption/FieldCaption.module.scss
+++ b/src/components/Common/FieldCaption/FieldCaption.module.scss
@@ -8,7 +8,6 @@
 }
 
 .optionalLabel {
-  content: var(--g-optionalLabel);
   font-size: smaller;
   color: var(--g-input-placeholderColor);
 }

--- a/src/components/Common/FieldCaption/FieldCaption.tsx
+++ b/src/components/Common/FieldCaption/FieldCaption.tsx
@@ -29,7 +29,7 @@ export const FieldCaption: React.FC<FieldCaptionProps> = ({
       htmlFor={as === 'label' ? htmlFor : undefined}
     >
       {children}
-      {!isRequired && <span className={styles.optionalLabel}>{t('optionalLabel')}</span>}
+      {!isRequired && <span className={styles.optionalLabel}> {t('optionalLabel')}</span>}
     </Component>
   )
 

--- a/src/components/Common/UI/Button/Button.module.scss
+++ b/src/components/Common/UI/Button/Button.module.scss
@@ -1,70 +1,38 @@
 .root {
   &:global(.react-aria-Button) {
-    --button-color: var(--g-button-primary-color);
-    --button-bg: var(--g-button-primary-bg);
-    --button-border-color: var(--g-button-primary-borderColor);
-    --button-hover-bg: var(--g-button-primary-hoverBg);
-    --button-hover-color: var(--g-button-primary-hoverColor);
-    --button-disabled-bg: var(--g-button-primary-disabledBg);
-    --button-focus-color: var(--g-button-primary-focusColor);
-
     position: relative;
     border: none;
-    color: var(--button-color);
-    background: var(--button-bg);
-    border-radius: var(--g-button-borderRadius);
+    color: var(--g-colorPrimaryContent);
+    background: var(--g-colorPrimary);
+    border-radius: var(--g-buttonRadius);
     vertical-align: middle;
-    font-size: var(--g-button-fontSize);
-    font-weight: var(--g-button-fontWeight);
+    font-size: toRem(14);
+    font-weight: var(--g-fontWeightMedium);
     line-height: toRem(24);
     letter-spacing: 0.32px;
     text-align: center;
     margin: 0;
     outline: none;
-    padding: var(--g-button-paddingY) var(--g-button-paddingX);
+    padding: toRem(8) toRem(16);
     text-decoration: none;
-    text-transform: var(--g-button-textStyle);
+    text-transform: none;
     cursor: pointer;
-
-    &[data-variant='link'] {
-      --button-color: var(--g-button-primary-bg);
-      --button-bg: transparent;
-      --button-hover-bg: transparent;
-      --button-hover-color: var(--g-button-primary-hoverBg);
-      --button-disabled-bg: disabled;
-      --button-focus-color: var(--g-button-primary-hoverBg);
-      padding: 0;
-      text-decoration: underline;
-    }
+    border: 1px solid var(--g-colorPrimary);
 
     &[data-variant='secondary'] {
-      --button-color: var(--g-button-secondary-color);
-      --button-bg: var(--g-button-secondary-bg);
-      --button-border-color: var(--g-button-secondary-borderColor);
-      --button-hover-bg: var(--g-button-secondary-hoverBg);
-      --button-hover-color: var(--g-button-secondary-hoverColor);
-      --button-disabled-bg: var(--g-button-secondary-disabledBg);
-      --button-focus-color: var(--g-button-secondary-focusColor);
-      border: var(--g-button-borderWidth) solid var(--button-border-color);
-      // Adjusting for border to ensure same height of the component
-      padding: calc(var(--g-button-paddingY) - var(--g-button-borderWidth))
-        calc(var(--g-button-paddingX) - var(--g-button-borderWidth));
+      color: var(--g-colorSecondaryContent);
+      background: var(--g-colorSecondary);
+      border-color: var(--g-colorSecondaryContent);
     }
 
-    &[data-variant='tertiary'],
     &[data-variant='icon'] {
-      --button-color: var(--g-button-tertiary-color);
-      --button-bg: var(--g-button-tertiary-bg);
-      --button-border-color: var(--g-button-tertiary-borderColor);
-      --button-hover-bg: var(--g-button-tertiary-hoverBg);
-      --button-hover-color: var(--g-button-tertiary-hoverColor);
-      --button-disabled-bg: var(--g-button-tertiary-disabledBg);
-      --button-focus-color: var(--g-button-tertiary-focusColor);
+      color: var(--g-colorSecondaryContent);
+      background: transparent;
+      border-color: transparent;
       text-decoration: underline;
     }
 
     &[data-variant='icon'] {
-      border-radius: 50%;
       padding: toRem(12);
       line-height: 0;
     }
@@ -72,34 +40,20 @@
     // Note: Error state is not currently customizable by partners - to be decided if this is required
     &[data-error] {
       &[data-variant='primary'] {
-        --button-color: var(--g-colors-gray-100);
-        --button-bg: var(--g-colors-error-500);
-        --button-border-color: transparent;
-        --button-hover-bg: var(--g-colors-error-800);
-        --button-hover-color: var(--g-colors-gray-200);
-        --button-disabled-bg: var(--g-colors-error-500);
-        --button-focus-color: var(--g-colors-error-500);
+        color: var(--g-colorErrorContent);
+        background: var(--g-colorError);
+        border-color: var(--g-colorError);
       }
 
-      &[data-variant='link'] {
-        --button-color: var(--g-colors-error-500);
-        --button-focus-color: var(--g-colors-error-500);
-      }
-
-      &[data-variant='secondary'],
-      &[data-variant='tertiary'] {
-        --button-color: var(--g-colors-error-500);
-        --button-bg: var(--g-colors-gray-100);
-        --button-border-color: var(--g-colors-error-500);
-        --button-hover-bg: var(--g-colors-error-100);
-        --button-hover-color: var(--g-colors-error-800);
-        --button-disabled-bg: var(--g-colors-gray-100);
-        --button-focus-color: var(--g-colors-error-500);
+      &[data-variant='secondary'] {
+        color: var(--g-colorError);
+        background: var(--g-colorErrorContent);
+        border-color: var(--g-colorError);
       }
     }
 
     &[data-loading='true'] {
-      color: transparent !important; //hide text
+      color: transparent;
 
       &::after {
         content: '';
@@ -112,25 +66,44 @@
         bottom: 0;
         margin: auto;
         mask: url('@/assets/icons/spinner_small.svg') no-repeat 50% 50%;
-        background-color: var(--button-color);
+        background-color: var(--g-colorPrimaryContent);
         animation: button-loading-spinner 1s ease infinite;
+      }
+
+      &[data-variant='primary'] {
+        &::after {
+          background-color: var(--g-colorPrimaryContent);
+        }
+      }
+
+      &[data-variant='secondary'] {
+        &::after {
+          background-color: var(--g-colorSecondaryContent);
+        }
+      }
+
+      &[data-variant='icon'] {
+        &::after {
+          background-color: var(--g-colorSecondaryContent);
+        }
       }
     }
 
-    &[data-hovered],
+    &[data-hovered] {
+      opacity: 0.8;
+    }
+
     &[data-pressed] {
-      background: var(--button-hover-bg);
-      color: var(--button-hover-color);
+      opacity: 1;
     }
 
     &[data-focus-visible] {
-      outline: var(--g-focus-borderWidth) solid var(--button-focus-color);
+      outline: var(--g-focus-borderWidth) solid var(--g-focusRingColor);
       outline-offset: 2px;
     }
 
     &[data-disabled] {
       opacity: 0.5;
-      background: var(--button-disabled-bg);
       cursor: not-allowed;
     }
   }

--- a/src/components/Common/UI/Button/Button.stories.tsx
+++ b/src/components/Common/UI/Button/Button.stories.tsx
@@ -93,23 +93,6 @@ export const ButtonGrid = () => {
         ))}
       </React.Fragment>
 
-      {/* Tertiary Button row */}
-      <React.Fragment key="row-tertiary">
-        <div key="label-tertiary" style={{ fontWeight: 'bold', alignSelf: 'center' }}>
-          Tertiary
-        </div>
-        {states.map((state, stateIdx) => (
-          <div
-            key={`tertiary-${stateIdx}`}
-            style={{ display: 'flex', justifyContent: 'center', padding: '8px 0' }}
-          >
-            <Components.Button variant="tertiary" onClick={() => {}} {...state.props}>
-              Tertiary
-            </Components.Button>
-          </div>
-        ))}
-      </React.Fragment>
-
       {/* Icon Button row */}
       <React.Fragment key="row-icon">
         <div key="label-icon" style={{ fontWeight: 'bold', alignSelf: 'center' }}>

--- a/src/components/Common/UI/Button/ButtonTypes.ts
+++ b/src/components/Common/UI/Button/ButtonTypes.ts
@@ -24,7 +24,7 @@ export interface ButtonProps
   /**
    * Visual style variant of the button
    */
-  variant?: 'primary' | 'secondary' | 'tertiary' | 'icon'
+  variant?: 'primary' | 'secondary' | 'icon'
   /**
    * Indicates if the button is in an error state
    */

--- a/src/contexts/ThemeProvider/ThemeProvider.tsx
+++ b/src/contexts/ThemeProvider/ThemeProvider.tsx
@@ -6,11 +6,100 @@ import { ThemeContext } from './useTheme'
 import type { GTheme } from '@/types/GTheme'
 import '@/styles/sdk.scss'
 import type { DeepPartial } from '@/types/Helpers'
+import { getRootFontSize, toRem } from '@/helpers/rem'
 
 export interface ThemeProviderProps {
   theme?: DeepPartial<GTheme>
   children?: React.ReactNode
 }
+
+const colors = {
+  gray: {
+    100: '#FFFFFF',
+    200: '#FBFAFA',
+    300: '#F4F4F3',
+    400: '#EAEAEA',
+    500: '#DCDCDC',
+    600: '#BABABC',
+    700: '#919197',
+    800: '#6C6C72',
+    900: '#525257',
+    1000: '#1C1C1C',
+  },
+  error: {
+    100: '#FFF7F5',
+    500: '#D5351F',
+    800: '#B41D08',
+  },
+  warning: {
+    100: '#FFFAF2',
+    500: '#E9B550',
+    700: '#B88023',
+    800: '#B88023',
+  },
+  success: {
+    100: '#F3FAFB',
+    400: '#2BABAD',
+    500: '#0A8080',
+    800: '#005961',
+  },
+  info: {
+    100: '#F3FAFB',
+    400: '#2BABAD',
+    500: '#0A8080',
+    800: '#005961',
+  },
+  orange: {
+    800: '#CA464A',
+  },
+}
+
+const defaultTheme = {
+  // Colors
+  colorBody: colors.gray[100],
+  colorBodyContent: colors.gray[1000],
+  colorPrimary: colors.gray[1000],
+  colorPrimaryContent: colors.gray[100],
+  colorSecondary: colors.gray[100],
+  colorSecondaryContent: colors.gray[1000],
+  colorInfo: colors.info[800],
+  colorInfoContent: colors.info[100],
+  colorWarning: colors.warning[800],
+  colorWarningContent: colors.warning[100],
+  colorError: colors.error[800],
+  colorErrorContent: colors.error[100],
+  colorSuccess: colors.success[800],
+  colorSuccessContent: colors.success[100],
+  // Radius
+  radius: '6px',
+  // Font
+  fontSizeRoot: getRootFontSize(),
+  fontFamily: 'Geist',
+  fontLineHeight: '1.5rem',
+  fontSizeSmall: toRem(14),
+  fontSizeRegular: toRem(16),
+  fontSizeMedium: toRem(18),
+  fontSizeHeading1: toRem(32),
+  fontSizeHeading2: toRem(24),
+  fontSizeHeading3: toRem(20),
+  fontSizeHeading4: toRem(18),
+  fontSizeHeading5: toRem(16),
+  fontSizeHeading6: toRem(14),
+  fontWeightRegular: '400',
+  fontWeightMedium: '500',
+  fontWeightSemibold: '600',
+  fontWeightBold: '700',
+  // Transitions
+  transitionDuration: '200ms',
+  // Shadows
+  shadowResting: '0px 1px 2px 0px rgba(10, 13, 18, 0.05)',
+  shadowTopmost: '0px 4px 6px 0px rgba(28, 28, 28, 0.05), 0px 10px 15px 0px rgba(28, 28, 28, 0.10)',
+  // Focus
+  focusRingColor: colors.gray[1000],
+  focusRingWidth: '2px',
+}
+
+type NewTheme = typeof defaultTheme
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   theme: partnerTheme = {},

--- a/src/contexts/ThemeProvider/createTheme.ts
+++ b/src/contexts/ThemeProvider/createTheme.ts
@@ -98,7 +98,7 @@ const createTypographyTheme = ({
 
 type ComponentThemes = Omit<
   GTheme,
-  'colors' | 'spacing' | 'typography' | 'radius' | 'rootFS' | 'optionalLabel' | 'transitionDuration'
+  'colors' | 'spacing' | 'typography' | 'radius' | 'rootFS' | 'transitionDuration'
 >
 
 const createComponentThemes = ({
@@ -284,7 +284,6 @@ export const createTheme = (overrides: DeepPartial<GTheme> = {}) => {
     radius: partnerRadius,
     transitionDuration: partnerTransitionDuration,
     rootFS: partnerRootFS,
-    optionalLabel: partnerOptionalLabel,
     ...partnerTheme
   } = overrides
 
@@ -308,7 +307,6 @@ export const createTheme = (overrides: DeepPartial<GTheme> = {}) => {
     colors,
     radius,
     rootFS: partnerRootFS ?? getRootFontSize(),
-    optionalLabel: partnerOptionalLabel ?? ' (optional)',
     transitionDuration,
     ...componentThemes,
   } satisfies GTheme

--- a/src/contexts/ThemeProvider/theme.ts
+++ b/src/contexts/ThemeProvider/theme.ts
@@ -1,0 +1,93 @@
+import '@/styles/sdk.scss'
+import { getRootFontSize, toRem } from '@/helpers/rem'
+
+// Colors are for internal use in our theme currently
+// We don't export them for partner use or overrides
+const colors = {
+  neutral: {
+    100: '#FFFFFF',
+    200: '#FBFAFA',
+    300: '#F4F4F3',
+    400: '#EAEAEA',
+    500: '#DCDCDC',
+    600: '#BABABC',
+    700: '#919197',
+    800: '#6C6C72',
+    900: '#525257',
+    1000: '#1C1C1C',
+  },
+  error: {
+    100: '#FFF7F5',
+    500: '#D5351F',
+    800: '#B41D08',
+  },
+  warning: {
+    100: '#FFFAF2',
+    500: '#E9B550',
+    700: '#B88023',
+    800: '#B88023',
+  },
+  success: {
+    100: '#F3FAFB',
+    400: '#2BABAD',
+    500: '#0A8080',
+    800: '#005961',
+  },
+  info: {
+    100: '#F3FAFB',
+    400: '#2BABAD',
+    500: '#0A8080',
+    800: '#005961',
+  },
+  orange: {
+    800: '#CA464A',
+  },
+}
+
+export const gustoSDKTheme = {
+  // Colors
+  colorBody: colors.neutral[100],
+  colorBodyContent: colors.neutral[1000],
+  colorPrimary: colors.neutral[1000],
+  colorPrimaryContent: colors.neutral[100],
+  colorSecondary: colors.neutral[100],
+  colorSecondaryContent: colors.neutral[1000],
+  colorInfo: colors.info[800],
+  colorInfoContent: colors.info[100],
+  colorWarning: colors.warning[800],
+  colorWarningContent: colors.warning[100],
+  colorError: colors.error[800],
+  colorErrorContent: colors.error[100],
+  colorSuccess: colors.success[800],
+  colorSuccessContent: colors.success[100],
+  // Radius
+  buttonRadius: '6px',
+  inputRadius: '6px',
+  // Font
+  fontSizeRoot: getRootFontSize(),
+  fontFamily: 'Geist',
+  fontLineHeight: toRem(24),
+  fontSizeSmall: toRem(14),
+  fontSizeRegular: toRem(16),
+  fontSizeMedium: toRem(18),
+  fontSizeHeading1: toRem(32),
+  fontSizeHeading2: toRem(24),
+  fontSizeHeading3: toRem(20),
+  fontSizeHeading4: toRem(18),
+  fontSizeHeading5: toRem(16),
+  fontSizeHeading6: toRem(14),
+  fontWeightRegular: '400',
+  fontWeightMedium: '500',
+  fontWeightSemibold: '600',
+  fontWeightBold: '700',
+  // Transitions
+  transitionDuration: '200ms',
+  // Shadows
+  shadowResting: '0px 1px 2px 0px rgba(10, 13, 18, 0.05)',
+  shadowTopmost: '0px 4px 6px 0px rgba(28, 28, 28, 0.05), 0px 10px 15px 0px rgba(28, 28, 28, 0.10)',
+  // Focus
+  focusRingColor: colors.neutral[1000],
+  focusRingWidth: '2px',
+}
+
+export type GustoSDKTheme = typeof gustoSDKTheme

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -4,7 +4,7 @@
     "requiredField": "is a required field",
     "errorEncountered": "There was a problem with your submission"
   },
-  "optionalLabel": " (optional)",
+  "optionalLabel": "(optional)",
   "progressBarLabel": "You are on step {{currentStep}} of {{totalSteps}}",
   "errors": {
     "errorHeading": "Error",

--- a/src/types/GTheme.d.ts
+++ b/src/types/GTheme.d.ts
@@ -251,5 +251,4 @@ export interface GTheme {
   card: GThemeCard
   link: GThemeLink
   badge: GThemeBadge
-  optionalLabel: string //This is a string pulled from translations to indicate (optional) on form elements
 }


### PR DESCRIPTION
This updates to add infrastructure for new theme variables.

The theme variables represent a more simplified partner theme that carries over the core entries of the previous theme but in a way that will be simpler for partners to interface with.

We currently support both the legacy theme (previous approach) and the updated approach. This will allow us to incrementally update components to use the new theming infrastructure while we make the migration. It will also allow us to make changes to the new theme as we implement it with more of our components.

This PR also updates the button to use the new theme variables as a first component to get the migration.

## Button using new theme variables

<img width="1586" height="730" alt="Screenshot 2025-07-21 at 4 21 42 PM" src="https://github.com/user-attachments/assets/c5dc3472-f90a-4710-bd24-7e0c122dfad5" />

## Both old and new variables getting injected into the document head

<img width="401" height="787" alt="Screenshot 2025-07-21 at 4 23 38 PM" src="https://github.com/user-attachments/assets/528a64d5-31d1-4b4c-9187-ebd1ce610cab" />

