### PR TITLE
chore: bumps embedded client to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.13.4",
       "license": "MIT",
       "dependencies": {
-        "@gusto/embedded-api": "^0.7.0",
+        "@gusto/embedded-api": "^0.7.1",
         "@hookform/error-message": "^2.0.1",
         "@hookform/resolvers": "^5.2.2",
         "@internationalized/date": "^3.9.0",
@@ -1632,9 +1632,9 @@
       }
     },
     "node_modules/@gusto/embedded-api": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@gusto/embedded-api/-/embedded-api-0.7.0.tgz",
-      "integrity": "sha512-loZBVcAOwXD0ELR3fFtjbGVEgbs1l50V1lsXZwqNE6WcPtonfzLSK4S8eKKfWx3xOsWIPneO+GHtNp53jHmf/A==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@gusto/embedded-api/-/embedded-api-0.7.1.tgz",
+      "integrity": "sha512-oOa3WZuwdnyEmsjnCeV94sPynhXwDEJkZ9cRnKFDqiw3JfTAjPmnFF8WNk1HqDR/XmUchZapeQ8MJpQ4oj0veg==",
       "dependencies": {
         "zod": "^3.20.0"
       },

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@gusto/embedded-api": "^0.7.0",
+    "@gusto/embedded-api": "^0.7.1",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^5.2.2",
     "@internationalized/date": "^3.9.0",


### PR DESCRIPTION
bumps embedded client to latest to fix missing QPs in GET payrolls API

embedded api client update here: https://github.com/Gusto/gusto-typescript-client/pull/73/files#diff-cbf1b5d477bbd44560629acaaf5720ee82847350bddb3c9df236ca454e372032 

ran `npm install @gusto/embedded-api@latest`