### PR TITLE
docs: expand 0.40.0 changelog with full commit list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,55 +47,6 @@ The following prebuilt components have been removed: `CompensationForm`,
 testing artifacts. Use the corresponding hooks directly (e.g., `useCompensationForm`)
 to build custom form UI.
 
-### Features & Enhancements
-
-#### Journey-based export namespaces
-
-Components are now organized into **journey-based namespaces** that group everything a partner needs for a specific integration use case. Three new namespaces are available:
-
-- **`EmployeeOnboarding`** -- all components for onboarding employees (flows, employee list, profile, compensation, taxes, payment method, deductions, documents, etc.)
-- **`EmployeeManagement`** -- components for steady-state employee management (employee list, dashboard, terminations, employee documents)
-- **`CompanyOnboarding`** -- all components for onboarding a company (flow, overview, document signing, bank account, locations, pay schedule, taxes, signatory management)
-- **`ContractorOnboarding`** -- all components for onboarding contractors (flow, contractor list, profile, address, payment method, new hire report, submit)
-
-```tsx
-// Recommended (journey namespace)
-import { EmployeeOnboarding } from '@gusto/embedded-react-sdk'
-;<EmployeeOnboarding.OnboardingFlow companyId={companyId} onEvent={handleEvent} />
-
-// Also works (journey namespace, management)
-import { EmployeeManagement } from '@gusto/embedded-react-sdk'
-;<EmployeeManagement.DashboardFlow employeeId={employeeId} onEvent={handleEvent} />
-
-// Also works (journey namespace, company)
-import { CompanyOnboarding } from '@gusto/embedded-react-sdk'
-;<CompanyOnboarding.OnboardingFlow companyId={companyId} onEvent={handleEvent} />
-
-// Also works (journey namespace, contractor)
-import { ContractorOnboarding } from '@gusto/embedded-react-sdk'
-;<ContractorOnboarding.OnboardingFlow companyId={companyId} onEvent={handleEvent} />
-```
-
-Each journey namespace is self-contained -- partners should not need to import from multiple namespaces to complete a single integration.
-
-### Deprecations
-
-#### `Employee.*`, `Company.*`, and `Contractor.*` umbrella namespaces
-
-The flat `Employee`, `Company`, and `Contractor` namespace exports are now **deprecated** in favor of the journey-based namespaces above. Existing imports continue to work without changes, but partners should migrate at their convenience:
-
-```tsx
-// Deprecated (still works)
-import { Employee } from '@gusto/embedded-react-sdk'
-;<Employee.OnboardingFlow companyId={companyId} onEvent={handleEvent} />
-
-// Recommended
-import { EmployeeOnboarding } from '@gusto/embedded-react-sdk'
-;<EmployeeOnboarding.OnboardingFlow companyId={companyId} onEvent={handleEvent} />
-```
-
-The `Employee`, `Company`, and `Contractor` umbrella namespaces will be removed in a future major version. The `Payroll` and `InformationRequests` namespaces are unaffected and remain the primary import path for those domains.
-
 #### `Employee.ManagementEmployeeList` removed
 
 `ManagementEmployeeList` is no longer exported from the `Employee` umbrella namespace. Use `EmployeeManagement.EmployeeList` instead:
