### PR TITLE
chore: add auto-labeling workflow for PRs

### DIFF
--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -105,52 +105,52 @@ jobs:
           COMMIT_MESSAGES="${{ steps.commit-messages.outputs.messages }}"
 
           # feat: new features
-          if echo "$COMMIT_MESSAGES" | grep -qE "^feat(\(.+\))?:"; then
+          if echo "$COMMIT_MESSAGES" | grep -qE '(^|\n)feat(\(.+\))?:'; then
             LABELS+=("feat")
           fi
 
           # fix: bug fixes
-          if echo "$COMMIT_MESSAGES" | grep -qE "^fix(\(.+\))?:"; then
+          if echo "$COMMIT_MESSAGES" | grep -qE '(^|\n)fix(\(.+\))?:'; then
             LABELS+=("fix")
           fi
 
           # docs: documentation
-          if echo "$COMMIT_MESSAGES" | grep -qE "^docs(\(.+\))?:"; then
+          if echo "$COMMIT_MESSAGES" | grep -qE '(^|\n)docs(\(.+\))?:'; then
             LABELS+=("docs")
           fi
 
           # chore: maintenance
-          if echo "$COMMIT_MESSAGES" | grep -qE "^chore(\(.+\))?:"; then
+          if echo "$COMMIT_MESSAGES" | grep -qE '(^|\n)chore(\(.+\))?:'; then
             LABELS+=("chore")
           fi
 
           # style: code style changes
-          if echo "$COMMIT_MESSAGES" | grep -qE "^style(\(.+\))?:"; then
+          if echo "$COMMIT_MESSAGES" | grep -qE '(^|\n)style(\(.+\))?:'; then
             LABELS+=("style")
           fi
 
           # refactor: code refactoring
-          if echo "$COMMIT_MESSAGES" | grep -qE "^refactor(\(.+\))?:"; then
+          if echo "$COMMIT_MESSAGES" | grep -qE '(^|\n)refactor(\(.+\))?:'; then
             LABELS+=("refactor")
           fi
 
           # perf: performance improvements
-          if echo "$COMMIT_MESSAGES" | grep -qE "^perf(\(.+\))?:"; then
+          if echo "$COMMIT_MESSAGES" | grep -qE '(^|\n)perf(\(.+\))?:'; then
             LABELS+=("perf")
           fi
 
           # test: testing
-          if echo "$COMMIT_MESSAGES" | grep -qE "^test(\(.+\))?:"; then
+          if echo "$COMMIT_MESSAGES" | grep -qE '(^|\n)test(\(.+\))?:'; then
             LABELS+=("test")
           fi
 
-          # build: build system changes
-          if echo "$COMMIT_MESSAGES" | grep -qE "^build(\(.+\))?:"; then
+          # build: build system changes (commit message)
+          if echo "$COMMIT_MESSAGES" | grep -qE '(^|\n)build(\(.+\))?:'; then
             LABELS+=("build")
           fi
 
           # ci: CI/CD changes
-          if echo "$COMMIT_MESSAGES" | grep -qE "^ci(\(.+\))?:"; then
+          if echo "$COMMIT_MESSAGES" | grep -qE '(^|\n)ci(\(.+\))?:'; then
             LABELS+=("ci")
           fi
 


### PR DESCRIPTION
## 🏷️ Auto-Label PRs Based on Changed Files

I've been noticing that Dependabot automatically tags all the PRs it creates, which got me thinking... based on our project structure, we could implement similar auto-tagging for all PRs depending on the files edited.

### What This Adds

This workflow automatically labels PRs based on:

**📁 Domain Labels** (based on file paths):
- `domain:payroll` - Changes in Payroll components
- `domain:company` - Company-related changes  
- `domain:employee` - Employee-related changes
- `domain:contractor` - Contractor-related changes

**🎯 Area Labels** (based on file paths):
- `common-ui` - Common/Base UI components
- `styles` - SCSS/CSS changes
- `docs` - Documentation changes
- `build` - Build/config changes

**🔄 Type Labels** (based on conventional commits):
- `feat`, `fix`, `docs`, `chore`, `style`, `refactor`, `perf`, `test`, `build`, `ci`

### Why This Helps

While it might not be something we get a ton of immediate use out of, my hope is that as we ramp other people onto this project, this makes GitHub a bit more friendly by:

- 📊 **Better filtering** - Easily find PRs by domain or change type
- 🎯 **Clearer context** - Reviewers can quickly understand the scope of changes
- 🔍 **Improved searchability** - Historical PRs become easier to find
- 🤖 **Zero maintenance** - Runs automatically, no manual tagging needed

### How It Works

The workflow triggers on PR open/sync and analyzes:
1. **Changed file paths** to determine domain and area
2. **Commit messages** to detect conventional commit types (feat:, fix:, etc.)
3. **Automatically applies** relevant labels