### PR TITLE
fix: vite needs css file name on v6

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,6 +76,7 @@ export default defineConfig(({ mode }) => {
         fileName: 'index',
         entry: resolve(__dirname, 'src/index.ts'),
         formats: ['es'],
+        cssFileName: 'style',
       },
       minify: !isDev,
       sourcemap: !isDev,


### PR DESCRIPTION
Vite had a long standing issue where css files were emitted as `style.css` with no ability to customize the name. Since V6 the default name comes from your file name setting. When upgrading from v5 -> v6 this caused our css filename to shift from `style.css` to `index.css`. 

This change updates our setting to emit `style.css` again to not cause a style breaking change

## Image of Dist showing Style.css again
<img width="180" height="452" alt="Screenshot 2025-07-22 at 2 18 24 PM" src="https://github.com/user-attachments/assets/e1d8376c-df3b-4ab2-8727-fb9e867bba32" />
