### PR TITLE
fix: contractor profile UX fixes, settings panel wiring, and skeleton loading state

### DIFF
--- a/sdk-app/src/design/DesignLayout.tsx
+++ b/sdk-app/src/design/DesignLayout.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { Outlet } from 'react-router-dom'
+import { Outlet, useOutletContext } from 'react-router-dom'
+import type { EntityIds } from '../useEntities'
 import { useResolvedTheme } from '../useThemeModeContext'
 import { darkTheme } from '../darkTheme'
 import { BreakpointSwitcher } from './BreakpointSwitcher'
@@ -9,6 +10,7 @@ import styles from './DesignLayout.module.scss'
 import { GustoProvider } from '@/contexts/GustoProvider/GustoProvider'
 
 export function DesignLayout() {
+  const { entities } = useOutletContext<{ entities: EntityIds }>()
   const [breakpoint, setBreakpoint] = useState<BreakpointOption>('large')
   const resolvedTheme = useResolvedTheme()
 
@@ -20,7 +22,7 @@ export function DesignLayout() {
       theme={resolvedTheme === 'dark' ? darkTheme : undefined}
     >
       <div className={styles.bodyContent} style={maxWidth ? { maxWidth } : undefined}>
-        <Outlet />
+        <Outlet context={{ entities }} />
       </div>
       <div className={styles.switcherContainer}>
         <BreakpointSwitcher value={breakpoint} onChange={setBreakpoint} />

--- a/sdk-app/src/design/prototypes/contractor-management/ContractorList/SkeletonDataView.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/ContractorList/SkeletonDataView.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react'
+import { Skeleton } from '../ContractorProfile/components/Skeleton'
+import { DataView, useDataView } from '@/components/Common'
+
+interface Column {
+  title: string | ReactNode
+  skeletonWidth?: number
+}
+
+interface SkeletonDataViewProps<T> {
+  label: string
+  data: T[]
+  columns: {
+    title: string | ReactNode
+    render: (item: T) => ReactNode
+    skeletonWidth?: number
+  }[]
+  isFetching: boolean
+  itemMenu?: (item: T) => ReactNode
+  emptyState?: () => ReactNode
+  placeholderRows?: number
+}
+
+const SKELETON_HEADER_WIDTH = 60
+const SKELETON_CELL_WIDTH = 100
+const SKELETON_HEIGHT = 16
+
+function useSkeletonColumns(columns: Column[]) {
+  return columns.map(col => ({
+    title: <Skeleton width={SKELETON_HEADER_WIDTH} height={SKELETON_HEIGHT} />,
+    render: () => (
+      <Skeleton width={col.skeletonWidth ?? SKELETON_CELL_WIDTH} height={SKELETON_HEIGHT} />
+    ),
+  }))
+}
+
+export function SkeletonDataView<T>({
+  label,
+  data,
+  columns,
+  isFetching,
+  itemMenu,
+  emptyState,
+  placeholderRows = 3,
+}: SkeletonDataViewProps<T>) {
+  const placeholders = Array.from({ length: placeholderRows }) as T[]
+  const skeletonColumns = useSkeletonColumns(columns)
+
+  const dataViewProps = useDataView<T>({
+    data: isFetching ? placeholders : data,
+    columns: isFetching ? skeletonColumns : columns,
+    itemMenu: isFetching ? undefined : itemMenu,
+    emptyState,
+  })
+
+  return <DataView label={label} {...dataViewProps} />
+}

--- a/sdk-app/src/design/prototypes/contractor-management/ContractorList/index.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/ContractorList/index.tsx
@@ -3,7 +3,8 @@ import { useOutletContext } from 'react-router-dom'
 import type { Contractor } from '@gusto/embedded-api/models/components/contractor'
 import { useContractorsList } from '@gusto/embedded-api/react-query/contractorsList'
 import type { EntityIds } from '../../../../useEntities'
-import { DataView, EmptyData, Flex, Loading, useDataView } from '@/components/Common'
+import { SkeletonDataView } from './SkeletonDataView'
+import { EmptyData, Flex } from '@/components/Common'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu/HamburgerMenu'
 import { ContractorOnboardingStatusBadge } from '@/components/Common/OnboardingStatusBadge'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
@@ -17,44 +18,6 @@ function formatRate(contractor: Contractor) {
   return contractor.wageType ?? '–'
 }
 
-function ActiveContractorsTable({ contractors }: { contractors: Contractor[] }) {
-  const dataViewProps = useDataView<Contractor>({
-    data: contractors,
-    columns: [
-      {
-        title: 'Name',
-        render: contractor => contractorName(contractor),
-      },
-      {
-        title: 'Type',
-        render: contractor => contractor.type ?? '–',
-      },
-      {
-        title: 'Rate',
-        render: contractor => formatRate(contractor),
-      },
-    ],
-    itemMenu: () => (
-      <HamburgerMenu
-        items={[
-          {
-            label: 'View details',
-            onClick: () => {},
-          },
-          {
-            label: 'Dismiss contractor',
-            onClick: () => {},
-          },
-        ]}
-        triggerLabel="Actions"
-      />
-    ),
-    emptyState: () => <EmptyData title="No active contractors found." />,
-  })
-
-  return <DataView label="Active contractors" {...dataViewProps} />
-}
-
 function contractorName(contractor: Contractor) {
   return contractor.type === CONTRACTOR_TYPE.BUSINESS
     ? contractor.businessName
@@ -64,77 +27,123 @@ function contractorName(contractor: Contractor) {
       })
 }
 
-function OnboardingContractorsTable({ contractors }: { contractors: Contractor[] }) {
-  const dataViewProps = useDataView<Contractor>({
-    data: contractors,
-    columns: [
-      {
-        title: 'Name',
-        render: contractor => contractorName(contractor),
-      },
-      {
-        title: 'Type',
-        render: contractor => contractor.type ?? '–',
-      },
-      {
-        title: 'Onboarding status',
-        render: contractor => (
-          <ContractorOnboardingStatusBadge
-            onboarded={contractor.onboarded}
-            onboardingStatus={contractor.onboardingStatus}
-          />
-        ),
-      },
-    ],
-    itemMenu: () => (
-      <HamburgerMenu
-        items={[
-          {
-            label: 'View details',
-            onClick: () => {},
-          },
-        ]}
-        triggerLabel="Actions"
-      />
-    ),
-    emptyState: () => <EmptyData title="No contractors currently onboarding." />,
-  })
-
-  return <DataView label="Onboarding contractors" {...dataViewProps} />
+function contractorMenu(actions: { label: string; onClick: () => void }[]) {
+  return function ContractorMenu() {
+    return <HamburgerMenu items={actions} triggerLabel="Actions" />
+  }
 }
 
-function DismissedContractorsTable({ contractors }: { contractors: Contractor[] }) {
-  const dataViewProps = useDataView<Contractor>({
-    data: contractors,
-    columns: [
-      {
-        title: 'Name',
-        render: contractor => contractorName(contractor),
-      },
-      {
-        title: 'Type',
-        render: contractor => contractor.type ?? '–',
-      },
-      {
-        title: 'Dismissal date',
-        render: contractor => contractor.dismissalDate ?? '–',
-      },
-    ],
-    itemMenu: () => (
-      <HamburgerMenu
-        items={[
-          {
-            label: 'View details',
-            onClick: () => {},
-          },
-        ]}
-        triggerLabel="Actions"
-      />
-    ),
-    emptyState: () => <EmptyData title="No dismissed contractors found." />,
-  })
+function ActiveContractorsTable({
+  contractors,
+  isFetching,
+}: {
+  contractors: Contractor[]
+  isFetching: boolean
+}) {
+  return (
+    <SkeletonDataView
+      label="Active contractors"
+      data={contractors}
+      isFetching={isFetching}
+      columns={[
+        {
+          title: 'Name',
+          render: contractor => contractorName(contractor),
+          skeletonWidth: 120,
+        },
+        {
+          title: 'Type',
+          render: contractor => contractor.type ?? '–',
+          skeletonWidth: 80,
+        },
+        {
+          title: 'Rate',
+          render: contractor => formatRate(contractor),
+          skeletonWidth: 100,
+        },
+      ]}
+      itemMenu={contractorMenu([
+        { label: 'View details', onClick: () => {} },
+        { label: 'Dismiss contractor', onClick: () => {} },
+      ])}
+      emptyState={() => <EmptyData title="No active contractors found." />}
+    />
+  )
+}
 
-  return <DataView label="Dismissed contractors" {...dataViewProps} />
+function OnboardingContractorsTable({
+  contractors,
+  isFetching,
+}: {
+  contractors: Contractor[]
+  isFetching: boolean
+}) {
+  return (
+    <SkeletonDataView
+      label="Onboarding contractors"
+      data={contractors}
+      isFetching={isFetching}
+      columns={[
+        {
+          title: 'Name',
+          render: contractor => contractorName(contractor),
+          skeletonWidth: 120,
+        },
+        {
+          title: 'Type',
+          render: contractor => contractor.type ?? '–',
+          skeletonWidth: 80,
+        },
+        {
+          title: 'Onboarding status',
+          render: contractor => (
+            <ContractorOnboardingStatusBadge
+              onboarded={contractor.onboarded}
+              onboardingStatus={contractor.onboardingStatus}
+            />
+          ),
+          skeletonWidth: 90,
+        },
+      ]}
+      itemMenu={contractorMenu([{ label: 'View details', onClick: () => {} }])}
+      emptyState={() => <EmptyData title="No contractors currently onboarding." />}
+    />
+  )
+}
+
+function DismissedContractorsTable({
+  contractors,
+  isFetching,
+}: {
+  contractors: Contractor[]
+  isFetching: boolean
+}) {
+  return (
+    <SkeletonDataView
+      label="Dismissed contractors"
+      data={contractors}
+      isFetching={isFetching}
+      columns={[
+        {
+          title: 'Name',
+          render: contractor => contractorName(contractor),
+          skeletonWidth: 120,
+        },
+        {
+          title: 'Type',
+          render: contractor => contractor.type ?? '–',
+          skeletonWidth: 80,
+        },
+        {
+          title: 'Dismissal date',
+          render: contractor => contractor.dismissalDate ?? '–',
+          skeletonWidth: 80,
+        },
+      ]}
+      itemMenu={contractorMenu([{ label: 'View details', onClick: () => {} }])}
+      emptyState={() => <EmptyData title="No dismissed contractors found." />}
+    />
+  )
 }
 
 function ContractorListContent() {
@@ -180,11 +189,11 @@ function ContractorListContent() {
   const renderTable = () => {
     switch (selectedTab) {
       case 'active':
-        return <ActiveContractorsTable contractors={contractors} />
+        return <ActiveContractorsTable contractors={contractors} isFetching={isFetching} />
       case 'onboarding':
-        return <OnboardingContractorsTable contractors={contractors} />
+        return <OnboardingContractorsTable contractors={contractors} isFetching={isFetching} />
       case 'dismissed':
-        return <DismissedContractorsTable contractors={contractors} />
+        return <DismissedContractorsTable contractors={contractors} isFetching={isFetching} />
     }
   }
 
@@ -200,7 +209,7 @@ function ContractorListContent() {
       </Flex>
       <Flex flexDirection="column" gap={0}>
         <Components.Tabs onSelectionChange={setSelectedTab} tabs={tabs} selectedId={selectedTab} />
-        {isFetching ? <Loading /> : renderTable()}
+        {renderTable()}
       </Flex>
     </Flex>
   )

--- a/sdk-app/src/design/prototypes/contractor-management/ContractorList/index.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/ContractorList/index.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
+import { useOutletContext } from 'react-router-dom'
 import type { Contractor } from '@gusto/embedded-api/models/components/contractor'
 import { useContractorsList } from '@gusto/embedded-api/react-query/contractorsList'
+import type { EntityIds } from '../../../../useEntities'
 import { DataView, EmptyData, Flex, Loading, useDataView } from '@/components/Common'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu/HamburgerMenu'
 import { ContractorOnboardingStatusBadge } from '@/components/Common/OnboardingStatusBadge'
@@ -137,7 +139,8 @@ function DismissedContractorsTable({ contractors }: { contractors: Contractor[] 
 
 function ContractorListContent() {
   const Components = useComponentContext()
-  const companyId = String(import.meta.env.VITE_COMPANY_ID || '')
+  const { entities } = useOutletContext<{ entities: EntityIds }>()
+  const companyId = entities.companyId
   const [selectedTab, setSelectedTab] = useState('active')
 
   const queryParams = useMemo(() => {

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/ContractorProfileComponents.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/ContractorProfileComponents.tsx
@@ -245,10 +245,6 @@ function AddPaymentMethodContent() {
   const { contractorId, onEvent } = useFlow<ContractorProfileContextInterface>()
 
   const contractor = useContractorData(contractorId)
-  const { data: paymentMethodData } = useContractorPaymentMethodGetSuspense({
-    contractorUuid: contractor?.uuid ?? '',
-  })
-  const paymentMethod = paymentMethodData.contractorPaymentMethod
 
   const queryClient = useQueryClient()
   const gustoClient = useGustoEmbeddedContext()
@@ -260,40 +256,35 @@ function AddPaymentMethodContent() {
   if (!contractor) return null
 
   const handleSave = async (data: {
-    type: 'Check' | 'Direct Deposit'
-    name?: string
-    routingNumber?: string
-    accountNumber?: string
-    accountType?: 'Checking' | 'Savings'
+    name: string
+    routingNumber: string
+    accountNumber: string
+    accountType: 'Checking' | 'Savings'
   }) => {
-    let version = paymentMethod?.version as string
-
-    if (data.type === 'Direct Deposit') {
-      await createBankAccount({
-        request: {
-          contractorUuid: contractor.uuid,
-          requestBody: {
-            name: data.name!,
-            routingNumber: data.routingNumber!,
-            accountNumber: data.accountNumber!,
-            accountType: data.accountType!,
-          },
-        },
-      })
-
-      const getPaymentMethodQuery = buildContractorPaymentMethodGetQuery(gustoClient, {
+    await createBankAccount({
+      request: {
         contractorUuid: contractor.uuid,
-      })
-      const updatedPaymentMethod = await queryClient.fetchQuery(getPaymentMethodQuery)
-      version = updatedPaymentMethod.contractorPaymentMethod?.version as string
-    }
+        requestBody: {
+          name: data.name,
+          routingNumber: data.routingNumber,
+          accountNumber: data.accountNumber,
+          accountType: data.accountType,
+        },
+      },
+    })
+
+    const getPaymentMethodQuery = buildContractorPaymentMethodGetQuery(gustoClient, {
+      contractorUuid: contractor.uuid,
+    })
+    const updatedPaymentMethod = await queryClient.fetchQuery(getPaymentMethodQuery)
+    const version = updatedPaymentMethod.contractorPaymentMethod?.version as string
 
     await updatePaymentMethod({
       request: {
         contractorUuid: contractor.uuid,
         requestBody: {
           version,
-          type: data.type,
+          type: 'Direct Deposit',
         },
       },
     })
@@ -304,7 +295,6 @@ function AddPaymentMethodContent() {
   return (
     <ContractorPaymentMethodForm
       variant="add"
-      paymentMethodType={paymentMethod?.type ?? 'Check'}
       isPending={isPaymentMethodPending || isBankAccountPending}
       onCancel={() => {
         onEvent(componentEvents.CANCEL)
@@ -331,11 +321,6 @@ function EditPaymentMethodContent() {
   })
   const bankAccounts = bankAccountsData.contractorBankAccountList ?? []
 
-  const { data: paymentMethodData } = useContractorPaymentMethodGetSuspense({
-    contractorUuid: contractor?.uuid ?? '',
-  })
-  const paymentMethod = paymentMethodData.contractorPaymentMethod
-
   const queryClient = useQueryClient()
   const gustoClient = useGustoEmbeddedContext()
   const { mutateAsync: updatePaymentMethod, isPending: isPaymentMethodPending } =
@@ -346,40 +331,35 @@ function EditPaymentMethodContent() {
   if (!contractor) return null
 
   const handleSave = async (data: {
-    type: 'Check' | 'Direct Deposit'
-    name?: string
-    routingNumber?: string
-    accountNumber?: string
-    accountType?: 'Checking' | 'Savings'
+    name: string
+    routingNumber: string
+    accountNumber: string
+    accountType: 'Checking' | 'Savings'
   }) => {
-    let version = paymentMethod?.version as string
-
-    if (data.type === 'Direct Deposit') {
-      await createBankAccount({
-        request: {
-          contractorUuid: contractor.uuid,
-          requestBody: {
-            name: data.name!,
-            routingNumber: data.routingNumber!,
-            accountNumber: data.accountNumber!,
-            accountType: data.accountType!,
-          },
-        },
-      })
-
-      const getPaymentMethodQuery = buildContractorPaymentMethodGetQuery(gustoClient, {
+    await createBankAccount({
+      request: {
         contractorUuid: contractor.uuid,
-      })
-      const updatedPaymentMethod = await queryClient.fetchQuery(getPaymentMethodQuery)
-      version = updatedPaymentMethod.contractorPaymentMethod?.version as string
-    }
+        requestBody: {
+          name: data.name,
+          routingNumber: data.routingNumber,
+          accountNumber: data.accountNumber,
+          accountType: data.accountType,
+        },
+      },
+    })
+
+    const getPaymentMethodQuery = buildContractorPaymentMethodGetQuery(gustoClient, {
+      contractorUuid: contractor.uuid,
+    })
+    const updatedPaymentMethod = await queryClient.fetchQuery(getPaymentMethodQuery)
+    const version = updatedPaymentMethod.contractorPaymentMethod?.version as string
 
     await updatePaymentMethod({
       request: {
         contractorUuid: contractor.uuid,
         requestBody: {
           version,
-          type: data.type,
+          type: 'Direct Deposit',
         },
       },
     })
@@ -391,7 +371,6 @@ function EditPaymentMethodContent() {
     <ContractorPaymentMethodForm
       variant="edit"
       bankAccount={bankAccounts[0]}
-      paymentMethodType={paymentMethod?.type ?? 'Check'}
       isPending={isPaymentMethodPending || isBankAccountPending}
       onCancel={() => {
         onEvent(componentEvents.CANCEL)

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/ContractorProfileComponents.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/ContractorProfileComponents.tsx
@@ -52,10 +52,10 @@ function ProfileSkeleton() {
         <Skeleton width={80} height={18} />
       </Flex>
       <Flex flexDirection="column" gap={24}>
-        <Components.Box header={<Skeleton width={120} height={42} />}>
+        <Components.Box header={<Skeleton width={120} height={32} />}>
           <Skeleton width="100%" height={331} />
         </Components.Box>
-        <Components.Box header={<Skeleton width={120} height={42} />}>
+        <Components.Box header={<Skeleton width={120} height={32} />}>
           <Skeleton width="100%" height={88} />
         </Components.Box>
       </Flex>

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/ContractorProfileComponents.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/ContractorProfileComponents.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import type { Contractor } from '@gusto/embedded-api/models/components/contractor'
-import { useContractorsListSuspense } from '@gusto/embedded-api/react-query/contractorsList'
+import { useContractorsGetSuspense } from '@gusto/embedded-api/react-query/contractorsGet'
 import { useContractorPaymentMethodGetBankAccountsSuspense } from '@gusto/embedded-api/react-query/contractorPaymentMethodGetBankAccounts'
 import {
   useContractorPaymentMethodGetSuspense,
@@ -30,23 +30,22 @@ import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentCon
 import { componentEvents, type EventType } from '@/shared/constants'
 
 export interface ContractorProfileContextInterface extends FlowContextInterface {
-  companyId: string
+  contractorId: string
   successMessage?: string
   selectedTab: string
   component: React.ComponentType | null
 }
 
-function useContractorData(companyId: string) {
-  const { data } = useContractorsListSuspense({ companyUuid: companyId })
-  const contractor = data.contractors?.[0]
-  return contractor
+function useContractorData(contractorId: string) {
+  const { data } = useContractorsGetSuspense({ contractorUuid: contractorId })
+  return data.contractor
 }
 
 export function ProfileViewContextual() {
-  const { companyId } = useFlow<ContractorProfileContextInterface>()
+  const { contractorId } = useFlow<ContractorProfileContextInterface>()
   const Components = useComponentContext()
 
-  const contractor = useContractorData(companyId)
+  const contractor = useContractorData(contractorId)
 
   if (!contractor) {
     return <Components.Text>No contractors found for this company.</Components.Text>
@@ -182,9 +181,9 @@ function ProfileViewContent({ contractor }: { contractor: Contractor }) {
 }
 
 function EditAddressContent() {
-  const { companyId, onEvent } = useFlow<ContractorProfileContextInterface>()
+  const { contractorId, onEvent } = useFlow<ContractorProfileContextInterface>()
 
-  const contractor = useContractorData(companyId)
+  const contractor = useContractorData(contractorId)
   const { data: addressData } = useContractorsGetAddressSuspense({
     contractorUuid: contractor?.uuid ?? '',
   })
@@ -243,9 +242,9 @@ export function EditAddressContextual() {
 }
 
 function AddPaymentMethodContent() {
-  const { companyId, onEvent } = useFlow<ContractorProfileContextInterface>()
+  const { contractorId, onEvent } = useFlow<ContractorProfileContextInterface>()
 
-  const contractor = useContractorData(companyId)
+  const contractor = useContractorData(contractorId)
   const { data: paymentMethodData } = useContractorPaymentMethodGetSuspense({
     contractorUuid: contractor?.uuid ?? '',
   })
@@ -324,9 +323,9 @@ export function AddPaymentMethodContextual() {
 }
 
 function EditPaymentMethodContent() {
-  const { companyId, onEvent } = useFlow<ContractorProfileContextInterface>()
+  const { contractorId, onEvent } = useFlow<ContractorProfileContextInterface>()
 
-  const contractor = useContractorData(companyId)
+  const contractor = useContractorData(contractorId)
   const { data: bankAccountsData } = useContractorPaymentMethodGetBankAccountsSuspense({
     contractorUuid: contractor?.uuid ?? '',
   })
@@ -411,9 +410,9 @@ export function EditPaymentMethodContextual() {
 }
 
 function EditCompensationContent() {
-  const { companyId, onEvent } = useFlow<ContractorProfileContextInterface>()
+  const { contractorId, onEvent } = useFlow<ContractorProfileContextInterface>()
 
-  const contractor = useContractorData(companyId)
+  const contractor = useContractorData(contractorId)
   const { mutateAsync: updateContractor, isPending } = useContractorsUpdateMutation()
 
   if (!contractor) return null
@@ -453,9 +452,9 @@ export function EditCompensationContextual() {
 }
 
 function EditBasicDetailsContent() {
-  const { companyId, onEvent } = useFlow<ContractorProfileContextInterface>()
+  const { contractorId, onEvent } = useFlow<ContractorProfileContextInterface>()
 
-  const contractor = useContractorData(companyId)
+  const contractor = useContractorData(contractorId)
   const { mutateAsync: updateContractor, isPending } = useContractorsUpdateMutation()
 
   if (!contractor) return null

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/ContractorProfileComponents.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/ContractorProfileComponents.tsx
@@ -70,7 +70,7 @@ function ProfileViewData() {
   const contractor = useContractorData(contractorId)
 
   if (!contractor) {
-    return <Components.Text>No contractors found for this company.</Components.Text>
+    return <Components.Text>No contractor found for this contractor ID.</Components.Text>
   }
 
   return <ProfileViewContent contractor={contractor} />
@@ -215,7 +215,7 @@ function EditAddressContent() {
 
   const contractor = useContractorData(contractorId)
   const { data: addressData } = useContractorsGetAddressSuspense({
-    contractorUuid: contractor?.uuid ?? '',
+    contractorUuid: contractorId,
   })
   const address = addressData.contractorAddress
 
@@ -347,7 +347,7 @@ function EditPaymentMethodContent() {
 
   const contractor = useContractorData(contractorId)
   const { data: bankAccountsData } = useContractorPaymentMethodGetBankAccountsSuspense({
-    contractorUuid: contractor?.uuid ?? '',
+    contractorUuid: contractorId,
   })
   const bankAccounts = bankAccountsData.contractorBankAccountList ?? []
 

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/ContractorProfileComponents.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/ContractorProfileComponents.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { Suspense, useState } from 'react'
 import type { Contractor } from '@gusto/embedded-api/models/components/contractor'
 import { useContractorsGetSuspense } from '@gusto/embedded-api/react-query/contractorsGet'
 import { useContractorPaymentMethodGetBankAccountsSuspense } from '@gusto/embedded-api/react-query/contractorPaymentMethodGetBankAccounts'
@@ -23,6 +23,7 @@ import { ContractorDocuments } from './components/ContractorDocuments'
 import { ContractorPay } from './components/ContractorPay'
 import { ContractorPayForm } from './components/ContractorPayForm'
 import { ContractorDetailsForm } from './components/ContractorDetailsForm'
+import { Skeleton } from './components/Skeleton'
 import { Flex } from '@/components/Common'
 import { useFlow, type FlowContextInterface } from '@/components/Flow/useFlow'
 import { BaseComponent } from '@/components/Base'
@@ -41,7 +42,28 @@ function useContractorData(contractorId: string) {
   return data.contractor
 }
 
-export function ProfileViewContextual() {
+function ProfileSkeleton() {
+  const Components = useComponentContext()
+
+  return (
+    <Flex flexDirection="column" gap={24}>
+      <Flex flexDirection="column" gap={4}>
+        <Skeleton width={200} height={28} />
+        <Skeleton width={80} height={18} />
+      </Flex>
+      <Flex flexDirection="column" gap={24}>
+        <Components.Box header={<Skeleton width={120} height={42} />}>
+          <Skeleton width="100%" height={331} />
+        </Components.Box>
+        <Components.Box header={<Skeleton width={120} height={42} />}>
+          <Skeleton width="100%" height={88} />
+        </Components.Box>
+      </Flex>
+    </Flex>
+  )
+}
+
+function ProfileViewData() {
   const { contractorId } = useFlow<ContractorProfileContextInterface>()
   const Components = useComponentContext()
 
@@ -52,6 +74,14 @@ export function ProfileViewContextual() {
   }
 
   return <ProfileViewContent contractor={contractor} />
+}
+
+export function ProfileViewContextual() {
+  return (
+    <Suspense fallback={<ProfileSkeleton />}>
+      <ProfileViewData />
+    </Suspense>
+  )
 }
 
 function ProfileViewContent({ contractor }: { contractor: Contractor }) {

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/components/ContractorPaymentMethod.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/components/ContractorPaymentMethod.tsx
@@ -58,11 +58,7 @@ export function ContractorPaymentMethod({
     ),
   })
 
-  if (isRemovingAccount) {
-    return <Loading />
-  }
-
-  if (paymentMethodType === 'Check') {
+  if (paymentMethodType === 'Check' && !isRemovingAccount) {
     return (
       <Components.Box
         header={
@@ -100,7 +96,11 @@ export function ContractorPaymentMethod({
         </Flex>
       }
     >
-      <DataView isWithinBox label="Bank accounts" {...dataViewProps} />
+      {isRemovingAccount ? (
+        <Loading />
+      ) : (
+        <DataView isWithinBox label="Bank accounts" {...dataViewProps} />
+      )}
     </Components.Box>
   )
 }

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/components/ContractorPaymentMethod.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/components/ContractorPaymentMethod.tsx
@@ -1,5 +1,6 @@
 import type { ContractorBankAccount } from '@gusto/embedded-api/models/components/contractorbankaccount'
-import { DataView, Flex, Loading, useDataView } from '@/components/Common'
+import { Skeleton } from './Skeleton'
+import { DataView, Flex, useDataView } from '@/components/Common'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu/HamburgerMenu'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import CirclePlus from '@/assets/icons/plus-circle.svg?react'
@@ -97,7 +98,7 @@ export function ContractorPaymentMethod({
       }
     >
       {isRemovingAccount ? (
-        <Loading />
+        <Skeleton width="100%" height={48} />
       ) : (
         <DataView isWithinBox label="Bank accounts" {...dataViewProps} />
       )}

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/components/ContractorPaymentMethodForm.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/components/ContractorPaymentMethodForm.tsx
@@ -1,5 +1,5 @@
 import type { ContractorBankAccount } from '@gusto/embedded-api/models/components/contractorbankaccount'
-import { FormProvider, useForm, useWatch } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { TextInputField, RadioGroupField, Flex } from '@/components/Common'
@@ -9,34 +9,26 @@ import { Form as HtmlForm } from '@/components/Common/Form/Form'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { accountNumberValidation, routingNumberValidation } from '@/helpers/validations'
 
-const PaymentMethodFormSchema = z.discriminatedUnion('type', [
-  z.object({
-    type: z.literal('Direct Deposit'),
-    name: z.string().min(1),
-    routingNumber: routingNumberValidation,
-    accountNumber: z.any(),
-    accountType: z.enum(['Checking', 'Savings']),
-  }),
-  z.object({
-    type: z.literal('Check'),
-  }),
-])
+const BankAccountFormSchema = z.object({
+  name: z.string().min(1),
+  routingNumber: routingNumberValidation,
+  accountNumber: z.any(),
+  accountType: z.enum(['Checking', 'Savings']),
+})
 
-type PaymentMethodFormValues = z.input<typeof PaymentMethodFormSchema>
+type BankAccountFormValues = z.input<typeof BankAccountFormSchema>
 
 interface ContractorPaymentMethodFormProps {
   variant: 'add' | 'edit'
   bankAccount?: ContractorBankAccount
-  paymentMethodType: 'Check' | 'Direct Deposit'
   isPending?: boolean
   onCancel?: () => void
-  onSave?: (data: PaymentMethodFormValues) => void | Promise<void>
+  onSave?: (data: BankAccountFormValues) => void | Promise<void>
 }
 
 export function ContractorPaymentMethodForm({
   variant,
   bankAccount,
-  paymentMethodType,
   isPending,
   onCancel,
   onSave,
@@ -44,10 +36,9 @@ export function ContractorPaymentMethodForm({
   const Components = useComponentContext()
   const { baseSubmitHandler } = useBase()
 
-  const formMethods = useForm<PaymentMethodFormValues>({
-    resolver: zodResolver(PaymentMethodFormSchema),
+  const formMethods = useForm<BankAccountFormValues>({
+    resolver: zodResolver(BankAccountFormSchema),
     defaultValues: {
-      type: paymentMethodType,
       name: bankAccount?.name ?? '',
       routingNumber: bankAccount?.routingNumber ?? '',
       accountNumber: bankAccount?.hiddenAccountNumber ?? '',
@@ -55,24 +46,19 @@ export function ContractorPaymentMethodForm({
     },
   })
 
-  const watchedType = useWatch({ control: formMethods.control, name: 'type' })
-
-  const handleSubmit = async (data: PaymentMethodFormValues) => {
+  const handleSubmit = async (data: BankAccountFormValues) => {
     await baseSubmitHandler(data, async payload => {
-      if (payload.type === 'Direct Deposit') {
-        const { name, accountNumber, routingNumber, accountType } = payload
-        const hasChanged =
-          !bankAccount ||
-          name !== bankAccount.name ||
-          routingNumber !== bankAccount.routingNumber ||
-          accountType !== bankAccount.accountType ||
-          accountNumber !== bankAccount.hiddenAccountNumber
-        if (hasChanged) {
-          const result = accountNumberValidation.safeParse(accountNumber)
-          if (!result.success) {
-            formMethods.setError('accountNumber', { type: 'validate' })
-            return
-          }
+      const hasChanged =
+        !bankAccount ||
+        payload.name !== bankAccount.name ||
+        payload.routingNumber !== bankAccount.routingNumber ||
+        payload.accountType !== bankAccount.accountType ||
+        payload.accountNumber !== bankAccount.hiddenAccountNumber
+      if (hasChanged) {
+        const result = accountNumberValidation.safeParse(payload.accountNumber)
+        if (!result.success) {
+          formMethods.setError('accountNumber', { type: 'validate' })
+          return
         }
       }
       await onSave?.(payload)
@@ -85,65 +71,43 @@ export function ContractorPaymentMethodForm({
         <Flex flexDirection="column" gap={24}>
           <Flex flexDirection="column" gap={4}>
             <Components.Heading as="h2">
-              {variant === 'add'
-                ? 'Add contractor payment method'
-                : 'Edit contractor payment method'}
+              {variant === 'add' ? 'Add bank account' : 'Edit bank account'}
             </Components.Heading>
             <Components.Text variant="supporting">
-              Choose how this contractor gets paid.
+              Enter the bank account details for direct deposit.
             </Components.Text>
           </Flex>
 
-          <RadioGroupField
-            name="type"
-            label="Payment method"
-            shouldVisuallyHideLabel
-            options={[
-              {
-                value: 'Direct Deposit',
-                label: 'Direct deposit',
-                description: 'Deposit the payment directly into their bank account.',
-              },
-              {
-                value: 'Check',
-                label: 'Check',
-                description: 'Pay by physical check.',
-              },
-            ]}
-          />
-
-          {watchedType === 'Direct Deposit' && (
-            <Flex flexDirection="column" gap={20}>
-              <TextInputField
-                name="name"
-                label="Account nickname"
-                isRequired
-                errorMessage="Account nickname is required"
-              />
-              <TextInputField
-                name="routingNumber"
-                label="Routing number"
-                isRequired
-                description="9 digits, on the bottom left of a check"
-                errorMessage="Enter a valid 9-digit routing number"
-              />
-              <TextInputField
-                name="accountNumber"
-                label="Account number"
-                isRequired
-                errorMessage="Enter a valid account number"
-              />
-              <RadioGroupField
-                name="accountType"
-                label="Account type"
-                isRequired
-                options={[
-                  { value: 'Checking', label: 'Checking' },
-                  { value: 'Savings', label: 'Savings' },
-                ]}
-              />
-            </Flex>
-          )}
+          <Flex flexDirection="column" gap={20}>
+            <TextInputField
+              name="name"
+              label="Account nickname"
+              isRequired
+              errorMessage="Account nickname is required"
+            />
+            <TextInputField
+              name="routingNumber"
+              label="Routing number"
+              isRequired
+              description="9 digits, on the bottom left of a check"
+              errorMessage="Enter a valid 9-digit routing number"
+            />
+            <TextInputField
+              name="accountNumber"
+              label="Account number"
+              isRequired
+              errorMessage="Enter a valid account number"
+            />
+            <RadioGroupField
+              name="accountType"
+              label="Account type"
+              isRequired
+              options={[
+                { value: 'Checking', label: 'Checking' },
+                { value: 'Savings', label: 'Savings' },
+              ]}
+            />
+          </Flex>
 
           <ActionsLayout>
             <Components.Button variant="secondary" onClick={onCancel}>

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/components/Skeleton.module.scss
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/components/Skeleton.module.scss
@@ -1,0 +1,20 @@
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--g-colorBodyAccent) 25%,
+    var(--g-colorBody) 50%,
+    var(--g-colorBodyAccent) 75%
+  );
+  background-size: 200% 100%;
+  animation: pulse 1.5s infinite linear;
+  border-radius: toRem(4);
+}
+
+@keyframes pulse {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/components/Skeleton.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/components/Skeleton.tsx
@@ -1,0 +1,15 @@
+import type { CSSProperties } from 'react'
+import cn from 'classnames'
+import styles from './Skeleton.module.scss'
+
+interface SkeletonProps {
+  width?: CSSProperties['width']
+  height?: CSSProperties['height']
+  className?: string
+}
+
+export function Skeleton({ width, height, className }: SkeletonProps) {
+  return (
+    <div className={cn(styles.skeleton, className)} style={{ width, height }} aria-hidden="true" />
+  )
+}

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/contractorProfileStateMachine.ts
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/contractorProfileStateMachine.ts
@@ -29,22 +29,13 @@ const toProfileWithMessage = (message: string) =>
     }),
   )
 
-const toProfilePay = reduce(
-  (ctx: ContractorProfileContextInterface): ContractorProfileContextInterface => ({
-    ...ctx,
-    component: ProfileViewContextual as ComponentType,
-    successMessage: undefined,
-    selectedTab: 'pay',
-  }),
-)
-
-const toProfilePayWithMessage = (message: string) =>
+const toEditWithTab = (component: ComponentType, selectedTab: string) =>
   reduce(
     (ctx: ContractorProfileContextInterface): ContractorProfileContextInterface => ({
       ...ctx,
-      component: ProfileViewContextual as ComponentType,
-      successMessage: message,
-      selectedTab: 'pay',
+      component,
+      successMessage: undefined,
+      selectedTab,
     }),
   )
 
@@ -53,62 +44,32 @@ export const contractorProfileStateMachine = {
     transition(
       'contractor/address/edit',
       'editAddress',
-      reduce(
-        (ctx: ContractorProfileContextInterface): ContractorProfileContextInterface => ({
-          ...ctx,
-          component: EditAddressContextual as ComponentType,
-          successMessage: undefined,
-        }),
-      ),
+      toEditWithTab(EditAddressContextual, 'basic-details'),
     ),
     transition(
       'contractor/paymentMethod/add',
       'addPaymentMethod',
-      reduce(
-        (ctx: ContractorProfileContextInterface): ContractorProfileContextInterface => ({
-          ...ctx,
-          component: AddPaymentMethodContextual as ComponentType,
-          successMessage: undefined,
-        }),
-      ),
+      toEditWithTab(AddPaymentMethodContextual, 'pay'),
     ),
     transition(
       'contractor/paymentMethod/edit',
       'editPaymentMethod',
-      reduce(
-        (ctx: ContractorProfileContextInterface): ContractorProfileContextInterface => ({
-          ...ctx,
-          component: EditPaymentMethodContextual as ComponentType,
-          successMessage: undefined,
-        }),
-      ),
+      toEditWithTab(EditPaymentMethodContextual, 'pay'),
     ),
     transition(
       'contractor/paymentMethod/removed',
       'profile',
-      toProfilePayWithMessage('Payment method updated to Check'),
+      toProfileWithMessage('Payment method updated to Check'),
     ),
     transition(
       'contractor/details/edit',
       'editBasicDetails',
-      reduce(
-        (ctx: ContractorProfileContextInterface): ContractorProfileContextInterface => ({
-          ...ctx,
-          component: EditBasicDetailsContextual as ComponentType,
-          successMessage: undefined,
-        }),
-      ),
+      toEditWithTab(EditBasicDetailsContextual, 'basic-details'),
     ),
     transition(
       'contractor/compensation/edit',
       'editCompensation',
-      reduce(
-        (ctx: ContractorProfileContextInterface): ContractorProfileContextInterface => ({
-          ...ctx,
-          component: EditCompensationContextual as ComponentType,
-          successMessage: undefined,
-        }),
-      ),
+      toEditWithTab(EditCompensationContextual, 'pay'),
     ),
   ),
   editAddress: state<MachineTransition>(
@@ -123,17 +84,17 @@ export const contractorProfileStateMachine = {
     transition(
       componentEvents.CONTRACTOR_PAYMENT_METHOD_UPDATED,
       'profile',
-      toProfilePayWithMessage('Payment method updated successfully'),
+      toProfileWithMessage('Payment method updated successfully'),
     ),
-    transition(componentEvents.CANCEL, 'profile', toProfilePay),
+    transition(componentEvents.CANCEL, 'profile', toProfile),
   ),
   editPaymentMethod: state<MachineTransition>(
     transition(
       componentEvents.CONTRACTOR_PAYMENT_METHOD_UPDATED,
       'profile',
-      toProfilePayWithMessage('Payment method updated successfully'),
+      toProfileWithMessage('Payment method updated successfully'),
     ),
-    transition(componentEvents.CANCEL, 'profile', toProfilePay),
+    transition(componentEvents.CANCEL, 'profile', toProfile),
   ),
   editBasicDetails: state<MachineTransition>(
     transition(
@@ -147,8 +108,8 @@ export const contractorProfileStateMachine = {
     transition(
       componentEvents.CONTRACTOR_UPDATED,
       'profile',
-      toProfilePayWithMessage('Compensation updated successfully'),
+      toProfileWithMessage('Compensation updated successfully'),
     ),
-    transition(componentEvents.CANCEL, 'profile', toProfilePay),
+    transition(componentEvents.CANCEL, 'profile', toProfile),
   ),
 }

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/index.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/index.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from 'react'
+import { useOutletContext } from 'react-router-dom'
 import { createMachine } from 'robot3'
+import type { EntityIds } from '../../../../useEntities'
 import { contractorProfileStateMachine } from './contractorProfileStateMachine'
 import type { ContractorProfileContextInterface } from './ContractorProfileComponents'
 import { ProfileViewContextual } from './ContractorProfileComponents'
@@ -8,7 +10,7 @@ import { BaseComponent, useBase } from '@/components/Base'
 
 function ContractorProfileRoot() {
   const { onEvent } = useBase()
-  const companyId = String(import.meta.env.VITE_COMPANY_ID || '')
+  const { entities } = useOutletContext<{ entities: EntityIds }>()
 
   const machine = useMemo(
     () =>
@@ -18,11 +20,11 @@ function ContractorProfileRoot() {
         (initialContext: ContractorProfileContextInterface) => ({
           ...initialContext,
           component: ProfileViewContextual,
-          companyId,
+          contractorId: entities.contractorId,
           selectedTab: 'basic-details',
         }),
       ),
-    [companyId],
+    [entities.contractorId],
   )
 
   return <Flow machine={machine} onEvent={onEvent} />

--- a/sdk-app/src/design/prototypes/contractor-management/contractorProfile/index.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/contractorProfile/index.tsx
@@ -5,6 +5,7 @@ import type { EntityIds } from '../../../../useEntities'
 import { contractorProfileStateMachine } from './contractorProfileStateMachine'
 import type { ContractorProfileContextInterface } from './ContractorProfileComponents'
 import { ProfileViewContextual } from './ContractorProfileComponents'
+import { EmptyData } from '@/components/Common'
 import { Flow } from '@/components/Flow/Flow'
 import { BaseComponent, useBase } from '@/components/Base'
 
@@ -26,6 +27,10 @@ function ContractorProfileRoot() {
       ),
     [entities.contractorId],
   )
+
+  if (!entities.contractorId) {
+    return <EmptyData title="No contractor selected. Set a Contractor ID in the settings panel." />
+  }
 
   return <Flow machine={machine} onEvent={onEvent} />
 }


### PR DESCRIPTION
## Summary

- Fix contractor profile always returning to the Pay tab after editing any form
- Wire up design prototypes (contractor profile + contractor list) to use settings panel entity IDs instead of hardcoded env vars
- Simplify payment method form to a direct bank account entry (no payment type radio selection)
- Add reusable Skeleton component and profile-level skeleton loading state
- Keep payment box header visible during bank account removal loading state

## Changes

- **Tab persistence**: State machine stamps `selectedTab` on outgoing transitions based on which tab the edit belongs to, so returning from any edit lands on the correct tab
- **Entity ID wiring**: `DesignLayout` forwards entities from App's outlet context; contractor profile fetches by `contractorId` via `useContractorsGetSuspense` instead of listing all and picking first; contractor list reads `companyId` from outlet context
- **Payment method form**: Removed payment type radio selection — the form now only handles bank account entry. Removing an account (switching to Check) is handled separately via the existing remove action
- **Skeleton component**: New `Skeleton` component modeled after shadcn with configurable `width` and `height` props. Used in a new `ProfileSkeleton` fallback that shows placeholder bars for the contractor name/label and two Box containers while the profile data loads
- **Loading state fix**: Bank account removal loading spinner now renders inside the Box content area instead of replacing the entire component

## Demo

<!-- Include screenshots or screen recordings showing the changes. Delete this section if not applicable -->

## Related

<!-- Link to relevant resources -->

## Testing

1. Run `npm run sdk-app`
2. Navigate to Design > Contractor Profile
3. From the Details tab, edit address or details → verify you return to the Details tab
4. From the Pay tab, edit compensation or payment method → verify you return to the Pay tab
5. Open Settings panel, change Contractor ID → verify the profile updates accordingly
6. Click "Add bank account" → verify it goes straight to bank account fields (no radio selection)
7. On a contractor with a bank account, remove it → verify the box header stays visible during loading
8. Hard refresh the profile page → verify the skeleton loading state appears briefly

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)