### PR TITLE
chore: partner hooks BaseHookReady typing (SDK-778)

### DIFF
--- a/.claude/commands/create-hook.md
+++ b/.claude/commands/create-hook.md
@@ -112,9 +112,11 @@ Key imports:
 
 - `import { useDeriveFieldsMetadata } from '@/partner-hook-utils/form/useDeriveFieldsMetadata'`
 - `import { useErrorHandling } from '@/partner-hook-utils/useErrorHandling'`
-- `import type { HookSubmitResult } from '@/partner-hook-utils/types'`
+- `import type { BaseFormHookReady, FieldsMetadata, HookLoadingResult, HookSubmitResult } from '@/partner-hook-utils/types'`
 - `import { createGetFormSubmissionValues } from '@/partner-hook-utils/form/getFormSubmissionValues'`
 - `import { composeSubmitHandler } from '@/partner-hook-utils/form/composeSubmitHandler'`
+
+**Typing:** Declare a ready-state interface that extends `BaseFormHookReady<FieldsMetadata, {Name}FormData>`, narrow `data`, `status`, and `actions` as needed, and annotate the hook with `HookLoadingResult | Use{Name}Ready`. Export `Use{Name}Result` as `HookLoadingResult | Use{Name}Ready`. Document-sign hooks always set `status.mode` to `'create'` on the ready branch (see JSDoc on `BaseFormHookReady` in `src/partner-hook-utils/types.ts`). Non-form hooks use `BaseHookReady<TData, TStatus>` instead of `Omit<BaseHookReady, …>`.
 
 #### `index.ts`
 

--- a/src/components/Company/DocumentSigner/shared/useSignCompanyForm/useSignCompanyForm.test.tsx
+++ b/src/components/Company/DocumentSigner/shared/useSignCompanyForm/useSignCompanyForm.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/test/mocks/apis/company_forms'
 import { setupApiTestMocks } from '@/test/mocks/apiServer'
 import { GustoTestProvider } from '@/test/GustoTestApiProvider'
+import { fieldsMetadataEntry } from '@/test/fieldsMetadata'
 
 type ReadyResult = Extract<UseSignCompanyFormResult, { isLoading: false }>
 
