### PR TITLE
fix: remove italic styling and normalize text size in company address list

### DIFF
--- a/src/components/Company/Locations/LocationsList/List.module.scss
+++ b/src/components/Company/Locations/LocationsList/List.module.scss
@@ -1,6 +1,6 @@
 .addressCell {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: toRem(4);
   container-type: normal;
 }

--- a/src/components/Company/Locations/LocationsList/List.module.scss
+++ b/src/components/Company/Locations/LocationsList/List.module.scss
@@ -3,4 +3,5 @@
   flex-direction: column;
   gap: toRem(4);
   container-type: normal;
+  font-style: normal;
 }

--- a/src/components/Company/Locations/LocationsList/List.module.scss
+++ b/src/components/Company/Locations/LocationsList/List.module.scss
@@ -1,0 +1,6 @@
+.addressCell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  container-type: normal;
+}

--- a/src/components/Company/Locations/LocationsList/List.tsx
+++ b/src/components/Company/Locations/LocationsList/List.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useLocationsList } from './useLocationsList'
+import styles from './List.module.scss'
 import PencilSvg from '@/assets/icons/pencil.svg?react'
 import { DataView, EmptyData, useDataView, VisuallyHidden } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
@@ -33,7 +34,7 @@ export const List = () => {
         title: t('locationListCol1'),
         render: location => {
           return (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <div className={styles.addressCell}>
               <Components.Text as="div">{getStreet(location)}</Components.Text>
               <Components.Text as="div">{getCityStateZip(location)}</Components.Text>
             </div>

--- a/src/components/Company/Locations/LocationsList/List.tsx
+++ b/src/components/Company/Locations/LocationsList/List.tsx
@@ -34,10 +34,10 @@ export const List = () => {
         title: t('locationListCol1'),
         render: location => {
           return (
-            <div className={styles.addressCell}>
-              <Components.Text as="div">{getStreet(location)}</Components.Text>
-              <Components.Text as="div">{getCityStateZip(location)}</Components.Text>
-            </div>
+            <address className={styles.addressCell}>
+              <Components.Text as="span">{getStreet(location)}</Components.Text>
+              <Components.Text as="span">{getCityStateZip(location)}</Components.Text>
+            </address>
           )
         },
       },

--- a/src/components/Company/Locations/LocationsList/List.tsx
+++ b/src/components/Company/Locations/LocationsList/List.tsx
@@ -33,14 +33,10 @@ export const List = () => {
         title: t('locationListCol1'),
         render: location => {
           return (
-            <>
-              <address>
-                <Components.Text as="div">{getStreet(location)}</Components.Text>
-                <Components.Text as="div" size="sm">
-                  {getCityStateZip(location)}
-                </Components.Text>
-              </address>
-            </>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <Components.Text as="div">{getStreet(location)}</Components.Text>
+              <Components.Text as="div">{getCityStateZip(location)}</Components.Text>
+            </div>
           )
         },
       },


### PR DESCRIPTION
## Summary

- Remove the HTML `<address>` tag in the company locations table which was applying browser-default italic styling
- Normalize both address lines to the same text size (city/state/zip was previously smaller)

## Changes

- Replaced `<address>` wrapper with a CSS module flex column layout (`.addressCell` in `List.module.scss`)
- Removed `size="sm"` from the city/state/zip text so both lines render at the same size
- Uses `toRem(4)` for gap spacing to match codebase convention

## Testing

- View in SDK dev app at `/company/Locations`
- Verify address text is not italicized and both lines are the same font size