### PR TITLE
feat: update field components to use new theme variables

### DIFF
--- a/src/components/Common/FieldCaption/FieldCaption.module.scss
+++ b/src/components/Common/FieldCaption/FieldCaption.module.scss
@@ -1,7 +1,7 @@
 .root {
-  font-size: var(--g-input-labelFontSize);
-  font-weight: var(--g-input-labelFontWeight);
-  color: var(--g-input-labelColor);
+  font-size: var(--g-inputLabelFontSize);
+  font-weight: var(--g-inputLabelFontWeight);
+  color: var(--g-inputLabelColor);
   margin: 0;
   padding: 0;
   line-height: 1.3;
@@ -9,5 +9,5 @@
 
 .optionalLabel {
   font-size: smaller;
-  color: var(--g-input-placeholderColor);
+  color: var(--g-inputPlaceholderColor);
 }

--- a/src/components/Common/FieldDescription/FieldDescription.module.scss
+++ b/src/components/Common/FieldDescription/FieldDescription.module.scss
@@ -1,7 +1,7 @@
 .root {
   display: block;
-  font-size: var(--g-typography-fontSize-small);
-  font-weight: var(--g-typography-fontWeight-regular);
+  font-size: var(--g-fontSizeSmall);
+  font-weight: var(--g-fontWeightRegular);
   line-height: 1.3;
-  color: var(--g-input-descriptionColor);
+  color: var(--g-inputDescriptionColor);
 }

--- a/src/components/Common/FieldErrorMessage/FieldErrorMessage.module.scss
+++ b/src/components/Common/FieldErrorMessage/FieldErrorMessage.module.scss
@@ -3,7 +3,7 @@
   align-items: center;
   font-size: toRem(14);
   line-height: toRem(18);
-  color: var(--g-colors-error-500);
+  color: var(--g-inputErrorColor);
   margin: 0;
 
   &.withErrorIcon {

--- a/src/components/Common/FieldLayout/FieldLayout.module.scss
+++ b/src/components/Common/FieldLayout/FieldLayout.module.scss
@@ -9,14 +9,14 @@
   flex-direction: column;
 
   &.withVisibleLabel {
-    margin-bottom: var(--g-spacing-4);
+    margin-bottom: toRem(4);
   }
 
   &.withDescription {
-    margin-bottom: var(--g-spacing-8);
+    margin-bottom: toRem(8);
   }
 }
 
 .errorMessage {
-  margin-top: var(--g-spacing-4);
+  margin-top: toRem(4);
 }

--- a/src/components/Common/HorizontalFieldLayout/HorizontalFieldLayout.module.scss
+++ b/src/components/Common/HorizontalFieldLayout/HorizontalFieldLayout.module.scss
@@ -6,7 +6,7 @@
     '. description'
     '. error';
   grid-template-columns: max-content 1fr;
-  column-gap: var(--g-spacing-12);
+  column-gap: toRem(12);
   align-items: start;
 
   &.withoutVisibleLabel {
@@ -31,9 +31,9 @@
 
 .label {
   grid-area: label;
-  font-size: var(--g-input-labelFontSize);
-  font-weight: var(--g-input-labelFontWeight);
-  color: var(--g-input-labelColor);
+  font-size: var(--g-inputLabelFontSize);
+  font-weight: var(--g-inputLabelFontWeight);
+  color: var(--g-inputLabelColor);
   forced-color-adjust: none;
   height: 100%;
   display: flex;
@@ -46,5 +46,5 @@
 
 .errorMessage {
   grid-area: error;
-  margin-top: var(--g-spacing-4);
+  margin-top: toRem(4);
 }

--- a/src/contexts/ThemeProvider/theme.ts
+++ b/src/contexts/ThemeProvider/theme.ts
@@ -70,6 +70,12 @@ export const gustoSDKTheme = {
   inputPlaceholderColor: colors.neutral[800],
   inputAdornmentColor: colors.neutral[800],
   inputDisabledBackgroundColor: colors.neutral[300],
+  // Field Colors
+  inputLabelColor: colors.neutral[1000],
+  inputLabelFontSize: toRem(16),
+  inputLabelFontWeight: '500',
+  inputDescriptionColor: colors.neutral[900],
+  inputErrorColor: colors.error[500],
   // Radius
   inputRadius: toRem(8),
   buttonRadius: toRem(8),


### PR DESCRIPTION
Updates the Field components to use the new theme variables
* FieldLayout
* FieldDescription
* FieldCaption
* FieldErrorMessage
* HorizontalFieldLayout

Adds new theme variables relating to inputs, since inputs are such a key part of the SDK and will likely get a lot of partner attention if the theming system is going to be viable.

## Examples after update

https://github.com/user-attachments/assets/f7f6faf4-ec19-46f7-8a6d-e8cb16829510

https://github.com/user-attachments/assets/2d0371a6-b7ae-43d6-a866-5f88331b76ae
