### PR TITLE
feat: update InternalError, Loading, and PaginationControl theme vars

### DIFF
--- a/src/components/Common/InternalError/InternalError.module.scss
+++ b/src/components/Common/InternalError/InternalError.module.scss
@@ -1,15 +1,15 @@
 .internalErrorCardTitle {
-  color: var(--g-colors-gray-1000);
+  color: var(--g-colorBodyContent);
 }
 
 .internalErrorCard {
-  background-color: var(--g-colors-gray-100);
-  border-right: 1px solid var(--g-card-borderColor);
-  border-bottom: 1px solid var(--g-card-borderColor);
-  border-left: 1px solid var(--g-card-borderColor);
+  background-color: var(--g-colorBody);
+  border-right: 1px solid var(--g-colorSecondaryAccent);
+  border-bottom: 1px solid var(--g-colorSecondaryAccent);
+  border-left: 1px solid var(--g-colorSecondaryAccent);
   box-shadow:
     0px 1px 18px rgba(0, 0, 0, 0.08),
-    inset 0 4px 0 var(--g-colors-error-500);
+    inset 0 4px 0 var(--g-colorErrorContent);
   padding: toRem(20);
   display: flex;
   flex-direction: column;
@@ -19,9 +19,9 @@
 }
 
 .errorMessage {
-  font-size: var(--g-typography-fontSize-small);
-  font-weight: var(--g-typography-fontWeight-medium);
-  color: var(--g-colors-error-500);
+  font-size: var(--g-fontSizeSmall);
+  font-weight: var(--g-fontWeightMedium);
+  color: var(--g-colorErrorContent);
   line-height: normal;
   margin-top: toRem(6);
 }

--- a/src/components/Common/Loading/Loading.module.scss
+++ b/src/components/Common/Loading/Loading.module.scss
@@ -8,13 +8,13 @@
 .skeleton {
   background: linear-gradient(
     90deg,
-    var(--g-colors-gray-300) 25%,
-    var(--g-colors-gray-400) 50%,
-    var(--g-colors-gray-300) 75%
+    var(--g-colorSecondaryAccent) 25%,
+    var(--g-colorSecondary) 50%,
+    var(--g-colorSecondaryAccent) 75%
   );
   background-size: 200% 100%;
   animation: pulse 1.5s infinite linear;
-  border-radius: 4px;
+  border-radius: toRem(4);
 }
 
 .skeletonBox {

--- a/src/components/Common/PaginationControl/PaginationControl.module.scss
+++ b/src/components/Common/PaginationControl/PaginationControl.module.scss
@@ -1,13 +1,12 @@
 .paginationControl {
   width: 100%;
-  margin-bottom: var(--g-spacing-20);
-  font-size: var(--g-typography-fontSize-small);
-  margin-top: var(--g-spacing-8);
+  margin-bottom: toRem(20);
+  margin-top: toRem(8);
 
   &Count {
     display: flex;
     align-items: center;
-    gap: var(--g-spacing-12);
+    gap: toRem(12);
   }
 
   &Buttons {


### PR DESCRIPTION
This updates InternalError, Loading, and PaginationControl components to use the new theme variables.

## Internal Error Before

<img width="664" height="227" alt="Screenshot 2025-08-08 at 9 05 59 AM" src="https://github.com/user-attachments/assets/81644432-a5cb-46ec-9092-0e71bf6a5bf8" />

## Internal Error After

<img width="653" height="216" alt="Screenshot 2025-08-08 at 9 08 45 AM" src="https://github.com/user-attachments/assets/8efb0f6f-ea63-4aea-b24e-fa114eeef02c" />

## Loading Before

https://github.com/user-attachments/assets/6fd4f794-3147-4921-9009-e72162ee73d7

## Loading After

https://github.com/user-attachments/assets/5aa81b1e-f6b7-4d0d-adc0-b6c554114ddb

## Pagination Control Before

<img width="430" height="122" alt="Screenshot 2025-08-08 at 9 21 11 AM" src="https://github.com/user-attachments/assets/b659ce19-14e6-4578-b4d1-e15b54535d08" />

## Pagination Control After

<img width="442" height="126" alt="Screenshot 2025-08-08 at 9 21 46 AM" src="https://github.com/user-attachments/assets/3d35d017-c77d-4312-8d2b-2dfa54a182b2" />


