### PR TITLE
fix: add flex properties to box so content fills remaining space in p…

### DIFF
--- a/src/components/Common/UI/Box/Box.module.scss
+++ b/src/components/Common/UI/Box/Box.module.scss
@@ -1,5 +1,7 @@
 .root {
   width: 100%;
+  display: flex;
+  flex-direction: column;
   background-color: var(--g-colorBody);
   box-shadow: var(--g-shadowResting);
   border-radius: var(--g-boxRadius);
@@ -12,10 +14,12 @@
 }
 
 .content {
+  flex: 1;
   padding: toRem(20);
 }
 
 .contentFlush {
+  flex: 1;
   padding: 0;
 }
 


### PR DESCRIPTION
…arent containers

## Summary

Forces box content to fill the remaining space of parent containers. This is useful when two boxes are side by side.

## Changes

Add flex properties to Box.module.scss
