### PR TITLE
chore: release 0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.40.0
 
 ### Breaking Changes
 
@@ -113,6 +113,10 @@ import { EmployeeManagement } from '@gusto/embedded-react-sdk'
 #### Internal restructuring: `EmployeeList` feature module
 
 The `Employee/EmployeeList/` directory has been restructured into a feature module layout (`Employee/employee-list/`) with `shared/`, `onboarding/`, and `management/` subdirectories. This is an internal change -- all public exports remain the same and no partner action is required.
+
+### Chores & Maintenance
+
+- Migrate Employee Profile to hook-based architecture
 
 ## 0.39.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-react-sdk",
-      "version": "0.39.0",
+      "version": "0.40.0",
       "license": "MIT",
       "dependencies": {
         "@gusto/embedded-api": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "homepage": "https://github.com/Gusto/embedded-react-sdk",
   "bugs": {
     "url": "https://github.com/Gusto/embedded-react-sdk/issues"


### PR DESCRIPTION
## Summary

Release `0.40.0`, promoting the curated `Unreleased` section of `CHANGELOG.md` to a versioned release.

During 0.x.x, `feat!:` (breaking changes) bumps MINOR, so `0.39.0` → `0.40.0`.

### Highlights

**Breaking Changes**
- `composeSubmitHandler` now returns `{ handleSubmit, errorHandling }` instead of just the submit handler
- Hooks graduated from `@gusto/embedded-react-sdk/UNSTABLE_Hooks` to the main entry point; the `UNSTABLE_Hooks` entry has been removed
- Prebuilt hook form components (`CompensationForm`, `EmployeeDetailsForm`, `WorkAddressForm`, `HomeAddressForm`, `PayScheduleForm`, `SignCompanyForm`, `SignEmployeeForm`, `SignEmployeeI9Form`) removed — use the hooks directly

**Features & Enhancements**
- Journey-based export namespaces (`EmployeeOnboarding`, `EmployeeManagement`, `CompanyOnboarding`, `ContractorOnboarding`)

**Deprecations**
- `Employee.*`, `Company.*`, `Contractor.*` umbrella namespaces deprecated in favor of journey namespaces (existing imports still work)
- `Employee.ManagementEmployeeList` removed — use `EmployeeManagement.EmployeeList`
- Internal restructuring: `EmployeeList` feature module

See `CHANGELOG.md` for the full release notes.

## Test plan

- [ ] CI passes (build, lint, tests)
- [ ] After merge, run the [Publish to NPM](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish.yaml) workflow

Made with [Cursor](https://cursor.com)