### PR TITLE
fix: add spacing to file input wrapper for error message

### DIFF
--- a/src/components/InformationRequests/InformationRequestForm/InformationRequestForm.module.scss
+++ b/src/components/InformationRequests/InformationRequestForm/InformationRequestForm.module.scss
@@ -15,7 +15,6 @@
 .questionDescription {
   display: flex;
   flex-direction: column;
-  gap: toRem(2);
   padding: 0 toRem(16);
 }
 

--- a/src/components/InformationRequests/InformationRequestForm/InformationRequestForm.module.scss
+++ b/src/components/InformationRequests/InformationRequestForm/InformationRequestForm.module.scss
@@ -24,8 +24,7 @@
 }
 
 .fileInputWrapper {
-  margin-top: toRem(-16);
-  margin-bottom: toRem(-16);
+  padding: 0 toRem(16);
 }
 
 .divider {

--- a/src/components/InformationRequests/InformationRequestForm/InformationRequestForm.tsx
+++ b/src/components/InformationRequests/InformationRequestForm/InformationRequestForm.tsx
@@ -167,10 +167,10 @@ function Root({ companyId, requestId, dictionary }: InformationRequestFormProps)
     return (
       <div key={fieldName} className={styles.questionCard}>
         <div className={styles.questionDescription}>
-          <Text weight="medium">
+          <Text size="sm" weight="medium">
             {isDocumentType ? t('questionTypes.document') : t('questionTypes.answer')}
           </Text>
-          <Text>
+          <Text size="sm" variant="supporting">
             {/* SECURITY: XSS mitigated via DOMPurify with strict allowlist. Pattern matches TaxInputs.tsx */}
             <span
               dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Summary

Adds spacing on file input wrapper. Input error message now aligns with other request types.

## Changes

- Remove margins on file input wrapper
- Add padding

## Demo

<img width="508" height="471" alt="Screenshot 2026-04-10 at 2 53 01 PM" src="https://github.com/user-attachments/assets/57fde6d8-c0dc-4839-a242-2e803ce05ef7" />