@@ -287,8 +288,10 @@ describe('useSignCompanyForm', () => {
     const readyResult = result.current
     assertReady(readyResult)
 
-    expect(readyResult.form.fieldsMetadata.signature.isRequired).toBe(true)
-    expect(readyResult.form.fieldsMetadata.confirmSignature.isRequired).toBe(true)
+    expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'signature').isRequired).toBe(true)
+    expect(
+      fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'confirmSignature').isRequired,
+    ).toBe(true)
   })
 
   it('provides errorHandling in loading state', () => {

--- a/src/components/Company/DocumentSigner/shared/useSignCompanyForm/useSignCompanyForm.tsx
+++ b/src/components/Company/DocumentSigner/shared/useSignCompanyForm/useSignCompanyForm.tsx
@@ -16,7 +16,12 @@ import { SignatureField, ConfirmSignatureField } from './fields'
 import { useDeriveFieldsMetadata } from '@/partner-hook-utils/form/useDeriveFieldsMetadata'
 import { createGetFormSubmissionValues } from '@/partner-hook-utils/form/getFormSubmissionValues'
 import { useErrorHandling } from '@/partner-hook-utils/useErrorHandling'
-import type { HookSubmitResult } from '@/partner-hook-utils/types'
+import type {
+  BaseFormHookReady,
+  FieldsMetadata,
+  HookLoadingResult,
+  HookSubmitResult,
+} from '@/partner-hook-utils/types'
 import { useBaseSubmit } from '@/components/Base/useBaseSubmit'
 import { SDKInternalError } from '@/types/sdkError'
 
@@ -34,6 +39,22 @@ export interface UseSignCompanyFormProps {
   shouldFocusError?: boolean
 }
 
+export interface UseSignCompanyFormReady extends BaseFormHookReady<
+  FieldsMetadata,
+  SignCompanyFormData
+> {
+  data: {
+    companyForm: Form
+    pdfUrl: string | null
+  }
+  status: { isPending: boolean; mode: 'create' }
+  actions: {
+    onSubmit: (
+      callbacks?: SignCompanyFormSubmitCallbacks,
+    ) => Promise<HookSubmitResult<Form> | undefined>
+  }
+}
+
 const HARDCODED_DEFAULTS: SignCompanyFormData = {
   signature: '',
   confirmSignature: false,
@@ -45,7 +66,7 @@ export function useSignCompanyForm({
   defaultValues: partnerDefaults,
   validationMode = 'onSubmit',
   shouldFocusError = true,
-}: UseSignCompanyFormProps) {
+}: UseSignCompanyFormProps): HookLoadingResult | UseSignCompanyFormReady {
   const formQuery = useCompanyFormsGet({ formId })
   const pdfQuery = useCompanyFormsGetPdf({ formId })
 
@@ -149,6 +170,7 @@ export function useSignCompanyForm({
     },
     status: {
       isPending,
+      mode: 'create' as const,
     },
     actions: { onSubmit },
     errorHandling,
@@ -164,7 +186,6 @@ export function useSignCompanyForm({
   }
 }
 
-export type UseSignCompanyFormResult = ReturnType<typeof useSignCompanyForm>
-export type UseSignCompanyFormReady = Extract<UseSignCompanyFormResult, { data: object }>
+export type UseSignCompanyFormResult = HookLoadingResult | UseSignCompanyFormReady
 export type SignCompanyFormFieldsMetadata = UseSignCompanyFormReady['form']['fieldsMetadata']
 export type SignCompanyFormFields = UseSignCompanyFormReady['form']['Fields']

--- a/src/components/Company/PaySchedule/shared/usePayScheduleForm/usePayScheduleForm.tsx
+++ b/src/components/Company/PaySchedule/shared/usePayScheduleForm/usePayScheduleForm.tsx
@@ -30,7 +30,12 @@ import { useDeriveFieldsMetadata } from '@/partner-hook-utils/form/useDeriveFiel
 import { createGetFormSubmissionValues } from '@/partner-hook-utils/form/getFormSubmissionValues'
 import { withOptions } from '@/partner-hook-utils/form/withOptions'
 import { useErrorHandling } from '@/partner-hook-utils/useErrorHandling'
-import type { HookSubmitResult } from '@/partner-hook-utils/types'
+import type {
+  BaseFormHookReady,
+  FieldsMetadata,
+  HookLoadingResult,
+  HookSubmitResult,
+} from '@/partner-hook-utils/types'
 import { useBaseSubmit } from '@/components/Base/useBaseSubmit'
 import { parsePaymentSpeedDays } from '@/hooks/useCompanyPaymentSpeed'
 import { formatDateToStringDate } from '@/helpers/dateFormatting'
@@ -44,6 +49,22 @@ export interface UsePayScheduleFormProps {
   defaultValues?: Partial<PayScheduleFormData>
   validationMode?: UseFormProps['mode']
   shouldFocusError?: boolean
+}
+
+export interface UsePayScheduleFormReady extends BaseFormHookReady<
+  FieldsMetadata,
+  PayScheduleFormData
+> {
+  data: {
+    paySchedule: PaySchedule | null
+    payPeriodPreview: PaySchedulePreviewPayPeriod[] | null
+    payPreviewLoading: boolean
+    paymentSpeedDays: number | null
+  }
+  status: { isPending: boolean; mode: 'create' | 'update' }
+  actions: {
+    onSubmit: () => Promise<HookSubmitResult<PaySchedule> | undefined>
+  }
 }
 
 const FREQUENCY_OPTIONS: Array<{ value: PayScheduleFrequency; label: string }> = [
@@ -85,7 +106,7 @@ export function usePayScheduleForm({
   defaultValues: partnerDefaults,
   validationMode = 'onSubmit',
   shouldFocusError = true,
-}: UsePayScheduleFormProps) {
+}: UsePayScheduleFormProps): HookLoadingResult | UsePayScheduleFormReady {
   const payScheduleQuery = usePaySchedulesGet(
     { companyId, payScheduleId: payScheduleId ?? '' },
     { enabled: !!payScheduleId },
@@ -307,7 +328,6 @@ export function usePayScheduleForm({
   }
 }
 
-export type UsePayScheduleFormResult = ReturnType<typeof usePayScheduleForm>
-export type UsePayScheduleFormReady = Extract<UsePayScheduleFormResult, { data: object }>
+export type UsePayScheduleFormResult = HookLoadingResult | UsePayScheduleFormReady
 export type PayScheduleFieldsMetadata = UsePayScheduleFormReady['form']['fieldsMetadata']
 export type PayScheduleFormFields = UsePayScheduleFormReady['form']['Fields']

--- a/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.tsx
+++ b/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.tsx
@@ -36,7 +36,12 @@ import { withOptions } from '@/partner-hook-utils/form/withOptions'
 import { createGetFormSubmissionValues } from '@/partner-hook-utils/form/getFormSubmissionValues'
 import { useDeriveFieldsMetadata } from '@/partner-hook-utils/form/useDeriveFieldsMetadata'
 import { useErrorHandling } from '@/partner-hook-utils/useErrorHandling'
-import type { HookSubmitResult } from '@/partner-hook-utils/types'
+import type {
+  BaseFormHookReady,
+  FieldsMetadata,
+  HookLoadingResult,
+  HookSubmitResult,
+} from '@/partner-hook-utils/types'
 import { FlsaStatus, PAY_PERIODS, TIP_CREDITS_UNSUPPORTED_STATES } from '@/shared/constants'
 import { useBaseSubmit } from '@/components/Base/useBaseSubmit'
 import { SDKInternalError } from '@/types/sdkError'
@@ -61,6 +66,25 @@ export interface UseCompensationFormProps {
   defaultValues?: Partial<CompensationFormData>
   validationMode?: UseFormProps['mode']
   shouldFocusError?: boolean
+}
+
+export interface UseCompensationFormReady extends BaseFormHookReady<
+  FieldsMetadata,
+  CompensationFormData
+> {
+  data: {
+    compensation: Compensation | null
+    jobs: Job[] | undefined
+    currentJob: Job | null
+    minimumWages: MinimumWage[]
+  }
+  status: { isPending: boolean; mode: 'create' | 'update' }
+  actions: {
+    onSubmit: (
+      callbacks?: CompensationSubmitCallbacks,
+      options?: CompensationSubmitOptions,
+    ) => Promise<HookSubmitResult<Compensation | undefined> | undefined>
+  }
 }
 
 function findCurrentCompensation(job?: Job | null): Compensation | undefined {
@@ -109,7 +133,7 @@ export function useCompensationForm({
   defaultValues: partnerDefaults,
   validationMode = 'onSubmit',
   shouldFocusError = true,
-}: UseCompensationFormProps) {
+}: UseCompensationFormProps): HookLoadingResult | UseCompensationFormReady {
   const jobsQuery = useJobsAndCompensationsGetJobs(
     { employeeId: employeeId ?? '' },
     { enabled: !!employeeId },
@@ -464,7 +488,6 @@ export function useCompensationForm({
   }
 }
 
-export type UseCompensationFormResult = ReturnType<typeof useCompensationForm>
-export type UseCompensationFormReady = Extract<UseCompensationFormResult, { data: object }>
+export type UseCompensationFormResult = HookLoadingResult | UseCompensationFormReady
 export type CompensationFieldsMetadata = UseCompensationFormReady['form']['fieldsMetadata']
 export type CompensationFormFields = UseCompensationFormReady['form']['Fields']

--- a/src/components/Employee/Dashboard/hooks/useEmployeeBasicDetails.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeBasicDetails.tsx
@@ -12,16 +12,14 @@ export interface UseEmployeeBasicDetailsProps {
   employeeId: string
 }
 
-interface UseEmployeeBasicDetailsReady extends Omit<BaseHookReady, 'data' | 'status'> {
-  data: {
+type UseEmployeeBasicDetailsReady = BaseHookReady<
+  {
     employee: Employee
     currentHomeAddress?: EmployeeAddress
     currentWorkAddress?: EmployeeWorkAddress
-  }
-  status: {
-    isPending: boolean
-  }
-}
+  },
+  { isPending: boolean }
+>
 
 export type UseEmployeeBasicDetailsResult = HookLoadingResult | UseEmployeeBasicDetailsReady
 

--- a/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
@@ -26,8 +26,8 @@ export interface UseEmployeeCompensationProps {
   employeeId: string
 }
 
-interface UseEmployeeCompensationReady extends Omit<BaseHookReady, 'data' | 'status'> {
-  data: {
+interface UseEmployeeCompensationReady extends BaseHookReady<
+  {
     primaryJob?: Job
     employeePaymentMethod?: NonNullable<
       GetV1EmployeesEmployeeIdPaymentMethodResponse['employeePaymentMethod']
@@ -35,10 +35,9 @@ interface UseEmployeeCompensationReady extends Omit<BaseHookReady, 'data' | 'sta
     bankAccounts: EmployeeBankAccount[]
     garnishmentList: Garnishment[]
     payStubs: EmployeePayStub[]
-  }
-  status: {
-    isPending: boolean
-  }
+  },
+  { isPending: boolean }
+> {
   pagination: {
     payStubs?: PaginationControlProps
   }

--- a/src/components/Employee/Dashboard/hooks/useEmployeeForms.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeForms.tsx
@@ -7,14 +7,7 @@ export interface UseEmployeeFormsProps {
   employeeId: string
 }
 
-interface UseEmployeeFormsReady extends Omit<BaseHookReady, 'data' | 'status'> {
-  data: {
-    formList: Form[]
-  }
-  status: {
-    isPending: boolean
-  }
-}
+type UseEmployeeFormsReady = BaseHookReady<{ formList: Form[] }, { isPending: boolean }>
 
 export type UseEmployeeFormsResult = HookLoadingResult | UseEmployeeFormsReady
 

--- a/src/components/Employee/Dashboard/hooks/useEmployeeTaxes.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeTaxes.tsx
@@ -17,15 +17,13 @@ export interface UseEmployeeTaxesProps {
   employeeId: string
 }
 
-interface UseEmployeeTaxesReady extends Omit<BaseHookReady, 'data' | 'status'> {
-  data: {
+type UseEmployeeTaxesReady = BaseHookReady<
+  {
     employeeFederalTax?: EmployeeFederalTax
     employeeStateTaxesList: EmployeeStateTax[]
-  }
-  status: {
-    isPending: boolean
-  }
-}
+  },
+  { isPending: boolean }
+>
 
 export type UseEmployeeTaxesResult = HookLoadingResult | UseEmployeeTaxesReady
 

--- a/src/components/Employee/DocumentSigner/shared/useSignEmployeeForm/useSignEmployeeForm.test.tsx
+++ b/src/components/Employee/DocumentSigner/shared/useSignEmployeeForm/useSignEmployeeForm.test.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/test/mocks/apis/employee_forms'
 import { setupApiTestMocks } from '@/test/mocks/apiServer'
 import { GustoTestProvider } from '@/test/GustoTestApiProvider'
+import { fieldsMetadataEntry } from '@/test/fieldsMetadata'
 import type { FieldMetadataWithOptions } from '@/partner-hook-utils/types'
 
 type ReadyResult = Extract<UseSignEmployeeFormResult, { isLoading: false }>
@@ -237,8 +238,12 @@ describe('useSignEmployeeForm', () => {
       const readyResult = result.current
       assertReady(readyResult)
 
-      expect(readyResult.form.fieldsMetadata.signature.isRequired).toBe(true)
-      expect(readyResult.form.fieldsMetadata.confirmSignature.isRequired).toBe(true)
+      expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'signature').isRequired).toBe(
+        true,
+      )
+      expect(
+        fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'confirmSignature').isRequired,
+      ).toBe(true)
     })
   })
 
@@ -350,15 +355,16 @@ describe('useSignEmployeeForm', () => {
       expect(readyResult.form.preparers!.canAdd).toBe(true)
       expect(readyResult.form.preparers!.canRemove).toBe(true)
       expect(readyResult.form.Fields.Preparer1).toBeDefined()
-      expect(readyResult.form.Fields.Preparer1!.FirstName).toBeDefined()
-      expect(readyResult.form.Fields.Preparer1!.LastName).toBeDefined()
-      expect(readyResult.form.Fields.Preparer1!.Street1).toBeDefined()
-      expect(readyResult.form.Fields.Preparer1!.Street2).toBeDefined()
-      expect(readyResult.form.Fields.Preparer1!.City).toBeDefined()
-      expect(readyResult.form.Fields.Preparer1!.State).toBeDefined()
-      expect(readyResult.form.Fields.Preparer1!.Zip).toBeDefined()
-      expect(readyResult.form.Fields.Preparer1!.Signature).toBeDefined()
-      expect(readyResult.form.Fields.Preparer1!.ConfirmSignature).toBeDefined()
+      const preparer1 = readyResult.form.Fields.Preparer1 as Record<string, unknown>
+      expect(preparer1.FirstName).toBeDefined()
+      expect(preparer1.LastName).toBeDefined()
+      expect(preparer1.Street1).toBeDefined()
+      expect(preparer1.Street2).toBeDefined()
+      expect(preparer1.City).toBeDefined()
+      expect(preparer1.State).toBeDefined()
+      expect(preparer1.Zip).toBeDefined()
+      expect(preparer1.Signature).toBeDefined()
+      expect(preparer1.ConfirmSignature).toBeDefined()
       expect(readyResult.form.Fields.Preparer2).toBeUndefined()
     })
 
@@ -875,9 +881,10 @@ describe('useSignEmployeeForm', () => {
         expect((result.current as ReadyResult).form.preparers!.count).toBe(1)
       })
 
-      expect((result.current as ReadyResult).form.fieldsMetadata.preparerStreet2.isRequired).toBe(
-        false,
-      )
+      expect(
+        fieldsMetadataEntry((result.current as ReadyResult).form.fieldsMetadata, 'preparerStreet2')
+          .isRequired,
+      ).toBe(false)
     })
   })
 

--- a/src/components/Employee/DocumentSigner/shared/useSignEmployeeForm/useSignEmployeeForm.tsx
+++ b/src/components/Employee/DocumentSigner/shared/useSignEmployeeForm/useSignEmployeeForm.tsx
@@ -58,7 +58,12 @@ import { useDeriveFieldsMetadata } from '@/partner-hook-utils/form/useDeriveFiel
 import { withOptions } from '@/partner-hook-utils/form/withOptions'
 import { createGetFormSubmissionValues } from '@/partner-hook-utils/form/getFormSubmissionValues'
 import { useErrorHandling } from '@/partner-hook-utils/useErrorHandling'
-import type { HookSubmitResult } from '@/partner-hook-utils/types'
+import type {
+  BaseFormHookReady,
+  FieldsMetadata,
+  HookLoadingResult,
+  HookSubmitResult,
+} from '@/partner-hook-utils/types'
 import { useBaseSubmit } from '@/components/Base/useBaseSubmit'
 import { I9_FORM_NAME, STATES_ABBR } from '@/shared/constants'
 
@@ -123,9 +128,31 @@ export interface UseSignEmployeeFormProps {
   formId: string
 }
 
+export interface UseSignEmployeeFormReady extends BaseFormHookReady<
+  FieldsMetadata,
+  SignEmployeeFormData
+> {
+  data: {
+    form: Form
+    pdfUrl: string | null | undefined
+  }
+  status: { isPending: boolean; mode: 'create' }
+  actions: {
+    onSubmit: () => Promise<HookSubmitResult<Form> | undefined>
+    addPreparer?: () => void
+    removePreparer?: () => void
+  }
+  form: BaseFormHookReady<FieldsMetadata, SignEmployeeFormData>['form'] & {
+    preparers?: { count: number; canAdd: boolean; canRemove: boolean }
+  }
+}
+
 // ── Hook ───────────────────────────────────────────────────────────────
 
-export function useSignEmployeeForm({ employeeId, formId }: UseSignEmployeeFormProps) {
+export function useSignEmployeeForm({
+  employeeId,
+  formId,
+}: UseSignEmployeeFormProps): HookLoadingResult | UseSignEmployeeFormReady {
   const formQuery = useEmployeeFormsGet({ employeeId, formId })
   const pdfQuery = useEmployeeFormsGetPdf({ employeeId, formId })
 
@@ -259,7 +286,7 @@ export function useSignEmployeeForm({ employeeId, formId }: UseSignEmployeeFormP
   return {
     isLoading: false as const,
     data: { form, pdfUrl },
-    status: { isPending },
+    status: { isPending, mode: 'create' as const },
     actions: {
       onSubmit,
       ...(isI9 ? { addPreparer, removePreparer } : {}),
@@ -324,7 +351,6 @@ function buildPreparerPayload(payload: SignEmployeeFormOutputs, count: number) {
   return result
 }
 
-export type UseSignEmployeeFormResult = ReturnType<typeof useSignEmployeeForm>
-export type UseSignEmployeeFormReady = Extract<UseSignEmployeeFormResult, { data: object }>
+export type UseSignEmployeeFormResult = HookLoadingResult | UseSignEmployeeFormReady
 export type SignEmployeeFormFieldsMetadata = UseSignEmployeeFormReady['form']['fieldsMetadata']
 export type SignEmployeeFormFields = UseSignEmployeeFormReady['form']['Fields']

--- a/src/components/Employee/Profile/shared/useEmployeeDetailsForm/useEmployeeDetailsForm.test.tsx
+++ b/src/components/Employee/Profile/shared/useEmployeeDetailsForm/useEmployeeDetailsForm.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/test/mocks/apis/employees'
 import { setupApiTestMocks } from '@/test/mocks/apiServer'
 import { GustoTestProvider } from '@/test/GustoTestApiProvider'
+import { fieldsMetadataEntry } from '@/test/fieldsMetadata'
 import { getFixture } from '@/test/mocks/fixtures/getFixture'
 
 type ReadyResult = Extract<UseEmployeeDetailsFormResult, { isLoading: false }>
@@ -235,9 +236,11 @@ describe('useEmployeeDetailsForm', () => {
       const readyResult = result.current
       assertReady(readyResult)
 
-      expect(readyResult.form.fieldsMetadata.email.isRequired).toBe(true)
-      expect(readyResult.form.fieldsMetadata.ssn.isRequired).toBe(true)
-      expect(readyResult.form.fieldsMetadata.dateOfBirth.isRequired).toBe(false)
+      expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'email').isRequired).toBe(true)
+      expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'ssn').isRequired).toBe(true)
+      expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'dateOfBirth').isRequired).toBe(
+        false,
+      )
     })
 
     it('always includes API-required fields on create', async () => {
@@ -257,9 +260,11 @@ describe('useEmployeeDetailsForm', () => {
       const readyResult = result.current
       assertReady(readyResult)
 
-      expect(readyResult.form.fieldsMetadata.firstName.isRequired).toBe(true)
-      expect(readyResult.form.fieldsMetadata.lastName.isRequired).toBe(true)
-      expect(readyResult.form.fieldsMetadata.email.isRequired).toBe(true)
+      expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'firstName').isRequired).toBe(
+        true,
+      )
+      expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'lastName').isRequired).toBe(true)
+      expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'email').isRequired).toBe(true)
     })
   })
 
