### PR TITLE
fix: update contractor profile ssn ein validation

### DIFF
--- a/src/components/Contractor/Profile/ContractorProfile.stories.tsx
+++ b/src/components/Contractor/Profile/ContractorProfile.stories.tsx
@@ -26,7 +26,11 @@ function InteractiveStory({
   isEditing?: boolean
 }) {
   // Create validation schema for stories (with mock translation)
-  const validationSchema = createContractorProfileValidationSchema((key: string) => key)
+  const validationSchema = createContractorProfileValidationSchema(
+    (key: string) => key,
+    false,
+    false,
+  )
 
   const formMethods = useForm({
     resolver: zodResolver(validationSchema),
@@ -66,7 +70,10 @@ function InteractiveStory({
     isSubmitting: false,
   }
 
-  const mockData: Omit<ContractorProfileFormProps, 'formMethods' | 'className'> = {
+  const mockData: Omit<
+    ContractorProfileFormProps,
+    'formMethods' | 'className' | 'hasSsn' | 'hasEin'
+  > = {
     handleSubmit: formMethods.handleSubmit(data => {
       mockSubmitAction(data)
     }),
@@ -97,6 +104,8 @@ function InteractiveStory({
             shouldShowBusinessFields={shouldShowBusinessFields}
             shouldShowIndividualFields={shouldShowIndividualFields}
             shouldShowHourlyRate={shouldShowHourlyRate}
+            hasSsn={false}
+            hasEin={false}
           />
         </ThemeProvider>
       </LocaleProvider>

--- a/src/components/Contractor/Profile/ContractorProfile.tsx
+++ b/src/components/Contractor/Profile/ContractorProfile.tsx
@@ -59,7 +59,14 @@ function Root({
     defaultValues,
     existingContractor,
   })
-  return <ContractorProfileForm {...hookData} className={className} />
+  return (
+    <ContractorProfileForm
+      {...hookData}
+      hasSsn={existingContractor?.hasSsn ?? false}
+      hasEin={existingContractor?.hasEin ?? false}
+      className={className}
+    />
+  )
 }
 
 // Re-export types and enums for convenience

--- a/src/components/Contractor/Profile/ContractorProfileForm.tsx
+++ b/src/components/Contractor/Profile/ContractorProfileForm.tsx
@@ -11,12 +11,14 @@ import { NumberInputField } from '@/components/Common/Fields/NumberInputField'
 import { RadioGroupField } from '@/components/Common/Fields/RadioGroupField'
 import { SwitchField } from '@/components/Common/Fields/SwitchField'
 import { DatePickerField } from '@/components/Common/Fields/DatePickerField'
-import { normalizeSSN } from '@/helpers/ssn'
-import { normalizeEin } from '@/helpers/federalEin'
+import { normalizeSSN, usePlaceholderSSN } from '@/helpers/ssn'
+import { normalizeEin, usePlaceholderEin } from '@/helpers/federalEin'
 
 // Pure presentation component - takes all data as props
 export type ContractorProfileFormProps = ReturnType<typeof useContractorProfile> & {
   className?: string
+  hasSsn: boolean
+  hasEin: boolean
 }
 
 export function ContractorProfileForm({
@@ -31,10 +33,14 @@ export function ContractorProfileForm({
   wageTypeOptions,
   isEditing,
   className,
+  hasSsn,
+  hasEin,
 }: ContractorProfileFormProps) {
   const Components = useComponentContext()
   useI18n('Contractor.Profile')
   const { t } = useTranslation('Contractor.Profile')
+  const ssnPlaceholder = usePlaceholderSSN(hasSsn)
+  const einPlaceholder = usePlaceholderEin(hasEin)
 
   return (
     <section className={className}>
@@ -87,7 +93,7 @@ export function ContractorProfileForm({
                 <TextInputField
                   name="ssn"
                   label={t('fields.ssn.label')}
-                  placeholder={t('fields.ssn.placeholder')}
+                  placeholder={ssnPlaceholder}
                   transform={normalizeSSN}
                   isRequired
                 />
@@ -105,7 +111,7 @@ export function ContractorProfileForm({
                 <TextInputField
                   name="ein"
                   label={t('fields.ein.label')}
-                  placeholder={t('fields.ein.placeholder')}
+                  placeholder={einPlaceholder}
                   transform={normalizeEin}
                   isRequired
                 />

--- a/src/i18n/en/Contractor.Profile.json
+++ b/src/i18n/en/Contractor.Profile.json
@@ -22,8 +22,7 @@
       "label": "Middle Initial"
     },
     "ssn": {
-      "label": "Social Security Number",
-      "placeholder": "XXX-XX-XXXX"
+      "label": "Social Security Number"
     },
     "businessName": {
       "label": "Business Name"
@@ -39,8 +38,7 @@
       "label": "Hourly Rate"
     },
     "ein": {
-      "label": "EIN",
-      "placeholder": "XX-XXXXXXX"
+      "label": "EIN"
     }
   },
   "validations": {

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -452,7 +452,6 @@ export interface ContractorProfile{
 };
 "ssn":{
 "label":string;
-"placeholder":string;
 };
 "businessName":{
 "label":string;
@@ -469,7 +468,6 @@ export interface ContractorProfile{
 };
 "ein":{
 "label":string;
-"placeholder":string;
 };
 };
 "validations":{


### PR DESCRIPTION
This updates to not validate SSN/EIN if the values are undefined and the contractor already has an SSN/EIN through the hasSsn/hasEin properties.

This also
* Updates the SSN/EIN placeholders to use the centralized ones in common
* Updates to just use a placeholder for EIN when it is present instead of rendering the masked version since that fails validation

## Proof of functionality

### SSN

https://github.com/user-attachments/assets/fde51e9a-7ff5-43b6-a5c6-56c72c4ce92a

### EIN

Note: on EIN we have some zod validation issues going on with the submission. However, this is still evidence of the fix as it getting to the zod validation failures means the form successfully submitted. We are tackling zod validation issues separately

https://github.com/user-attachments/assets/f71f56a2-6346-426b-8e2a-406adc8a070b

