### PR TITLE
chore: add prototype-app design prototyping environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "sdk-app:local": "npx tsx sdk-app/scripts/start.ts dev --env=local",
     "sdk-app-prod": "npx tsx sdk-app/scripts/start.ts prod --env=demo",
     "sdk-app:setup": "npx tsx sdk-app/scripts/setup.ts",
-    "sdk-app:analyze-props": "npx tsx sdk-app/scripts/analyze-component-props.ts"
+    "sdk-app:analyze-props": "npx tsx sdk-app/scripts/analyze-component-props.ts",
+    "prototype-app": "vite --config prototype-app/vite.config.ts"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",

--- a/prototype-app/index.html
+++ b/prototype-app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Prototype App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/prototype-app/src/App.module.scss
+++ b/prototype-app/src/App.module.scss
@@ -1,9 +1,9 @@
 :root {
   --color-bg: #ffffff;
   --color-bg-sidebar: #f8f9fa;
-  --color-bg-topbar: #1a1a2e;
+  --color-bg-topbar: #ffffff;
   --color-text: #1a1a2e;
-  --color-text-topbar: #e0e0e0;
+  --color-text-topbar: #131313;
   --color-text-muted: #6c757d;
   --color-border: #dee2e6;
   --color-active: #0d6efd;
@@ -40,6 +40,10 @@ body {
   align-items: center;
   padding: 0.75rem 1.5rem;
   background: var(--color-bg-topbar);
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
+  position: relative;
+  z-index: 10;
 }
 
 .title {
@@ -48,8 +52,11 @@ body {
   color: var(--color-text-topbar);
   text-decoration: none;
 
-  &:hover {
-    color: #ffffff;
+  span {
+    font-weight: 400;
+    color: var(--color-text-muted);
+    margin-left: 0.25rem;
+    font-size: 1rem;
   }
 }
 

--- a/prototype-app/src/App.module.scss
+++ b/prototype-app/src/App.module.scss
@@ -1,0 +1,66 @@
+:root {
+  --color-bg: #ffffff;
+  --color-bg-sidebar: #f8f9fa;
+  --color-bg-topbar: #1a1a2e;
+  --color-text: #1a1a2e;
+  --color-text-topbar: #e0e0e0;
+  --color-text-muted: #6c757d;
+  --color-border: #dee2e6;
+  --color-active: #0d6efd;
+  --color-active-bg: #e7f1ff;
+  --color-hover-bg: #f0f0f0;
+  --color-success: #198754;
+  --color-warning: #ffc107;
+  --color-danger: #dc3545;
+  --color-badge-bg: #e9ecef;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-size: 0.875rem;
+  color: var(--color-text);
+  background: var(--color-bg);
+}
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  background: var(--color-bg-topbar);
+}
+
+.title {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--color-text-topbar);
+  text-decoration: none;
+
+  &:hover {
+    color: #ffffff;
+  }
+}
+
+.body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.main {
+  flex: 1;
+  overflow-y: auto;
+  padding: 2rem;
+}

--- a/prototype-app/src/App.tsx
+++ b/prototype-app/src/App.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import { Outlet, Link } from 'react-router-dom'
+import { Sidebar } from './Sidebar'
+import styles from './App.module.scss'
+import { GustoProvider } from '@/contexts/GustoProvider/GustoProvider'
+
+export function App() {
+  const [searchQuery, setSearchQuery] = useState('')
+
+  return (
+    <GustoProvider config={{ baseUrl: 'http://localhost:0' }}>
+      <div className={styles.layout}>
+        <nav className={styles.nav}>
+          <Link to="/" className={styles.title}>
+            Prototype App
+          </Link>
+        </nav>
+        <div className={styles.body}>
+          <Sidebar searchQuery={searchQuery} onSearchChange={setSearchQuery} />
+          <main className={styles.main}>
+            <Outlet />
+          </main>
+        </div>
+      </div>
+    </GustoProvider>
+  )
+}

--- a/prototype-app/src/App.tsx
+++ b/prototype-app/src/App.tsx
@@ -12,7 +12,7 @@ export function App() {
       <div className={styles.layout}>
         <nav className={styles.nav}>
           <Link to="/" className={styles.title}>
-            Prototype App
+            Embedded React SDK<span>/ Design</span>
           </Link>
         </nav>
         <div className={styles.body}>

--- a/prototype-app/src/Home.module.scss
+++ b/prototype-app/src/Home.module.scss
@@ -1,0 +1,76 @@
+.root {
+  max-width: toRem(768);
+  margin: 0 auto;
+
+  h1 {
+    font-size: toRem(24);
+    font-weight: 600;
+    margin-bottom: toRem(8);
+  }
+
+  h2 {
+    font-size: toRem(18);
+    font-weight: 600;
+    margin-top: toRem(32);
+    margin-bottom: toRem(12);
+  }
+
+  > p {
+    color: #6c757d;
+    line-height: 1.6;
+    margin-bottom: toRem(16);
+  }
+
+  ol {
+    padding-left: toRem(20);
+    margin-bottom: toRem(16);
+
+    li {
+      padding: toRem(6) 0;
+      line-height: 1.5;
+    }
+  }
+
+  code {
+    background: #e9ecef;
+    padding: toRem(2) toRem(6);
+    border-radius: toRem(4);
+    font-family: monospace;
+    font-size: toRem(13);
+  }
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(toRem(256), 1fr));
+  gap: toRem(16);
+}
+
+.card {
+  display: block;
+  padding: toRem(20);
+  border: 1px solid #dee2e6;
+  border-radius: toRem(8);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+
+  &:hover {
+    border-color: #0d6efd;
+    box-shadow: 0 toRem(2) toRem(8) rgba(13, 110, 253, 0.1);
+  }
+
+  h3 {
+    font-size: toRem(15);
+    font-weight: 600;
+    margin-bottom: toRem(6);
+  }
+
+  p {
+    font-size: toRem(13);
+    color: #6c757d;
+    line-height: 1.4;
+  }
+}

--- a/prototype-app/src/Home.tsx
+++ b/prototype-app/src/Home.tsx
@@ -1,0 +1,68 @@
+import { Link } from 'react-router-dom'
+import styles from './Home.module.scss'
+
+const PROTOTYPES = [
+  {
+    path: '/component-showcase',
+    title: 'Component Showcase',
+    description:
+      'A single page demonstrating SDK components like Button, TextInput, Select, Alert, and more.',
+  },
+  {
+    path: '/sample-flow',
+    title: 'Sample Flow',
+    description:
+      'A multi-page prototype showing how to build a step-by-step flow with sub-navigation.',
+  },
+  // Add new prototypes here
+]
+
+export function Home() {
+  return (
+    <div className={styles.root}>
+      <h1>Prototype App</h1>
+      <p>
+        A lightweight environment for designing and prototyping new UI components using the SDK
+        component library.
+      </p>
+
+      <h2>Prototypes</h2>
+      <div className={styles.grid}>
+        {PROTOTYPES.map(({ path, title, description }) => (
+          <Link key={path} to={path} className={styles.card}>
+            <h3>{title}</h3>
+            <p>{description}</p>
+          </Link>
+        ))}
+      </div>
+
+      <h2>How to add a new prototype</h2>
+      <ol>
+        <li>
+          Create a directory in <code>prototype-app/src/prototypes/your-feature/</code>
+        </li>
+        <li>
+          Add an <code>index.tsx</code> — for single-page prototypes this is all you need
+        </li>
+        <li>
+          For multi-page prototypes, add an <code>{'<Outlet />'}</code> in your index and create
+          sub-page components
+        </li>
+        <li>
+          Register routes in <code>prototype-app/src/main.tsx</code>
+        </li>
+        <li>
+          Add an entry to <code>PROTOTYPES</code> in <code>prototype-app/src/Home.tsx</code>
+        </li>
+      </ol>
+
+      <h2>Available components</h2>
+      <p>
+        You have access to all SDK UI components. SDK components that are exposed as adapter hooks
+        can be accessed via <code>useComponentContext()</code> from{' '}
+        <code>@/contexts/ComponentAdapter/useComponentContext</code>. This gives you Button,
+        TextInput, Select, Alert, Badge, Card, Table, Modal, and 30+ more.
+      </p>
+    </div>
+  )
+}

--- a/prototype-app/src/Home.tsx
+++ b/prototype-app/src/Home.tsx
@@ -1,21 +1,6 @@
 import { Link } from 'react-router-dom'
+import { CATEGORIES, categorizedRegistry } from './registry'
 import styles from './Home.module.scss'
-
-const PROTOTYPES = [
-  {
-    path: '/component-showcase',
-    title: 'Component Showcase',
-    description:
-      'A single page demonstrating SDK components like Button, TextInput, Select, Alert, and more.',
-  },
-  {
-    path: '/sample-flow',
-    title: 'Sample Flow',
-    description:
-      'A multi-page prototype showing how to build a step-by-step flow with sub-navigation.',
-  },
-  // Add new prototypes here
-]
 
 export function Home() {
   return (
@@ -28,12 +13,14 @@ export function Home() {
 
       <h2>Prototypes</h2>
       <div className={styles.grid}>
-        {PROTOTYPES.map(({ path, title, description }) => (
-          <Link key={path} to={path} className={styles.card}>
-            <h3>{title}</h3>
-            <p>{description}</p>
-          </Link>
-        ))}
+        {CATEGORIES.flatMap(category =>
+          categorizedRegistry[category].map(({ name, path, description }) => (
+            <Link key={path} to={path} className={styles.card}>
+              <h3>{name}</h3>
+              <p>{description}</p>
+            </Link>
+          )),
+        )}
       </div>
 
       <h2>How to add a new prototype</h2>
@@ -52,7 +39,8 @@ export function Home() {
           Register routes in <code>prototype-app/src/main.tsx</code>
         </li>
         <li>
-          Add an entry to <code>PROTOTYPES</code> in <code>prototype-app/src/Home.tsx</code>
+          Add an entry to <code>categorizedRegistry</code> in{' '}
+          <code>prototype-app/src/registry.ts</code>
         </li>
       </ol>
 

--- a/prototype-app/src/Home.tsx
+++ b/prototype-app/src/Home.tsx
@@ -5,7 +5,7 @@ import styles from './Home.module.scss'
 export function Home() {
   return (
     <div className={styles.root}>
-      <h1>Prototype App</h1>
+      <h1>Embeddedd React SDK Design Sandbox</h1>
       <p>
         A lightweight environment for designing and prototyping new UI components using the SDK
         component library.

--- a/prototype-app/src/Sidebar.module.scss
+++ b/prototype-app/src/Sidebar.module.scss
@@ -1,0 +1,102 @@
+.root {
+  width: 16.25rem;
+  background: var(--color-bg-sidebar);
+  border-right: 0.0625rem solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.search {
+  padding: 0.75rem;
+  border-bottom: 0.0625rem solid var(--color-border);
+
+  input {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 0.0625rem solid var(--color-border);
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+    outline: none;
+    background: #fff;
+
+    &:focus {
+      border-color: var(--color-active);
+      box-shadow: 0 0 0 0.125rem rgba(13, 110, 253, 0.15);
+    }
+  }
+}
+
+.list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+}
+
+.category {
+  margin-bottom: 0.25rem;
+}
+
+.categoryHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03125rem;
+  color: var(--color-text-muted);
+  user-select: none;
+
+  &:hover {
+    color: var(--color-text);
+  }
+}
+
+.categoryCount {
+  background: var(--color-badge-bg);
+  padding: 0.0625rem 0.375rem;
+  border-radius: 0.625rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+}
+
+.categoryArrow {
+  font-size: 0.625rem;
+  transition: transform 0.15s;
+  margin-right: 0.375rem;
+}
+
+.categoryArrowCollapsed {
+  transform: rotate(-90deg);
+}
+
+.items {
+  list-style: none;
+}
+
+.item a {
+  display: block;
+  padding: 0.375rem 1rem 0.375rem 1.75rem;
+  color: var(--color-text);
+  text-decoration: none;
+  font-size: 0.8125rem;
+  border-left: 0.1875rem solid transparent;
+  transition:
+    background 0.1s,
+    border-color 0.1s;
+
+  &:hover {
+    background: var(--color-hover-bg);
+  }
+
+  &:global(.active) {
+    background: var(--color-active-bg);
+    border-left-color: var(--color-active);
+    color: var(--color-active);
+    font-weight: 500;
+  }
+}

--- a/prototype-app/src/Sidebar.tsx
+++ b/prototype-app/src/Sidebar.tsx
@@ -1,0 +1,94 @@
+import { useState, useMemo } from 'react'
+import { NavLink } from 'react-router-dom'
+import { categorizedRegistry, CATEGORIES, type Category } from './registry'
+import styles from './Sidebar.module.scss'
+
+interface SidebarProps {
+  searchQuery: string
+  onSearchChange: (query: string) => void
+}
+
+function CategorySection({
+  category,
+  items,
+  searchQuery,
+}: {
+  category: Category
+  items: { name: string; path: string }[]
+  searchQuery: string
+}) {
+  const [collapsed, setCollapsed] = useState(false)
+
+  const filteredItems = useMemo(() => {
+    if (!searchQuery) return items
+    const q = searchQuery.toLowerCase()
+    return items.filter(item => item.name.toLowerCase().includes(q))
+  }, [items, searchQuery])
+
+  if (filteredItems.length === 0) return null
+
+  return (
+    <div className={styles.category}>
+      <div
+        className={styles.categoryHeader}
+        onClick={() => {
+          setCollapsed(!collapsed)
+        }}
+        role="button"
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') setCollapsed(!collapsed)
+        }}
+      >
+        <span>
+          <span
+            className={`${styles.categoryArrow} ${collapsed ? styles.categoryArrowCollapsed : ''}`}
+          >
+            ▾
+          </span>
+          {category}
+        </span>
+        <span className={styles.categoryCount}>{filteredItems.length}</span>
+      </div>
+      {!collapsed && (
+        <ul className={styles.items}>
+          {filteredItems.map(item => (
+            <li key={item.name} className={styles.item}>
+              <NavLink to={item.path}>{item.name}</NavLink>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export function Sidebar({ searchQuery, onSearchChange }: SidebarProps) {
+  return (
+    <aside className={styles.root}>
+      <div className={styles.search}>
+        <input
+          type="text"
+          placeholder="Search prototypes..."
+          value={searchQuery}
+          onChange={e => {
+            onSearchChange(e.target.value)
+          }}
+        />
+      </div>
+      <div className={styles.list}>
+        {CATEGORIES.map(category => {
+          const items = categorizedRegistry[category]
+          return (
+            <CategorySection
+              key={category}
+              category={category}
+              items={items}
+              searchQuery={searchQuery}
+            />
+          )
+        })}
+      </div>
+    </aside>
+  )
+}

--- a/prototype-app/src/Sidebar.tsx
+++ b/prototype-app/src/Sidebar.tsx
@@ -31,6 +31,7 @@ function CategorySection({
     <div className={styles.category}>
       <div
         className={styles.categoryHeader}
+        aria-label={`${category} (${filteredItems.length})`}
         onClick={() => {
           setCollapsed(!collapsed)
         }}
@@ -53,7 +54,7 @@ function CategorySection({
       {!collapsed && (
         <ul className={styles.items}>
           {filteredItems.map(item => (
-            <li key={item.name} className={styles.item}>
+            <li key={item.path} className={styles.item}>
               <NavLink to={item.path}>{item.name}</NavLink>
             </li>
           ))}
@@ -69,6 +70,7 @@ export function Sidebar({ searchQuery, onSearchChange }: SidebarProps) {
       <div className={styles.search}>
         <input
           type="text"
+          aria-label="Search prototypes"
           placeholder="Search prototypes..."
           value={searchQuery}
           onChange={e => {

--- a/prototype-app/src/main.tsx
+++ b/prototype-app/src/main.tsx
@@ -1,0 +1,37 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import { App } from './App'
+import { Home } from './Home'
+import { ComponentShowcase } from './prototypes/component-showcase'
+import { SampleFlowLayout } from './prototypes/sample-flow'
+import { StepOne } from './prototypes/sample-flow/StepOne'
+import { StepTwo } from './prototypes/sample-flow/StepTwo'
+import '@/styles/sdk.scss'
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    children: [
+      { index: true, element: <Home /> },
+      { path: 'component-showcase', element: <ComponentShowcase /> },
+      {
+        path: 'sample-flow',
+        element: <SampleFlowLayout />,
+        children: [
+          { index: true, element: <StepOne /> },
+          { path: 'step-one', element: <StepOne /> },
+          { path: 'step-two', element: <StepTwo /> },
+        ],
+      },
+      // Add new prototype routes here
+    ],
+  },
+])
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <RouterProvider router={router} />
+  </StrictMode>,
+)

--- a/prototype-app/src/main.tsx
+++ b/prototype-app/src/main.tsx
@@ -7,7 +7,6 @@ import { ComponentShowcase } from './prototypes/component-showcase'
 import { SampleFlowLayout } from './prototypes/sample-flow'
 import { StepOne } from './prototypes/sample-flow/StepOne'
 import { StepTwo } from './prototypes/sample-flow/StepTwo'
-import '@/styles/sdk.scss'
 
 const router = createBrowserRouter([
   {

--- a/prototype-app/src/prototypes/component-showcase/index.tsx
+++ b/prototype-app/src/prototypes/component-showcase/index.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+export function ComponentShowcase() {
+  const Components = useComponentContext()
+  const [textValue, setTextValue] = useState('')
+  const [selectValue, setSelectValue] = useState('')
+
+  return (
+    <div style={{ maxWidth: '48rem' }}>
+      <Components.Heading as="h1">Component Showcase</Components.Heading>
+      <Components.Text>
+        A single-page prototype demonstrating the SDK component library. Use this as a reference for
+        available components and their props.
+      </Components.Text>
+
+      {/* Buttons */}
+      <section style={{ marginTop: '2rem' }}>
+        <Components.Heading as="h2">Buttons</Components.Heading>
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <Components.Button variant="primary">Primary</Components.Button>
+          <Components.Button variant="secondary">Secondary</Components.Button>
+          <Components.Button variant="tertiary">Tertiary</Components.Button>
+          <Components.Button variant="error">Error</Components.Button>
+          <Components.Button variant="primary" isDisabled>
+            Disabled
+          </Components.Button>
+          <Components.Button variant="primary" isLoading>
+            Loading
+          </Components.Button>
+        </div>
+      </section>
+
+      {/* Text Input */}
+      <section style={{ marginTop: '2rem' }}>
+        <Components.Heading as="h2">Text Input</Components.Heading>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: '24rem' }}>
+          <Components.TextInput
+            label="Full name"
+            placeholder="Jane Doe"
+            value={textValue}
+            onChange={setTextValue}
+          />
+          <Components.TextInput label="With error" isInvalid value="" onChange={() => {}} />
+          <Components.TextInput
+            label="Disabled"
+            isDisabled
+            value="Cannot edit"
+            onChange={() => {}}
+          />
+        </div>
+      </section>
+
+      {/* Select */}
+      <section style={{ marginTop: '2rem' }}>
+        <Components.Heading as="h2">Select</Components.Heading>
+        <div style={{ maxWidth: '24rem' }}>
+          <Components.Select
+            label="Department"
+            options={[
+              { value: 'eng', label: 'Engineering' },
+              { value: 'design', label: 'Design' },
+              { value: 'product', label: 'Product' },
+              { value: 'marketing', label: 'Marketing' },
+            ]}
+            value={selectValue}
+            onChange={setSelectValue}
+          />
+          {selectValue && <Components.Text size="sm">Selected: {selectValue}</Components.Text>}
+        </div>
+      </section>
+
+      {/* Alerts */}
+      <section style={{ marginTop: '2rem' }}>
+        <Components.Heading as="h2">Alerts</Components.Heading>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+          <Components.Alert status="info" label="This is an info alert" />
+          <Components.Alert status="success" label="This is a success alert" />
+          <Components.Alert status="warning" label="This is a warning alert" />
+          <Components.Alert status="error" label="This is an error alert" />
+        </div>
+      </section>
+
+      {/* Badges */}
+      <section style={{ marginTop: '2rem' }}>
+        <Components.Heading as="h2">Badges</Components.Heading>
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <Components.Badge status="info">Info</Components.Badge>
+          <Components.Badge status="success">Success</Components.Badge>
+          <Components.Badge status="warning">Warning</Components.Badge>
+          <Components.Badge status="error">Error</Components.Badge>
+        </div>
+      </section>
+
+      {/* Typography */}
+      <section style={{ marginTop: '2rem' }}>
+        <Components.Heading as="h2">Typography</Components.Heading>
+        <Components.Heading as="h1">Heading 1</Components.Heading>
+        <Components.Heading as="h2">Heading 2</Components.Heading>
+        <Components.Heading as="h3">Heading 3</Components.Heading>
+        <Components.Heading as="h4">Heading 4</Components.Heading>
+        <Components.Text size="lg">Text — Large</Components.Text>
+        <Components.Text size="md">Text — Medium</Components.Text>
+        <Components.Text size="sm">Text — Small</Components.Text>
+        <Components.Text size="xs">Text — Extra Small</Components.Text>
+      </section>
+    </div>
+  )
+}

--- a/prototype-app/src/prototypes/sample-flow/SampleFlow.module.scss
+++ b/prototype-app/src/prototypes/sample-flow/SampleFlow.module.scss
@@ -17,7 +17,9 @@
   color: #6c757d;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
-  transition: color 0.15s, border-color 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 
   &:hover {
     color: #212529;

--- a/prototype-app/src/prototypes/sample-flow/SampleFlow.module.scss
+++ b/prototype-app/src/prototypes/sample-flow/SampleFlow.module.scss
@@ -1,0 +1,37 @@
+.layout {
+  max-width: toRem(640);
+}
+
+.nav {
+  display: flex;
+  gap: toRem(4);
+  margin-bottom: toRem(24);
+  border-bottom: 1px solid #dee2e6;
+}
+
+.step,
+.stepActive {
+  padding: toRem(8) toRem(16);
+  font-size: toRem(14);
+  text-decoration: none;
+  color: #6c757d;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.15s, border-color 0.15s;
+
+  &:hover {
+    color: #212529;
+  }
+}
+
+.stepActive {
+  color: #0d6efd;
+  border-bottom-color: #0d6efd;
+  font-weight: 500;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: toRem(16);
+}

--- a/prototype-app/src/prototypes/sample-flow/StepOne.tsx
+++ b/prototype-app/src/prototypes/sample-flow/StepOne.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common/Flex/Flex'
+
+export function StepOne() {
+  const Components = useComponentContext()
+  const navigate = useNavigate()
+
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [department, setDepartment] = useState('')
+
+  return (
+    <>
+      <Flex flexDirection="column" gap={4}>
+        <Components.Heading as="h2">Employee Information</Components.Heading>
+        <Components.Text variant="supporting">
+          Enter the new employee details below.
+        </Components.Text>
+      </Flex>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: '24rem' }}>
+        <Components.TextInput
+          label="First name"
+          placeholder="Jane"
+          value={firstName}
+          onChange={setFirstName}
+        />
+        <Components.TextInput
+          label="Last name"
+          placeholder="Doe"
+          value={lastName}
+          onChange={setLastName}
+        />
+        <Components.Select
+          label="Department"
+          options={[
+            { value: 'engineering', label: 'Engineering' },
+            { value: 'design', label: 'Design' },
+            { value: 'product', label: 'Product' },
+            { value: 'sales', label: 'Sales' },
+          ]}
+          value={department}
+          onChange={setDepartment}
+        />
+      </div>
+
+      <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+        <Components.Button variant="primary" onClick={() => navigate('/sample-flow/step-two')}>
+          Continue
+        </Components.Button>
+      </div>
+    </>
+  )
+}

--- a/prototype-app/src/prototypes/sample-flow/StepTwo.tsx
+++ b/prototype-app/src/prototypes/sample-flow/StepTwo.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+export function StepTwo() {
+  const Components = useComponentContext()
+  const navigate = useNavigate()
+
+  return (
+    <>
+      <Components.Heading as="h2">Review</Components.Heading>
+      <Components.Text>
+        Review the employee information before submitting. In a real prototype, this page would
+        display the data collected from previous steps.
+      </Components.Text>
+
+      <Components.Alert
+        status="info"
+        label="This is a placeholder review step. Replace this with your actual review UI."
+      />
+
+      <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+        <Components.Button variant="secondary" onClick={() => navigate('/sample-flow/step-one')}>
+          Back
+        </Components.Button>
+        <Components.Button variant="primary" onClick={() => navigate('/')}>
+          Submit
+        </Components.Button>
+      </div>
+    </>
+  )
+}

--- a/prototype-app/src/prototypes/sample-flow/index.tsx
+++ b/prototype-app/src/prototypes/sample-flow/index.tsx
@@ -1,0 +1,33 @@
+import { Outlet, NavLink, useLocation } from 'react-router-dom'
+import styles from './SampleFlow.module.scss'
+
+const STEPS = [
+  { path: '/sample-flow/step-one', label: 'Step 1: Employee Info' },
+  { path: '/sample-flow/step-two', label: 'Step 2: Review' },
+]
+
+export function SampleFlowLayout() {
+  const location = useLocation()
+  const isIndex = location.pathname === '/sample-flow'
+
+  return (
+    <div className={styles.layout}>
+      <nav className={styles.nav}>
+        {STEPS.map(({ path, label }) => (
+          <NavLink
+            key={path}
+            to={path}
+            className={({ isActive }) =>
+              isActive || (isIndex && path === STEPS[0].path) ? styles.stepActive : styles.step
+            }
+          >
+            {label}
+          </NavLink>
+        ))}
+      </nav>
+      <div className={styles.content}>
+        <Outlet />
+      </div>
+    </div>
+  )
+}

--- a/prototype-app/src/prototypes/sample-flow/index.tsx
+++ b/prototype-app/src/prototypes/sample-flow/index.tsx
@@ -4,7 +4,7 @@ import styles from './SampleFlow.module.scss'
 const STEPS = [
   { path: '/sample-flow/step-one', label: 'Step 1: Employee Info' },
   { path: '/sample-flow/step-two', label: 'Step 2: Review' },
-]
+] as const
 
 export function SampleFlowLayout() {
   const location = useLocation()

--- a/prototype-app/src/registry.ts
+++ b/prototype-app/src/registry.ts
@@ -1,0 +1,18 @@
+export type Category = (typeof CATEGORIES)[number]
+
+export const CATEGORIES = ['Examples'] as const
+
+export interface PrototypeEntry {
+  name: string
+  path: string
+}
+
+export type CategorizedRegistry = Record<Category, PrototypeEntry[]>
+
+export const categorizedRegistry: CategorizedRegistry = {
+  Examples: [
+    { name: 'Component Showcase', path: '/component-showcase' },
+    { name: 'Sample Flow', path: '/sample-flow' },
+  ],
+  // Add new categories and prototypes here
+}

--- a/prototype-app/src/registry.ts
+++ b/prototype-app/src/registry.ts
@@ -5,14 +5,25 @@ export const CATEGORIES = ['Examples'] as const
 export interface PrototypeEntry {
   name: string
   path: string
+  description: string
 }
 
 export type CategorizedRegistry = Record<Category, PrototypeEntry[]>
 
 export const categorizedRegistry: CategorizedRegistry = {
   Examples: [
-    { name: 'Component Showcase', path: '/component-showcase' },
-    { name: 'Sample Flow', path: '/sample-flow' },
+    {
+      name: 'Component Showcase',
+      path: '/component-showcase',
+      description:
+        'A single page demonstrating SDK components like Button, TextInput, Select, Alert, and more.',
+    },
+    {
+      name: 'Sample Flow',
+      path: '/sample-flow',
+      description:
+        'A multi-page prototype showing how to build a step-by-step flow with sub-navigation.',
+    },
   ],
   // Add new categories and prototypes here
 }

--- a/prototype-app/src/scss.d.ts
+++ b/prototype-app/src/scss.d.ts
@@ -1,0 +1,1 @@
+declare module '*.scss'

--- a/prototype-app/tsconfig.json
+++ b/prototype-app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./src", "../src"],
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0",
+    "rootDir": "..",
+    "baseUrl": "..",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "noEmit": true
+  }
+}

--- a/prototype-app/vite.config.ts
+++ b/prototype-app/vite.config.ts
@@ -1,0 +1,22 @@
+import react from '@vitejs/plugin-react-swc'
+import { defineConfig } from 'vite'
+import { resolve } from 'path'
+import { scssPreprocessorOptions, svgrPlugin } from '../vite.config'
+
+export default defineConfig({
+  root: resolve(__dirname),
+  plugins: [react(), svgrPlugin()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, '../src'),
+    },
+  },
+  css: {
+    preprocessorOptions: scssPreprocessorOptions,
+  },
+  server: {
+    port: 5300,
+    strictPort: false,
+    open: true,
+  },
+})


### PR DESCRIPTION
## Summary

Adds a new standalone `prototype-app/` project (sibling to `sdk-app/`) that provides a lightweight environment for designers to build and prototype new UI components using the SDK component library — without any backend or API connections.

## Changes

- New `prototype-app/` Vite project with its own config, tsconfig, and routing
- Sidebar navigation matching the sdk-app design (search, collapsible categories, active states)
- Two starter prototypes: a single-page component showcase and a multi-page sample flow
- Central prototype registry for easy addition of new prototypes
- `npm run prototype-app` script added to root package.json (runs on port 5300)

## Demo

Run `npm run prototype-app` to start the dev server at http://localhost:5300. The home page lists all available prototypes with instructions on how to add new ones.

## Related

<!-- No Jira ticket or Figma link for this change -->

## Testing

1. Run `npm run prototype-app`
2. Verify the home page renders with the prototype card grid
3. Click "Component Showcase" — verify SDK components render (Buttons, TextInput, Select, Alerts, Badges, Typography)
4. Click "Sample Flow" — verify multi-page navigation between Step 1 and Step 2
5. Test sidebar search filtering
6. Test sidebar category collapse/expand