### PR TITLE
fix: add spacing between dl items when rendered without dividing lines

### DIFF
--- a/src/components/Common/UI/DescriptionList/DescriptionList.module.scss
+++ b/src/components/Common/UI/DescriptionList/DescriptionList.module.scss
@@ -1,6 +1,10 @@
 .root {
   width: 100%;
 
+  .item:not(:last-child) {
+    margin-bottom: toRem(16);
+  }
+
   dt {
     font-weight: var(--g-fontWeightMedium);
     color: var(--g-colorBodyContent);
@@ -17,6 +21,10 @@
     justify-content: space-between;
     align-items: baseline;
     gap: toRem(16);
+
+    &:not(:last-child) {
+      margin-bottom: toRem(16);
+    }
 
     dt {
       flex-shrink: 0;

--- a/src/components/Common/UI/DescriptionList/DescriptionList.module.scss
+++ b/src/components/Common/UI/DescriptionList/DescriptionList.module.scss
@@ -22,10 +22,6 @@
     align-items: baseline;
     gap: toRem(16);
 
-    &:not(:last-child) {
-      margin-bottom: toRem(16);
-    }
-
     dt {
       flex-shrink: 0;
     }


### PR DESCRIPTION
## Summary

Add spacing to DescriptionList items when they are rendered without dividing lines.

## Changes

Added margins to DescriptionList stylesheet.

## Demo

**After**

<img width="724" height="205" alt="Screenshot 2026-04-13 at 7 04 57 PM" src="https://github.com/user-attachments/assets/84b092d6-bf3d-41c4-b359-b7eb6638e652" />

**Before**

<img width="724" height="166" alt="Screenshot 2026-04-13 at 7 05 20 PM" src="https://github.com/user-attachments/assets/6ae90bbe-fd4b-44c1-a863-24092ee2f6b2" />


