### PR TITLE
fix: correctly pass contractor id from profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
-        "@gusto/embedded-api": "^0.6.7",
+        "@gusto/embedded-api": "^0.6.8",
         "@hookform/error-message": "^2.0.1",
         "@hookform/resolvers": "^3.10.0",
         "@internationalized/date": "^3.8.0",
@@ -1623,9 +1623,9 @@
       }
     },
     "node_modules/@gusto/embedded-api": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@gusto/embedded-api/-/embedded-api-0.6.7.tgz",
-      "integrity": "sha512-2y5R+fRDPlje7PxwbKzM4V9IZOCvrHnHfcAYrli/Ih+vHvZLkm+U5hVvuUESYONVhYtQ76vf2vbKK5rG0nxiHg==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@gusto/embedded-api/-/embedded-api-0.6.8.tgz",
+      "integrity": "sha512-tCKXAsxZSXlxsW7BZQBQozJ2gXfZQsBg4M93gptBFx3raBZHqs42KaHSFJWdGjow6Zls+LbSkonBk1Otz/OliQ==",
       "dependencies": {
         "zod": "^3.20.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
-        "@gusto/embedded-api": "^0.6.6",
+        "@gusto/embedded-api": "^0.6.7",
         "@hookform/error-message": "^2.0.1",
         "@hookform/resolvers": "^3.10.0",
         "@internationalized/date": "^3.8.0",
@@ -1623,14 +1623,16 @@
       }
     },
     "node_modules/@gusto/embedded-api": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@gusto/embedded-api/-/embedded-api-0.6.6.tgz",
