### PR TITLE
fix: exclude admin_onboarding_review from contractor self-onboarding statuses

### DIFF
--- a/src/components/Contractor/Profile/useContractorProfile.test.tsx
+++ b/src/components/Contractor/Profile/useContractorProfile.test.tsx
@@ -639,6 +639,24 @@ describe('useContractorProfile', () => {
       expect(result.current.shouldShowEmailField).toBe(true)
     })
 
+    it('should default selfOnboarding to false when onboarding status is admin_onboarding_review', () => {
+      const contractor = {
+        ...baseContractor,
+        onboardingStatus: ContractorOnboardingStatus.ADMIN_ONBOARDING_REVIEW,
+      }
+      const { result } = renderHook(
+        () =>
+          useContractorProfile({
+            ...defaultProps,
+            contractorId: contractor.uuid,
+            existingContractor: contractor,
+          }),
+        { wrapper: ({ children }) => <TestWrapper>{children}</TestWrapper> },
+      )
+      expect(result.current.formMethods.getValues('selfOnboarding')).toBe(false)
+      expect(result.current.shouldShowEmailField).toBe(false)
+    })
+
     it('should update selfOnboarding when contractor transitions from self_onboarding_invited to admin_onboarding_incomplete', async () => {
       const selfOnboardingContractor = {
         ...baseContractor,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -298,7 +298,6 @@ export const ContractorSelfOnboardingStatuses = new Set([
   ContractorOnboardingStatus.SELF_ONBOARDING_INVITED,
   ContractorOnboardingStatus.SELF_ONBOARDING_STARTED,
   ContractorOnboardingStatus.SELF_ONBOARDING_REVIEW,
-  ContractorOnboardingStatus.ADMIN_ONBOARDING_REVIEW,
 ])
 
 /**Map of API response flsa statuses */


### PR DESCRIPTION
## Summary

- Removes `ADMIN_ONBOARDING_REVIEW` from `ContractorSelfOnboardingStatuses` in `src/shared/constants.ts`. That status represents an admin-onboarded contractor whose basic profile has been completed, not a self-onboarding flow, so it should not flip the profile form's `selfOnboarding` default to `true`.
- Aligns the SDK's set with ZenPayroll's canonical `SELF_ONBOARDING_STATUSES` definition (gws-flows `app/services/records/contractor_onboarding_status.rb`) and the `ContractorOnboardingHandler` in `update_onboarding_type.rb`, both of which scope self-onboarding to the four `self_onboarding_*` statuses only.
- Adds a regression test in `useContractorProfile.test.tsx` that reproduces the original bug: when `existingContractor.onboardingStatus === admin_onboarding_review`, the form should default `selfOnboarding` to `false` and hide the email field.

## Bug repro (before the fix)

1. Create a contractor with self-onboarding **unchecked**.
2. Proceed to the home address step (status transitions to `admin_onboarding_review`).
3. Exit the flow and reopen the contractor's profile.
4. The self-onboarding toggle appears **checked** (incorrect — nothing about this contractor is self-onboarding).

## Test plan

- [x] New unit test `should default selfOnboarding to false when onboarding status is admin_onboarding_review` passes.
- [x] All 27 existing tests in `useContractorProfile.test.tsx` still pass.


## Before

https://github.com/user-attachments/assets/8ad92340-4c73-4fed-b2cf-ad7f923e175e

## After

https://github.com/user-attachments/assets/498ea984-3ec2-408e-92f4-e6e5b8b099da

Made with [Cursor](https://cursor.com)