### PR TITLE
feat: implement responsive layout for edit employee payroll

### DIFF
--- a/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.module.scss
+++ b/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.module.scss
@@ -1,3 +1,22 @@
+.container {
+  position: relative;
+}
+
+.headerSection {
+  background-color: var(--g-colorBody);
+  border-bottom: 1px solid var(--g-colorBorder);
+  width: 100%;
+  padding-bottom: toRem(32);
+}
+
+.headerSectionSticky {
+  position: sticky;
+  top: 0;
+  padding-top: toRem(16);
+  padding-bottom: toRem(20);
+  z-index: 1;
+}
+
 .fieldGroup {
   padding: toRem(32) 0;
   border-top: 1px solid var(--g-colorBorder);
@@ -5,4 +24,12 @@
   display: flex;
   flex-direction: column;
   gap: toRem(32);
+
+  &:first-child {
+    border-top: none;
+  }
+}
+
+.grossPayLabel {
+  color: var(--g-colorBodySubContent);
 }

--- a/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.test.tsx
+++ b/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.test.tsx
@@ -205,19 +205,19 @@ describe('PayrollEditEmployeePresentation', () => {
     renderWithProviders(<PayrollEditEmployeePresentation {...defaultProps} />)
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument()
     })
-    expect(screen.getByText("Edit John Doe's payroll")).toBeInTheDocument()
+    expect(screen.getByText('Edit payroll for John Doe')).toBeInTheDocument()
   })
 
   it('displays gross pay correctly', async () => {
     renderWithProviders(<PayrollEditEmployeePresentation {...defaultProps} />)
 
     await waitFor(() => {
-      // Now dynamically calculated instead of hardcoded
-      expect(screen.getByText('$2,691.35')).toBeInTheDocument()
+      expect(
+        screen.getByText('Gross pay: $2,691.35 (excluding reimbursements)'),
+      ).toBeInTheDocument()
     })
-    expect(screen.getByText('Gross pay (excluding reimbursements)')).toBeInTheDocument()
   })
 
   it('renders job titles as headings', async () => {
@@ -1006,7 +1006,9 @@ describe('PayrollEditEmployeePresentation', () => {
 
       // Initial: 10 hours × $25/hour = $250.00
       await waitFor(() => {
-        expect(screen.getByText('$250.00')).toBeInTheDocument()
+        expect(
+          screen.getByText('Gross pay: $250.00 (excluding reimbursements)'),
+        ).toBeInTheDocument()
       })
 
       // Update to 8 hours: 8 × $25 = $200.00
@@ -1015,7 +1017,9 @@ describe('PayrollEditEmployeePresentation', () => {
       await user.type(regularHoursInput, '8')
 
       await waitFor(() => {
-        expect(screen.getByText('$200.00')).toBeInTheDocument()
+        expect(
+          screen.getByText('Gross pay: $200.00 (excluding reimbursements)'),
+        ).toBeInTheDocument()
       })
     })
 
@@ -1025,7 +1029,7 @@ describe('PayrollEditEmployeePresentation', () => {
       )
 
       await waitFor(() => {
-        expect(screen.getByText('$0.00')).toBeInTheDocument()
+        expect(screen.getByText('Gross pay: $0.00 (excluding reimbursements)')).toBeInTheDocument()
       })
     })
   })

--- a/src/i18n/en/Payroll.PayrollEditEmployee.json
+++ b/src/i18n/en/Payroll.PayrollEditEmployee.json
@@ -1,6 +1,7 @@
 {
-  "pageTitle": "Edit {{employeeName}}'s payroll",
+  "pageTitle": "Edit payroll for {{employeeName}}",
   "grossPayLabel": "Gross pay (excluding reimbursements)",
+  "grossPayLabelMobile": "Gross pay: {{grossPay}} (excluding reimbursements)",
   "regularHoursTitle": "Regular hours",
   "hoursUnit": "Hours",
   "saveButton": "Save",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -965,6 +965,7 @@ export interface PayrollPayrollConfiguration{
 export interface PayrollPayrollEditEmployee{
 "pageTitle":string;
 "grossPayLabel":string;
+"grossPayLabelMobile":string;
 "regularHoursTitle":string;
 "hoursUnit":string;
 "saveButton":string;


### PR DESCRIPTION
This updates to add a baseline of responsive behavior for the actions on mobile following the figma here https://www.figma.com/design/6dxOSiONDiJoa9zY1wOwbs/Frontend-SDK-Partner-Design-File?node-id=9829-20709&t=v3skgtggoFsfawSA-4

## Desktop

* Heading text and actions side by side
* Heading inline with the document

## Mobile
* Actions render inline at the bottom instead
* Header becomes sticky for visibility as you edit fields

We may need to dial this in further with design feedback, but this prevents the header from being broken on small screens in the meantime

## Proof of functionality

https://github.com/user-attachments/assets/d1ede869-7a6f-404d-a3a7-b0b2faeb52ed
