### PR TITLE
feat: update edit employee to receive actual data

### DIFF
--- a/src/components/Payroll/PayrollConfiguration/PayrollConfiguration.tsx
+++ b/src/components/Payroll/PayrollConfiguration/PayrollConfiguration.tsx
@@ -1,12 +1,10 @@
 import { useState, useEffect } from 'react'
 import { useEmployeesListSuspense } from '@gusto/embedded-api/react-query/employeesList'
-import { usePayrollsPrepareMutation } from '@gusto/embedded-api/react-query/payrollsPrepare'
 import { usePayrollsGetSuspense } from '@gusto/embedded-api/react-query/payrollsGet'
 import { usePayrollsCalculateMutation } from '@gusto/embedded-api/react-query/payrollsCalculate'
-import { usePaySchedulesGet } from '@gusto/embedded-api/react-query/paySchedulesGet'
 import type { Employee } from '@gusto/embedded-api/models/components/employee'
-import type { PayrollPrepared } from '@gusto/embedded-api/models/components/payrollprepared'
 import { PayrollProcessingRequestStatus } from '@gusto/embedded-api/models/components/payrollprocessingrequest'
+import { usePreparedPayrollData } from '../usePreparedPayrollData'
 import { PayrollEditEmployee } from '../PayrollEditEmployee/PayrollEditEmployee'
 import { PayrollConfigurationPresentation } from './PayrollConfigurationPresentation'
 import type { BaseComponentInterface } from '@/components/Base/Base'
@@ -48,35 +46,17 @@ export const Root = ({ onEvent, companyId, payrollId, dictionary }: PayrollConfi
     companyId,
   })
 
-  const { mutateAsync: preparePayroll, isPending: isPreparePayrollPending } =
-    usePayrollsPrepareMutation()
   const { mutateAsync: calculatePayroll } = usePayrollsCalculateMutation()
-  const [preparedPayroll, setPreparedPayroll] = useState<PayrollPrepared | undefined>()
   const [editedEmployeeId, setEditedEmployeeId] = useState<string | undefined>(undefined)
 
-  const { data: payScheduleData } = usePaySchedulesGet(
-    {
-      companyId,
-      payScheduleId: preparedPayroll?.payPeriod?.payScheduleUuid || '',
-    },
-    {
-      enabled: Boolean(preparedPayroll?.payPeriod?.payScheduleUuid),
-    },
-  )
-
-  useEffect(() => {
-    const handlePreparePayroll = async () => {
-      const result = await preparePayroll({
-        request: {
-          companyId,
-          payrollId,
-        },
-      })
-      setPreparedPayroll(result.payrollPrepared)
-    }
-
-    void handlePreparePayroll()
-  }, [companyId, payrollId, preparePayroll])
+  const {
+    preparedPayroll,
+    paySchedule,
+    isLoading: isPreparedPayrollDataLoading,
+  } = usePreparedPayrollData({
+    companyId,
+    payrollId,
+  })
 
   const onBack = () => {
     onEvent(componentEvents.RUN_PAYROLL_BACK)
@@ -95,9 +75,13 @@ export const Root = ({ onEvent, companyId, payrollId, dictionary }: PayrollConfi
   }
 
   const wrappedOnEvent: OnEventType<string, unknown> = (event, payload) => {
-    if (event === componentEvents.RUN_PAYROLL_EMPLOYEE_SAVED) {
+    if (
+      event === componentEvents.RUN_PAYROLL_EMPLOYEE_SAVED ||
+      event === componentEvents.RUN_PAYROLL_EMPLOYEE_CANCELLED
+    ) {
       setEditedEmployeeId(undefined)
     }
+
     onEvent(event as EventType, payload)
   }
 
@@ -114,13 +98,22 @@ export const Root = ({ onEvent, companyId, payrollId, dictionary }: PayrollConfi
     }
   }, [isCalculated, onEvent])
 