@@ -384,9 +389,11 @@ describe('useEmployeeDetailsForm', () => {
       const readyResult = result.current
       assertReady(readyResult)
 
-      expect(readyResult.form.fieldsMetadata.email.isRequired).toBe(false)
-      expect(readyResult.form.fieldsMetadata.ssn.isRequired).toBe(true)
-      expect(readyResult.form.fieldsMetadata.firstName.isRequired).toBe(false)
+      expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'email').isRequired).toBe(false)
+      expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'ssn').isRequired).toBe(true)
+      expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'firstName').isRequired).toBe(
+        false,
+      )
     })
 
     it('reports ssn as required in metadata even when has_ssn is true', async () => {
@@ -419,8 +426,9 @@ describe('useEmployeeDetailsForm', () => {
       const readyResult = result.current
       assertReady(readyResult)
 
-      expect(readyResult.form.fieldsMetadata.ssn.isRequired).toBe(true)
-      expect(readyResult.form.fieldsMetadata.ssn.hasRedactedValue).toBe(true)
+      const ssnMeta = fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'ssn')
+      expect(ssnMeta.isRequired).toBe(true)
+      expect(ssnMeta.hasRedactedValue).toBe(true)
     })
 
     it('allows empty ssn submission when has_ssn is true despite optionalFieldsToRequire', async () => {

--- a/src/components/Employee/Profile/shared/useEmployeeDetailsForm/useEmployeeDetailsForm.tsx
+++ b/src/components/Employee/Profile/shared/useEmployeeDetailsForm/useEmployeeDetailsForm.tsx
@@ -26,7 +26,12 @@ import {
 import { useDeriveFieldsMetadata } from '@/partner-hook-utils/form/useDeriveFieldsMetadata'
 import { createGetFormSubmissionValues } from '@/partner-hook-utils/form/getFormSubmissionValues'
 import { useErrorHandling } from '@/partner-hook-utils/useErrorHandling'
-import type { HookSubmitResult } from '@/partner-hook-utils/types'
+import type {
+  BaseFormHookReady,
+  FieldsMetadata,
+  HookLoadingResult,
+  HookSubmitResult,
+} from '@/partner-hook-utils/types'
 import { EmployeeOnboardingStatus } from '@/shared/constants'
 import { useBaseSubmit } from '@/components/Base/useBaseSubmit'
 import { SDKInternalError } from '@/types/sdkError'
@@ -48,6 +53,21 @@ export interface UseEmployeeDetailsFormProps {
   defaultValues?: Partial<EmployeeDetailsFormData>
   validationMode?: UseFormProps['mode']
   shouldFocusError?: boolean
+}
+
+export interface UseEmployeeDetailsFormReady extends BaseFormHookReady<
+  FieldsMetadata,
+  EmployeeDetailsFormData
+> {
+  data: {
+    employee: Employee | null
+  }
+  status: { isPending: boolean; mode: 'create' | 'update' }
+  actions: {
+    onSubmit: (
+      callbacks?: EmployeeDetailsSubmitCallbacks,
+    ) => Promise<HookSubmitResult<Employee> | undefined>
+  }
 }
 
 const isCurrentlySelfOnboarding = (employee?: Employee) => {
@@ -79,7 +99,7 @@ export function useEmployeeDetailsForm({
   defaultValues: partnerDefaults,
   validationMode = 'onSubmit',
   shouldFocusError = true,
-}: UseEmployeeDetailsFormProps) {
+}: UseEmployeeDetailsFormProps): HookLoadingResult | UseEmployeeDetailsFormReady {
   const employeeQuery = useEmployeesGet({ employeeId: employeeId ?? '' }, { enabled: !!employeeId })
 
   const employee = employeeQuery.data?.employee
@@ -262,7 +282,6 @@ export function useEmployeeDetailsForm({
   }
 }
 
-export type UseEmployeeDetailsFormResult = ReturnType<typeof useEmployeeDetailsForm>
-export type UseEmployeeDetailsFormReady = Extract<UseEmployeeDetailsFormResult, { data: object }>
+export type UseEmployeeDetailsFormResult = HookLoadingResult | UseEmployeeDetailsFormReady
 export type EmployeeDetailsFieldsMetadata = UseEmployeeDetailsFormReady['form']['fieldsMetadata']
 export type EmployeeDetailsFormFields = UseEmployeeDetailsFormReady['form']['Fields']

--- a/src/components/Employee/Profile/shared/useHomeAddressForm/useHomeAddressForm.tsx
+++ b/src/components/Employee/Profile/shared/useHomeAddressForm/useHomeAddressForm.tsx
@@ -26,7 +26,12 @@ import { useDeriveFieldsMetadata } from '@/partner-hook-utils/form/useDeriveFiel
 import { createGetFormSubmissionValues } from '@/partner-hook-utils/form/getFormSubmissionValues'
 import { withOptions } from '@/partner-hook-utils/form/withOptions'
 import { useErrorHandling } from '@/partner-hook-utils/useErrorHandling'
-import type { HookSubmitResult } from '@/partner-hook-utils/types'
+import type {
+  BaseFormHookReady,
+  FieldsMetadata,
+  HookLoadingResult,
+  HookSubmitResult,
+} from '@/partner-hook-utils/types'
 import { useBaseSubmit } from '@/components/Base/useBaseSubmit'
 import { SDKInternalError } from '@/types/sdkError'
 import { STATES_ABBR } from '@/shared/constants'
@@ -47,6 +52,22 @@ export interface UseHomeAddressFormProps {
   shouldFocusError?: boolean
 }
 
+export interface UseHomeAddressFormReady extends BaseFormHookReady<
+  FieldsMetadata,
+  HomeAddressFormData
+> {
+  data: {
+    homeAddress: EmployeeAddress | null
+    homeAddresses: EmployeeAddress[] | undefined
+  }
+  status: { isPending: boolean; mode: 'create' | 'update' }
+  actions: {
+    onSubmit: (
+      options?: HomeAddressSubmitOptions,
+    ) => Promise<HookSubmitResult<EmployeeAddress> | undefined>
+  }
+}
+
 const getActiveHomeAddress = (addresses?: EmployeeAddress[]) => {
   if (!addresses || addresses.length === 0) return undefined
   return addresses.find(address => address.active) ?? addresses[0]
@@ -59,7 +80,7 @@ export function useHomeAddressForm({
   defaultValues: partnerDefaults,
   validationMode = 'onSubmit',
   shouldFocusError = true,
-}: UseHomeAddressFormProps) {
+}: UseHomeAddressFormProps): HookLoadingResult | UseHomeAddressFormReady {
   const homeAddressesQuery = useEmployeeAddressesGet(
     { employeeId: employeeId ?? '' },
     { enabled: !!employeeId },
@@ -250,7 +271,6 @@ export function useHomeAddressForm({
   }
 }
 
-export type UseHomeAddressFormResult = ReturnType<typeof useHomeAddressForm>
-export type UseHomeAddressFormReady = Extract<UseHomeAddressFormResult, { data: object }>
+export type UseHomeAddressFormResult = HookLoadingResult | UseHomeAddressFormReady
 export type HomeAddressFieldsMetadata = UseHomeAddressFormReady['form']['fieldsMetadata']
 export type HomeAddressFormFields = UseHomeAddressFormReady['form']['Fields']

--- a/src/components/Employee/Profile/shared/useWorkAddressForm/useWorkAddressForm.tsx
+++ b/src/components/Employee/Profile/shared/useWorkAddressForm/useWorkAddressForm.tsx
@@ -20,7 +20,12 @@ import { useDeriveFieldsMetadata } from '@/partner-hook-utils/form/useDeriveFiel
 import { createGetFormSubmissionValues } from '@/partner-hook-utils/form/getFormSubmissionValues'
 import { withOptions } from '@/partner-hook-utils/form/withOptions'
 import { useErrorHandling } from '@/partner-hook-utils/useErrorHandling'
-import type { HookSubmitResult } from '@/partner-hook-utils/types'
+import type {
+  BaseFormHookReady,
+  FieldsMetadata,
+  HookLoadingResult,
+  HookSubmitResult,
+} from '@/partner-hook-utils/types'
 import { useBaseSubmit } from '@/components/Base/useBaseSubmit'
 import { SDKInternalError } from '@/types/sdkError'
 import { addressInline } from '@/helpers/formattedStrings'
@@ -47,6 +52,24 @@ export interface UseWorkAddressFormProps {
   shouldFocusError?: boolean
 }
 
+export interface UseWorkAddressFormReady extends BaseFormHookReady<
+  FieldsMetadata,
+  WorkAddressFormData
+> {
+  data: {
+    workAddress: EmployeeWorkAddress | null
+    workAddresses: EmployeeWorkAddress[] | undefined
+    companyLocations: Location[] | undefined
+  }
+  status: { isPending: boolean; mode: 'create' | 'update' }
+  actions: {
+    onSubmit: (
+      callbacks?: WorkAddressSubmitCallbacks,
+      options?: WorkAddressSubmitOptions,
+    ) => Promise<HookSubmitResult<EmployeeWorkAddress> | undefined>
+  }
+}
+
 export function useWorkAddressForm({
   companyId,
   employeeId,
@@ -55,7 +78,7 @@ export function useWorkAddressForm({
   defaultValues: partnerDefaults,
   validationMode = 'onSubmit',
   shouldFocusError = true,
-}: UseWorkAddressFormProps) {
+}: UseWorkAddressFormProps): HookLoadingResult | UseWorkAddressFormReady {
   const locationsQuery = useLocationsGet({ companyId })
   const workAddressesQuery = useEmployeeAddressesGetWorkAddresses(
     { employeeId: employeeId ?? '' },
@@ -225,7 +248,6 @@ export function useWorkAddressForm({
   }
 }
 
-export type UseWorkAddressFormResult = ReturnType<typeof useWorkAddressForm>
-export type UseWorkAddressFormReady = Extract<UseWorkAddressFormResult, { data: object }>
+export type UseWorkAddressFormResult = HookLoadingResult | UseWorkAddressFormReady
 export type WorkAddressFieldsMetadata = UseWorkAddressFormReady['form']['fieldsMetadata']
 export type WorkAddressFormFields = UseWorkAddressFormReady['form']['Fields']

--- a/src/components/Employee/employee-list/shared/useEmployeeList.tsx
+++ b/src/components/Employee/employee-list/shared/useEmployeeList.tsx
@@ -38,15 +38,11 @@ export interface UseEmployeeListProps {
   employeeType?: EmployeeType
 }
 
-interface UseEmployeeListReady extends Omit<BaseHookReady, 'data' | 'status'> {
-  data: {
-    employees: EmployeeWithActions[]
-  }
+interface UseEmployeeListReady extends BaseHookReady<
+  { employees: EmployeeWithActions[] },
+  { isFetching: boolean; isPending: boolean }
+> {
   pagination: PaginationControlProps
-  status: {
-    isFetching: boolean
-    isPending: boolean
-  }
   actions: {
     onDelete: (
       employeeId: string,

--- a/src/partner-hook-utils/types.ts
+++ b/src/partner-hook-utils/types.ts
@@ -54,16 +54,32 @@ export interface HookErrorHandling {
   clearSubmitError: () => void
 }
 
-/** Base shape for non-form hooks. Individual hooks override `data`. */
-export interface BaseHookReady {
+/**
+ * Base shape for non-form hooks in the ready (loaded) state.
+ * Pass `TData` / `TStatus` so each hook narrows payload and status without `Omit` + rewrite.
+ */
+export interface BaseHookReady<
+  TData extends Record<string, unknown> = Record<string, unknown>,
+  TStatus extends Record<string, unknown> = Record<string, unknown>,
+> {
   isLoading: false
-  data: Record<string, unknown>
-  status: Record<string, unknown>
+  data: TData
+  status: TStatus
   errorHandling: HookErrorHandling
 }
 
-/** Base shape for form hooks. Individual hooks override `data`, `actions`, and `form`. */
-export interface BaseFormHookReady<TFieldsMetadata extends FieldsMetadata = FieldsMetadata> {
+/**
+ * Base shape for form hooks in the ready state.
+ * Individual hooks override `data`, `actions`, and `form`.
+ *
+ * `status.mode` matches {@link HookSubmitResult} (`create` | `update`). Document-sign hooks
+ * surface `mode: 'create'` only — that reflects the submit/API contract, not “create entity”
+ * in the domain sense.
+ */
+export interface BaseFormHookReady<
+  TFieldsMetadata extends FieldsMetadata = FieldsMetadata,
+  TFormData extends FieldValues = FieldValues,
+> {
   isLoading: false
   data: Record<string, unknown>
   status: { isPending: boolean; mode: 'create' | 'update' }
@@ -72,7 +88,7 @@ export interface BaseFormHookReady<TFieldsMetadata extends FieldsMetadata = Fiel
   form: {
     Fields: Record<string, unknown>
     fieldsMetadata: TFieldsMetadata
-    hookFormInternals: HookFormInternals
+    hookFormInternals: HookFormInternals<TFormData>
     getFormSubmissionValues: () => Record<string, unknown> | undefined
   }
 }

--- a/src/test/fieldsMetadata.ts
+++ b/src/test/fieldsMetadata.ts
@@ -1,0 +1,9 @@
+import { expect } from 'vitest'
+import type { FieldMetadata, FieldsMetadata } from '@/partner-hook-utils/types'
+
+/** Asserts a key exists on fieldsMetadata and returns it with a narrowed type (for tests). */
+export function fieldsMetadataEntry(meta: FieldsMetadata, key: string): FieldMetadata {
+  const entry = meta[key]
+  expect(entry).toBeDefined()
+  return entry as FieldMetadata
+}


### PR DESCRIPTION
## Summary
Update `BaseHookReady` / `BaseFormHookReady` in `src/partner-hook-utils/types.ts` and apply across partner form hooks (including sign hooks with `mode: 'create'`), list, and dashboard hooks.

- Updates `.claude/commands/create-hook.md` for the typing pattern
- Adds `src/test/fieldsMetadata.ts` for hook tests asserting `fieldsMetadata`

## Testing
- Pre-commit: `npm run build`, lint-staged

Ticket: SDK-778

Made with [Cursor](https://cursor.com)