### PR TITLE
chore: upgrade embedded api to 0.6.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
-        "@gusto/embedded-api": "^0.6.10",
+        "@gusto/embedded-api": "^0.6.11",
         "@hookform/error-message": "^2.0.1",
         "@hookform/resolvers": "^5.2.2",
         "@internationalized/date": "^3.9.0",
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/@gusto/embedded-api": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/@gusto/embedded-api/-/embedded-api-0.6.10.tgz",
-      "integrity": "sha512-A6Dwlz5+jQWp0AcXMs6KTUPgQbQiXTkGjqPeQMRBcHUV6DhMtpzPYpXHkVuybjMmsYW5vMM8sY7kjUsoK5kuEw==",
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/@gusto/embedded-api/-/embedded-api-0.6.11.tgz",
+      "integrity": "sha512-0f8R5kRqtooSREK23mBq5RcXUIE/E/AvevgkP7AjDFJS22XyDLfzCqlPTsUtTZCt01xOVmn6ykQ2n+HBpHFxbQ==",
       "dependencies": {
         "zod": "^3.20.0"
       },

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@gusto/embedded-api": "^0.6.10",
+    "@gusto/embedded-api": "^0.6.11",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^5.2.2",
     "@internationalized/date": "^3.9.0",


### PR DESCRIPTION
This upgrades the embedded api to 0.6.11 to resolve zod validation errors around employee paid time off