-  if (isPreparePayrollPending || isCalculating) {
+  if (isPreparedPayrollDataLoading || isCalculating) {
     return <LoadingIndicator />
   }
 
-  return editedEmployeeId ? (
-    <PayrollEditEmployee onEvent={wrappedOnEvent} employeeId={editedEmployeeId} />
-  ) : (
+  if (editedEmployeeId) {
+    return (
+      <PayrollEditEmployee
+        onEvent={wrappedOnEvent}
+        employeeId={editedEmployeeId}
+        companyId={companyId}
+        payrollId={payrollId}
+      />
+    )
+  }
+
+  return (
     <PayrollConfigurationPresentation
       onBack={onBack}
       onCalculatePayroll={onCalculatePayroll}
@@ -128,7 +121,7 @@ export const Root = ({ onEvent, companyId, payrollId, dictionary }: PayrollConfi
       employeeCompensations={preparedPayroll?.employeeCompensations || []}
       employeeDetails={employeeData.showEmployees || []}
       payPeriod={preparedPayroll?.payPeriod}
-      paySchedule={payScheduleData?.payScheduleObject}
+      paySchedule={paySchedule}
       isOffCycle={preparedPayroll?.offCycle}
     />
   )

--- a/src/components/Payroll/PayrollConfiguration/PayrollConfigurationPresentation.tsx
+++ b/src/components/Payroll/PayrollConfiguration/PayrollConfigurationPresentation.tsx
@@ -4,6 +4,7 @@ import type { PayrollPayPeriodType } from '@gusto/embedded-api/models/components
 import type { PayScheduleObject } from '@gusto/embedded-api/models/components/payscheduleobject'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
+import type { PayrollEmployeeCompensationsType } from '@gusto/embedded-api/models/components/payrollemployeecompensationstype'
 import {
   useFormatEmployeePayRate,
   getRegularHours,
@@ -163,7 +164,7 @@ export const PayrollConfigurationPresentation = ({
           },
           {
             title: <Text weight="semibold">{t('tableColumns.totalPay')}</Text>,
-            render: (item: EmployeeCompensations) => {
+            render: (item: PayrollEmployeeCompensationsType) => {
               const employee = employeeMap.get(item.employeeUuid || '')
               const calculatedGrossPay = employee
                 ? calculateGrossPay(item, employee, payPeriod?.startDate, paySchedule, isOffCycle)

--- a/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployee.stories.tsx
+++ b/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployee.stories.tsx
@@ -1,10 +1,109 @@
 import { action } from '@ladle/react'
+import type { Employee } from '@gusto/embedded-api/models/components/employee'
+import type { PayrollEmployeeCompensationsType } from '@gusto/embedded-api/models/components/payrollemployeecompensationstype'
 import { PayrollEditEmployeePresentation } from './PayrollEditEmployeePresentation'
 
 export default {
   title: 'Domain/Payroll/PayrollEditEmployee',
 }
 
-export const PayrollEditEmployeeStory = () => {
-  return <PayrollEditEmployeePresentation onDone={action('done')} />
+const mockEmployee: Employee = {
+  uuid: 'test-employee-uuid',
+  firstName: 'John',
+  lastName: 'Doe',
+  email: 'john.doe@example.com',
+  companyUuid: 'test-company-uuid',
+  managerUuid: null,
+  version: 'test-version',
+  currentEmploymentStatus: 'full_time',
+  onboardingStatus: 'onboarding_completed',
+  preferredFirstName: null,
+  departmentUuid: 'test-department-uuid',
+  employeeCode: 'JD001',
+  paymentMethod: 'Direct Deposit',
+  department: 'Engineering',
+  terminated: false,
+  twoPercentShareholder: false,
+  onboarded: true,
+  historical: false,
+  hasSsn: true,
+  onboardingDocumentsConfig: {
+    uuid: null,
+    i9Document: false,
+  },
+  jobs: [
+    {
+      uuid: 'test-job-uuid',
+      version: 'test-version',
+      employeeUuid: 'test-employee-uuid',
+      currentCompensationUuid: 'test-compensation-uuid',
+      paymentUnit: 'Hour',
+      primary: true,
+      twoPercentShareholder: false,
+      stateWcCovered: null,
+      stateWcClassCode: null,
+      title: 'Software Engineer',
+      compensations: [
+        {
+          uuid: 'test-compensation-uuid',
+          employeeUuid: 'test-employee-uuid',
+          version: 'test-version',
+          paymentUnit: 'Hour',
+          flsaStatus: 'Nonexempt',
+          adjustForMinimumWage: false,
+          minimumWages: [],
+          jobUuid: 'test-job-uuid',
+          effectiveDate: '2025-01-01',
+          rate: '22.00',
+        },
+      ],
+      rate: '22.00',
+      hireDate: '2024-01-01',
+    },
+  ],
+  eligiblePaidTimeOff: [],
+  terminations: [],
+  garnishments: [],
+  dateOfBirth: '1990-01-01',
+  ssn: '123-45-6789',
+}
+
+const mockEmployeeCompensation: PayrollEmployeeCompensationsType = {
+  excluded: false,
+  employeeUuid: 'test-employee-uuid',
+  hourlyCompensations: [
+    {
+      name: 'Regular Hours',
+      hours: '40.000',
+      flsaStatus: 'Nonexempt',
+      jobUuid: 'test-job-uuid',
+      amount: '880.0',
+      compensationMultiplier: 1.0,
+    },
+  ],
+  paidTimeOff: [
+    {
+      name: 'Vacation Hours',
+      hours: '8.0',
+    },
+  ],
+  grossPay: 880.0,
+  fixedCompensations: [],
+  paymentMethod: 'Direct Deposit',
+  memo: null,
+  version: 'v1',
+  netPay: 767.99,
+  checkAmount: 767.99,
+}
+
+export const Default = () => {
+  return (
+    <PayrollEditEmployeePresentation
+      onSave={action('save')}
+      onCancel={action('cancel')}
+      employee={mockEmployee}
+      employeeCompensation={mockEmployeeCompensation}
+      grossPay={880.0}
+    />
+  )
 }

--- a/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployee.tsx
+++ b/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployee.tsx
@@ -1,36 +1,88 @@
+import { useEmployeesGetSuspense } from '@gusto/embedded-api/react-query/employeesGet'
+import { calculateGrossPay } from '../helpers'
+import { usePreparedPayrollData } from '../usePreparedPayrollData'
 import { PayrollEditEmployeePresentation } from './PayrollEditEmployeePresentation'
 import { componentEvents } from '@/shared/constants'
 import type { BaseComponentInterface } from '@/components/Base/Base'
 import { BaseComponent } from '@/components/Base/Base'
-
-//TODO: Use Speakeasy type
-interface Employee {
-  employeeId: string
-}
+import { useComponentDictionary } from '@/i18n'
+import { useBase } from '@/components/Base/useBase'
 
 // TODO: Replace this hook with call to Speakeasy instead
-const useEditEmployeeApi = ({ employeeId }: Employee) => {
+const useEditEmployeeApi = ({ employeeId }: { employeeId: string }) => {
   const mutate = async () => {}
   return { mutate }
 }
 
-interface PayrollEditEmployeeProps extends BaseComponentInterface {
+interface PayrollEditEmployeeProps extends BaseComponentInterface<'Payroll.PayrollEditEmployee'> {
   employeeId: string
+  companyId: string
+  payrollId: string
 }
 
-export const PayrollEditEmployee = ({
+export function PayrollEditEmployee(props: PayrollEditEmployeeProps & BaseComponentInterface) {
+  return (
+    <BaseComponent {...props}>
+      <Root {...props}>{props.children}</Root>
+    </BaseComponent>
+  )
+}
+
+export const Root = ({
   employeeId,
+  companyId,
+  payrollId,
   onEvent,
-  ...baseProps
+  dictionary,
 }: PayrollEditEmployeeProps) => {
+  useComponentDictionary('Payroll.PayrollEditEmployee', dictionary)
+
+  const { LoadingIndicator } = useBase()
+
+  const { data: employeeData } = useEmployeesGetSuspense({ employeeId })
+  const { preparedPayroll, paySchedule, isLoading } = usePreparedPayrollData({
+    companyId,
+    payrollId,
+  })
+
   const { mutate } = useEditEmployeeApi({ employeeId })
-  const onDone = async () => {
+
+  const employee = employeeData.employee!
+
+  const employeeCompensation = preparedPayroll?.employeeCompensations?.find(
+    compensation => compensation.employeeUuid === employeeId,
+  )
+
+  const onSave = async () => {
     await mutate()
     onEvent(componentEvents.RUN_PAYROLL_EMPLOYEE_SAVED)
   }
+
+  const onCancel = () => {
+    onEvent(componentEvents.RUN_PAYROLL_EMPLOYEE_CANCELLED)
+  }
+
+  if (isLoading) {
+    return <LoadingIndicator />
+  }
+
   return (
-    <BaseComponent {...baseProps} onEvent={onEvent}>
-      <PayrollEditEmployeePresentation onDone={onDone} />
-    </BaseComponent>
+    <PayrollEditEmployeePresentation
+      onSave={onSave}
+      onCancel={onCancel}
+      employee={employee}
+      grossPay={
+        employeeCompensation
+          ? calculateGrossPay(
+              employeeCompensation,
+              employee,
+              preparedPayroll?.payPeriod?.startDate,
+              paySchedule,
+              preparedPayroll?.offCycle,
+            )
+          : 0
+      }
+      employeeCompensation={employeeCompensation}
+    />
   )
 }

--- a/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.tsx
+++ b/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.tsx
@@ -1,34 +1,94 @@
 import { FormProvider, useForm } from 'react-hook-form'
+import type { Employee } from '@gusto/embedded-api/models/components/employee'
 import { useTranslation } from 'react-i18next'
-import { Flex, NumberInputField } from '@/components/Common'
+import type { PayrollEmployeeCompensationsType } from '@gusto/embedded-api/models/components/payrollemployeecompensationstype'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Flex, Grid, NumberInputField } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
 import { Form } from '@/components/Common/Form'
+import { formatNumberAsCurrency } from '@/helpers/formattedStrings'
 
 interface PayrollEditEmployeeProps {
-  onDone: () => void
+  onSave: () => void
+  onCancel: () => void
+  employee: Employee
+  employeeCompensation?: PayrollEmployeeCompensationsType
+  grossPay: number
 }
 
-export const PayrollEditEmployeePresentation = ({ onDone }: PayrollEditEmployeeProps) => {
+export const PayrollEditEmployeeFormSchema = z.object({
+  hours: z.number(),
+  overtime: z.number(),
+  doubleOvertime: z.number(),
+})
+
+export type PayrollEditEmployeeFormValues = z.infer<typeof PayrollEditEmployeeFormSchema>
+
+export const PayrollEditEmployeePresentation = ({
+  onSave,
+  onCancel,
+  employee,
+  grossPay,
+  employeeCompensation,
+}: PayrollEditEmployeeProps) => {
   const { Button, Heading, Text } = useComponentContext()
-  useI18n('Payroll.PayrollEditEmployee')
+
   const { t } = useTranslation('Payroll.PayrollEditEmployee')
-  const formHandlers = useForm()
+  useI18n('Payroll.PayrollEditEmployee')
+
+  const formHandlers = useForm<PayrollEditEmployeeFormValues>({
+    resolver: zodResolver(PayrollEditEmployeeFormSchema),
+  })
+
+  const employeeName = `${employee.firstName} ${employee.lastName}`
+
   return (
     <Flex flexDirection="column" gap={20}>
-      <Heading as="h2">{t('pageTitle', { employeeName: 'Hannah Arendt' })}</Heading>
-      <Heading as="h1">$1,173.08</Heading>
-      <Text>{t('labels.grossPay')}</Text>
-      <Heading as="h3">{t('labels.regularHours')}</Heading>
+      <Flex justifyContent="space-between">
+        <Flex flexDirection="column" gap={8}>
+          <Heading as="h2">{t('pageTitle', { employeeName })}</Heading>
+          <Heading as="h1">{formatNumberAsCurrency(grossPay || 0)}</Heading>
+          <Text>{t('grossPayLabel')}</Text>
+        </Flex>
+        <Flex gap={12} justifyContent="flex-end">
+          <Button variant="secondary" onClick={onCancel} title={t('cancelButton')}>
+            {t('cancelButton')}
+          </Button>
+          <Button onClick={onSave} title={t('saveButton')}>
+            {t('saveButton')}
+          </Button>
+        </Flex>
+      </Flex>
+      <Heading as="h3">{t('regularHoursTitle')}</Heading>
       <FormProvider {...formHandlers}>
         <Form>
-          <NumberInputField defaultValue={40} isRequired label={t('labels.hours')} name="hours" />
+          <Grid gridTemplateColumns={{ base: '1fr', small: [320, 320] }} gap={20}>
+            <NumberInputField
+              defaultValue={40}
+              isRequired
+              label={t('hoursUnit')}
+              name="hours"
+              adornmentEnd={t('hoursUnit')}
+            />
+            <NumberInputField
+              defaultValue={0}
+              isRequired
+              label={t('overtimeLabel')}
+              name="overtime"
+              adornmentEnd={t('hoursUnit')}
+            />
+            <NumberInputField
+              defaultValue={0}
+              isRequired
+              label={t('doubleOvertimeLabel')}
+              name="doubleOvertime"
+              adornmentEnd={t('hoursUnit')}
+            />
+          </Grid>
         </Form>
       </FormProvider>
-
-      <Button onClick={onDone} title={t('buttons.doneTitle')}>
-        {t('buttons.done')}
-      </Button>
     </Flex>
   )
 }

--- a/src/components/Payroll/helpers.ts
+++ b/src/components/Payroll/helpers.ts
@@ -1,17 +1,20 @@
 import type { Employee } from '@gusto/embedded-api/models/components/employee'
-import type {
-  EmployeeCompensations,
-  PayrollShowFixedCompensations,
-} from '@gusto/embedded-api/models/components/payrollshow'
+import type { PayrollShowFixedCompensations } from '@gusto/embedded-api/models/components/payrollshow'
 import { useCallback } from 'react'
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import type { PayScheduleObject } from '@gusto/embedded-api/models/components/payscheduleobject'
 import type { Compensation, MinimumWages } from '@gusto/embedded-api/models/components/compensation'
+import type { PayrollEmployeeCompensationsType } from '@gusto/embedded-api/models/components/payrollemployeecompensationstype'
 import { formatPayRate } from '@/helpers/formattedStrings'
 import { useLocale } from '@/contexts/LocaleProvider/useLocale'
 
 const REGULAR_HOURS_NAME = 'regular hours'
+
+// Utility to get the primary job from an employee
+export const getPrimaryJob = (employee: Employee) => {
+  return employee.jobs?.find(job => job.primary) || employee.jobs?.[0] || null
+}
 
 const roundToSixDecimals = (value: number): number => {
   return Math.round(value * 1_000_000) / 1_000_000
@@ -49,7 +52,7 @@ export const formatEmployeePayRate = ({
     return null
   }
 
-  const primaryJob = employee.jobs.find(job => job.primary) || employee.jobs[0]
+  const primaryJob = getPrimaryJob(employee)
   if (!primaryJob?.compensations) {
     return null
   }
@@ -85,7 +88,7 @@ export const getEmployeePayRateInfo = (employee: Employee | undefined) => {
     return null
   }
 
-  const primaryJob = employee.jobs.find(job => job.primary) || employee.jobs[0]
+  const primaryJob = getPrimaryJob(employee)
   if (!primaryJob?.compensations) {
     return null
   }
@@ -104,7 +107,7 @@ export const getEmployeePayRateInfo = (employee: Employee | undefined) => {
   return { rate, paymentUnit }
 }
 
-export const getRegularHours = (compensation: EmployeeCompensations) => {
+export const getRegularHours = (compensation: PayrollEmployeeCompensationsType) => {
   if (!compensation.hourlyCompensations) return 0
 
   return compensation.hourlyCompensations
@@ -112,14 +115,14 @@ export const getRegularHours = (compensation: EmployeeCompensations) => {
     .reduce((sum, hourlyCompensation) => sum + parseFloat(hourlyCompensation.hours || '0'), 0)
 }
 
-export const getTotalPtoHours = (compensation: EmployeeCompensations) => {
+export const getTotalPtoHours = (compensation: PayrollEmployeeCompensationsType) => {
   if (!compensation.paidTimeOff) {
     return 0
   }
   return compensation.paidTimeOff.reduce((sum, pto) => sum + parseFloat(pto.hours || '0'), 0)
 }
 
-export const getAdditionalEarnings = (compensation: EmployeeCompensations) => {
+export const getAdditionalEarnings = (compensation: PayrollEmployeeCompensationsType) => {
   if (!compensation.fixedCompensations) {
     return 0
   }
@@ -133,7 +136,7 @@ export const getAdditionalEarnings = (compensation: EmployeeCompensations) => {
     .reduce((sum, fixedCompensation) => sum + parseFloat(fixedCompensation.amount || '0'), 0)
 }
 
-export const getReimbursements = (compensation: EmployeeCompensations) => {
+export const getReimbursements = (compensation: PayrollEmployeeCompensationsType) => {
   if (!compensation.fixedCompensations) {
     return 0
   }
@@ -255,7 +258,7 @@ const getHourlyRateForJob = (employee: Employee, jobUuid: string, effectiveDate:
 }
 
 const getPrimaryHourlyRate = (employee: Employee, effectiveDate: Date): number => {
-  const primaryJob = employee.jobs?.find(job => job.primary) || employee.jobs?.[0]
+  const primaryJob = getPrimaryJob(employee)
   if (!primaryJob?.compensations) {
     return 0
   }
@@ -264,7 +267,7 @@ const getPrimaryHourlyRate = (employee: Employee, effectiveDate: Date): number =
   return compensation ? calculateHourlyRate(compensation) : 0
 }
 
-const getTotalOutstandingPtoHours = (compensation: EmployeeCompensations): number => {
+const getTotalOutstandingPtoHours = (compensation: PayrollEmployeeCompensationsType): number => {
   if (!compensation.paidTimeOff) {
     return 0
   }
@@ -276,7 +279,7 @@ const getTotalOutstandingPtoHours = (compensation: EmployeeCompensations): numbe
 }
 
 const getPtoHours = (
-  compensation: EmployeeCompensations,
+  compensation: PayrollEmployeeCompensationsType,
   isSalariedWithExpectedHours: boolean,
   hoursInPayPeriod: number,
   offCycle: boolean,
@@ -297,7 +300,7 @@ const getPtoHours = (
 
 const calculateMinimumWageAdjustment = (
   primaryCompensation: Compensation,
-  compensation: EmployeeCompensations,
+  compensation: PayrollEmployeeCompensationsType,
   effectiveDate: Date,
 ): number => {
   if (!primaryCompensation.adjustForMinimumWage) return 0
@@ -325,7 +328,7 @@ const calculateMinimumWageAdjustment = (
 }
 
 const calculateRegularPlusOvertimePay = (
-  compensation: EmployeeCompensations,
+  compensation: PayrollEmployeeCompensationsType,
   employee: Employee,
   effectiveDate: Date,
   isSalariedWithExpectedHours: boolean,
@@ -369,7 +372,7 @@ const calculateRegularPlusOvertimePay = (
 }
 
 const calculatePtoPay = (
-  compensation: EmployeeCompensations,
+  compensation: PayrollEmployeeCompensationsType,
   employee: Employee,
   effectiveDate: Date,
   isSalariedWithExpectedHours: boolean,
@@ -387,7 +390,7 @@ const calculatePtoPay = (
 }
 
 const isSalariedWithPayPeriodExpectedHours = (
-  compensation: EmployeeCompensations,
+  compensation: PayrollEmployeeCompensationsType,
   isSalaried: boolean,
   hoursInPayPeriod: number,
 ): boolean => {
@@ -404,7 +407,7 @@ const isSalariedWithPayPeriodExpectedHours = (
 }
 
 export const calculateGrossPay = (
-  compensation: EmployeeCompensations,
+  compensation: PayrollEmployeeCompensationsType,
   employee: Employee,
   compensationEffectiveDateString?: string,
   paySchedule?: PayScheduleObject,
@@ -418,7 +421,7 @@ export const calculateGrossPay = (
     ? new Date(compensationEffectiveDateString)
     : new Date()
 
-  const primaryJob = employee.jobs?.find(job => job.primary) || employee.jobs?.[0]
+  const primaryJob = getPrimaryJob(employee)
   if (!primaryJob?.compensations) {
     return 0
   }

--- a/src/components/Payroll/usePreparedPayrollData.ts
+++ b/src/components/Payroll/usePreparedPayrollData.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react'
+import { usePayrollsPrepareMutation } from '@gusto/embedded-api/react-query/payrollsPrepare'
+import { usePaySchedulesGet } from '@gusto/embedded-api/react-query/paySchedulesGet'
+import type { PayrollPrepared } from '@gusto/embedded-api/models/components/payrollprepared'
+import type { PayScheduleObject } from '@gusto/embedded-api/models/components/payscheduleobject'
+
+interface UsePreparedPayrollDataParams {
+  companyId: string
+  payrollId: string
+}
+
+interface UsePreparedPayrollDataReturn {
+  preparedPayroll: PayrollPrepared | undefined
+  paySchedule: PayScheduleObject | undefined
+  isLoading: boolean
+}
+
+export const usePreparedPayrollData = ({
+  companyId,
+  payrollId,
+}: UsePreparedPayrollDataParams): UsePreparedPayrollDataReturn => {
+  const { mutateAsync: preparePayroll, isPending: isPreparePayrollPending } =
+    usePayrollsPrepareMutation()
+  const [preparedPayroll, setPreparedPayroll] = useState<PayrollPrepared | undefined>()
+
+  const { data: payScheduleData, isLoading: isPayScheduleLoading } = usePaySchedulesGet(
+    {
+      companyId,
+      payScheduleId: preparedPayroll?.payPeriod?.payScheduleUuid || '',
+    },
+    {
+      enabled: Boolean(preparedPayroll?.payPeriod?.payScheduleUuid),
+    },
+  )
+
+  useEffect(() => {
+    const handlePreparePayroll = async () => {
+      const result = await preparePayroll({
+        request: {
+          companyId,
+          payrollId,
+        },
+      })
+      setPreparedPayroll(result.payrollPrepared)
+    }
+
+    void handlePreparePayroll()
+  }, [companyId, payrollId, preparePayroll])
+
+  const isLoading = isPreparePayrollPending || isPayScheduleLoading
+
+  return {
+    preparedPayroll,
+    paySchedule: payScheduleData?.payScheduleObject,
+    isLoading,
+  }
+}

--- a/src/i18n/en/Payroll.PayrollEditEmployee.json
+++ b/src/i18n/en/Payroll.PayrollEditEmployee.json
@@ -1,12 +1,11 @@
 {
   "pageTitle": "Edit {{employeeName}}'s payroll",
-  "labels": {
-    "grossPay": "Gross pay",
-    "regularHours": "Regular hours",
-    "hours": "Hours"
-  },
-  "buttons": {
-    "done": "Done",
-    "doneTitle": "Done"
-  }
+  "grossPayLabel": "Gross pay (excluding reimbursements)",
+  "regularHoursTitle": "Regular hours",
+  "regularHoursLabel": "Regular hours",
+  "overtimeLabel": "Overtime",
+  "doubleOvertimeLabel": "Double overtime",
+  "hoursUnit": "hrs",
+  "saveButton": "Save",
+  "cancelButton": "Cancel"
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -124,6 +124,7 @@ export const runPayrollEvents = {
   RUN_PAYROLL_EDITED: 'runPayroll/edited',
   RUN_PAYROLL_EMPLOYEE_EDITED: 'runPayroll/employee/edited',
   RUN_PAYROLL_EMPLOYEE_SAVED: 'runPayroll/employee/saved',
+  RUN_PAYROLL_EMPLOYEE_CANCELLED: 'runPayroll/employee/cancelled',
   RUN_PAYROLL_SELECTED: 'runPayroll/selected',
   RUN_PAYROLL_SUBMITTED: 'runPayroll/submitted',
 } as const

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -956,15 +956,14 @@ export interface PayrollPayrollConfiguration{
 };
 export interface PayrollPayrollEditEmployee{
 "pageTitle":string;
-"labels":{
-"grossPay":string;
-"regularHours":string;
-"hours":string;
-};
-"buttons":{
-"done":string;
-"doneTitle":string;
-};
+"grossPayLabel":string;
+"regularHoursTitle":string;
+"regularHoursLabel":string;
+"overtimeLabel":string;
+"doubleOvertimeLabel":string;
+"hoursUnit":string;
+"saveButton":string;
+"cancelButton":string;
 };
 export interface PayrollPayrollHistoryList{
 "period":string;


### PR DESCRIPTION
This is the first step implementing the edit employee functionality. It
* Centralizes the prepare endpoint functionality so that the edit employee component can access it independently while keeping the api simple (only uses ids)
* Retrieves all data needed to start populating the inputs

Follow up PRs will introduce the form functionality

## Proof of functionality

https://github.com/user-attachments/assets/7200cd5e-691e-4d92-bc7d-66befa99643f
