### PR TITLE
fix: pay schedule preview component was registered to rhf

### DIFF
--- a/src/components/Company/PaySchedule/PaySchedule.tsx
+++ b/src/components/Company/PaySchedule/PaySchedule.tsx
@@ -60,7 +60,6 @@ const Root = ({ companyId, children, defaultValues }: PayScheduleProps) => {
     day2: defaultValues?.day2 ?? undefined,
     customName: defaultValues?.customName ?? '',
     customTwicePerMonth: 'false',
-    payPeriodPreviewRange: 0,
   }
 
   const { data: paySchedules } = usePaySchedulesGetAllSuspense({

--- a/src/components/Company/PaySchedule/_parts/Edit.tsx
+++ b/src/components/Company/PaySchedule/_parts/Edit.tsx
@@ -25,7 +25,6 @@ export const Edit = () => {
 
   const frequency = useWatch({ name: 'frequency' })
   const customTwicePerMonth = useWatch({ name: 'customTwicePerMonth' })
-  const payPeriodPreviewRange = useWatch({ name: 'payPeriodPreviewRange' })
 
   const shouldShowDay1 =
     (frequency === 'Twice per month' && customTwicePerMonth === 'custom') || frequency === 'Monthly'
@@ -37,14 +36,6 @@ export const Edit = () => {
       setValue('day2', 31)
     }
   }, [frequency, customTwicePerMonth, setValue])
-
-  // This is a workaround to ensure that the pay period preview range is set when the selected pay period index changes
-  // TODO: Once we have a RHF free select, that can be used and this effect can be removed
-  useEffect(() => {
-    if (payPeriodPreviewRange === undefined) {
-      setValue('payPeriodPreviewRange', selectedPayPeriodIndex)
-    }
-  }, [selectedPayPeriodIndex, setValue, payPeriodPreviewRange])
 
   if (mode !== 'EDIT_PAY_SCHEDULE' && mode !== 'ADD_PAY_SCHEDULE') {
     return null
@@ -102,16 +93,16 @@ export const Edit = () => {
           {payPeriodPreview && payPeriodPreview[selectedPayPeriodIndex] ? (
             <div className={style.calendarContainer}>
               {!payPreviewLoading && (
-                <SelectField
-                  name="payPeriodPreviewRange"
+                <Components.Select
                   label={t('labels.preview')}
+                  isRequired
                   options={payPeriodPreview.map((period, index) => {
                     return {
                       value: String(index),
                       label: `${formatDateNamedWeekdayShortPlusDate(period.startDate)} – ${formatDateNamedWeekdayShortPlusDate(period.endDate)}`,
                     }
                   })}
-                  defaultValue={String(selectedPayPeriodIndex)}
+                  value={String(selectedPayPeriodIndex)}
                   onChange={(value: string) => {
                     const numericValue = Number(value)
                     if (!isNaN(numericValue)) {

--- a/src/components/Company/PaySchedule/usePaySchedule.ts
+++ b/src/components/Company/PaySchedule/usePaySchedule.ts
@@ -33,7 +33,6 @@ export const PayScheduleSchema = z.object({
   day2: z.number().min(1).max(31).optional(),
   customName: z.string().optional(),
   customTwicePerMonth: z.string().optional(),
-  payPeriodPreviewRange: z.number().optional(),
 })
 
 export type PayScheduleInputs = z.input<typeof PayScheduleSchema>


### PR DESCRIPTION
Due to the design of our inputs a few months ago, we used a `SelectField` to implement the PaySchedule preview component. The issue with this is it gets tracked by React Hook Forms and in this case will cause an error on edit of a pay schedule once the user changes the preview period resulting in an un-proceedable error. 

Our fix simply swaps out our Select Field for a Select instead and removed the schema changes needed to make this work. 

## Before
<img width="649" height="606" alt="Screenshot 2025-07-22 at 3 14 22 PM" src="https://github.com/user-attachments/assets/d0a65986-2a93-44d2-b436-24610eb7e8a2" />


## After
<img width="654" height="585" alt="Screenshot 2025-07-22 at 3 14 46 PM" src="https://github.com/user-attachments/assets/8eec76b4-9b92-4f57-86bb-eccfd32498fd" />

