### PR TITLE
chore: updates from npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13281,9 +13281,9 @@
       "peer": true
     },
     "node_modules/koa": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
-      "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.2.tgz",
+      "integrity": "sha512-+CCssgnrWKx9aI3OeZwroa/ckG4JICxvIFnSiOUyl2Uv+UTI+xIw0FfFrWS7cQFpoePpr9o8csss7KzsTzNL8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
While checking for issues from yesterdays chalk(ish) securit issue, I found this in our `npm audit` that could easily be fixed. 