### PR TITLE
fix: update useField to correctly handle component props

### DIFF
--- a/src/components/Common/Fields/CheckboxField/CheckboxField.tsx
+++ b/src/components/Common/Fields/CheckboxField/CheckboxField.tsx
@@ -3,7 +3,7 @@ import type { CheckboxProps } from '@/components/Common/UI/Checkbox/CheckboxType
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export interface CheckboxFieldProps
-  extends Omit<CheckboxProps, 'name' | 'value'>,
+  extends Omit<CheckboxProps, 'name' | 'value' | 'isInvalid'>,
     UseFieldProps<boolean> {}
 
 export const CheckboxField: React.FC<CheckboxFieldProps> = ({
@@ -14,6 +14,9 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
   isRequired,
   onChange,
   transform,
+  description,
+  onBlur,
+  inputRef,
   ...checkboxProps
 }: CheckboxFieldProps) => {
   const Components = useComponentContext()
@@ -25,7 +28,10 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
     isRequired,
     onChange,
     transform,
+    description,
+    onBlur,
+    inputRef,
   })
 
-  return <Components.Checkbox {...fieldProps} {...checkboxProps} />
+  return <Components.Checkbox {...checkboxProps} {...fieldProps} />
 }

--- a/src/components/Common/Fields/CheckboxGroupField/CheckboxGroupField.tsx
+++ b/src/components/Common/Fields/CheckboxGroupField/CheckboxGroupField.tsx
@@ -10,7 +10,7 @@ import {
 type GenericCheckboxGroupOption<TValue> = OptionWithGenericValue<TValue, CheckboxGroupOption>
 
 export interface CheckboxGroupFieldProps<TValue>
-  extends Omit<CheckboxGroupProps, 'value' | 'onChange' | 'options'>,
+  extends Omit<CheckboxGroupProps, 'value' | 'onChange' | 'options' | 'isInvalid'>,
     UseFieldProps<TValue[]> {
   options: GenericCheckboxGroupOption<TValue>[]
   convertValueToString?: (value: TValue) => string
@@ -25,6 +25,9 @@ export const CheckboxGroupField = <TValue = string,>({
   onChange: onChangeFromProps,
   transform,
   options,
+  description,
+  onBlur,
+  inputRef,
   convertValueToString,
   ...checkboxGroupProps
 }: CheckboxGroupFieldProps<TValue>) => {
@@ -37,6 +40,9 @@ export const CheckboxGroupField = <TValue = string,>({
     isRequired,
     onChange: onChangeFromProps,
     transform,
+    description,
+    onBlur,
+    inputRef,
   })
 
   const stringFieldProps = useStringifyGenericFieldValueArray<TValue, CheckboxGroupOption>({
@@ -46,5 +52,5 @@ export const CheckboxGroupField = <TValue = string,>({
     convertValueToString,
   })
 
-  return <Components.CheckboxGroup {...fieldProps} {...checkboxGroupProps} {...stringFieldProps} />
+  return <Components.CheckboxGroup {...checkboxGroupProps} {...fieldProps} {...stringFieldProps} />
 }

--- a/src/components/Common/Fields/ComboBoxField/ComboBoxField.tsx
+++ b/src/components/Common/Fields/ComboBoxField/ComboBoxField.tsx
@@ -9,7 +9,7 @@ import {
 type GenericComboBoxOption<TValue> = OptionWithGenericValue<TValue, ComboBoxOption>
 
 export interface ComboBoxFieldProps<TValue>
-  extends Omit<ComboBoxProps, 'name' | 'value' | 'onChange' | 'onBlur' | 'options'>,
+  extends Omit<ComboBoxProps, 'name' | 'value' | 'onChange' | 'options' | 'isInvalid'>,
     UseFieldProps<TValue> {
   options: GenericComboBoxOption<TValue>[]
   convertValueToString?: (value: TValue) => string
@@ -25,6 +25,9 @@ export const ComboBoxField = <TValue = string,>({
   transform,
   options,
   convertValueToString,
+  description,
+  onBlur,
+  inputRef,
   ...comboBoxProps
 }: ComboBoxFieldProps<TValue>) => {
   const Components = useComponentContext()
@@ -36,6 +39,9 @@ export const ComboBoxField = <TValue = string,>({
     isRequired,
     onChange: onChangeFromProps,
     transform,
+    description,
+    onBlur,
+    inputRef,
   })
 
   const stringFieldProps = useStringifyGenericFieldValue<TValue, ComboBoxOption>({

--- a/src/components/Common/Fields/DatePickerField/DatePickerField.tsx
+++ b/src/components/Common/Fields/DatePickerField/DatePickerField.tsx
@@ -5,7 +5,7 @@ import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentCon
 import { normalizeDateToLocal } from '@/helpers/dateFormatting'
 
 interface DatePickerFieldProps
-  extends Omit<DatePickerProps, 'name' | 'onChange' | 'onBlur'>,
+  extends Omit<DatePickerProps, 'name' | 'onChange' | 'isInvalid'>,
     UseFieldProps<Date | null> {}
 
 export const DatePickerField: React.FC<DatePickerFieldProps> = ({
@@ -16,6 +16,9 @@ export const DatePickerField: React.FC<DatePickerFieldProps> = ({
   isRequired,
   onChange,
   transform,
+  description,
+  onBlur,
+  inputRef,
   ...datePickerProps
 }: DatePickerFieldProps) => {
   const Components = useComponentContext()
@@ -27,6 +30,9 @@ export const DatePickerField: React.FC<DatePickerFieldProps> = ({
     isRequired,
     onChange,
     transform,
+    description,
+    onBlur,
+    inputRef,
   })
 
   /**
@@ -44,8 +50,8 @@ export const DatePickerField: React.FC<DatePickerFieldProps> = ({
 
   return (
     <Components.DatePicker
-      {...fieldProps}
       {...datePickerProps}
+      {...fieldProps}
       onChange={handleTimezoneSafeChange}
     />
   )

--- a/src/components/Common/Fields/NumberInputField/NumberInputField.tsx
+++ b/src/components/Common/Fields/NumberInputField/NumberInputField.tsx
@@ -3,7 +3,7 @@ import type { NumberInputProps } from '@/components/Common/UI/NumberInput/Number
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export interface NumberInputFieldProps
-  extends Omit<NumberInputProps, 'name' | 'value'>,
+  extends Omit<NumberInputProps, 'name' | 'value' | 'isInvalid'>,
     UseFieldProps<number> {}
 
 export const NumberInputField: React.FC<NumberInputFieldProps> = ({
@@ -14,6 +14,9 @@ export const NumberInputField: React.FC<NumberInputFieldProps> = ({
   isRequired,
   onChange,
   transform,
+  description,
+  onBlur,
+  inputRef,
   ...numberInputProps
 }: NumberInputFieldProps) => {
   const Components = useComponentContext()
@@ -35,7 +38,10 @@ export const NumberInputField: React.FC<NumberInputFieldProps> = ({
     isRequired,
     onChange,
     transform,
+    description,
+    onBlur,
+    inputRef,
   })
 
-  return <Components.NumberInput {...fieldProps} {...numberInputProps} />
+  return <Components.NumberInput {...numberInputProps} {...fieldProps} />
 }

--- a/src/components/Common/Fields/RadioGroupField/RadioGroupField.tsx
+++ b/src/components/Common/Fields/RadioGroupField/RadioGroupField.tsx
@@ -12,7 +12,7 @@ import {
 type GenericRadioGroupOption<TValue> = OptionWithGenericValue<TValue, RadioGroupOption>
 
 export interface RadioGroupFieldProps<TValue>
-  extends Omit<RadioGroupProps, 'value' | 'onChange' | 'options'>,
+  extends Omit<RadioGroupProps, 'value' | 'onChange' | 'options' | 'isInvalid'>,
     UseFieldProps<TValue> {
   options: GenericRadioGroupOption<TValue>[]
   convertValueToString?: (value: TValue) => string
@@ -28,6 +28,9 @@ export const RadioGroupField = <TValue = string,>({
   transform,
   options,
   convertValueToString,
+  description,
+  onBlur,
+  inputRef,
   ...radioGroupProps
 }: RadioGroupFieldProps<TValue>) => {
   const Components = useComponentContext()
@@ -39,6 +42,9 @@ export const RadioGroupField = <TValue = string,>({
     isRequired,
     onChange: onChangeFromProps,
     transform,
+    description,
+    onBlur,
+    inputRef,
   })
 
   const stringFieldProps = useStringifyGenericFieldValue<TValue, RadioGroupOption>({

--- a/src/components/Common/Fields/SelectField/SelectField.tsx
+++ b/src/components/Common/Fields/SelectField/SelectField.tsx
@@ -9,8 +9,8 @@ import {
 type GenericSelectOption<TValue> = OptionWithGenericValue<TValue, SelectOption>
 
 export interface SelectFieldProps<TValue>
-  extends Omit<SelectProps, 'name' | 'value' | 'onChange' | 'onBlur' | 'options'>,
-    UseFieldProps<TValue> {
+  extends Omit<SelectProps, 'name' | 'value' | 'onChange' | 'options' | 'isInvalid'>,
+    UseFieldProps<TValue, HTMLButtonElement> {
   options: GenericSelectOption<TValue>[]
   convertValueToString?: (value: TValue) => string
 }
@@ -25,10 +25,13 @@ export const SelectField = <TValue = string,>({
   transform,
   options,
   convertValueToString,
+  description,
+  onBlur,
+  inputRef,
   ...selectProps
 }: SelectFieldProps<TValue>) => {
   const Components = useComponentContext()
-  const { value, onChange, ...fieldProps } = useField<TValue>({
+  const { value, onChange, ...fieldProps } = useField<TValue, HTMLButtonElement>({
     name,
     rules,
     defaultValue,
@@ -36,6 +39,9 @@ export const SelectField = <TValue = string,>({
     isRequired,
     onChange: onChangeFromProps,
     transform,
+    description,
+    onBlur,
+    inputRef,
   })
 
   const stringFieldProps = useStringifyGenericFieldValue<TValue, SelectOption>({

--- a/src/components/Common/Fields/SwitchField/SwitchField.tsx
+++ b/src/components/Common/Fields/SwitchField/SwitchField.tsx
@@ -2,7 +2,7 @@ import { useField, type UseFieldProps } from '@/components/Common/Fields/hooks/u
 import type { SwitchProps } from '@/components/Common/UI/Switch/SwitchTypes'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 export interface SwitchFieldProps
-  extends Omit<SwitchProps, 'name' | 'checked' | 'onChange'>,
+  extends Omit<SwitchProps, 'name' | 'checked' | 'onChange' | 'isInvalid'>,
     UseFieldProps<boolean> {}
 
 export const SwitchField: React.FC<SwitchFieldProps> = ({
@@ -13,6 +13,9 @@ export const SwitchField: React.FC<SwitchFieldProps> = ({
   isRequired,
   onChange,
   transform,
+  description,
+  onBlur,
+  inputRef,
   ...switchProps
 }: SwitchFieldProps) => {
   const Components = useComponentContext()
@@ -24,7 +27,10 @@ export const SwitchField: React.FC<SwitchFieldProps> = ({
     isRequired,
     onChange,
     transform,
+    description,
+    onBlur,
+    inputRef,
   })
 
-  return <Components.Switch {...fieldProps} {...switchProps} />
+  return <Components.Switch {...switchProps} {...fieldProps} />
 }

--- a/src/components/Common/Fields/TextInputField/TextInputField.tsx
+++ b/src/components/Common/Fields/TextInputField/TextInputField.tsx
@@ -3,7 +3,7 @@ import type { TextInputProps } from '@/components/Common/UI/TextInput/TextInputT
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export interface TextInputFieldProps
-  extends Omit<TextInputProps, 'name' | 'value'>,
+  extends Omit<TextInputProps, 'name' | 'value' | 'isInvalid'>,
     UseFieldProps {}
 
 export const TextInputField: React.FC<TextInputFieldProps> = ({
@@ -14,6 +14,9 @@ export const TextInputField: React.FC<TextInputFieldProps> = ({
   isRequired,
   onChange,
   transform,
+  description,
+  onBlur,
+  inputRef,
   ...textInputProps
 }: TextInputFieldProps) => {
   const Components = useComponentContext()
@@ -25,7 +28,10 @@ export const TextInputField: React.FC<TextInputFieldProps> = ({
     isRequired,
     onChange,
     transform,
+    description,
+    onBlur,
+    inputRef,
   })
 
-  return <Components.TextInput {...fieldProps} {...textInputProps} />
+  return <Components.TextInput {...textInputProps} {...fieldProps} />
 }

--- a/src/components/Common/UI/Checkbox/CheckboxTypes.ts
+++ b/src/components/Common/UI/Checkbox/CheckboxTypes.ts
@@ -3,7 +3,7 @@ import type { SharedHorizontalFieldLayoutProps } from '@/components/Common/Horiz
 
 export interface CheckboxProps
   extends SharedHorizontalFieldLayoutProps,
-    Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id' | 'className' | 'onBlur'> {
+    Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id' | 'className'> {
   /**
    * Current checked state of the checkbox
    */
@@ -24,6 +24,10 @@ export interface CheckboxProps
    * Disables the checkbox and prevents interaction
    */
   isDisabled?: boolean
+  /**
+   * Handler for blur events
+   */
+  onBlur?: () => void
 }
 
 /**

--- a/src/components/Common/UI/ComboBox/ComboBoxTypes.ts
+++ b/src/components/Common/UI/ComboBox/ComboBoxTypes.ts
@@ -1,4 +1,4 @@
-import type { InputHTMLAttributes, Ref, FocusEvent } from 'react'
+import type { InputHTMLAttributes, Ref } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
 export interface ComboBoxOption {
@@ -34,7 +34,7 @@ export interface ComboBoxProps
   /**
    * Handler for blur events
    */
-  onBlur?: (e: FocusEvent) => void
+  onBlur?: () => void
   /**
    * Array of options to display in the dropdown
    */

--- a/src/components/Common/UI/DatePicker/DatePickerTypes.ts
+++ b/src/components/Common/UI/DatePicker/DatePickerTypes.ts
@@ -1,4 +1,4 @@
-import type { InputHTMLAttributes, Ref, FocusEvent } from 'react'
+import type { InputHTMLAttributes, Ref } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
 export interface DatePickerProps
@@ -23,7 +23,7 @@ export interface DatePickerProps
   /**
    * Handler for blur events
    */
-  onBlur?: (e: FocusEvent) => void
+  onBlur?: () => void
   /**
    * Label text for the date picker field
    */

--- a/src/components/Common/UI/NumberInput/NumberInputTypes.ts
+++ b/src/components/Common/UI/NumberInput/NumberInputTypes.ts
@@ -1,4 +1,4 @@
-import type { FocusEventHandler, InputHTMLAttributes, Ref } from 'react'
+import type { InputHTMLAttributes, Ref } from 'react'
 import type { InputProps } from '../Input/InputTypes'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
@@ -35,7 +35,7 @@ export interface NumberInputProps
   /**
    * Handler for blur events
    */
-  onBlur?: FocusEventHandler<HTMLElement>
+  onBlur?: () => void
   /**
    * Element to display at the start of the input
    */

--- a/src/components/Common/UI/Select/SelectTypes.ts
+++ b/src/components/Common/UI/Select/SelectTypes.ts
@@ -1,4 +1,4 @@
-import type { FocusEvent, Ref, SelectHTMLAttributes } from 'react'
+import type { Ref, SelectHTMLAttributes } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
 export interface SelectOption {
@@ -34,7 +34,7 @@ export interface SelectProps
   /**
    * Handler for blur events
    */
-  onBlur?: (e: FocusEvent) => void
+  onBlur?: () => void
   /**
    * Array of options to display in the select dropdown
    */

--- a/src/components/Common/UI/Switch/SwitchTypes.ts
+++ b/src/components/Common/UI/Switch/SwitchTypes.ts
@@ -1,4 +1,4 @@
-import type { FocusEvent, InputHTMLAttributes, Ref } from 'react'
+import type { InputHTMLAttributes, Ref } from 'react'
 import type { SharedHorizontalFieldLayoutProps } from '@/components/Common/HorizontalFieldLayout/HorizontalFieldLayoutTypes'
 
 export interface SwitchProps
@@ -7,7 +7,7 @@ export interface SwitchProps
   /**
    * Handler for blur events
    */
-  onBlur?: (e: FocusEvent) => void
+  onBlur?: () => void
   /**
    * Callback when switch state changes
    */

--- a/src/components/Common/UI/TextInput/TextInputTypes.ts
+++ b/src/components/Common/UI/TextInput/TextInputTypes.ts
@@ -6,7 +6,7 @@ export interface TextInputProps
   extends SharedFieldLayoutProps,
     Pick<
       InputHTMLAttributes<HTMLInputElement>,
-      'name' | 'id' | 'placeholder' | 'className' | 'type' | 'onBlur'
+      'name' | 'id' | 'placeholder' | 'className' | 'type'
     > {
   /**
    * React ref for the input element
@@ -28,6 +28,10 @@ export interface TextInputProps
    * Disables the input and prevents interaction
    */
   isDisabled?: boolean
+  /**
+   * Handler for blur events
+   */
+  onBlur?: () => void
   /**
    * Element to display at the start of the input
    */


### PR DESCRIPTION
This makes the following updates to field components
* Ensures description gets passed through to useField so it is correctly processed
* Omits `isInvalid` from component prop types so that that is completely controlled by hook form in the field components
* Updates onBlur to have no arguments for compatibility with useField and ensures onBlur gets called
* Passes onBlur and inputRef to useField so those can be correctly set from outside the component

## Proof of functionality

https://github.com/user-attachments/assets/62007163-4657-4936-a277-9d0d2197c016

