### PR TITLE
fix: remove overriding text instances in payroll receipt data views

### DIFF
--- a/src/components/Payroll/PayrollReceipts/PayrollReceiptsPresentation.tsx
+++ b/src/components/Payroll/PayrollReceipts/PayrollReceiptsPresentation.tsx
@@ -170,23 +170,18 @@ export const PayrollReceiptsPresentation = ({
         columns={[
           {
             title: t('sections.debitedLabel'),
-            render: (item: { label: string; amount: number }) => <Text>{item.label}</Text>,
+            render: (item: { label: string; amount: number }) => item.label,
           },
           {
             title: t('breakdown.amount'),
-            render: (item: { label: string; amount: number }) => (
-              <Text>{formatNumberAsCurrency(item.amount)}</Text>
-            ),
+            render: (item: { label: string; amount: number }) =>
+              formatNumberAsCurrency(item.amount),
           },
         ]}
         data={breakdownData}
         footer={() => ({
-          'column-0': <Text weight="semibold">{t('breakdown.totals')}</Text>,
-          'column-1': (
-            <Text weight="semibold">
-              {formatNumberAsCurrency(parseFloat(receiptData.totals?.companyDebit || '0'))}
-            </Text>
-          ),
+          'column-0': t('breakdown.totals'),
+          'column-1': formatNumberAsCurrency(parseFloat(receiptData.totals?.companyDebit || '0')),
         })}
       />
     </Flex>
@@ -199,23 +194,18 @@ export const PayrollReceiptsPresentation = ({
         columns={[
           {
             title: t('sections.taxLabel'),
-            render: (tax: TaxBreakdownItem) => <Text>{tax.name}</Text>,
+            render: (tax: TaxBreakdownItem) => tax.name,
           },
           {
             title: t('tax.amount'),
-            render: (tax: TaxBreakdownItem) => (
-              <Text>{formatNumberAsCurrency(parseFloat(tax.amount || '0'))}</Text>
-            ),
+            render: (tax: TaxBreakdownItem) =>
+              formatNumberAsCurrency(parseFloat(tax.amount || '0')),
           },
         ]}
         data={receiptData.taxes || []}
         footer={() => ({
-          'column-0': <Text weight="semibold">{t('breakdown.totals')}</Text>,
-          'column-1': (
-            <Text weight="semibold">
-              {formatNumberAsCurrency(parseFloat(receiptData.totals?.taxDebit || '0'))}
-            </Text>
-          ),
+          'column-0': t('breakdown.totals'),
+          'column-1': formatNumberAsCurrency(parseFloat(receiptData.totals?.taxDebit || '0')),
         })}
       />
     </Flex>
@@ -224,30 +214,19 @@ export const PayrollReceiptsPresentation = ({
   const renderEmployeeBreakdown = () => {
     const footerValues = [
       <Flex flexDirection="column" gap={4} key="totals">
-        <Text weight="semibold">{t('breakdown.totals')}</Text>
+        {t('breakdown.totals')}
         <Text size="sm" variant="supporting">
           {t('employee.totalEmployees', {
             count: receiptData.employeeCompensations?.length || 0,
           })}
         </Text>
       </Flex>,
-      <Text key="spacer">{'\u00A0'}</Text>,
-      <Text weight="semibold" key="childSupport">
-        {formatNumberAsCurrency(getTotalChildSupport())}
-      </Text>,
-      ...(withReimbursements
-        ? [
-            <Text weight="semibold" key="reimbursements">
-              {formatNumberAsCurrency(getTotalReimbursements())}
-            </Text>,
-          ]
-        : []),
-      <Text weight="semibold" key="taxes">
-        {formatNumberAsCurrency(getTotalTaxes())}
-      </Text>,
-      <Text weight="semibold" key="netPay">
-        {formatNumberAsCurrency(getTotalNetPay())}
-      </Text>,
+      '\u00A0',
+
+      formatNumberAsCurrency(getTotalChildSupport()),
+      ...(withReimbursements ? [formatNumberAsCurrency(getTotalReimbursements())] : []),
+      formatNumberAsCurrency(getTotalTaxes()),
+      formatNumberAsCurrency(getTotalNetPay()),
     ]
 
     const footerContent = footerValues.reduce<Record<string, React.ReactNode>>(
@@ -266,47 +245,35 @@ export const PayrollReceiptsPresentation = ({
           columns={[
             {
               title: t('employee.name'),
-              render: (employee: EmployeeBreakdownItem) => (
-                <Text>{getEmployeeFullName(employee)}</Text>
-              ),
+              render: (employee: EmployeeBreakdownItem) => getEmployeeFullName(employee),
             },
             {
               title: t('employee.paymentMethod'),
-              render: (employee: EmployeeBreakdownItem) => (
-                <Text>{employee.paymentMethod || 'N/A'}</Text>
-              ),
+              render: (employee: EmployeeBreakdownItem) => employee.paymentMethod || 'N/A',
             },
             {
               title: t('employee.childSupport'),
-              render: (employee: EmployeeBreakdownItem) => (
-                <Text>
-                  {formatNumberAsCurrency(parseFloat(employee.childSupportGarnishment || '0'))}
-                </Text>
-              ),
+              render: (employee: EmployeeBreakdownItem) =>
+                formatNumberAsCurrency(parseFloat(employee.childSupportGarnishment || '0')),
             },
             ...(withReimbursements
               ? [
                   {
                     title: t('employee.reimbursement'),
-                    render: (employee: EmployeeBreakdownItem) => (
-                      <Text>
-                        {formatNumberAsCurrency(parseFloat(employee.totalReimbursement || '0'))}
-                      </Text>
-                    ),
+                    render: (employee: EmployeeBreakdownItem) =>
+                      formatNumberAsCurrency(parseFloat(employee.totalReimbursement || '0')),
                   },
                 ]
               : []),
             {
               title: t('employee.totalTaxes'),
-              render: (employee: EmployeeBreakdownItem) => (
-                <Text>{formatNumberAsCurrency(parseFloat(employee.totalTax || '0'))}</Text>
-              ),
+              render: (employee: EmployeeBreakdownItem) =>
+                formatNumberAsCurrency(parseFloat(employee.totalTax || '0')),
             },
             {
               title: t('employee.netPay'),
-              render: (employee: EmployeeBreakdownItem) => (
-                <Text>{formatNumberAsCurrency(parseFloat(employee.netPay || '0'))}</Text>
-              ),
+              render: (employee: EmployeeBreakdownItem) =>
+                formatNumberAsCurrency(parseFloat(employee.netPay || '0')),
             },
           ]}
           data={receiptData.employeeCompensations || []}


### PR DESCRIPTION
## Summary

Remove instances of Text in payroll receipts. DataViews already receive Text as general component.

## Changes

Removed Text component from DataViews in PayrollReceiptPresentation

## Demo

**After**

<img width="1126" height="611" alt="Screenshot 2026-04-13 at 7 34 22 PM" src="https://github.com/user-attachments/assets/72806ee3-1d63-4531-a388-6a8ae4894ce7" />

**Before**

<img width="1123" height="612" alt="Screenshot 2026-04-13 at 7 35 08 PM" src="https://github.com/user-attachments/assets/84d8a785-a228-440c-9352-4930e38533f2" />



