### PR TITLE
fix: seed Start date from employee hire date in edit mode

### DIFF
--- a/src/components/Employee/Profile/AdminProfile.tsx
+++ b/src/components/Employee/Profile/AdminProfile.tsx
@@ -117,12 +117,6 @@ export function AdminProfile({
     shouldFocusError: false,
   })
 
-  const startDateForm = useForm<{ startDate: string }>({
-    defaultValues: { startDate: '' },
-    mode: 'onSubmit',
-    shouldFocusError: false,
-  })
-
   if (employeeDetails.isLoading || homeAddress.isLoading || workAddress.isLoading) {
     const loadingErrorHandling = composeErrorHandler([employeeDetails, homeAddress, workAddress])
     return <BaseLayout isLoading error={loadingErrorHandling.errors} />
@@ -133,7 +127,6 @@ export function AdminProfile({
       employeeDetails={employeeDetails}
       homeAddress={homeAddress}
       workAddress={workAddress}
-      startDateForm={startDateForm}
       isSelfOnboardingEnabled={isSelfOnboardingEnabled}
       isCreateMode={isCreateMode}
       employeeId={employeeId}
@@ -149,7 +142,6 @@ interface AdminProfileReadyProps {
   employeeDetails: UseEmployeeDetailsFormReady
   homeAddress: UseHomeAddressFormReady
   workAddress: UseWorkAddressFormReady
-  startDateForm: ReturnType<typeof useForm<{ startDate: string }>>
   isSelfOnboardingEnabled: boolean
   isCreateMode: boolean
   employeeId?: string
@@ -163,7 +155,6 @@ function AdminProfileReady({
   employeeDetails,
   homeAddress,
   workAddress,
-  startDateForm,
   isSelfOnboardingEnabled,
   isCreateMode,
   employeeId,
@@ -178,6 +169,12 @@ function AdminProfileReady({
 
   const employee = employeeDetails.data.employee ?? undefined
   const completedSelfOnboarding = checkHasCompletedSelfOnboarding(employee)
+
+  const startDateForm = useForm<{ startDate: string }>({
+    defaultValues: { startDate: employee?.jobs?.[0]?.hireDate ?? '' },
+    mode: 'onSubmit',
+    shouldFocusError: false,
+  })
 
   const EmployeeFields = employeeDetails.form.Fields
   const HomeAddressFields = homeAddress.form.Fields

--- a/src/components/Employee/Profile/Profile.test.tsx
+++ b/src/components/Employee/Profile/Profile.test.tsx
@@ -1124,7 +1124,7 @@ describe('Employee Profile', () => {
       )
     })
 
-    it('does not send effective_date in work address update payload (parity with main)', async () => {
+    it('does not send effective_date in work address update payload', async () => {
       const capturedUpdateWorkAddress = vi.fn()
 
       setupEmployeeHandlers({
@@ -1175,7 +1175,7 @@ describe('Employee Profile', () => {
       expect(body).not.toHaveProperty('effective_date')
     })
 
-    it('renders Start date empty in update mode regardless of work address effective_date (parity with main)', async () => {
+    it('renders Start date empty in update mode when employee has no jobs (does not fall back to work address effective_date)', async () => {
       setupEmployeeHandlers({
         employee: createEmployeeFixture({
           onboarding_status: 'admin_onboarding_incomplete',
@@ -1205,6 +1205,94 @@ describe('Employee Profile', () => {
       const monthSpinbutton = within(startDateGroup).getByRole('spinbutton', { name: /month/i })
 
       expect(monthSpinbutton).not.toHaveAttribute('aria-valuenow')
+    })
+
+    it('pre-fills Start date from employee.jobs[0].hireDate in update mode', async () => {
+      setupEmployeeHandlers({
+        employee: createEmployeeFixture({
+          onboarding_status: 'admin_onboarding_incomplete',
+          jobs: [
+            {
+              ...baseEmployee.jobs[0],
+              hire_date: '2024-03-15',
+            },
+          ],
+        }),
+      })
+
+      renderWithProviders(
+        <Profile
+          companyId={COMPANY_ID}
+          employeeId={EMPLOYEE_ID}
+          isAdmin
+          isSelfOnboardingEnabled={false}
+          onEvent={mockOnEvent}
+        />,
+      )
+
+      await waitForProfileToLoad()
+
+      const startDateGroup = screen.getByRole('group', { name: /Start date/ })
+      const monthSpinbutton = within(startDateGroup).getByRole('spinbutton', { name: /month/i })
+      const daySpinbutton = within(startDateGroup).getByRole('spinbutton', { name: /day/i })
+      const yearSpinbutton = within(startDateGroup).getByRole('spinbutton', { name: /year/i })
+
+      expect(monthSpinbutton).toHaveAttribute('aria-valuenow', '3')
+      expect(daySpinbutton).toHaveAttribute('aria-valuenow', '15')
+      expect(yearSpinbutton).toHaveAttribute('aria-valuenow', '2024')
+    })
+
+    it('allows submit in update mode without re-entering Start date when jobs[0].hireDate is set', async () => {
+      setupEmployeeHandlers({
+        employee: createEmployeeFixture({
+          onboarding_status: 'admin_onboarding_incomplete',
+          has_ssn: true,
+          jobs: [
+            {
+              ...baseEmployee.jobs[0],
+              hire_date: '2024-03-15',
+            },
+          ],
+        }),
+      })
+
+      server.use(
+        handleUpdateEmployee(async () => {
+          const fixture = await import('@/test/mocks/fixtures/get-v1-employees.json')
+          return HttpResponse.json({ ...fixture.default, version: 'updated-version' })
+        }),
+        http.put(`${API_BASE_URL}/v1/home_addresses/:home_address_uuid`, async () => {
+          const fixture =
+            await import('@/test/mocks/fixtures/get-v1-home_addresses-home_address_uuid.json')
+          return HttpResponse.json(fixture.default)
+        }),
+        http.put(`${API_BASE_URL}/v1/work_addresses/:work_address_uuid`, async () => {
+          const fixture =
+            await import('@/test/mocks/fixtures/get-v1-work_addresses-work_address_uuid.json')
+          return HttpResponse.json(fixture.default)
+        }),
+      )
+
+      renderWithProviders(
+        <Profile
+          companyId={COMPANY_ID}
+          employeeId={EMPLOYEE_ID}
+          isAdmin
+          isSelfOnboardingEnabled={false}
+          onEvent={mockOnEvent}
+        />,
+      )
+
+      await waitForProfileToLoad()
+
+      await user.click(screen.getByRole('button', { name: /Continue/ }))
+
+      await waitFor(() => {
+        expect(mockOnEvent).toHaveBeenCalledWith(
+          'employee/profile/done',
+          expect.objectContaining({ startDate: '2024-03-15' }),
+        )
+      })
     })
 
     it('EMPLOYEE_PROFILE_DONE event includes startDate', async () => {


### PR DESCRIPTION
## Summary

- After the hook migration ([#1570](https://github.com/Gusto/embedded-react-sdk/pull/1570)), editing an existing employee's Profile flagged **Start date** as required because `AdminProfile`'s standalone `startDateForm` defaulted to `''` and never read from the employee. Pre-hook, `Profile.tsx` seeded `startDate` from `employee.jobs[0].hireDate`, so the field was already populated when editing an onboarded employee.
- Move `startDateForm` construction into `AdminProfileReady` (where `employee` is loaded) and seed its default from `employee?.jobs?.[0]?.hireDate ?? ''`. This restores pre-hook behavior exactly.
- Create-mode behavior is unchanged: the user-entered `startDate` is still forwarded as `effectiveDate` to `createWorkAddress`, which is the only place that value actually hits an API (the backend uses it to set the initial work address's `effective_date`; without it, backend falls back to hire date or `1970-01-01` per [EMBC-690](https://gustohq.atlassian.net/browse/EMBC-690)).
- On update, `effectiveDate` is still not sent — the work address API does not accept effective_date changes on the initial work address.

## Why this is safe

| Mode   | Before                                                                                   | After                                                                        |
| ------ | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| Create | Empty field, user must enter a start date, sent as `effective_date` on create work address | Same                                                                         |
| Edit   | Empty field, `isRequired` blocks submit, value never sent anyway                          | Pre-filled from `jobs[0].hireDate`, submit succeeds, value still never sent  |

## Test plan

- [x] `npm run test -- --run src/components/Employee/Profile/Profile.test.tsx` — 49 passing (up from 47; +2 regression tests).
- [x] `npm run test -- --run src/components/Employee/OnboardingFlow/OnboardingFlow.test.tsx` — still green.
- [x] Manual: in sdk-app, edit an employee who has completed compensation and confirm Start date is pre-filled and Continue submits without a required error.

## Tests added

- `pre-fills Start date from employee.jobs[0].hireDate in update mode` — asserts month/day/year spinbuttons render the seeded date.
- `allows submit in update mode without re-entering Start date when jobs[0].hireDate is set` — the direct regression test; clicks Continue without touching the field and asserts `EMPLOYEE_PROFILE_DONE` fires with `startDate: '2024-03-15'`.
- Existing `jobs: []` empty-field test renamed to clarify its scope.

https://github.com/user-attachments/assets/ab23a1ac-a318-4f6c-83d6-ab6467ac52a4

Made with [Cursor](https://cursor.com)

[EMBC-690]: https://gustohq.atlassian.net/browse/EMBC-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