### PR TITLE
feat: add remaining payroll edit employee fields

### DIFF
--- a/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployee.stories.tsx
+++ b/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployee.stories.tsx
@@ -104,6 +104,7 @@ export const Default = () => {
       employee={mockEmployee}
       employeeCompensation={mockEmployeeCompensation}
       grossPay={880.0}
+      fixedCompensationTypes={[]}
     />
   )
 }

--- a/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployee.tsx
+++ b/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployee.tsx
@@ -106,6 +106,7 @@ export const Root = ({
           : 0
       }
       employeeCompensation={employeeCompensation}
+      fixedCompensationTypes={preparedPayroll?.fixedCompensationTypes || []}
     />
   )
 }

--- a/src/i18n/en/Payroll.PayrollEditEmployee.json
+++ b/src/i18n/en/Payroll.PayrollEditEmployee.json
@@ -13,5 +13,22 @@
   "timeOffTitle": "Time off",
   "timeOffBalance": {
     "remaining": "{{balance}} remaining"
+  },
+  "additionalEarningsTitle": "Additional earnings",
+  "reimbursementTitle": "Reimbursement",
+  "fixedCompensationNames": {
+    "bonus": "Bonus",
+    "paycheckTips": "Paycheck tips",
+    "correctionPayment": "Correction payment",
+    "commission": "Commission",
+    "cashTips": "Cash tips",
+    "reimbursement": "Reimbursement"
+  },
+  "paymentMethodTitle": "Payment",
+  "paymentMethodLabel": "Payment method",
+  "paymentMethodDescription": "Changing the default payment method will only apply to this payroll.",
+  "paymentMethodOptions": {
+    "directDeposit": "Direct deposit",
+    "check": "Check"
   }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -322,6 +322,30 @@ export const HOURS_COMPENSATION_NAMES = [
   COMPENSATION_NAME_DOUBLE_OVERTIME,
 ]
 
+export const COMPENSATION_NAME_BONUS = 'Bonus'
+export const COMPENSATION_NAME_PAYCHECK_TIPS = 'Paycheck Tips'
+export const COMPENSATION_NAME_CORRECTION_PAYMENT = 'Correction Payment'
+export const COMPENSATION_NAME_COMMISSION = 'Commission'
+export const COMPENSATION_NAME_CASH_TIPS = 'Cash Tips'
+export const COMPENSATION_NAME_REIMBURSEMENT = 'Reimbursement'
+
+export const FIXED_COMPENSATION_NAMES = [
+  COMPENSATION_NAME_BONUS,
+  COMPENSATION_NAME_PAYCHECK_TIPS,
+  COMPENSATION_NAME_CORRECTION_PAYMENT,
+  COMPENSATION_NAME_COMMISSION,
+  COMPENSATION_NAME_CASH_TIPS,
+]
+
+export const OWNERS_DRAW = "Owner's Draw"
+export const MIN_WAGE_ADJUST = 'Minimum Wage Adjustment'
+
+export const EXCLUDED_ADDITIONAL_EARNINGS = [
+  OWNERS_DRAW,
+  MIN_WAGE_ADJUST,
+  COMPENSATION_NAME_REIMBURSEMENT,
+]
+
 export const PAYROLL_PROCESSING_STATUS = {
   calculating: 'calculating',
   calculate_success: 'calculate_success',

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -978,6 +978,23 @@ export interface PayrollPayrollEditEmployee{
 "timeOffBalance":{
 "remaining":string;
 };
+"additionalEarningsTitle":string;
+"reimbursementTitle":string;
+"fixedCompensationNames":{
+"bonus":string;
+"paycheckTips":string;
+"correctionPayment":string;
+"commission":string;
+"cashTips":string;
+"reimbursement":string;
+};
+"paymentMethodTitle":string;
+"paymentMethodLabel":string;
+"paymentMethodDescription":string;
+"paymentMethodOptions":{
+"directDeposit":string;
+"check":string;
+};
 };
 export interface PayrollPayrollHistory{
 "title":string;


### PR DESCRIPTION
This PR adds the remaining fields for payroll edit employee. This includes
* Additional earnings
* Reimbursement
* Payment method

## Proof of functionality

https://github.com/user-attachments/assets/409fc7d8-48ab-4f45-bc34-08e6229cf172
