### PR TITLE
chore: add Cursor skill for migrating SDK components to hooks

### DIFF
--- a/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -238,19 +238,55 @@ Fields that may not exist are `undefined` — guard with truthiness checks:
 
 ### Validation Messages
 
-Every field has typed error codes. Provide `validationMessages` to map codes to localized strings. Without it, the raw error code string (e.g. "REQUIRED") is displayed to the user.
+Every field has typed error codes defined in its `fields.tsx`. Without `validationMessages`, the raw error code string (e.g. "REQUIRED") is displayed to the user.
+
+#### How error code typing works
+
+Field components have two generic parameters: `TErrorCode` (required keys) and `TOptionalErrorCode` (optional keys). The `ValidationMessages` type requires all `TErrorCode` keys and allows `TOptionalErrorCode` keys:
+
+```typescript
+// In fields.tsx — error codes derived from the schema's error codes constant
+export type SsnValidation = typeof ErrorCodes.INVALID_SSN // required key
+export type SsnRequiredValidation = typeof ErrorCodes.REQUIRED // optional key
+
+export type SsnFieldProps = HookFieldProps<
+  TextInputHookFieldProps<SsnValidation, SsnRequiredValidation>
+  //                        ^required       ^optional
+>
+```
+
+TypeScript enforces that all required keys are present. Optional keys are allowed but not enforced — provide them for any code that can realistically fire.
+
+#### Wiring up validationMessages
+
+Every field rendered in the component should have `validationMessages` covering all error codes that can fire. Check the field's type definition in `fields.tsx` to see which codes are required vs optional, then provide localized translations for each:
 
 ```tsx
+<EmployeeFields.FirstName
+  label={t('firstName')}
+  validationMessages={{
+    REQUIRED: t('validations.firstName'),      // required key — TypeScript enforces this
+    INVALID_NAME: t('validations.firstName'),   // required key — TypeScript enforces this
+  }}
+/>
+
 <EmployeeFields.Ssn
   label={t('ssnLabel')}
   validationMessages={{
-    INVALID_SSN: t('validations.ssn', { ns: 'common' }),
-    REQUIRED: t('validations.ssnRequired', { ns: 'common' }),
+    INVALID_SSN: t('validations.ssn', { ns: 'common' }),        // required key
+    REQUIRED: t('validations.ssnRequired', { ns: 'common' }),   // optional key — but fires when field is required
   }}
 />
 ```
 
-TypeScript enforces required error codes. Optional error codes (second generic parameter) are allowed but not required — provide them for any code that can realistically fire.
+#### Translation placement
+
+Validation translations should live in the component's translation namespace (e.g. `Employee.Profile.json`) or the `common.json` namespace for messages shared across components (e.g. SSN format, date of birth required). When migrating, check the existing component's translations and keep them consistent to avoid breaking changes.
+
+#### When validationMessages can be omitted
+
+- Fields whose error codes can never fire (e.g. `MiddleInitial` with `requiredFieldsConfig: 'never'` and no format validator)
+- Boolean fields (checkbox/switch) — always have a value so `REQUIRED` never fires
 
 ### Watching Form Values
 