-      "integrity": "sha512-TODIA2RDVjX7t5H5U6i1mMOwB7m29yDoyIePS9XYNEiWbtz0+n26RLw7IwugPEyMJwv/inpr/zZzFOdnd3m8+g==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@gusto/embedded-api/-/embedded-api-0.6.7.tgz",
+      "integrity": "sha512-2y5R+fRDPlje7PxwbKzM4V9IZOCvrHnHfcAYrli/Ih+vHvZLkm+U5hVvuUESYONVhYtQ76vf2vbKK5rG0nxiHg==",
+      "dependencies": {
+        "zod": "^3.20.0"
+      },
       "peerDependencies": {
         "@tanstack/react-query": "^5",
         "react": "^18 || ^19",
-        "react-dom": "^18 || ^19",
-        "zod": "^3"
+        "react-dom": "^18 || ^19"
       },
       "peerDependenciesMeta": {
         "@tanstack/react-query": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@gusto/embedded-api": "^0.6.6",
+    "@gusto/embedded-api": "^0.6.7",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^3.10.0",
     "@internationalized/date": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@gusto/embedded-api": "^0.6.7",
+    "@gusto/embedded-api": "^0.6.8",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^3.10.0",
     "@internationalized/date": "^3.8.0",

--- a/src/components/Company/BankAccount/BankAccount.tsx
+++ b/src/components/Company/BankAccount/BankAccount.tsx
@@ -17,7 +17,7 @@ export interface BankAccountProps extends BaseComponentInterface<'Company.BankAc
 function BankAccountFlow({ companyId, onEvent, dictionary }: BankAccountProps) {
   useComponentDictionary('Company.BankAccount', dictionary)
   const { data } = useBankAccountsGetSuspense({ companyId })
-  const companyBankAccountList = data.companyBankAccountList!
+  const companyBankAccountList = data.companyBankAccounts!
   //Currently, we only support a single default bank account per company.
   const bankAccount = companyBankAccountList.length > 0 ? companyBankAccountList[0]! : null
 

--- a/src/components/Company/BankAccount/BankAccountForm/BankAccountForm.tsx
+++ b/src/components/Company/BankAccount/BankAccountForm/BankAccountForm.tsx
@@ -42,7 +42,7 @@ function Root({ companyId, className, children, isEditing = false }: BankAccount
     await baseSubmitHandler(data, async payload => {
       const { companyBankAccount } = await createBankAccount({
         //Account type is always checking for company bank accounts
-        request: { companyId, requestBody: { ...payload, accountType: 'Checking' } },
+        request: { companyId, companyBankAccountRequest: { ...payload, accountType: 'Checking' } },
       })
 
       onEvent(componentEvents.COMPANY_BANK_ACCOUNT_CREATED, companyBankAccount)

--- a/src/components/Company/BankAccount/BankAccountList/BankAccountList.tsx
+++ b/src/components/Company/BankAccount/BankAccountList/BankAccountList.tsx
@@ -31,7 +31,7 @@ function Root({
   useI18n('Company.BankAccount')
   const { onEvent } = useBase()
   const { data } = useBankAccountsGetSuspense({ companyId })
-  const companyBankAccountList = data.companyBankAccountList!
+  const companyBankAccountList = data.companyBankAccounts!
   //Currently, we only support a single default bank account per company.
   const bankAccount = companyBankAccountList.length > 0 ? companyBankAccountList[0]! : null
   if (!bankAccount) {

--- a/src/components/Contractor/OnboardingFlow/onboardingStateMachine.ts
+++ b/src/components/Contractor/OnboardingFlow/onboardingStateMachine.ts
@@ -107,6 +107,7 @@ export const onboardingMachine = {
           return {
             ...ctx,
             component: NewHireReportContextual,
+            contractorId: ev.payload.contractorId,
             currentStep: 2,
             totalSteps: 3,
           }

--- a/src/components/Contractor/Submit/Submit.tsx
+++ b/src/components/Contractor/Submit/Submit.tsx
@@ -55,7 +55,7 @@ export const Root = ({ contractorId, selfOnboarding }: ContractorSubmitProps) =>
         componentEvents.CONTRACTOR_ONBOARDING_STATUS_UPDATED,
         response.contractorOnboardingStatus,
       )
-      onEvent(componentEvents.CONTRACTOR_SUBMIT_DONE)
+      onEvent(componentEvents.CONTRACTOR_SUBMIT_DONE, { message: t('submitDone.successMessage') })
     })
   }
   const handleInviteContractor = () => {

--- a/src/test/mocks/apis/company_bank_accounts.ts
+++ b/src/test/mocks/apis/company_bank_accounts.ts
@@ -2,7 +2,7 @@ import type { HttpResponseResolver } from 'msw'
 import { http, HttpResponse, type PathParams } from 'msw'
 import type { GetV1CompaniesCompanyIdBankAccountsRequest } from '@gusto/embedded-api/models/operations/getv1companiescompanyidbankaccounts'
 import type { CompanyBankAccount$Outbound } from '@gusto/embedded-api/models/components/companybankaccount'
-import type { PostV1CompaniesCompanyIdBankAccountsRequestBody } from '@gusto/embedded-api/models/operations/postv1companiescompanyidbankaccounts'
+import type { PostV1CompaniesCompanyIdBankAccountsRequest } from '@gusto/embedded-api/models/operations/postv1companiescompanyidbankaccounts'
 import type { PutV1CompaniesCompanyIdBankAccountsVerifyRequestBody } from '@gusto/embedded-api/models/operations/putv1companiescompanyidbankaccountsverify'
 import { getFixture } from '../fixtures/getFixture'
 import { API_BASE_URL } from '@/test/constants'
@@ -29,7 +29,7 @@ export const getEmptyCompanyBankAccounts = http.get(
 export function handlePostCompanyBankAccount(
   resolver: HttpResponseResolver<
     PathParams,
-    PostV1CompaniesCompanyIdBankAccountsRequestBody,
+    PostV1CompaniesCompanyIdBankAccountsRequest,
     CompanyBankAccount$Outbound
   >,
 ) {


### PR DESCRIPTION
Fixes an issue where you were unable to navigate from profile when self onboarding is set because the contractor ID wasn't correctly getting passed to the next component via the state machine.

This also resolves an issue when creating a contractor for the first time where there was an undefined error for message that was causing a crash.