### PR TITLE
feat: update Button styling and variants

### DIFF
--- a/.ladle/adapters/PlainComponentAdapter.tsx
+++ b/.ladle/adapters/PlainComponentAdapter.tsx
@@ -60,7 +60,6 @@ export const PlainComponentAdapter: ComponentsContextType = {
     )
   },
   Button: ({
-    isError = false,
     isLoading = false,
     isDisabled = false,
     buttonRef,
@@ -74,7 +73,7 @@ export const PlainComponentAdapter: ComponentsContextType = {
         ref={buttonRef}
         disabled={isDisabled || isLoading}
         onClick={onClick}
-        className={`button button-primary ${isError ? 'button-error' : ''} ${isLoading ? 'button-loading' : ''}`}
+        className={`button button-primary ${isLoading ? 'button-loading' : ''}`}
         {...props}
       >
         {isLoading ? <span className="button-loading-indicator">{children}</span> : children}
@@ -83,7 +82,6 @@ export const PlainComponentAdapter: ComponentsContextType = {
   },
 
   ButtonIcon: ({
-    isError = false,
     isLoading = false,
     isDisabled = false,
     buttonRef,
@@ -96,7 +94,7 @@ export const PlainComponentAdapter: ComponentsContextType = {
         ref={buttonRef}
         disabled={isDisabled || isLoading}
         onClick={onClick}
-        className={`button button-icon ${isError ? 'button-error' : ''} ${isLoading ? 'button-loading' : ''}`}
+        className={`button button-icon ${isLoading ? 'button-loading' : ''}`}
         {...props}
       >
         {isLoading ? <span className="button-loading-indicator">{children}</span> : children}

--- a/src/components/Common/UI/Button/Button.module.scss
+++ b/src/components/Common/UI/Button/Button.module.scss
@@ -9,6 +9,7 @@
     font-size: toRem(14);
     font-weight: var(--g-fontWeightMedium);
     line-height: toRem(24);
+    min-height: toRem(42);
     letter-spacing: 0.32px;
     text-align: center;
     margin: 0;
@@ -19,36 +20,59 @@
     cursor: pointer;
     border: 1px solid var(--g-colorPrimary);
 
+    &:hover:not([data-disabled]) {
+      background: var(--g-colorPrimaryAccent);
+      border-color: var(--g-colorPrimaryAccent);
+    }
+
+    &:active:not([data-disabled]) {
+      background: var(--g-colorPrimary);
+      border-color: var(--g-colorPrimary);
+    }
+
     &[data-variant='secondary'] {
       color: var(--g-colorSecondaryContent);
       background: var(--g-colorSecondary);
       border-color: var(--g-colorSecondaryContent);
+
+      &:hover:not([data-disabled]) {
+        background: var(--g-colorSecondaryAccent);
+      }
+
+      &:active:not([data-disabled]) {
+        background: var(--g-colorSecondary);
+      }
     }
 
-    &[data-variant='icon'] {
+    &[data-variant='tertiary'] {
       color: var(--g-colorSecondaryContent);
       background: transparent;
       border-color: transparent;
-      text-decoration: underline;
-    }
 
-    &[data-variant='icon'] {
-      padding: toRem(12);
-      line-height: 0;
-    }
-
-    // Note: Error state is not currently customizable by partners - to be decided if this is required
-    &[data-error] {
-      &[data-variant='primary'] {
-        color: var(--g-colorErrorContent);
-        background: var(--g-colorError);
-        border-color: var(--g-colorError);
+      &:hover:not([data-disabled]) {
+        background: var(--g-colorSecondaryAccent);
+        border-color: var(--g-colorSecondaryAccent);
       }
 
-      &[data-variant='secondary'] {
-        color: var(--g-colorError);
+      &:active:not([data-disabled]) {
+        background: transparent;
+        border-color: transparent;
+      }
+    }
+
+    &[data-variant='error'] {
+      color: var(--g-colorError);
+      background: var(--g-colorErrorContent);
+      border-color: var(--g-colorErrorContent);
+
+      &:hover:not([data-disabled]) {
+        background: var(--g-colorErrorAccent);
+        border-color: var(--g-colorErrorAccent);
+      }
+
+      &:active:not([data-disabled]) {
         background: var(--g-colorErrorContent);
-        border-color: var(--g-colorError);
+        border-color: var(--g-colorErrorContent);
       }
     }
 
@@ -82,19 +106,17 @@
         }
       }
 
-      &[data-variant='icon'] {
+      &[data-variant='tertiary'] {
         &::after {
           background-color: var(--g-colorSecondaryContent);
         }
       }
-    }
 
-    &[data-hovered] {
-      opacity: 0.8;
-    }
-
-    &[data-pressed] {
-      opacity: 1;
+      &[data-variant='error'] {
+        &::after {
+          background-color: var(--g-colorError);
+        }
+      }
     }
 
     &[data-focus-visible] {
@@ -102,8 +124,12 @@
       outline-offset: 2px;
     }
 
-    &[data-disabled] {
+    &[data-disabled]:not([data-loading='true']) {
       opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &[data-loading='true'] {
       cursor: not-allowed;
     }
   }

--- a/src/components/Common/UI/Button/Button.stories.tsx
+++ b/src/components/Common/UI/Button/Button.stories.tsx
@@ -16,11 +16,6 @@ export const Loading = () => {
   return <Components.Button isLoading>Loading Button</Components.Button>
 }
 
-export const Error = () => {
-  const Components = useComponentContext()
-  return <Components.Button isError>Error Button</Components.Button>
-}
-
 export const Disabled = () => {
   const Components = useComponentContext()
   return <Components.Button isDisabled>Disabled Button</Components.Button>
@@ -31,13 +26,8 @@ export const ButtonGrid = () => {
   const Components = useComponentContext()
   const states = [
     { label: 'Default', props: {} },
-    { label: 'Hover', props: { 'data-hovered': true } },
-    { label: 'Pressed', props: { 'data-pressed': true } },
-    { label: 'Focus', props: { 'data-focus-visible': true } },
     { label: 'Loading', props: { isLoading: true } },
     { label: 'Disabled', props: { isDisabled: true } },
-    { label: 'Error', props: { isError: true } },
-    { label: 'Error + Disabled', props: { isError: true, isDisabled: true } },
   ]
 
   return (
@@ -93,19 +83,36 @@ export const ButtonGrid = () => {
         ))}
       </React.Fragment>
 
-      {/* Icon Button row */}
-      <React.Fragment key="row-icon">
-        <div key="label-icon" style={{ fontWeight: 'bold', alignSelf: 'center' }}>
-          Icon
+      {/* Tertiary Button row */}
+      <React.Fragment key="row-tertiary">
+        <div key="label-tertiary" style={{ fontWeight: 'bold', alignSelf: 'center' }}>
+          Tertiary
         </div>
         {states.map((state, stateIdx) => (
           <div
-            key={`icon-${stateIdx}`}
+            key={`tertiary-${stateIdx}`}
             style={{ display: 'flex', justifyContent: 'center', padding: '8px 0' }}
           >
-            <Components.ButtonIcon aria-label="test-label" onClick={() => {}} {...state.props}>
-              ↓
-            </Components.ButtonIcon>
+            <Components.Button variant="tertiary" onClick={() => {}} {...state.props}>
+              Tertiary
+            </Components.Button>
+          </div>
+        ))}
+      </React.Fragment>
+
+      {/* Error Button row */}
+      <React.Fragment key="row-error">
+        <div key="label-error" style={{ fontWeight: 'bold', alignSelf: 'center' }}>
+          Error
+        </div>
+        {states.map((state, stateIdx) => (
+          <div
+            key={`error-${stateIdx}`}
+            style={{ display: 'flex', justifyContent: 'center', padding: '8px 0' }}
+          >
+            <Components.Button variant="error" onClick={() => {}} {...state.props}>
+              Error
+            </Components.Button>
           </div>
         ))}
       </React.Fragment>

--- a/src/components/Common/UI/Button/Button.test.tsx
+++ b/src/components/Common/UI/Button/Button.test.tsx
@@ -34,21 +34,11 @@ describe('Button', () => {
     expect(button).toHaveAttribute('data-loading', 'true')
   })
 
-  it('shows error state when isError is true', () => {
-    render(<Button isError>Error Button</Button>)
-    const button = screen.getByRole('button', { name: 'Error Button' })
-    expect(button).toHaveAttribute('data-error', 'true')
-  })
-
   describe('Accessibility', () => {
     const testCases = [
       { name: 'default', props: { children: 'Default Button' } },
       { name: 'disabled', props: { isDisabled: true, children: 'Disabled Button' } },
       { name: 'loading', props: { isLoading: true, children: 'Loading Button' } },
-      {
-        name: 'icon',
-        props: { variant: 'icon' as const, 'aria-label': 'Icon button', children: '×' },
-      },
     ]
 
     it.each(testCases)(

--- a/src/components/Common/UI/Button/Button.tsx
+++ b/src/components/Common/UI/Button/Button.tsx
@@ -4,7 +4,6 @@ import { type ButtonProps } from './ButtonTypes'
 import styles from './Button.module.scss'
 
 export function Button({
-  isError = false,
   isLoading = false,
   isDisabled = false,
   variant = 'primary',
@@ -32,7 +31,6 @@ export function Button({
       isDisabled={isDisabled || isLoading}
       data-variant={variant}
       data-loading={isLoading || undefined}
-      data-error={isError || undefined}
       onPress={handlePress}
     >
       {children}

--- a/src/components/Common/UI/Button/ButtonIcon.module.scss
+++ b/src/components/Common/UI/Button/ButtonIcon.module.scss
@@ -1,0 +1,15 @@
+.root {
+  &:global(.react-aria-Button) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: toRem(42);
+    line-height: 0;
+
+    svg {
+      flex-shrink: 0;
+      width: toRem(20);
+      height: toRem(20);
+    }
+  }
+}

--- a/src/components/Common/UI/Button/ButtonIcon.stories.tsx
+++ b/src/components/Common/UI/Button/ButtonIcon.stories.tsx
@@ -1,139 +1,153 @@
-import { useState } from 'react'
+import React from 'react'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
-// Adding a meta object for title
 export default {
   title: 'UI/Components/ButtonIcon',
 }
 
-// Wrapper component that uses the component context
-const ButtonStory = ({ ...props }) => {
+// Main ButtonIcon stories
+export const Default = () => {
   const Components = useComponentContext()
-  const [interactionState, setInteractionState] = useState<
-    | {
-        'data-hovered'?: true
-        'data-pressed'?: true
-        'data-focus-visible'?: true
-        isLoading?: true
-        isDisabled?: true
-        isError?: true
-      }
-    | undefined
-  >(undefined)
-
   return (
-    <>
-      <style>
-        {`
-        .container {
-          display: flex;
-          flex-direction: column;
-          gap: 16px;
-        }
-        .controls {
-          display: flex;
-          gap: 8px;
-        }
-        .controls label {
-          display: flex;
-          gap: 4px;
-          align-items: center;
-        }
-        `}
-      </style>
-      <div className="container">
-        <Components.ButtonIcon
-          {...props}
-          {...interactionState}
-          aria-label="test-label"
-          onClick={() => {}}
-        />
-        <div className="controls">
-          <label>
-            <input
-              type="checkbox"
-              onChange={e => {
-                if (e.target.checked) {
-                  setInteractionState({
-                    ...interactionState,
-                    'data-hovered': true,
-                  })
-                } else {
-                  setInteractionState(
-                    interactionState && {
-                      ...interactionState,
-                      'data-hovered': undefined,
-                    },
-                  )
-                }
-              }}
-            />{' '}
-            Hovered
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              onChange={e => {
-                if (e.target.checked) {
-                  setInteractionState({
-                    ...interactionState,
-                    'data-pressed': true,
-                  })
-                } else {
-                  setInteractionState(
-                    interactionState && {
-                      ...interactionState,
-                      'data-pressed': undefined,
-                    },
-                  )
-                }
-              }}
-            />{' '}
-            Pressed
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              onChange={e => {
-                if (e.target.checked) {
-                  setInteractionState({
-                    ...interactionState,
-                    'data-focus-visible': true,
-                  })
-                } else {
-                  setInteractionState(
-                    interactionState && {
-                      ...interactionState,
-                      'data-focus-visible': undefined,
-                    },
-                  )
-                }
-              }}
-            />{' '}
-            Focus
-          </label>
-        </div>
-      </div>
-    </>
+    <Components.ButtonIcon aria-label="test-label" onClick={() => {}}>
+      ↓
+    </Components.ButtonIcon>
   )
 }
 
-export const Default = () => <ButtonStory onClick={() => {}}>↓</ButtonStory>
+export const Loading = () => {
+  const Components = useComponentContext()
+  return (
+    <Components.ButtonIcon isLoading aria-label="test-label" onClick={() => {}}>
+      ↓
+    </Components.ButtonIcon>
+  )
+}
 
-export const Loading = () => (
-  <ButtonStory isLoading onClick={() => {}}>
-    ↓
-  </ButtonStory>
-)
+export const Disabled = () => {
+  const Components = useComponentContext()
+  return (
+    <Components.ButtonIcon isDisabled aria-label="test-label" onClick={() => {}}>
+      ↓
+    </Components.ButtonIcon>
+  )
+}
 
-export const Error = () => (
-  <ButtonStory isError onClick={() => {}}>
-    ↓
-  </ButtonStory>
-)
+// Grid view showing all variants and states
+export const ButtonIconGrid = () => {
+  const Components = useComponentContext()
+  const states = [
+    { label: 'Default', props: {} },
+    { label: 'Loading', props: { isLoading: true } },
+    { label: 'Disabled', props: { isDisabled: true } },
+  ]
 
-export const Disabled = () => (
-  <ButtonStory isDisabled onClick={() => {}}>
-    ↓
-  </ButtonStory>
-)
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `auto repeat(${states.length}, 1fr)`,
+        gap: '16px',
+        padding: '24px',
+        borderRadius: '8px',
+        margin: '24px 0',
+      }}
+    >
+      {/* Header row */}
+      <div style={{ gridColumn: '1 / 1' }}></div>
+      {states.map((state, idx) => (
+        <div key={idx} style={{ textAlign: 'center', fontWeight: 'bold', paddingBottom: '16px' }}>
+          {state.label}
+        </div>
+      ))}
+
+      {/* Primary ButtonIcon row */}
+      <React.Fragment key="row-primary">
+        <div key="label-primary" style={{ fontWeight: 'bold', alignSelf: 'center' }}>
+          Primary
+        </div>
+        {states.map((state, stateIdx) => (
+          <div
+            key={`primary-${stateIdx}`}
+            style={{ display: 'flex', justifyContent: 'center', padding: '8px 0' }}
+          >
+            <Components.ButtonIcon
+              variant="primary"
+              aria-label="test-label"
+              onClick={() => {}}
+              {...state.props}
+            >
+              ↓
+            </Components.ButtonIcon>
+          </div>
+        ))}
+      </React.Fragment>
+
+      {/* Secondary ButtonIcon row */}
+      <React.Fragment key="row-secondary">
+        <div key="label-secondary" style={{ fontWeight: 'bold', alignSelf: 'center' }}>
+          Secondary
+        </div>
+        {states.map((state, stateIdx) => (
+          <div
+            key={`secondary-${stateIdx}`}
+            style={{ display: 'flex', justifyContent: 'center', padding: '8px 0' }}
+          >
+            <Components.ButtonIcon
+              variant="secondary"
+              aria-label="test-label"
+              onClick={() => {}}
+              {...state.props}
+            >
+              ↓
+            </Components.ButtonIcon>
+          </div>
+        ))}
+      </React.Fragment>
+
+      {/* Tertiary ButtonIcon row */}
+      <React.Fragment key="row-tertiary">
+        <div key="label-tertiary" style={{ fontWeight: 'bold', alignSelf: 'center' }}>
+          Tertiary
+        </div>
+        {states.map((state, stateIdx) => (
+          <div
+            key={`tertiary-${stateIdx}`}
+            style={{ display: 'flex', justifyContent: 'center', padding: '8px 0' }}
+          >
+            <Components.ButtonIcon
+              variant="tertiary"
+              aria-label="test-label"
+              onClick={() => {}}
+              {...state.props}
+            >
+              ↓
+            </Components.ButtonIcon>
+          </div>
+        ))}
+      </React.Fragment>
+
+      {/* Error ButtonIcon row */}
+      <React.Fragment key="row-error">
+        <div key="label-error" style={{ fontWeight: 'bold', alignSelf: 'center' }}>
+          Error
+        </div>
+        {states.map((state, stateIdx) => (
+          <div
+            key={`error-${stateIdx}`}
+            style={{ display: 'flex', justifyContent: 'center', padding: '8px 0' }}
+          >
+            <Components.ButtonIcon
+              variant="error"
+              aria-label="test-label"
+              onClick={() => {}}
+              {...state.props}
+            >
+              ↓
+            </Components.ButtonIcon>
+          </div>
+        ))}
+      </React.Fragment>
+    </div>
+  )
+}

--- a/src/components/Common/UI/Button/ButtonIcon.test.tsx
+++ b/src/components/Common/UI/Button/ButtonIcon.test.tsx
@@ -14,7 +14,7 @@ describe('ButtonIcon', () => {
     renderWithProviders(<ButtonIcon aria-label="test-label">↓</ButtonIcon>)
     const button = screen.getByRole('button')
     expect(button).toBeInTheDocument()
-    expect(button).toHaveAttribute('data-variant', 'icon')
+    expect(button).toHaveAttribute('data-variant', 'tertiary')
   })
 
   it('handles press events', async () => {

--- a/src/components/Common/UI/Button/ButtonIcon.test.tsx
+++ b/src/components/Common/UI/Button/ButtonIcon.test.tsx
@@ -51,16 +51,6 @@ describe('ButtonIcon', () => {
     expect(button).toHaveAttribute('data-loading', 'true')
   })
 
-  it('shows error state when isError is true', () => {
-    renderWithProviders(
-      <ButtonIcon aria-label="test-label" isError>
-        ↓
-      </ButtonIcon>,
-    )
-    const button = screen.getByRole('button')
-    expect(button).toHaveAttribute('data-error', 'true')
-  })
-
   describe('Accessibility', () => {
     const testCases = [
       {

--- a/src/components/Common/UI/Button/ButtonIcon.tsx
+++ b/src/components/Common/UI/Button/ButtonIcon.tsx
@@ -1,6 +1,12 @@
+import classNames from 'classnames'
 import { type ButtonIconProps } from './ButtonTypes'
 import { Button } from './Button'
+import styles from './ButtonIcon.module.scss'
 
-export function ButtonIcon(props: ButtonIconProps) {
-  return <Button {...props} variant="icon" />
+export function ButtonIcon({ variant = 'tertiary', className, ...props }: ButtonIconProps) {
+  return (
+    <Button {...props} variant={variant} className={classNames(styles.root, className)}>
+      {props.children}
+    </Button>
+  )
 }

--- a/src/components/Common/UI/Button/ButtonTypes.ts
+++ b/src/components/Common/UI/Button/ButtonTypes.ts
@@ -24,11 +24,7 @@ export interface ButtonProps
   /**
    * Visual style variant of the button
    */
-  variant?: 'primary' | 'secondary' | 'icon'
-  /**
-   * Indicates if the button is in an error state
-   */
-  isError?: boolean
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'error'
   /**
    * Shows a loading spinner and disables the button
    */
@@ -51,7 +47,7 @@ export interface ButtonProps
   onFocus?: (e: FocusEvent) => void
 }
 
-export type ButtonIconProps = Omit<ButtonProps, 'variant'> & {
+export type ButtonIconProps = ButtonProps & {
   /**
    * Required aria-label for icon buttons to ensure accessibility
    */

--- a/src/contexts/ThemeProvider/theme.ts
+++ b/src/contexts/ThemeProvider/theme.ts
@@ -18,7 +18,7 @@ const colors = {
   },
   error: {
     100: '#FEF3F2',
-    500: '#FECDCA',
+    500: '#E62E05',
     800: '#B42318',
   },
   warning: {


### PR DESCRIPTION
This PR reorganizes Button per design feedback as we were updating to use the new tokens

* Adds a tertiary button
* "error" is now one of the button variants along with primary, secondary, tertiary
* ButtonIcon now supports all button variants above (including tertiary which is the default) which allows icon button to take on the other button states. This one is also from design request

## All button variants

<img width="936" height="505" alt="Screenshot 2025-07-23 at 2 00 23 PM" src="https://github.com/user-attachments/assets/06b986c9-fae9-4bef-8362-57f2d698abab" />

## All icon button variants

<img width="954" height="474" alt="Screenshot 2025-07-23 at 2 00 54 PM" src="https://github.com/user-attachments/assets/4336a138-7fd6-4faf-b91e-47d212e519b7" />

## Hover/active states

https://github.com/user-attachments/assets/b9f00236-c581-4d02-80c9-98c78ebc5508