@@ -110,13 +61,52 @@ import { EmployeeManagement } from '@gusto/embedded-react-sdk'
 ;<EmployeeManagement.EmployeeList companyId={companyId} onEvent={handleEvent} />
 ```
 
-#### Internal restructuring: `EmployeeList` feature module
+#### `Employee.*`, `Company.*`, and `Contractor.*` umbrella namespaces deprecated
 
-The `Employee/EmployeeList/` directory has been restructured into a feature module layout (`Employee/employee-list/`) with `shared/`, `onboarding/`, and `management/` subdirectories. This is an internal change -- all public exports remain the same and no partner action is required.
+The flat `Employee`, `Company`, and `Contractor` namespace exports are now **deprecated** in favor of the new journey-based namespaces (`EmployeeOnboarding`, `EmployeeManagement`, `CompanyOnboarding`, `ContractorOnboarding`). Existing imports continue to work without changes, but partners should migrate at their convenience:
+
+```tsx
+// Deprecated (still works)
+import { Employee } from '@gusto/embedded-react-sdk'
+;<Employee.OnboardingFlow companyId={companyId} onEvent={handleEvent} />
+
+// Recommended
+import { EmployeeOnboarding } from '@gusto/embedded-react-sdk'
+;<EmployeeOnboarding.OnboardingFlow companyId={companyId} onEvent={handleEvent} />
+```
+
+The `Employee`, `Company`, and `Contractor` umbrella namespaces will be removed in a future major version. The `Payroll` and `InformationRequests` namespaces are unaffected and remain the primary import path for those domains.
+
+### Features & Enhancements
+
+- Add journey-based export namespaces (`EmployeeOnboarding`, `EmployeeManagement`, `CompanyOnboarding`, `ContractorOnboarding`) grouping flows and components by integration use case
+- Add PolicySettings presentation component for time-off policy creation
+- Fetch and display holiday pay policy in PolicyList
+- Add `useHomeAddressForm` unstable hook
+- Merge `sdk-app` and `prototype-app` into a unified development environment
+
+### Fixes
+
+- Exclude `admin_onboarding_review` from contractor self-onboarding statuses
+- Add flex properties to Box so content fills remaining space in parent
+- Remove scroll-into-view behavior on alerts
+- Remove overriding text instances in payroll receipt data views
+- Add spacing between description list items when rendered without dividing lines
+- Make PaySchedule create/edit tests more robust
 
 ### Chores & Maintenance
 
 - Migrate Employee Profile to hook-based architecture
+- Replace error-handling helpers with `composeErrorHandler`
+- Partner hooks `BaseHookReady` typing (SDK-778)
+- Restructure `EmployeeList` into a feature module layout (internal, no public API change)
+- Update prototype app to use SDK components
+- Add document requirements list to contractor submit view
+- Add comprehensive Employee Profile component tests
+- Add Cursor skill for migrating SDK components to hooks
+- Add prototype-app design prototyping environment
+- Add RFC for SDK hooks approach for partner flexibility
+- Bump various dependencies (i18next, react-i18next, dompurify, @internationalized/date, @internationalized/number, eslint-plugin-react-hooks, msw, vite-plugin-checker, prettier, typescript-eslint, follow-redirects, react-router-dom, axe-core)
 
 ## 0.39.0
 


### PR DESCRIPTION
## Summary

The `0.40.0` release was merged with a non-standard changelog structure — a `Deprecations` section and long narrative blocks under `Features & Enhancements` — which is inconsistent with every prior release (`0.39.0` and older). This PR restructures the `0.40.0` entry so it matches the established changelog pattern.

### New structure (matches `0.39.0` and earlier)

- **Breaking Changes** — keep the detailed `####` subsections with code samples / migration steps consumers need, and fold in the previously-separate `Deprecations` entries (they're consumer-action guidance too):
  - `composeSubmitHandler` return-shape change
  - Hooks now exported from the main entry point (`UNSTABLE_Hooks` subpath removed)
  - Prebuilt hook form components removed
  - `Employee.ManagementEmployeeList` removed (moved up from Deprecations)
  - `Employee.*` / `Company.*` / `Contractor.*` umbrella namespaces deprecated (moved up from Deprecations)
- **Features & Enhancements** — plain bullet list (journey namespaces collapsed to a single line, plus the other `feat:` commits)
- **Fixes** — plain bullet list (all `fix:` commits from the release window)
- **Chores & Maintenance** — plain bullet list (all `refactor:` / `chore:` / `test:` / `docs:` commits, `EmployeeList` internal restructuring note moved here, and a consolidated dependency-bumps line)

Previously the section had a separate `### Deprecations` heading and embedded the Journey-Namespaces narrative under `### Features & Enhancements`, which no other release uses.

No code or version changes — `CHANGELOG.md` only.

## Test plan

- [x] `0.40.0` heading structure matches `0.39.0`: Breaking Changes → Features & Enhancements → Fixes → Chores & Maintenance
- [x] All migration-relevant detail (code samples, before/after) preserved under Breaking Changes