--- a/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: migrate-sdk-component-to-hooks
+description: >-
+  Migrate existing SDK components to the hook-based architecture. Use when
+  refactoring a component to use form hooks (useEmployeeDetailsForm,
+  useHomeAddressForm, useWorkAddressForm, useCompensationForm, etc.),
+  composing multiple hooks in a single component, or wiring up BaseComponent,
+  BaseLayout, SDKFormProvider, and composeSubmitHandler.
+---
+
+# Migrating SDK Components to Hook-Based Architecture
+
+Reference implementation: `Employee.Profile` — see `AdminProfile.tsx`, `EmployeeProfile.tsx`, and `Profile.tsx`.
+
+Hooks reference: `.claude/hooks-implementation.md` — covers schema, fields, hook internals, error handling, and exports in detail. Read it before starting a migration.
+
+## 1. Component Structure
+
+### Entry Point
+
+The public component wraps `BaseComponent` and forks to inner components as needed:
+
+```tsx
+export function MyComponent(props: MyComponentProps & BaseComponentInterface) {
+  return (
+    <BaseComponent {...props}>
+      <Root {...props} />
+    </BaseComponent>
+  )
+}
+```
+
+`BaseComponent` provides:
+
+- `BaseContext` (access via `useBase()`) — gives `onEvent`, `baseSubmitHandler`, error state
+- `BaseBoundaries` — `QueryErrorResetBoundary` + `ErrorBoundary` + `Suspense`
+- Top-level `BaseLayout` — renders generic errors from `useBaseSubmit`
+
+### Suspense Data Priming
+
+If the component receives an entity ID, prime suspense queries in a wrapper above `Root` so data is cached before hooks run:
+
+```tsx
+function RootWithEmployee({ employeeId, ...props }) {
+  useEmployeesGetSuspense({ employeeId })
+  useEmployeeAddressesGetSuspense({ employeeId })
+  return <Root {...props} employeeId={employeeId} />
+}
+```
+
+Do NOT use suspense queries inside the inner component — hooks use regular queries internally. The suspense wrapper exists only to warm the cache within the `Suspense` boundary that `BaseComponent` provides.
+
+### Inner Component Split
+
+When admin and self-service flows have significantly different field visibility, validation, or submission logic, split into separate components (e.g. `AdminProfile` / `EmployeeProfile`) rather than a single component with many conditionals.
+
+## 2. Hook Initialization
+
+Initialize all hooks at the top of the inner component. Pass `shouldFocusError: false` to every hook — `composeSubmitHandler` manages cross-form focus.
+
+```tsx
+const employeeDetails = useEmployeeDetailsForm({
+  companyId,
+  employeeId,
+  optionalFieldsToRequire,
+  shouldFocusError: false,
+})
+
+const homeAddress = useHomeAddressForm({
+  employeeId,
+  shouldFocusError: false,
+})
+```
+
+### Partial Update Recovery (Create Mode)
+
+When composing hooks that create entities sequentially (e.g. create employee → create home address → create work address), track the created ID in state so that if a later step fails, retrying doesn't re-create the first entity:
+
+```tsx
+const [resolvedEmployeeId, setResolvedEmployeeId] = useState(employeeId)
+```
+
+Pass `resolvedEmployeeId` to downstream hooks. Update it in the submit handler after a successful create.
+
+## 3. Loading and Error States with BaseLayout
+
+### Error Aggregation
+
+Aggregate errors from all hooks into a single array:
+
+```tsx
+const allErrors = [
+  ...employeeDetails.errorHandling.errors,
+  ...homeAddress.errorHandling.errors,
+  ...workAddress.errorHandling.errors,
+]
+```
+
+### Loading Gate
+
+When any hook is loading, render `BaseLayout` with `isLoading` and errors. This shows a loading indicator, or errors if a query failed (so users see a retry option instead of an infinite spinner):
+
+```tsx
+if (employeeDetails.isLoading || homeAddress.isLoading || workAddress.isLoading) {
+  return <BaseLayout isLoading error={allErrors} />
+}
+```
+
+### Ready State
+
+Wrap the form content in `BaseLayout` with errors to display error alerts above the form:
+
+```tsx
+return (
+  <section className={className}>
+    <BaseLayout error={allErrors}>
+      <Form onSubmit={composedHandler}>{/* form content */}</Form>
+    </BaseLayout>
+  </section>
+)
+```
+
+`BaseLayout` renders:
+
+- Loading indicator when `isLoading` is true and no errors
+- Error alert(s) above children when errors are present
+- Just children when neither loading nor errored
+
+## 4. SDKFormProvider and formHookResult Prop
+
+Hook fields need form context (react-hook-form `Control`, fields metadata, errors). Two ways to provide it:
+
+### SDKFormProvider
+
+Wraps a contiguous group of fields from **one** hook. Provides `FormProvider` + `FormFieldsMetadataProvider` + API field error syncing.
+
+```tsx
+<SDKFormProvider formHookResult={workAddress}>
+  <WorkAddressFields.Location label={t('workAddress')} />
+  <WorkAddressFields.EffectiveDate label={t('startDate')} />
+</SDKFormProvider>
+```
+
+### formHookResult Prop
+
+Pass the hook result directly to each field. Use when fields from one hook are scattered across the layout (interleaved with other hooks' fields or non-field UI).
+
+```tsx
+<EmployeeFields.FirstName
+  label={t('firstName')}
+  formHookResult={employeeDetails}
+  validationMessages={{ REQUIRED: t('validations.firstName') }}
+/>
+```
+
+`FormHookResult` types `control` as `unknown` so any hook result is assignable without casts or generics. The single `as Control` cast lives inside `useHookFieldResolution`.
+
+### Rules
+
+1. **Do NOT nest `SDKFormProvider`s** — use sibling providers for different hooks
+2. **Do NOT use both approaches for the same hook** — pick `SDKFormProvider` or `formHookResult` prop per hook, not both
+3. **Do NOT render fields from a different hook inside an `SDKFormProvider`**
+
+When a hook's fields are split across the layout, use `formHookResult` prop on **all** of that hook's fields.
+
+## 5. Composing Submissions with composeSubmitHandler
+
+`composeSubmitHandler` validates all forms simultaneously, focuses the first invalid field across forms, and only calls `onAllValid` when every form passes.
+
+```tsx
+const activeForms = [employeeDetails, ...(showHomeAddress ? [homeAddress] : []), workAddress]
+
+const composedHandler = composeSubmitHandler(activeForms, async () => {
+  const employeeResult = await employeeDetails.actions.onSubmit({
+    /* callbacks */
+  })
+  if (!employeeResult) return
+
+  const newId = employeeResult.data.uuid
+
+  if (showHomeAddress) {
+    const homeResult = await homeAddress.actions.onSubmit({ employeeId: newId })
+    if (!homeResult) {
+      if (!employeeId) setResolvedEmployeeId(newId)
+      return
+    }
+  }
+
+  await workAddress.actions.onSubmit(
+    {
+      /* callbacks */
+    },
+    { employeeId: newId },
+  )
+})
+```
+
+Key points:
+
+- `activeForms` array determines which forms are validated — conditionally exclude forms whose sections are hidden
+- Do NOT memoize `activeForms` or `composedHandler` — hook return values are not stable references
+- Submit sequentially, checking each result — return early on failure to prevent cascading errors
+- Update `resolvedEmployeeId` on partial failure in create mode
+
+## 6. Field Rendering
+
+### Using Hook Fields
+
+Each hook provides field components via `form.Fields`:
+
+```tsx
+const EmployeeFields = employeeDetails.form.Fields
+const HomeAddressFields = homeAddress.form.Fields
+```
+
+### Conditional Fields
+
+Fields that may not exist are `undefined` — guard with truthiness checks:
+
+```tsx
+{
+  WorkAddressFields.EffectiveDate && <WorkAddressFields.EffectiveDate label={t('startDate')} />
+}
+```
+
+### Validation Messages
+
+Every field has typed error codes. Provide `validationMessages` to map codes to localized strings. Without it, the raw error code string (e.g. "REQUIRED") is displayed to the user.
+
+```tsx
+<EmployeeFields.Ssn
+  label={t('ssnLabel')}
+  validationMessages={{
+    INVALID_SSN: t('validations.ssn', { ns: 'common' }),
+    REQUIRED: t('validations.ssnRequired', { ns: 'common' }),
+  }}
+/>
+```
+
+TypeScript enforces required error codes. Optional error codes (second generic parameter) are allowed but not required — provide them for any code that can realistically fire.
+
+### Watching Form Values
+
+When the component needs to react to field values (e.g. toggling sections based on a checkbox), use `useWatch` with the hook's `control`:
+
+```tsx
+const watchedValue = useWatch({
+  control: hookResult.form.hookFormInternals.formMethods.control,
+  name: 'fieldName',
+})
+```
+
+For read-only access without re-renders on every change (e.g. reading at submit time), use `getFormSubmissionValues()`:
+
+```tsx
+const startDate = workAddress.form.getFormSubmissionValues()?.effectiveDate
+```
+
+## 7. i18n
+
+- Call `useI18n('Namespace')` for each translation namespace the component uses
+- Call `useComponentDictionary('Namespace', dictionary)` to merge partner overrides
+- Use `useTranslation('Namespace')` for the `t` function
+- Keep translations consistent with the existing component to avoid breaking changes
+
+## 8. Events
+
+Use `onEvent` from `useBase()` to emit component events:
+
+```tsx
+const { onEvent } = useBase()
+// ...
+onEvent(componentEvents.EMPLOYEE_PROFILE_DONE, { ...data })
+```
+
+## 9. Cleanup Checklist
+
+After migration, remove dead code from the component directory:
+
+- [ ] Old monolithic form component files
+- [ ] Old context providers (e.g. `ProfileContext`)
+- [ ] Inline sub-components (e.g. `Head`, `Actions`, `WorkAddress`)
+- [ ] Helper utilities only used by the old implementation
+- [ ] Tests for deleted helpers
+- [ ] Unused imports in barrel files
+
+## 10. Migration Checklist
+
+- [ ] Entry point wraps `BaseComponent` and forks to inner component(s)
+- [ ] Suspense queries primed in wrapper above Root (if entity ID provided)
+- [ ] All hooks initialized with `shouldFocusError: false`
+- [ ] Errors aggregated from all hooks into single array
+- [ ] Loading state uses `<BaseLayout isLoading error={allErrors} />`
+- [ ] Ready state wraps content in `<BaseLayout error={allErrors}>`
+- [ ] SDKFormProvider rules followed (no nesting, no mixing, no cross-hook fields)
+- [ ] `composeSubmitHandler` used for multi-hook forms, not memoized
+- [ ] Partial update recovery handled for create mode
+- [ ] All field error codes have `validationMessages` for codes that can realistically fire
+- [ ] Events emitted via `onEvent` from `useBase()`
+- [ ] i18n namespaces loaded and translations consistent with prior component
+- [ ] Dead code from old implementation removed
+- [ ] All existing tests pass (`npm run test -- --run`)

--- a/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Migrate existing SDK components to the hook-based architecture. Use when
   refactoring a component to use form hooks (useEmployeeDetailsForm,
   useHomeAddressForm, useWorkAddressForm, useCompensationForm, etc.),
-  composing multiple hooks in a single component, or wiring up BaseComponent,
+  composing multiple hooks in a single component, or wiring up BaseBoundaries,
   BaseLayout, SDKFormProvider, and composeSubmitHandler.
 ---
 
@@ -18,23 +18,36 @@ Hooks reference: `.claude/hooks-implementation.md` — covers schema, fields, ho
 
 ### Entry Point
 
-The public component wraps `BaseComponent` and forks to inner components as needed:
+The public component wraps `BaseBoundaries` and forks to inner components as needed. `onEvent` is passed as a prop — do NOT use `BaseComponent` or `useBase()`.
 
 ```tsx
-export function MyComponent(props: MyComponentProps & BaseComponentInterface) {
+export function MyComponent({
+  FallbackComponent,
+  ...props
+}: MyComponentProps & BaseComponentInterface) {
   return (
-    <BaseComponent {...props}>
-      <Root {...props} />
-    </BaseComponent>
+    <BaseBoundaries componentName="Domain.MyComponent" FallbackComponent={FallbackComponent}>
+      {props.employeeId ? (
+        <RootWithEmployee {...props} employeeId={props.employeeId} />
+      ) : (
+        <Root {...props} />
+      )}
+    </BaseBoundaries>
   )
 }
 ```
 
-`BaseComponent` provides:
+`BaseBoundaries` provides:
 
-- `BaseContext` (access via `useBase()`) — gives `onEvent`, `baseSubmitHandler`, error state
-- `BaseBoundaries` — `QueryErrorResetBoundary` + `ErrorBoundary` + `Suspense`
-- Top-level `BaseLayout` — renders generic errors from `useBaseSubmit`
+- `QueryErrorResetBoundary` — resets React Query errors on retry
+- `ErrorBoundary` — catches render errors, shows `FallbackComponent`
+- `Suspense` — shows loading indicator while suspense queries resolve
+
+Unlike `BaseComponent`, `BaseBoundaries` does NOT provide `BaseContext`. This means:
+
+- `onEvent` is passed as a prop through to inner components, not accessed via `useBase()`
+- Error state is managed by the hooks' `errorHandling` bags, not `BaseContext`
+- `BaseLayout` is used explicitly inside the inner component for loading/error display
 
 ### Suspense Data Priming
 
@@ -48,7 +61,7 @@ function RootWithEmployee({ employeeId, ...props }) {
 }
 ```
 
-Do NOT use suspense queries inside the inner component — hooks use regular queries internally. The suspense wrapper exists only to warm the cache within the `Suspense` boundary that `BaseComponent` provides.
+Do NOT use suspense queries inside the inner component — hooks use regular queries internally. The suspense wrapper exists only to warm the cache within the `Suspense` boundary that `BaseBoundaries` provides.
 
 ### Inner Component Split
 
@@ -265,12 +278,13 @@ const startDate = workAddress.form.getFormSubmissionValues()?.effectiveDate
 
 ## 8. Events
 
-Use `onEvent` from `useBase()` to emit component events:
+`onEvent` is received as a prop and threaded through to inner components — do NOT use `useBase()`:
 
 ```tsx
-const { onEvent } = useBase()
-// ...
-onEvent(componentEvents.EMPLOYEE_PROFILE_DONE, { ...data })
+function Root({ onEvent, ...props }: MyComponentProps) {
+  // ...
+  onEvent(componentEvents.EMPLOYEE_PROFILE_DONE, { ...data })
+}
 ```
 
 ## 9. Cleanup Checklist
@@ -286,7 +300,7 @@ After migration, remove dead code from the component directory:
 
 ## 10. Migration Checklist
 
-- [ ] Entry point wraps `BaseComponent` and forks to inner component(s)
+- [ ] Entry point wraps `BaseBoundaries` (not `BaseComponent`) and forks to inner component(s)
 - [ ] Suspense queries primed in wrapper above Root (if entity ID provided)
 - [ ] All hooks initialized with `shouldFocusError: false`
 - [ ] Errors aggregated from all hooks into single array
@@ -296,7 +310,7 @@ After migration, remove dead code from the component directory:
 - [ ] `composeSubmitHandler` used for multi-hook forms, not memoized
 - [ ] Partial update recovery handled for create mode
 - [ ] All field error codes have `validationMessages` for codes that can realistically fire
-- [ ] Events emitted via `onEvent` from `useBase()`
+- [ ] `onEvent` passed as prop (not via `useBase()`)
 - [ ] i18n namespaces loaded and translations consistent with prior component
 - [ ] Dead code from old implementation removed
 - [ ] All existing tests pass (`npm run test -- --run`)

--- a/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -10,7 +10,10 @@ description: >-
 
 # Migrating SDK Components to Hook-Based Architecture
 
-Reference implementation: `Employee.Profile` — see `AdminProfile.tsx`, `EmployeeProfile.tsx`, and `Profile.tsx`. If the Profile migration has not been merged to main yet, reference PR #1570 or branch `sdk-777-profile-hook-migration`.
+Reference implementations:
+
+- **Single hook, single form** (recommended default): `PayScheduleForm` — see PR #1545 or branch `sdk-774-pay-schedule-hook`. Clean illustration of the `BaseBoundaries` + `Root` + single-hook shape.
+- **Multiple composed hooks with admin/self-service variants**: `Employee.Profile` (`Profile.tsx`, `AdminProfile.tsx`, `EmployeeProfile.tsx`) — PR #1570 or branch `sdk-777-profile-hook-migration`. Useful when composing hooks and aggregating errors, but its internal fork is a product-specific compromise, not the default model.
 
 Hooks reference: `.claude/hooks-implementation.md` — covers schema, fields, hook internals, error handling, and exports in detail. Read it before starting a migration.
 
@@ -18,48 +21,54 @@ Hooks reference: `.claude/hooks-implementation.md` — covers schema, fields, ho
 
 ### Entry Point
 
-The public component wraps `BaseBoundaries` and forks to inner components as needed. `onEvent` is passed as a prop — do NOT use `BaseComponent` or `useBase()`.
+The public component wraps `BaseBoundaries` and delegates to a single `Root` component that initializes the hook(s) and renders the form. `onEvent` is passed as a prop — do NOT use `BaseComponent` or `useBase()`.
+
+Reference: `PayScheduleForm` on branch `sdk-774-pay-schedule-hook` (PR #1545) is a clean example of the simple single-hook shape.
 
 ```tsx
-export function MyComponent({
-  FallbackComponent,
-  ...props
-}: MyComponentProps & BaseComponentInterface) {
+interface MyComponentProps extends UseMyFormProps {
+  onEvent: OnEventType<EventType, unknown>
+}
+
+export function MyComponent({ onEvent, ...hookProps }: MyComponentProps) {
   return (
-    <BaseBoundaries componentName="Domain.MyComponent" FallbackComponent={FallbackComponent}>
-      {props.employeeId ? (
-        <RootWithEmployee {...props} employeeId={props.employeeId} />
-      ) : (
-        <Root {...props} />
-      )}
+    <BaseBoundaries componentName="Domain.MyComponent">
+      <MyComponentRoot onEvent={onEvent} {...hookProps} />
     </BaseBoundaries>
   )
+}
+
+function MyComponentRoot({ onEvent, ...hookProps }: MyComponentProps) {
+  const form = useMyForm(hookProps)
+  // ...loading gate, handlers, render
 }
 ```
 
 `BaseBoundaries` provides:
 
 - `QueryErrorResetBoundary` — resets React Query errors on retry
-- `ErrorBoundary` — catches render errors, shows `FallbackComponent`
-- `Suspense` — shows loading indicator while suspense queries resolve
+- `ErrorBoundary` — catches render errors, shows `FallbackComponent` if supplied
+- `Suspense` — shows a loading indicator while suspense hooks (like `useI18n` / `useTranslation`) resolve
 
 Unlike `BaseComponent`, `BaseBoundaries` does NOT provide `BaseContext`. This means:
 
-- `onEvent` is passed as a prop through to inner components, not accessed via `useBase()`
+- `onEvent` is passed as a prop through to the `Root` component, not accessed via `useBase()`
 - Error state is managed by the hooks' `errorHandling` bags, not `BaseContext`
-- `BaseLayout` is used explicitly inside the inner component for loading/error display
+- `BaseLayout` is used explicitly inside `Root` for loading/error display
 
 ### Suspense Boundary
 
 `BaseBoundaries` provides a `Suspense` boundary. This is needed for `useI18n` / `useTranslation` and similar hooks that suspend. Prefer non-suspense queries for data fetching — the form hooks use regular queries internally and manage their own loading states via `isLoading`.
 
-### Inner Component Split
+### When to Split Into Multiple Components
 
-When admin and self-service flows have significantly different field visibility, validation, or submission logic, split into separate components (e.g. `AdminProfile` / `EmployeeProfile`) rather than a single component with many conditionals.
+Default to a single `Root`. Split only when two flows genuinely share very little — for example admin vs self-service variants with substantially different fields, validation, and submit sequences. In that case prefer **two separate public components** (`AdminFoo`, `EmployeeFoo`) over a single entry that forks internally.
+
+`Employee.Profile` forks internally (`AdminProfile` / `EmployeeProfile`) to preserve a single public `Profile` surface for partners; that is a product-specific compromise, not the recommended default.
 
 ## 2. Hook Initialization
 
-Initialize all hooks at the top of the inner component. Pass `shouldFocusError: false` to every hook — `composeSubmitHandler` manages cross-form focus.
+Initialize the hook(s) at the top of `Root`. When composing multiple form hooks, pass `shouldFocusError: false` to every hook so `composeSubmitHandler` manages cross-form focus instead of each hook competing for it.
 
 ```tsx
 const employeeDetails = useEmployeeDetailsForm({
@@ -339,7 +348,7 @@ const startDate = workAddress.form.getFormSubmissionValues()?.effectiveDate
 
 ## 8. Events
 
-`onEvent` is received as a prop and threaded through to inner components — do NOT use `useBase()`:
+`onEvent` is received as a prop on the public component and passed through to `Root` — do NOT use `useBase()`:
 
 ```tsx
 function Root({ onEvent, ...props }: MyComponentProps) {
@@ -361,7 +370,7 @@ After migration, remove dead code from the component directory:
 
 ## 10. Migration Checklist
 
-- [ ] Entry point wraps `BaseBoundaries` (not `BaseComponent`) and forks to inner component(s)
+- [ ] Public component wraps `BaseBoundaries` (not `BaseComponent`) and delegates to a single `Root` (split only when flows truly diverge)
 - [ ] All hooks initialized with `shouldFocusError: false`
 - [ ] Errors composed via `composeSubmitHandler` (multi-form) and/or `composeErrorHandler` (extra queries / submit state) rather than manual array spreading
 - [ ] Loading state uses `<BaseLayout isLoading error={errorHandling.errors} />`

--- a/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -14,6 +14,19 @@ Reference implementation: `PayScheduleForm` — PR #1545 or branch `sdk-774-pay-
 
 Hooks reference: `.claude/hooks-implementation.md` — covers schema, fields, hook internals, error handling, and exports in detail. Read it before starting a migration.
 
+## Core Principle: The Hook Owns the Business Logic
+
+Before writing any logic in the component, read the hook. Hooks encapsulate field visibility, conditional requiredness, derived data, loading states, and submit behavior. The component is a thin rendering layer around whatever the hook already exposes.
+
+Common anti-patterns to avoid:
+
+- Reaching for `useWatch` to gate field visibility when the hook already returns the field as `undefined` when it shouldn't be shown
+- Duplicating the hook's requiredness logic via component-level conditionals
+- Querying an entity in the component when the hook is already fetching and exposing it via `data` or `status`
+- Computing derived values (e.g. "is this schedule in create vs edit mode") in the component when the hook surfaces them
+
+**Rule of thumb**: if you're writing business logic in the component that every partner using the hook would also need, that logic belongs in the hook. Stop, move it into the hook, and re-export it via the hook's return shape. The SDK component and partner code should look identical in terms of which fields are shown and when.
+
 ## 1. Component Structure
 
 ### Entry Point
@@ -279,13 +292,15 @@ const HomeAddressFields = homeAddress.form.Fields
 
 ### Conditional Fields
 
-Fields that may not exist are `undefined` — guard with truthiness checks:
+**The hook controls field visibility.** When a field shouldn't be shown, the hook returns it as `undefined` on `form.Fields`. Guard with a truthiness check and render — do **not** use `useWatch` or component-level state to decide whether a field should appear:
 
 ```tsx
 {
   WorkAddressFields.EffectiveDate && <WorkAddressFields.EffectiveDate label={t('startDate')} />
 }
 ```
+
+If you find yourself manually gating visibility based on another field's value, that logic almost certainly belongs inside the hook's schema or `Fields` selection. Move it there instead of reproducing it per-component.
 
 ### Validation Messages
 
@@ -341,7 +356,9 @@ Validation translations should live in the component's translation namespace (e.
 
 ### Watching Form Values
 
-When the component needs to react to field values (e.g. toggling sections based on a checkbox), use `useWatch` with the hook's `control`:
+`useWatch` is a last resort — reach for it only when the reactive behavior is genuinely presentational and has no business meaning (e.g. showing a non-functional preview panel). Anything that affects which fields render, which are required, or which get submitted belongs in the hook.
+
+When `useWatch` is the right tool, use it with the hook's `control`:
 
 ```tsx
 const watchedValue = useWatch({
@@ -350,7 +367,7 @@ const watchedValue = useWatch({
 })
 ```
 
-For read-only access without re-renders on every change (e.g. reading at submit time), use `getFormSubmissionValues()`:
+For read-only access at submit time (no re-renders on change), use `getFormSubmissionValues()`:
 
 ```tsx
 const startDate = workAddress.form.getFormSubmissionValues()?.effectiveDate

--- a/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -10,10 +10,7 @@ description: >-
 
 # Migrating SDK Components to Hook-Based Architecture
 
-Reference implementations:
-
-- **Single hook, single form** (recommended default): `PayScheduleForm` — see PR #1545 or branch `sdk-774-pay-schedule-hook`. Clean illustration of the `BaseBoundaries` + `Root` + single-hook shape.
-- **Multiple composed hooks with admin/self-service variants**: `Employee.Profile` (`Profile.tsx`, `AdminProfile.tsx`, `EmployeeProfile.tsx`) — PR #1570 or branch `sdk-777-profile-hook-migration`. Useful when composing hooks and aggregating errors, but its internal fork is a product-specific compromise, not the default model.
+Reference implementation: `PayScheduleForm` — PR #1545 or branch `sdk-774-pay-schedule-hook`. For hook composition, error aggregation, and `composeSubmitHandler` patterns, `AdminProfile` / `EmployeeProfile` on PR #1570 / branch `sdk-777-profile-hook-migration` are also useful.
 
 Hooks reference: `.claude/hooks-implementation.md` — covers schema, fields, hook internals, error handling, and exports in detail. Read it before starting a migration.
 
@@ -21,9 +18,7 @@ Hooks reference: `.claude/hooks-implementation.md` — covers schema, fields, ho
 
 ### Entry Point
 
-The public component wraps `BaseBoundaries` and delegates to a single `Root` component that initializes the hook(s) and renders the form. `onEvent` is passed as a prop — do NOT use `BaseComponent` or `useBase()`.
-
-Reference: `PayScheduleForm` on branch `sdk-774-pay-schedule-hook` (PR #1545) is a clean example of the simple single-hook shape.
+The public component wraps `BaseBoundaries` and delegates to a single `Root` component that initializes the hook(s) and renders the form. `onEvent` is passed as a prop — do NOT use `BaseComponent` or `useBase()`. When admin and self-service flows diverge, create two separate public components rather than forking internally.
 
 ```tsx
 interface MyComponentProps extends UseMyFormProps {
@@ -59,12 +54,6 @@ Unlike `BaseComponent`, `BaseBoundaries` does NOT provide `BaseContext`. This me
 ### Suspense Boundary
 
 `BaseBoundaries` provides a `Suspense` boundary. This is needed for `useI18n` / `useTranslation` and similar hooks that suspend. Prefer non-suspense queries for data fetching — the form hooks use regular queries internally and manage their own loading states via `isLoading`.
-
-### When to Split Into Multiple Components
-
-Default to a single `Root`. Split only when two flows genuinely share very little — for example admin vs self-service variants with substantially different fields, validation, and submit sequences. In that case prefer **two separate public components** (`AdminFoo`, `EmployeeFoo`) over a single entry that forks internally.
-
-`Employee.Profile` forks internally (`AdminProfile` / `EmployeeProfile`) to preserve a single public `Profile` surface for partners; that is a product-specific compromise, not the recommended default.
 
 ## 2. Hook Initialization
 
@@ -370,7 +359,7 @@ After migration, remove dead code from the component directory:
 
 ## 10. Migration Checklist
 
-- [ ] Public component wraps `BaseBoundaries` (not `BaseComponent`) and delegates to a single `Root` (split only when flows truly diverge)
+- [ ] Public component wraps `BaseBoundaries` (not `BaseComponent`) and delegates to a single `Root`
 - [ ] All hooks initialized with `shouldFocusError: false`
 - [ ] Errors composed via `composeSubmitHandler` (multi-form) and/or `composeErrorHandler` (extra queries / submit state) rather than manual array spreading
 - [ ] Loading state uses `<BaseLayout isLoading error={errorHandling.errors} />`

--- a/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -391,13 +391,22 @@ function Root({ onEvent, ...props }: MyComponentProps) {
 }
 ```
 
-## 9. Cleanup Checklist
+## 9. Cleanup: Legacy Patterns to Remove
 
-After migration, remove dead code from the component directory:
+The pre-hook components were built around a pattern that split a single screen into inline sub-components (`Head`, `Actions`, specific field groups like `WorkAddress`, `HomeAddress`, `PersonalDetails`) backed by a domain context (e.g. `ProfileContext`) to thread form state, handlers, and flags between them. A thin monolithic file then wired everything together.
+
+The hook + `Root` shape replaces that entirely:
+
+- The hook owns state, validation, and submit logic
+- `Root` is the view layer that composes the hook and renders fields inline
+
+There's no longer a reason to split a single screen into `Head` / `Actions` / per-section files, and no reason for a sibling context to share form state — the hook result is the shared state. Keep `Root` as a flat, readable component. Only extract presentational fragments when they're genuinely reused or independently testable, not as a reflex.
+
+After migration, remove:
 
 - [ ] Old monolithic form component files
-- [ ] Old context providers (e.g. `ProfileContext`)
-- [ ] Inline sub-components (e.g. `Head`, `Actions`, `WorkAddress`)
+- [ ] Inline sub-components (`Head`, `Actions`, per-section field groupings) — their contents move into `Root`
+- [ ] Domain context providers (e.g. `ProfileContext`) that existed to share form state across those sub-components
 - [ ] Helper utilities only used by the old implementation
 - [ ] Tests for deleted helpers
 - [ ] Unused imports in barrel files

--- a/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -89,35 +89,49 @@ Pass `resolvedEmployeeId` to downstream hooks. Update it in the submit handler a
 
 ### Error Aggregation
 
-Aggregate errors from all hooks into a single array:
+Prefer `composeErrorHandler` / `composeSubmitHandler` over manual array spreading. These helpers produce a single `HookErrorHandling` bag — the same shape every SDK hook returns — that drives `BaseLayout`'s error alert, retry, and clear-submit-error behavior.
+
+**For multiple form hooks composed on a page**, use `composeSubmitHandler` — it returns both the submit handler and an aggregated `errorHandling` covering every form passed in:
 
 ```tsx
-const allErrors = [
-  ...employeeDetails.errorHandling.errors,
-  ...homeAddress.errorHandling.errors,
-  ...workAddress.errorHandling.errors,
-]
+const { handleSubmit, errorHandling } = composeSubmitHandler(
+  [employeeDetails, homeAddress, workAddress],
+  async () => {
+    /* submit sequence */
+  },
+)
 ```
+
+**For plain React Query fetches alongside hooks**, use `composeErrorHandler` to merge query errors, nested hook errors, and optional submit state from `useBaseSubmit`:
+
+```tsx
+const errorHandling = composeErrorHandler(
+  [workAddressesQuery, employeeDetails, homeAddress], // mix of queries and hook results
+  { submitError, setSubmitError }, // optional — from useBaseSubmit
+)
+```
+
+The returned bag has `{ errors, retryQueries, clearSubmitError }`. Since the shape matches a hook's `errorHandling`, you can nest further by feeding a composed bag back in via `{ errorHandling }`.
 
 ### Loading Gate
 
-When any hook is loading, render `BaseLayout` with `isLoading` and errors. This shows a loading indicator, or errors if a query failed (so users see a retry option instead of an infinite spinner):
+When any hook is loading, render `BaseLayout` with `isLoading` and the composed errors. This shows a loading indicator, or errors if a query failed (so users see a retry option instead of an infinite spinner):
 
 ```tsx
 if (employeeDetails.isLoading || homeAddress.isLoading || workAddress.isLoading) {
-  return <BaseLayout isLoading error={allErrors} />
+  return <BaseLayout isLoading error={errorHandling.errors} />
 }
 ```
 
 ### Ready State
 
-Wrap the form content in `BaseLayout` with errors to display error alerts above the form:
+Wrap the form content in `BaseLayout` with the composed errors to display error alerts above the form:
 
 ```tsx
 return (
   <section className={className}>
-    <BaseLayout error={allErrors}>
-      <Form onSubmit={composedHandler}>{/* form content */}</Form>
+    <BaseLayout error={errorHandling.errors}>
+      <Form onSubmit={handleSubmit}>{/* form content */}</Form>
     </BaseLayout>
   </section>
 )
@@ -168,12 +182,12 @@ When a hook's fields are split across the layout, use `formHookResult` prop on *
 
 ## 5. Composing Submissions with composeSubmitHandler
 
-`composeSubmitHandler` validates all forms simultaneously, focuses the first invalid field across forms, and only calls `onAllValid` when every form passes.
+`composeSubmitHandler` validates all forms simultaneously, focuses the first invalid field across forms, and only calls `onAllValid` when every form passes. It returns `{ handleSubmit, errorHandling }` — the `errorHandling` aggregates every form's error state so you can drive a single `BaseLayout` from it.
 
 ```tsx
 const activeForms = [employeeDetails, ...(showHomeAddress ? [homeAddress] : []), workAddress]
 
-const composedHandler = composeSubmitHandler(activeForms, async () => {
+const { handleSubmit, errorHandling } = composeSubmitHandler(activeForms, async () => {
   const employeeResult = await employeeDetails.actions.onSubmit({
     /* callbacks */
   })
@@ -200,10 +214,31 @@ const composedHandler = composeSubmitHandler(activeForms, async () => {
 
 Key points:
 
-- `activeForms` array determines which forms are validated — conditionally exclude forms whose sections are hidden
-- Do NOT memoize `activeForms` or `composedHandler` — hook return values are not stable references
+- `activeForms` array determines which forms are validated and contributes to `errorHandling` — conditionally exclude forms whose sections are hidden
+- Do NOT memoize `activeForms` or the `composeSubmitHandler` result — hook return values are not stable references
 - Submit sequentially, checking each result — return early on failure to prevent cascading errors
 - Update `resolvedEmployeeId` on partial failure in create mode
+- Pass `errorHandling.errors` to `BaseLayout` for a unified error surface across all forms
+
+### Adding Extra Queries or Submit State
+
+If the component has React Query fetches outside the form hooks (e.g. a read-only lookup) or screen-level submit state from `useBaseSubmit`, feed them through `composeErrorHandler` alongside the composed submit result:
+
+```tsx
+const { handleSubmit, errorHandling: formsErrorHandling } = composeSubmitHandler(
+  [employeeDetails, homeAddress],
+  async () => {
+    /* ... */
+  },
+)
+
+const errorHandling = composeErrorHandler(
+  [workAddressesQuery, { errorHandling: formsErrorHandling }],
+  { submitError, setSubmitError }, // optional
+)
+
+return <BaseLayout error={errorHandling.errors}>{/* ... */}</BaseLayout>
+```
 
 ## 6. Field Rendering
 
@@ -327,11 +362,10 @@ After migration, remove dead code from the component directory:
 ## 10. Migration Checklist
 
 - [ ] Entry point wraps `BaseBoundaries` (not `BaseComponent`) and forks to inner component(s)
-- [ ] Suspense queries primed in wrapper above Root (if entity ID provided)
 - [ ] All hooks initialized with `shouldFocusError: false`
-- [ ] Errors aggregated from all hooks into single array
-- [ ] Loading state uses `<BaseLayout isLoading error={allErrors} />`
-- [ ] Ready state wraps content in `<BaseLayout error={allErrors}>`
+- [ ] Errors composed via `composeSubmitHandler` (multi-form) and/or `composeErrorHandler` (extra queries / submit state) rather than manual array spreading
+- [ ] Loading state uses `<BaseLayout isLoading error={errorHandling.errors} />`
+- [ ] Ready state wraps content in `<BaseLayout error={errorHandling.errors}>`
 - [ ] SDKFormProvider rules followed (no nesting, no mixing, no cross-hook fields)
 - [ ] `composeSubmitHandler` used for multi-hook forms, not memoized
 - [ ] Partial update recovery handled for create mode

--- a/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -127,16 +127,15 @@ const { handleSubmit, errorHandling } = composeSubmitHandler(
 )
 ```
 
-**For plain React Query fetches alongside hooks**, use `composeErrorHandler` to merge query errors, nested hook errors, and optional submit state from `useBaseSubmit`:
+**For plain React Query fetches alongside hooks**, use `composeErrorHandler` to merge query errors and nested hook errors:
 
 ```tsx
-const errorHandling = composeErrorHandler(
-  [workAddressesQuery, employeeDetails, homeAddress], // mix of queries and hook results
-  { submitError, setSubmitError }, // optional — from useBaseSubmit
-)
+const errorHandling = composeErrorHandler([workAddressesQuery, employeeDetails, homeAddress]) // mix of queries and hook results
 ```
 
 The returned bag has `{ errors, retryQueries, clearSubmitError }`. Since the shape matches a hook's `errorHandling`, you can nest further by feeding a composed bag back in via `{ errorHandling }`.
+
+The second argument — `{ submitError, setSubmitError }` from `useBaseSubmit` — is only relevant when the component itself runs a submit via `useBaseSubmit`. In a fully hook-driven migration the form hooks own their own submit state, so this can be omitted. Include it only if you have a screen-level submit outside the form hooks that needs to surface errors through the same `BaseLayout`.
 
 ### Loading Gate
 
@@ -245,9 +244,9 @@ Key points:
 - Update `resolvedEmployeeId` on partial failure in create mode
 - Pass `errorHandling.errors` to `BaseLayout` for a unified error surface across all forms
 
-### Adding Extra Queries or Submit State
+### Adding Extra Queries
 
-If the component has React Query fetches outside the form hooks (e.g. a read-only lookup) or screen-level submit state from `useBaseSubmit`, feed them through `composeErrorHandler` alongside the composed submit result:
+If the component has React Query fetches outside the form hooks (e.g. a read-only lookup), feed them through `composeErrorHandler` alongside the composed submit result:
 
 ```tsx
 const { handleSubmit, errorHandling: formsErrorHandling } = composeSubmitHandler(
@@ -257,13 +256,15 @@ const { handleSubmit, errorHandling: formsErrorHandling } = composeSubmitHandler
   },
 )
 
-const errorHandling = composeErrorHandler(
-  [workAddressesQuery, { errorHandling: formsErrorHandling }],
-  { submitError, setSubmitError }, // optional
-)
+const errorHandling = composeErrorHandler([
+  workAddressesQuery,
+  { errorHandling: formsErrorHandling },
+])
 
 return <BaseLayout error={errorHandling.errors}>{/* ... */}</BaseLayout>
 ```
+
+Pass `{ submitError, setSubmitError }` from `useBaseSubmit` as the second argument only if the component runs its own screen-level submit outside the form hooks. Most hook-driven migrations won't need it — the form hooks manage their own submit state.
 
 ## 6. Field Rendering
 

--- a/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -75,13 +75,40 @@ const homeAddress = useHomeAddressForm({
 
 ### Partial Update Recovery (Create Mode)
 
-When composing hooks that create entities sequentially (e.g. create employee → create home address → create work address), track the created ID in state so that if a later step fails, retrying doesn't re-create the first entity:
+When composing hooks that create entities sequentially (e.g. create employee → create home address → create work address), a mid-sequence failure can leave the first entity created and the downstream ones not. Without recovery, a retry would create a second root entity.
+
+Three rules keep this correct and non-disruptive:
+
+**1. Prefer the onSubmit escape hatch over component state.** Hooks typically accept an entity id as an `onSubmit` argument so a downstream hook can target a just-created parent without the component having to thread it through props. Use that first:
+
+```tsx
+const employeeResult = await employeeDetails.actions.onSubmit()
+if (!employeeResult) return
+await homeAddress.actions.onSubmit({ employeeId: employeeResult.data.uuid })
+```
+
+**2. Defer to the partner for id updates on success.** When creation succeeds, emit the created entity via `onEvent` and let the partner decide what to do — usually navigate away or pass the new id back through props. Do **not** stash the id in component state on success. Storing it triggers a re-render mid-submission, which can flip the hook back into loading state and unmount the form under the user.
+
+**3. Only flip to update mode internally on failure.** If a create partially fails (root created, child errored), then — and only then — capture the created id in state so a retry targets the existing root instead of creating a duplicate:
 
 ```tsx
 const [resolvedEmployeeId, setResolvedEmployeeId] = useState(employeeId)
+
+// In the composed submit handler:
+const employeeResult = await employeeDetails.actions.onSubmit()
+if (!employeeResult) return
+
+const newId = employeeResult.data.uuid
+
+const homeResult = await homeAddress.actions.onSubmit({ employeeId: newId })
+if (!homeResult) {
+  if (!employeeId) setResolvedEmployeeId(newId) // recovery only
+  return
+}
+// success path: no setState — partner navigates / re-renders via onEvent
 ```
 
-Pass `resolvedEmployeeId` to downstream hooks. Update it in the submit handler after a successful create.
+Pass `resolvedEmployeeId` to downstream hooks so retries reuse the created root. `Employee.Profile` is the reference for this pattern.
 
 ## 3. Loading and Error States with BaseLayout
 

--- a/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -49,19 +49,9 @@ Unlike `BaseComponent`, `BaseBoundaries` does NOT provide `BaseContext`. This me
 - Error state is managed by the hooks' `errorHandling` bags, not `BaseContext`
 - `BaseLayout` is used explicitly inside the inner component for loading/error display
 
-### Suspense Data Priming
+### Suspense Boundary
 
-If the component receives an entity ID, prime suspense queries in a wrapper above `Root` so data is cached before hooks run:
-
-```tsx
-function RootWithEmployee({ employeeId, ...props }) {
-  useEmployeesGetSuspense({ employeeId })
-  useEmployeeAddressesGetSuspense({ employeeId })
-  return <Root {...props} employeeId={employeeId} />
-}
-```
-
-Do NOT use suspense queries inside the inner component — hooks use regular queries internally. The suspense wrapper exists only to warm the cache within the `Suspense` boundary that `BaseBoundaries` provides.
+`BaseBoundaries` provides a `Suspense` boundary. This is needed for `useI18n` / `useTranslation` and similar hooks that suspend. Prefer non-suspense queries for data fetching — the form hooks use regular queries internally and manage their own loading states via `isLoading`.
 
 ### Inner Component Split
 

--- a/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 
 # Migrating SDK Components to Hook-Based Architecture
 
-Reference implementation: `Employee.Profile` — see `AdminProfile.tsx`, `EmployeeProfile.tsx`, and `Profile.tsx`.
+Reference implementation: `Employee.Profile` — see `AdminProfile.tsx`, `EmployeeProfile.tsx`, and `Profile.tsx`. If the Profile migration has not been merged to main yet, reference PR #1570 or branch `sdk-777-profile-hook-migration`.
 
 Hooks reference: `.claude/hooks-implementation.md` — covers schema, fields, hook internals, error handling, and exports in detail. Read it before starting a migration.
 


### PR DESCRIPTION
## Summary

- Adds a new Cursor skill at `.cursor/skills/migrate-sdk-component-to-hooks/SKILL.md` that documents the full component migration workflow
- Covers BaseComponent/BaseLayout integration, SDKFormProvider rules, composeSubmitHandler usage, error/loading state patterns, validation messages, partial update recovery, and cleanup checklist
- Complements the existing `.claude/hooks-implementation.md` which covers hook internals — this skill covers the component-level migration patterns

## Test plan

- [ ] Verify skill is discoverable in Cursor when working on component migrations
- [ ] Verify guidance is consistent with existing Profile migration and hooks-implementation.md


Made with [Cursor](https://cursor.com)