### PR TITLE
chore: lets lock react-aria on 1.12.1 while 1.12.2 is non functional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "dompurify": "^3.2.5",
         "i18next": "^25.5.2",
         "react-aria": "^3.43.1",
-        "react-aria-components": "^1.12.1",
+        "react-aria-components": "1.12.1",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
         "react-error-boundary": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "dompurify": "^3.2.5",
     "i18next": "^25.5.2",
     "react-aria": "^3.43.1",
-    "react-aria-components": "^1.12.1",
+    "react-aria-components": "1.12.1",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-error-boundary": "^6.0.0",


### PR DESCRIPTION
Just being a bit defensive around React-aria no longer rendering our table headers correctly