### PR TITLE
fix: remove default garnishment selection in deductions form

### DIFF
--- a/src/components/Employee/Deductions/DeductionsForm/DeductionsForm.test.tsx
+++ b/src/components/Employee/Deductions/DeductionsForm/DeductionsForm.test.tsx
@@ -107,6 +107,18 @@ describe('DeductionsForm', () => {
       })
     })
 
+    it('does not show a form until a deduction type is selected', async () => {
+      renderDeductionsForm()
+
+      await waitFor(() => {
+        expect(screen.getByText('Add Deduction')).toBeInTheDocument()
+      })
+
+      expect(screen.queryByText('Garnishment type')).not.toBeInTheDocument()
+      expect(screen.queryByText('Description')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument()
+    })
+
     it('can switch between garnishment or custom deduction', async () => {
       renderDeductionsForm()
 
@@ -151,6 +163,11 @@ describe('DeductionsForm', () => {
     it('can go back to empty state when canceling with no deductions', async () => {
       renderDeductionsForm()
 
+      const garnishmentRadio = await screen.findByLabelText(
+        'Garnishment (a court-ordered deduction)',
+      )
+      await user.click(garnishmentRadio)
+
       await waitFor(() => {
         expect(screen.getByLabelText('Agency')).toBeInTheDocument()
       })
@@ -179,6 +196,11 @@ describe('DeductionsForm', () => {
         ],
         null,
       )
+
+      const garnishmentRadio = await screen.findByLabelText(
+        'Garnishment (a court-ordered deduction)',
+      )
+      await user.click(garnishmentRadio)
 
       await waitFor(() => {
         expect(screen.getByLabelText('Agency')).toBeInTheDocument()

--- a/src/components/Employee/Deductions/DeductionsForm/DeductionsForm.tsx
+++ b/src/components/Employee/Deductions/DeductionsForm/DeductionsForm.tsx
@@ -70,9 +70,13 @@ function Root({ className, employeeId, deductionId, dictionary }: DeductionsForm
       value: a.state as string,
     })) || []
 
-  // if deduction exists check if it has a type, else if does not exist default to garnishment
-  const [isGarnishment, setIsGarnishment] = useState(
-    (deductionType && SUPPORTED_GARNISHMENT_TYPES.includes(deductionType)) || !deduction,
+  // if deduction exists check if it has a type, else no default selection
+  const [isGarnishment, setIsGarnishment] = useState<boolean | null>(
+    deduction
+      ? deductionType && SUPPORTED_GARNISHMENT_TYPES.includes(deductionType)
+        ? true
+        : false
+      : null,
   )
   const [selectedGarnishment, setSelectedGarnishment] = useState<GarnishmentType>(
     deductionType || 'child_support',
@@ -96,7 +100,7 @@ function Root({ className, employeeId, deductionId, dictionary }: DeductionsForm
     ? deductionType
       ? 'garnishment'
       : 'custom'
-    : 'garnishment'
+    : undefined
 
   // filter out specific fipsCodes/counties as mapped to selected state agency
   // some states only have 1 fips code/county to cover the entire state,
@@ -176,40 +180,41 @@ function Root({ className, employeeId, deductionId, dictionary }: DeductionsForm
               )}
             </Flex>
 
-            <hr />
+            {isGarnishment !== null && <hr />}
           </>
         )}
 
-        {isGarnishment ? (
-          <>
-            {selectedGarnishment === 'child_support' ? (
-              <ChildSupportForm
-                deduction={deduction}
-                employeeId={employeeId}
-                handleStateAgencySelect={handleStateAgencySelect}
-                stateAgencies={stateAgencies}
-                counties={counties}
-                singleAllCountiesFipsCode={singleAllCountiesFipsCode}
-                selectedAgency={selectedAgency}
-                onCancel={handleCancel}
-              />
-            ) : (
-              <GarnishmentForm
-                deduction={deduction}
-                employeeId={employeeId}
-                selectedGarnishmentType={selectedGarnishment}
-                selectedGarnishmentTitle={garnishmentPlaceholder!}
-                onCancel={handleCancel}
-              />
-            )}
-          </>
-        ) : (
-          <CustomDeductionForm
-            deduction={deduction}
-            employeeId={employeeId}
-            onCancel={handleCancel}
-          />
-        )}
+        {isGarnishment !== null &&
+          (isGarnishment ? (
+            <>
+              {selectedGarnishment === 'child_support' ? (
+                <ChildSupportForm
+                  deduction={deduction}
+                  employeeId={employeeId}
+                  handleStateAgencySelect={handleStateAgencySelect}
+                  stateAgencies={stateAgencies}
+                  counties={counties}
+                  singleAllCountiesFipsCode={singleAllCountiesFipsCode}
+                  selectedAgency={selectedAgency}
+                  onCancel={handleCancel}
+                />
+              ) : (
+                <GarnishmentForm
+                  deduction={deduction}
+                  employeeId={employeeId}
+                  selectedGarnishmentType={selectedGarnishment}
+                  selectedGarnishmentTitle={garnishmentPlaceholder!}
+                  onCancel={handleCancel}
+                />
+              )}
+            </>
+          ) : (
+            <CustomDeductionForm
+              deduction={deduction}
+              employeeId={employeeId}
+              onCancel={handleCancel}
+            />
+          ))}
       </Grid>
     </section>
   )


### PR DESCRIPTION
## Summary

Remove the default "Garnishment" pre-selection when adding a new employee deduction. The radio group now starts empty, and sub-forms only appear after the user explicitly selects a deduction type.

## Changes

- Deduction type radio group no longer pre-selects "Garnishment" in add mode
- Sub-forms (ChildSupport, Garnishment, CustomDeduction) and the `<hr>` separator are hidden until a selection is made
- Edit mode behavior is unchanged — it still infers the type from the existing deduction

## Testing

- `npm run test -- --run src/components/Employee/Deductions/DeductionsForm/DeductionsForm.test.tsx`
- New test verifies no form renders until a deduction type is selected
- Existing tests updated to explicitly select a radio option before asserting on form content