### PR TITLE
feat: add Contractor List design prototype

### DIFF
--- a/sdk-app/src/design/prototypes/contractor-management/ContractorList/index.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/ContractorList/index.tsx
@@ -1,6 +1,7 @@
-import { Suspense, useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { Contractor } from '@gusto/embedded-api/models/components/contractor'
-import { useContractorsListSuspense } from '@gusto/embedded-api/react-query/contractorsList'
+import { useContractorsList } from '@gusto/embedded-api/react-query/contractorsList'
+import { keepPreviousData } from '@tanstack/react-query'
 import { DataView, EmptyData, Flex, useDataView } from '@/components/Common'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu/HamburgerMenu'
 import { ContractorOnboardingStatusBadge } from '@/components/Common/OnboardingStatusBadge'
@@ -140,69 +141,73 @@ function ContractorListContent() {
   const companyId = String(import.meta.env.VITE_COMPANY_ID || '')
   const [selectedTab, setSelectedTab] = useState('active')
 
-  const { data: activeData } = useContractorsListSuspense({
-    companyUuid: companyId,
-    onboardedActive: true,
-  })
+  const queryParams = useMemo(() => {
+    switch (selectedTab) {
+      case 'active':
+        return { companyUuid: companyId, onboardedActive: true }
+      case 'onboarding':
+        return { companyUuid: companyId, onboardedActive: false }
+      case 'dismissed':
+        return { companyUuid: companyId, terminatedToday: true }
+      default:
+        return { companyUuid: companyId, onboardedActive: true }
+    }
+  }, [companyId, selectedTab])
 
-  const { data: onboardingData } = useContractorsListSuspense({
-    companyUuid: companyId,
-    onboardedActive: false,
+  const { data, isFetching } = useContractorsList(queryParams, {
+    placeholderData: keepPreviousData,
   })
-
-  const { data: dismissedData } = useContractorsListSuspense({
-    companyUuid: companyId,
-    terminatedToday: true,
-  })
-
-  const totalContractors =
-    (activeData.contractors?.length ?? 0) +
-    (onboardingData.contractors?.length ?? 0) +
-    (dismissedData.contractors?.length ?? 0)
+  const contractors = data?.contractors ?? []
 
   const tabs = [
     {
       id: 'active',
       label: 'Active',
-      content: <ActiveContractorsTable contractors={activeData.contractors ?? []} />,
+      content: null,
     },
     {
       id: 'onboarding',
       label: 'Onboarding',
-      content: <OnboardingContractorsTable contractors={onboardingData.contractors ?? []} />,
+      content: null,
     },
     {
       id: 'dismissed',
       label: 'Dismissed',
-      content: <DismissedContractorsTable contractors={dismissedData.contractors ?? []} />,
+      content: null,
     },
   ]
+
+  const renderTable = () => {
+    switch (selectedTab) {
+      case 'active':
+        return <ActiveContractorsTable contractors={contractors} />
+      case 'onboarding':
+        return <OnboardingContractorsTable contractors={contractors} />
+      case 'dismissed':
+        return <DismissedContractorsTable contractors={contractors} />
+    }
+  }
+
+  if (!data && isFetching) {
+    return <Components.Text>Loading contractors...</Components.Text>
+  }
 
   return (
     <Flex flexDirection="column" gap={24}>
       <Flex justifyContent="space-between" alignItems="center">
-        <Flex flexDirection="column" gap={4}>
-          <Components.Heading as="h1" styledAs="h2">
-            Contractors
-          </Components.Heading>
-          <Components.Text variant="supporting">{totalContractors} contractors</Components.Text>
-        </Flex>
-
+        <Components.Heading as="h1" styledAs="h2">
+          Contractors
+        </Components.Heading>
         <Components.Button variant="primary" onClick={() => {}}>
           Add contractor
         </Components.Button>
       </Flex>
       <Components.Tabs onSelectionChange={setSelectedTab} tabs={tabs} selectedId={selectedTab} />
+      {renderTable()}
     </Flex>
   )
 }
 
 export default function ContractorList() {
-  const Components = useComponentContext()
-
-  return (
-    <Suspense fallback={<Components.Text>Loading contractors...</Components.Text>}>
-      <ContractorListContent />
-    </Suspense>
-  )
+  return <ContractorListContent />
 }

--- a/sdk-app/src/design/prototypes/contractor-management/ContractorList/index.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/ContractorList/index.tsx
@@ -1,0 +1,208 @@
+import { Suspense, useState } from 'react'
+import type { Contractor } from '@gusto/embedded-api/models/components/contractor'
+import { useContractorsListSuspense } from '@gusto/embedded-api/react-query/contractorsList'
+import { DataView, EmptyData, Flex, useDataView } from '@/components/Common'
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu/HamburgerMenu'
+import { ContractorOnboardingStatusBadge } from '@/components/Common/OnboardingStatusBadge'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { CONTRACTOR_TYPE } from '@/shared/constants'
+import { firstLastName } from '@/helpers/formattedStrings'
+
+function formatRate(contractor: Contractor) {
+  if (contractor.wageType === 'Hourly' && contractor.hourlyRate) {
+    return `Hourly — $${contractor.hourlyRate}/hr`
+  }
+  return contractor.wageType ?? '–'
+}
+
+function ActiveContractorsTable({ contractors }: { contractors: Contractor[] }) {
+  const dataViewProps = useDataView<Contractor>({
+    data: contractors,
+    columns: [
+      {
+        title: 'Name',
+        render: contractor => contractorName(contractor),
+      },
+      {
+        title: 'Type',
+        render: contractor => contractor.type ?? '–',
+      },
+      {
+        title: 'Rate',
+        render: contractor => formatRate(contractor),
+      },
+    ],
+    itemMenu: () => (
+      <HamburgerMenu
+        items={[
+          {
+            label: 'View details',
+            onClick: () => {},
+          },
+          {
+            label: 'Dismiss contractor',
+            onClick: () => {},
+          },
+        ]}
+        triggerLabel="Actions"
+      />
+    ),
+    emptyState: () => <EmptyData title="No active contractors found." />,
+  })
+
+  return <DataView label="Active contractors" {...dataViewProps} />
+}
+
+function contractorName(contractor: Contractor) {
+  return contractor.type === CONTRACTOR_TYPE.BUSINESS
+    ? contractor.businessName
+    : firstLastName({
+        first_name: contractor.firstName,
+        last_name: contractor.lastName,
+      })
+}
+
+function OnboardingContractorsTable({ contractors }: { contractors: Contractor[] }) {
+  const dataViewProps = useDataView<Contractor>({
+    data: contractors,
+    columns: [
+      {
+        title: 'Name',
+        render: contractor => contractorName(contractor),
+      },
+      {
+        title: 'Type',
+        render: contractor => contractor.type ?? '–',
+      },
+      {
+        title: 'Onboarding status',
+        render: contractor => (
+          <ContractorOnboardingStatusBadge
+            onboarded={contractor.onboarded}
+            onboardingStatus={contractor.onboardingStatus}
+          />
+        ),
+      },
+    ],
+    itemMenu: () => (
+      <HamburgerMenu
+        items={[
+          {
+            label: 'View details',
+            onClick: () => {},
+          },
+        ]}
+        triggerLabel="Actions"
+      />
+    ),
+    emptyState: () => <EmptyData title="No contractors currently onboarding." />,
+  })
+
+  return <DataView label="Onboarding contractors" {...dataViewProps} />
+}
+
+function DismissedContractorsTable({ contractors }: { contractors: Contractor[] }) {
+  const dataViewProps = useDataView<Contractor>({
+    data: contractors,
+    columns: [
+      {
+        title: 'Name',
+        render: contractor => contractorName(contractor),
+      },
+      {
+        title: 'Type',
+        render: contractor => contractor.type ?? '–',
+      },
+      {
+        title: 'Dismissal date',
+        render: contractor => contractor.dismissalDate ?? '–',
+      },
+    ],
+    itemMenu: () => (
+      <HamburgerMenu
+        items={[
+          {
+            label: 'View details',
+            onClick: () => {},
+          },
+        ]}
+        triggerLabel="Actions"
+      />
+    ),
+    emptyState: () => <EmptyData title="No dismissed contractors found." />,
+  })
+
+  return <DataView label="Dismissed contractors" {...dataViewProps} />
+}
+
+function ContractorListContent() {
+  const Components = useComponentContext()
+  const companyId = String(import.meta.env.VITE_COMPANY_ID || '')
+  const [selectedTab, setSelectedTab] = useState('active')
+
+  const { data: activeData } = useContractorsListSuspense({
+    companyUuid: companyId,
+    onboardedActive: true,
+  })
+
+  const { data: onboardingData } = useContractorsListSuspense({
+    companyUuid: companyId,
+    onboardedActive: false,
+  })
+
+  const { data: dismissedData } = useContractorsListSuspense({
+    companyUuid: companyId,
+    terminatedToday: true,
+  })
+
+  const totalContractors =
+    (activeData.contractors?.length ?? 0) +
+    (onboardingData.contractors?.length ?? 0) +
+    (dismissedData.contractors?.length ?? 0)
+
+  const tabs = [
+    {
+      id: 'active',
+      label: 'Active',
+      content: <ActiveContractorsTable contractors={activeData.contractors ?? []} />,
+    },
+    {
+      id: 'onboarding',
+      label: 'Onboarding',
+      content: <OnboardingContractorsTable contractors={onboardingData.contractors ?? []} />,
+    },
+    {
+      id: 'dismissed',
+      label: 'Dismissed',
+      content: <DismissedContractorsTable contractors={dismissedData.contractors ?? []} />,
+    },
+  ]
+
+  return (
+    <Flex flexDirection="column" gap={24}>
+      <Flex justifyContent="space-between" alignItems="center">
+        <Flex flexDirection="column" gap={4}>
+          <Components.Heading as="h1" styledAs="h2">
+            Contractors
+          </Components.Heading>
+          <Components.Text variant="supporting">{totalContractors} contractors</Components.Text>
+        </Flex>
+
+        <Components.Button variant="primary" onClick={() => {}}>
+          Add contractor
+        </Components.Button>
+      </Flex>
+      <Components.Tabs onSelectionChange={setSelectedTab} tabs={tabs} selectedId={selectedTab} />
+    </Flex>
+  )
+}
+
+export default function ContractorList() {
+  const Components = useComponentContext()
+
+  return (
+    <Suspense fallback={<Components.Text>Loading contractors...</Components.Text>}>
+      <ContractorListContent />
+    </Suspense>
+  )
+}

--- a/sdk-app/src/design/registry.ts
+++ b/sdk-app/src/design/registry.ts
@@ -25,5 +25,10 @@ export const categorizedRegistry: CategorizedRegistry = {
       path: '/design/contractor-profile',
       description: 'A prototype for managing contractor profiles.',
     },
+    {
+      name: 'Contractor List',
+      path: '/design/contractor-list',
+      description: 'A prototype for managing contractor lists.',
+    },
   ],
 }

--- a/sdk-app/src/main.tsx
+++ b/sdk-app/src/main.tsx
@@ -8,6 +8,7 @@ import { DesignLayout } from './design/DesignLayout'
 import { DesignHome } from './design/DesignHome'
 import { ComponentShowcase } from './design/prototypes/component-showcase'
 import { ContractorProfile } from './design/prototypes/contractor-management/contractorProfile'
+import ContractorList from './design/prototypes/contractor-management/ContractorList'
 import './app.scss'
 import '@/styles/sdk.scss'
 
@@ -25,6 +26,7 @@ const router = createBrowserRouter([
           { index: true, element: <DesignHome /> },
           { path: 'component-showcase', element: <ComponentShowcase /> },
           { path: 'contractor-profile', element: <ContractorProfile /> },
+          { path: 'contractor-list', element: <ContractorList /> },
         ],
       },
     ],


### PR DESCRIPTION
## Summary

Adds a new Contractor List design prototype page with tabbed views for Active, Onboarding, and Dismissed contractors, each backed by real API data.

## Changes

- New `ContractorList` prototype component with three DataView tables filtered by contractor status
- Active tab: Name, Type, Rate columns with View details / Dismiss contractor menu actions
- Onboarding tab: Name, Type, Onboarding status (badge) columns with View details menu
- Dismissed tab: Name, Type, Dismissal date columns with View details menu
- Registered prototype in design registry and routing

## Demo

<img width="1071" height="757" alt="Screenshot 2026-04-20 at 2 32 35 PM" src="https://github.com/user-attachments/assets/75b7343f-f367-479d-896a-369cb7292044" />
<img width="1071" height="766" alt="Screenshot 2026-04-20 at 2 32 45 PM" src="https://github.com/user-attachments/assets/3814b8bf-ff88-414f-814c-6af480feaefd" />
<img width="1072" height="770" alt="Screenshot 2026-04-20 at 2 32 52 PM" src="https://github.com/user-attachments/assets/34eb5a31-67c7-4b1f-ab21-73be6563ec94" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)