### PR TITLE
feat: update payroll configuration to use prepare endpoint

### DIFF
--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -138,6 +138,7 @@ export const BaseComponent = <TResourceKey extends keyof Resources = keyof Resou
         onEvent,
         throwError,
         baseSubmitHandler,
+        LoadingIndicator: LoaderComponent,
       }}
     >
       <QueryErrorResetBoundary>

--- a/src/components/Base/useBase.tsx
+++ b/src/components/Base/useBase.tsx
@@ -3,6 +3,7 @@ import type { APIError } from '@gusto/embedded-api/models/errors/apierror'
 import type { SDKValidationError } from '@gusto/embedded-api/models/errors/sdkvalidationerror'
 import type { UnprocessableEntityErrorObject } from '@gusto/embedded-api/models/errors/unprocessableentityerrorobject'
 import { type EventType } from '@/shared/constants'
+import type { LoadingIndicatorContextProps } from '@/contexts/LoadingIndicatorProvider/useLoadingIndicator'
 
 export type OnEventType<K, T> = (type: K, data?: T) => void
 
@@ -22,6 +23,7 @@ interface BaseContextProps {
     formData: T,
     componentHandler: (payload: T) => Promise<void>,
   ) => Promise<void>
+  LoadingIndicator: LoadingIndicatorContextProps['LoadingIndicator']
 }
 
 export const BaseContext = createContext<BaseContextProps | undefined>(undefined)

--- a/src/components/Payroll/PayrollList/PayrollList.tsx
+++ b/src/components/Payroll/PayrollList/PayrollList.tsx
@@ -1,5 +1,6 @@
 import { usePayrollsListSuspense } from '@gusto/embedded-api/react-query/payrollsList'
 import { usePaySchedulesGetAllSuspense } from '@gusto/embedded-api/react-query/paySchedulesGetAll'
+import { ProcessingStatuses } from '@gusto/embedded-api/models/operations/getv1companiescompanyidpayrolls'
 import { PayrollListPresentation } from './PayrollListPresentation'
 import type { BaseComponentInterface } from '@/components/Base'
 import { BaseComponent } from '@/components/Base'
@@ -12,6 +13,7 @@ interface PayrollListBlockProps extends BaseComponentInterface {
 export const PayrollList = ({ companyId, onEvent }: PayrollListBlockProps) => {
   const { data: payrollsData } = usePayrollsListSuspense({
     companyId,
+    processingStatuses: [ProcessingStatuses.Unprocessed],
   })
   const payrollList = payrollsData.payrollList!
   const { data: paySchedulesData } = usePaySchedulesGetAllSuspense({


### PR DESCRIPTION
This updates the PayrollConfiguration component to use the prepare payroll endpoint instead of the get single payroll endpoint. This is because when we are editing payroll, we need to use the prepare endpoint first since the pay has not been calculated, see slack thread here: https://gustohq.slack.com/archives/C0327091JD8/p1757026541659839

This also updates the payroll list to only fetch unprocessed payrolls since we are currently working on the edit view.

Note that the gross pay has not been calculated when we use the prepare endpoint. This means that the gross pay is displaying as 0 for now. There is a separate ticket for this here https://gustohq.atlassian.net/browse/GWS-5505

## Proof of functionality

https://github.com/user-attachments/assets/004055bc-ed06-41a5-aa39-af5eb2d8387a

