### PR TITLE
fix: removed scroll into view on alerts

### DIFF
--- a/prototype-app/src/main.tsx
+++ b/prototype-app/src/main.tsx
@@ -7,6 +7,7 @@ import { ComponentShowcase } from './prototypes/component-showcase'
 import { SampleFlowLayout } from './prototypes/sample-flow'
 import { StepOne } from './prototypes/sample-flow/StepOne'
 import { StepTwo } from './prototypes/sample-flow/StepTwo'
+import '@/styles/sdk.scss'
 
 const router = createBrowserRouter([
   {

--- a/prototype-app/src/prototypes/component-showcase/index.tsx
+++ b/prototype-app/src/prototypes/component-showcase/index.tsx
@@ -74,10 +74,18 @@ export function ComponentShowcase() {
       <section style={{ marginTop: '2rem' }}>
         <Components.Heading as="h2">Alerts</Components.Heading>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-          <Components.Alert status="info" label="This is an info alert" />
-          <Components.Alert status="success" label="This is a success alert" />
-          <Components.Alert status="warning" label="This is a warning alert" />
-          <Components.Alert status="error" label="This is an error alert" />
+          <Components.Alert status="info" label="This is an info alert" disableScrollIntoView />
+          <Components.Alert
+            status="success"
+            label="This is a success alert"
+            disableScrollIntoView
+          />
+          <Components.Alert
+            status="warning"
+            label="This is a warning alert"
+            disableScrollIntoView
+          />
+          <Components.Alert status="error" label="This is an error alert" disableScrollIntoView />
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Fixed component showcase view from starting scrolled below the top content.

## Changes

Set disableScrollIntoView to prevent automatic scrolling to alert components.

