### PR TITLE
feat: add GWS component adapter system for DS convergence testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@vitejs/plugin-react-swc": "^4.3.0",
         "@vitest/coverage-v8": "^4.1.5",
         "axe-core": "^4.11.3",
+        "bootstrap": "^5.3.3",
         "dotenv": "^17.4.2",
         "eslint": "^9.39.4",
         "eslint-plugin-import": "^2.31.0",
@@ -3828,6 +3829,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@react-aria/autocomplete": {
@@ -9305,6 +9318,26 @@
       "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.3.0",
     "@vitest/coverage-v8": "^4.1.5",
+    "bootstrap": "^5.3.3",
     "axe-core": "^4.11.3",
     "dotenv": "^17.4.2",
     "eslint": "^9.39.4",

--- a/sdk-app/src/AdapterModeContext.ts
+++ b/sdk-app/src/AdapterModeContext.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react'
+import type { AdapterOption } from './design/component-adapters/types'
+
+export interface AdapterModeContextValue {
+  adapter: AdapterOption
+  setAdapter: (adapter: AdapterOption) => void
+}
+
+export const AdapterModeContext = createContext<AdapterModeContextValue>({
+  adapter: 'default',
+  setAdapter: () => {},
+})
+
+export const AdapterModeProvider = AdapterModeContext.Provider

--- a/sdk-app/src/AdapterSwitcher.module.scss
+++ b/sdk-app/src/AdapterSwitcher.module.scss
@@ -1,0 +1,49 @@
+.root {
+  display: inline-flex;
+  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.08);
+  border-radius: 0.375rem;
+}
+
+.option {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  font-family: inherit;
+  text-decoration: none;
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  cursor: pointer;
+  max-height: 2.3rem;
+  transition:
+    background 0.15s,
+    color 0.15s;
+
+  &:first-child {
+    border-radius: 0.375rem 0 0 0.375rem;
+  }
+
+  &:last-child {
+    border-radius: 0 0.375rem 0.375rem 0;
+    margin-left: -1px;
+  }
+
+  &:hover {
+    background: var(--color-hover-bg);
+    color: var(--color-text);
+  }
+}
+
+.active {
+  background: var(--color-active);
+  color: #fff;
+  border-color: var(--color-active);
+  z-index: 1;
+
+  &:hover {
+    background: var(--color-active);
+    color: #fff;
+  }
+}

--- a/sdk-app/src/AdapterSwitcher.tsx
+++ b/sdk-app/src/AdapterSwitcher.tsx
@@ -1,0 +1,25 @@
+import { useAdapterModeContext } from './useAdapterModeContext'
+import { ADAPTER_OPTIONS } from './design/component-adapters/types'
+import styles from './AdapterSwitcher.module.scss'
+
+export function AdapterSwitcher() {
+  const { adapter, setAdapter } = useAdapterModeContext()
+
+  return (
+    <div className={styles.root}>
+      {ADAPTER_OPTIONS.map(({ label, key }) => (
+        <button
+          key={key}
+          type="button"
+          className={`${styles.option} ${adapter === key ? styles.active : ''}`}
+          onClick={() => {
+            setAdapter(key)
+          }}
+          title={`${label} adapter`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/sdk-app/src/App.tsx
+++ b/sdk-app/src/App.tsx
@@ -9,6 +9,8 @@ import { useDemoManager } from './useDemoManager'
 import { useAppMode } from './useAppMode'
 import { useThemeMode } from './useThemeMode'
 import { ThemeModeProvider } from './ThemeModeContext'
+import { useAdapterMode } from './useAdapterMode'
+import { AdapterModeProvider } from './AdapterModeContext'
 
 export function App() {
   const [settingsOpen, setSettingsOpen] = useState(false)
@@ -17,6 +19,7 @@ export function App() {
   const demoManager = useDemoManager()
   const mode = useAppMode()
   const themeMode = useThemeMode()
+  const adapterMode = useAdapterMode()
 
   const handleCreateNewDemo = async (demoType: string) => {
     const result = await demoManager.createNewDemo(demoType)
@@ -34,43 +37,45 @@ export function App() {
 
   return (
     <ThemeModeProvider value={themeMode}>
-      <div className="app-layout">
-        <TopBar
-          companyId={entities.companyId}
-          tokenStatus={demoManager.tokenStatus}
-          onOpenSettings={() => {
-            setSettingsOpen(true)
-          }}
-        />
-        <div className="app-body">
-          <Sidebar mode={mode} searchQuery={searchQuery} onSearchChange={setSearchQuery} />
-          <main className="main-content">
-            <Outlet context={{ entities }} />
-          </main>
-        </div>
-        <DemoSettingsPanel
-          isOpen={settingsOpen}
-          onClose={() => {
-            setSettingsOpen(false)
-          }}
-          entities={entities}
-          onUpdateEntity={updateEntity}
-          onResetToDefaults={resetToDefaults}
-          tokenStatus={demoManager.tokenStatus}
-          isCreatingDemo={demoManager.isCreatingDemo}
-          demoError={demoManager.demoError}
-          proxyMode={demoManager.proxyMode}
-          onCreateNewDemo={handleCreateNewDemo}
-          onRefreshToken={demoManager.refreshToken}
-        />
-        {demoManager.tokenStatus === 'expired' && (
-          <TokenExpiredOverlay
-            onRefresh={demoManager.refreshToken}
-            isRefreshing={demoManager.isCreatingDemo}
-            error={demoManager.demoError}
+      <AdapterModeProvider value={adapterMode}>
+        <div className="app-layout">
+          <TopBar
+            companyId={entities.companyId}
+            tokenStatus={demoManager.tokenStatus}
+            onOpenSettings={() => {
+              setSettingsOpen(true)
+            }}
           />
-        )}
-      </div>
+          <div className="app-body">
+            <Sidebar mode={mode} searchQuery={searchQuery} onSearchChange={setSearchQuery} />
+            <main className="main-content">
+              <Outlet context={{ entities }} />
+            </main>
+          </div>
+          <DemoSettingsPanel
+            isOpen={settingsOpen}
+            onClose={() => {
+              setSettingsOpen(false)
+            }}
+            entities={entities}
+            onUpdateEntity={updateEntity}
+            onResetToDefaults={resetToDefaults}
+            tokenStatus={demoManager.tokenStatus}
+            isCreatingDemo={demoManager.isCreatingDemo}
+            demoError={demoManager.demoError}
+            proxyMode={demoManager.proxyMode}
+            onCreateNewDemo={handleCreateNewDemo}
+            onRefreshToken={demoManager.refreshToken}
+          />
+          {demoManager.tokenStatus === 'expired' && (
+            <TokenExpiredOverlay
+              onRefresh={demoManager.refreshToken}
+              isRefreshing={demoManager.isCreatingDemo}
+              error={demoManager.demoError}
+            />
+          )}
+        </div>
+      </AdapterModeProvider>
     </ThemeModeProvider>
   )
 }

--- a/sdk-app/src/ComponentRenderer.tsx
+++ b/sdk-app/src/ComponentRenderer.tsx
@@ -6,6 +6,7 @@ import { useResolvedTheme } from './useThemeModeContext'
 import { darkTheme } from './darkTheme'
 import type { EntityIds } from './useEntities'
 import styles from './ComponentRenderer.module.scss'
+import { useAdapterComponents } from './useAdapterModeContext'
 import { GustoProvider } from '@/contexts'
 
 interface ComponentRendererProps {
@@ -124,6 +125,7 @@ export function ComponentRenderer({ entities }: ComponentRendererProps) {
     component: string
   }>()
   const resolvedTheme = useResolvedTheme()
+  const adapterComponents = useAdapterComponents()
   const [events, setEvents] = useState<EventLogEntry[]>([])
   const [eventsOpen, setEventsOpen] = useState(true)
   const [resetKey, setResetKey] = useState(0)
@@ -258,6 +260,7 @@ export function ComponentRenderer({ entities }: ComponentRendererProps) {
               <GustoProvider
                 config={{ baseUrl: `${window.location.origin}/api/` }}
                 theme={resolvedTheme === 'dark' ? darkTheme : undefined}
+                components={adapterComponents}
                 key={providerKey}
               >
                 <Suspense fallback={<div className={styles.contentLoading}>Loading...</div>}>

--- a/sdk-app/src/TopBar.tsx
+++ b/sdk-app/src/TopBar.tsx
@@ -1,3 +1,4 @@
+import { AdapterSwitcher } from './AdapterSwitcher'
 import { ModeSwitcher } from './ModeSwitcher'
 import { ThemeSwitcher } from './ThemeSwitcher'
 import { useAppMode } from './useAppMode'
@@ -100,6 +101,7 @@ export function TopBar({ companyId, tokenStatus, onOpenSettings }: TopBarProps) 
         <div className={styles.actions}>
           <ThemeSwitcher />
           <ModeSwitcher />
+          <AdapterSwitcher />
           <button className={styles.settingsBtn} onClick={onOpenSettings} type="button">
             <SettingsIcon />
             Settings

--- a/sdk-app/src/design/DesignLayout.tsx
+++ b/sdk-app/src/design/DesignLayout.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import { useResolvedTheme } from '../useThemeModeContext'
 import { darkTheme } from '../darkTheme'
+import { useAdapterComponents } from '../useAdapterModeContext'
 import { BreakpointSwitcher } from './BreakpointSwitcher'
 import { breakpointToMaxWidth } from './breakpointConstants'
 import type { BreakpointOption } from './breakpointConstants'
@@ -11,6 +12,7 @@ import { GustoProvider } from '@/contexts/GustoProvider/GustoProvider'
 export function DesignLayout() {
   const [breakpoint, setBreakpoint] = useState<BreakpointOption>('large')
   const resolvedTheme = useResolvedTheme()
+  const adapterComponents = useAdapterComponents()
 
   const maxWidth = breakpointToMaxWidth(breakpoint)
 
@@ -18,6 +20,7 @@ export function DesignLayout() {
     <GustoProvider
       config={{ baseUrl: `${window.location.origin}/api/` }}
       theme={resolvedTheme === 'dark' ? darkTheme : undefined}
+      components={adapterComponents}
     >
       <div className={styles.bodyContent} style={maxWidth ? { maxWidth } : undefined}>
         <Outlet />

--- a/sdk-app/src/design/component-adapters/gws/GwsBox.tsx
+++ b/sdk-app/src/design/component-adapters/gws/GwsBox.tsx
@@ -1,0 +1,14 @@
+import cn from 'classnames'
+import type { BoxProps } from '@/components/Common/UI/Box/BoxTypes'
+
+export function GwsBox({ children, header, footer, withPadding = true, className }: BoxProps) {
+  return (
+    <div className={cn('card w-100', className)} data-testid="data-box">
+      <div className="card-body d-flex flex-column">
+        {header && <div className="mb-3">{header}</div>}
+        <div className="flex-grow-1">{children}</div>
+        {footer && <div className="pt-4">{footer}</div>}
+      </div>
+    </div>
+  )
+}

--- a/sdk-app/src/design/component-adapters/gws/GwsButton.tsx
+++ b/sdk-app/src/design/component-adapters/gws/GwsButton.tsx
@@ -1,0 +1,42 @@
+import cn from 'classnames'
+import type { ButtonProps } from '@/components/Common/UI/Button/ButtonTypes'
+
+const VARIANT_CLASS: Record<string, string> = {
+  primary: 'btn-primary',
+  secondary: 'btn-outline-secondary',
+  tertiary: 'btn-link',
+  error: 'btn-outline-danger',
+}
+
+export function GwsButton({
+  variant = 'primary',
+  isLoading,
+  isDisabled,
+  icon,
+  children,
+  buttonRef,
+  className,
+  ...props
+}: ButtonProps) {
+  const disabled = isDisabled || isLoading
+
+  return (
+    <button
+      ref={buttonRef}
+      className={cn('btn', VARIANT_CLASS[variant], className)}
+      disabled={disabled}
+      aria-busy={isLoading || undefined}
+      data-loading={isLoading || undefined}
+      {...props}
+    >
+      {isLoading ? (
+        <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true" />
+      ) : (
+        <>
+          {icon && <span className="me-2">{icon}</span>}
+          {children}
+        </>
+      )}
+    </button>
+  )
+}

--- a/sdk-app/src/design/component-adapters/gws/GwsButtonIcon.tsx
+++ b/sdk-app/src/design/component-adapters/gws/GwsButtonIcon.tsx
@@ -1,0 +1,24 @@
+import cn from 'classnames'
+import { GwsButton } from './GwsButton'
+import type { ButtonIconProps } from '@/components/Common/UI/Button/ButtonTypes'
+
+export function GwsButtonIcon({
+  children,
+  variant = 'tertiary',
+  className,
+  'aria-label': ariaLabel,
+  ...props
+}: ButtonIconProps) {
+  return (
+    <GwsButton
+      variant={variant}
+      className={cn('btn-sm px-2', className)}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      {...props}
+    >
+      {children}
+      <span className="visually-hidden">{ariaLabel}</span>
+    </GwsButton>
+  )
+}

--- a/sdk-app/src/design/component-adapters/gws/GwsHeading.tsx
+++ b/sdk-app/src/design/component-adapters/gws/GwsHeading.tsx
@@ -1,0 +1,42 @@
+import cn from 'classnames'
+import type { HeadingProps } from '@/components/Common/UI/Heading/HeadingTypes'
+
+const HEADING_TO_FS: Record<string, string> = {
+  h1: 'fs-1',
+  h2: 'fs-2',
+  h3: 'fs-3',
+  h4: 'fs-4',
+  h5: 'fs-5',
+  h6: 'fs-6',
+}
+
+const ALIGN_CLASS: Record<string, string> = {
+  start: 'text-start',
+  center: 'text-center',
+  end: 'text-end',
+}
+
+export function GwsHeading({
+  as: Component,
+  styledAs,
+  textAlign,
+  className,
+  children,
+  ...props
+}: HeadingProps) {
+  const visualLevel = styledAs ?? Component
+
+  return (
+    <Component
+      className={cn(
+        HEADING_TO_FS[visualLevel],
+        'mb-0',
+        textAlign && ALIGN_CLASS[textAlign],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Component>
+  )
+}

--- a/sdk-app/src/design/component-adapters/gws/GwsTable.tsx
+++ b/sdk-app/src/design/component-adapters/gws/GwsTable.tsx
@@ -1,0 +1,72 @@
+import cn from 'classnames'
+import type { TableProps } from '@/components/Common/UI/Table/TableTypes'
+
+export function GwsTable({
+  className,
+  headers,
+  rows,
+  footer,
+  emptyState,
+  isWithinBox,
+  hasCheckboxColumn,
+  ...props
+}: TableProps) {
+  return (
+    <div className={isWithinBox ? undefined : 'table-responsive w-100'}>
+      <table className={cn('table', { 'mb-0': isWithinBox }, className)} {...props}>
+        <thead>
+          <tr>
+            {headers.map((header, index) => (
+              <th
+                key={header.key}
+                scope="col"
+                className={cn({
+                  'checkbox-column': hasCheckboxColumn && index === 0,
+                })}
+              >
+                {header.content}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="table-group-divider">
+          {rows.length === 0 && emptyState ? (
+            <tr>
+              <td colSpan={headers.length} className="text-center bg-body-secondary">
+                {emptyState}
+              </td>
+            </tr>
+          ) : (
+            rows.map(row => (
+              <tr key={row.key} className="align-middle">
+                {row.data.map((cell, index) => {
+                  const isRowHeader = hasCheckboxColumn ? index === 1 : index === 0
+                  return isRowHeader ? (
+                    <th key={cell.key} scope="row">
+                      {cell.content}
+                    </th>
+                  ) : (
+                    <td key={cell.key}>{cell.content}</td>
+                  )
+                })}
+              </tr>
+            ))
+          )}
+        </tbody>
+        {footer && footer.length > 0 && (
+          <tfoot>
+            <tr>
+              {footer.length === 1 && footer[0] ? (
+                <td key={footer[0].key} colSpan={headers.length}>
+                  {footer[0].content}
+                </td>
+              ) : (
+                footer.map(cell => <td key={cell.key}>{cell.content}</td>)
+              )}
+            </tr>
+          </tfoot>
+        )}
+      </table>
+    </div>
+  )
+}

--- a/sdk-app/src/design/component-adapters/gws/GwsTabs.module.scss
+++ b/sdk-app/src/design/component-adapters/gws/GwsTabs.module.scss
@@ -1,0 +1,28 @@
+.navHighlights {
+  border-bottom: 1px solid var(--bs-border-color);
+
+  :global(.nav-item) {
+    padding-bottom: 0.5rem;
+    font-size: 16px;
+    font-weight: 500;
+
+    &:hover {
+      :global(.nav-link:not(.active)) {
+        color: var(--bs-primary);
+      }
+      border-bottom: 3px solid var(--bs-border-color);
+    }
+
+    &:has(:global(.active)) {
+      border-bottom: 3px solid var(--bs-primary);
+    }
+  }
+
+  :global(.nav-link) {
+    color: var(--bs-primary);
+  }
+
+  :global(.active) {
+    color: var(--bs-primary);
+  }
+}

--- a/sdk-app/src/design/component-adapters/gws/GwsTabs.tsx
+++ b/sdk-app/src/design/component-adapters/gws/GwsTabs.tsx
@@ -1,0 +1,59 @@
+import cn from 'classnames'
+import styles from './GwsTabs.module.scss'
+import type { TabsProps } from '@/components/Common/UI/Tabs/TabsTypes'
+
+export function GwsTabs({
+  tabs,
+  selectedId,
+  onSelectionChange,
+  className,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  ...props
+}: TabsProps) {
+  const activeId = selectedId ?? tabs[0]?.id
+
+  return (
+    <div className={cn('w-100', className)} {...props}>
+      <ul
+        className={cn('nav mb-4', styles.navHighlights)}
+        role="tablist"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+      >
+        {tabs.map(tab => (
+          <li key={tab.id} className="nav-item" role="presentation">
+            <button
+              type="button"
+              role="tab"
+              className={cn('nav-link', { active: tab.id === activeId, disabled: tab.isDisabled })}
+              id={`tab-${tab.id}`}
+              aria-controls={`tabpanel-${tab.id}`}
+              aria-selected={tab.id === activeId}
+              tabIndex={tab.id === activeId ? 0 : -1}
+              disabled={tab.isDisabled}
+              onClick={() => {
+                if (!tab.isDisabled) onSelectionChange(tab.id)
+              }}
+            >
+              {tab.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="tab-content">
+        {tabs.map(tab => (
+          <div
+            key={tab.id}
+            role="tabpanel"
+            id={`tabpanel-${tab.id}`}
+            aria-labelledby={`tab-${tab.id}`}
+            className={cn('tab-pane fade', { 'show active': tab.id === activeId })}
+          >
+            {tab.content}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/sdk-app/src/design/component-adapters/gws/GwsText.tsx
+++ b/sdk-app/src/design/component-adapters/gws/GwsText.tsx
@@ -1,0 +1,50 @@
+import cn from 'classnames'
+import type { TextProps } from '@/components/Common/UI/Text/TextTypes'
+
+const SIZE_CLASS: Record<string, string> = {
+  xs: 'small',
+  sm: 'large',
+  md: '',
+  lg: 'fs-5',
+}
+
+const WEIGHT_CLASS: Record<string, string> = {
+  regular: 'fw-normal',
+  medium: 'fw-medium',
+  semibold: 'fw-semibold',
+  bold: 'fw-bold',
+}
+
+const ALIGN_CLASS: Record<string, string> = {
+  start: 'text-start',
+  center: 'text-center',
+  end: 'text-end',
+}
+
+export function GwsText({
+  as: Component = 'p',
+  size = 'md',
+  weight,
+  textAlign,
+  variant,
+  className,
+  children,
+  ...props
+}: TextProps) {
+  return (
+    <Component
+      className={cn(
+        'mb-0',
+        SIZE_CLASS[size],
+        weight && WEIGHT_CLASS[weight],
+        textAlign && ALIGN_CLASS[textAlign],
+        variant === 'supporting' && 'text-muted',
+        variant === 'leading' && 'fw-medium',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Component>
+  )
+}

--- a/sdk-app/src/design/component-adapters/gws/gws-overrides.scss
+++ b/sdk-app/src/design/component-adapters/gws/gws-overrides.scss
@@ -1,0 +1,103 @@
+$gws-primary: #343a40;
+$gws-gray-100: #f8f9fa;
+$gws-gray-600: #6c757d;
+$gws-gray-800: #343a40;
+
+:root {
+  --bs-body-font-family: var(--font_family, var(--bs-font-sans-serif));
+  --bs-primary: #{$gws-primary};
+  --bs-secondary: #{$gws-primary};
+}
+
+// Focus ring — matches gws-flows application.scss
+.btn,
+.btn-close,
+.dropdown-toggle,
+.dropdown-item,
+.nav-link,
+.selectable-item {
+  &:focus-visible {
+    outline: 2px solid $gws-gray-800;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 3px #fff0;
+  }
+}
+
+.btn {
+  --bs-btn-disabled-opacity: 1;
+  --bs-btn-font-weight: 400;
+  --bs-btn-border-radius: var(--bs-border-radius);
+
+  &:hover {
+    filter: brightness(95%);
+  }
+}
+
+.btn-primary {
+  --bs-btn-color: #fff;
+  --bs-btn-bg: #{$gws-primary};
+  --bs-btn-hover-color: #fff;
+  --bs-btn-hover-bg: #{$gws-primary};
+  --bs-btn-active-color: #fff;
+  --bs-btn-active-bg: #{$gws-primary};
+  --bs-btn-border-color: #{$gws-primary};
+  --bs-btn-hover-border-color: #{$gws-primary};
+  --bs-btn-active-border-color: #{$gws-primary};
+  --bs-btn-disabled-bg: #{$gws-gray-600};
+  --bs-btn-disabled-border-color: #{$gws-gray-600};
+  --bs-btn-disabled-color: #fff;
+}
+
+@mixin gws-outline-variant($color) {
+  --bs-btn-color: #{$color};
+  --bs-btn-border-color: #{$color};
+  --bs-btn-hover-color: #{$color};
+  --bs-btn-hover-border-color: #{$color};
+  --bs-btn-active-color: #{$color};
+  --bs-btn-active-border-color: #{$color};
+  --bs-btn-hover-bg: #{$gws-gray-100};
+  --bs-btn-active-bg: transparent;
+  --bs-btn-disabled-color: #{$color};
+  --bs-btn-disabled-border-color: #{$color};
+}
+
+.btn-outline-primary {
+  @include gws-outline-variant($gws-primary);
+}
+
+.btn-outline-secondary {
+  @include gws-outline-variant($gws-primary);
+  --bs-btn-disabled-color: #{$gws-gray-600};
+  --bs-btn-disabled-border-color: #{$gws-gray-600};
+}
+
+.btn-outline-danger {
+  @include gws-outline-variant(var(--bs-danger));
+}
+
+// Secondary/outline button hover and focus backgrounds — matches gws-flows application.scss
+.btn-outline-primary,
+.btn-outline-secondary {
+  &:not(:active):not(:disabled) {
+    &:hover {
+      background-color: $gws-gray-100;
+    }
+
+    &:focus-visible {
+      background-color: white;
+    }
+  }
+}
+
+// Link-style button (tertiary) — strip decoration and match gws-flows btn-link behavior
+.btn-link {
+  --bs-btn-color: #{$gws-primary};
+  --bs-btn-hover-color: #{$gws-primary};
+  --bs-btn-active-color: #{$gws-primary};
+  --bs-btn-disabled-color: #{$gws-gray-600};
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/sdk-app/src/design/component-adapters/gws/index.ts
+++ b/sdk-app/src/design/component-adapters/gws/index.ts
@@ -1,0 +1,20 @@
+import 'bootstrap/dist/css/bootstrap.min.css'
+import './gws-overrides.scss'
+import { GwsBox } from './GwsBox'
+import { GwsButton } from './GwsButton'
+import { GwsButtonIcon } from './GwsButtonIcon'
+import { GwsHeading } from './GwsHeading'
+import { GwsTable } from './GwsTable'
+import { GwsTabs } from './GwsTabs'
+import { GwsText } from './GwsText'
+import type { ComponentsContextType } from '@/contexts/ComponentAdapter/useComponentContext'
+
+export const gwsComponentOverrides: Partial<ComponentsContextType> = {
+  Box: GwsBox,
+  Button: GwsButton,
+  ButtonIcon: GwsButtonIcon,
+  Heading: GwsHeading,
+  Table: GwsTable,
+  Tabs: GwsTabs,
+  Text: GwsText,
+}

--- a/sdk-app/src/design/component-adapters/resolveAdapter.ts
+++ b/sdk-app/src/design/component-adapters/resolveAdapter.ts
@@ -1,0 +1,15 @@
+import type { AdapterOption } from './types'
+import { gwsComponentOverrides } from './gws'
+import type { ComponentsContextType } from '@/contexts/ComponentAdapter/useComponentContext'
+
+export function resolveAdapterComponents(
+  adapter: AdapterOption,
+): Partial<ComponentsContextType> | undefined {
+  switch (adapter) {
+    case 'gws':
+      return gwsComponentOverrides
+    case 'default':
+    default:
+      return undefined
+  }
+}

--- a/sdk-app/src/design/component-adapters/types.ts
+++ b/sdk-app/src/design/component-adapters/types.ts
@@ -1,0 +1,6 @@
+export type AdapterOption = 'default' | 'gws'
+
+export const ADAPTER_OPTIONS: { label: string; key: AdapterOption }[] = [
+  { label: 'Default', key: 'default' },
+  { label: 'GWS', key: 'gws' },
+]

--- a/sdk-app/src/design/prototypes/contractor-management/ContractorList/index.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/ContractorList/index.tsx
@@ -16,20 +16,21 @@ function formatRate(contractor: Contractor) {
 }
 
 function ActiveContractorsTable({ contractors }: { contractors: Contractor[] }) {
+  const Components = useComponentContext()
   const dataViewProps = useDataView<Contractor>({
     data: contractors,
     columns: [
       {
         title: 'Name',
-        render: contractor => contractorName(contractor),
+        render: contractor => <Components.Text>{contractorName(contractor)}</Components.Text>,
       },
       {
         title: 'Type',
-        render: contractor => contractor.type ?? '–',
+        render: contractor => <Components.Text>{contractor.type ?? '–'}</Components.Text>,
       },
       {
         title: 'Rate',
-        render: contractor => formatRate(contractor),
+        render: contractor => <Components.Text>{formatRate(contractor)}</Components.Text>,
       },
     ],
     itemMenu: () => (
@@ -153,7 +154,7 @@ function ContractorListContent() {
     }
   }, [companyId, selectedTab])
 
-  const { data, isFetching } = useContractorsList(queryParams)
+  const { data, isPending } = useContractorsList(queryParams)
   const contractors = data?.contractors ?? []
 
   const tabs = [
@@ -197,7 +198,7 @@ function ContractorListContent() {
       </Flex>
       <Flex flexDirection="column" gap={0}>
         <Components.Tabs onSelectionChange={setSelectedTab} tabs={tabs} selectedId={selectedTab} />
-        {isFetching ? <Loading /> : renderTable()}
+        {isPending ? <Loading /> : renderTable()}
       </Flex>
     </Flex>
   )

--- a/sdk-app/src/useAdapterMode.ts
+++ b/sdk-app/src/useAdapterMode.ts
@@ -1,0 +1,33 @@
+import { useState, useCallback } from 'react'
+import type { AdapterOption } from './design/component-adapters/types'
+
+const STORAGE_KEY = 'sdk-app-adapter-mode'
+
+function loadAdapter(): AdapterOption {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'default' || stored === 'gws') return stored
+  } catch {
+    // Storage unavailable
+  }
+  return 'default'
+}
+
+function saveAdapter(adapter: AdapterOption) {
+  try {
+    localStorage.setItem(STORAGE_KEY, adapter)
+  } catch {
+    // Storage full or unavailable
+  }
+}
+
+export function useAdapterMode() {
+  const [adapter, setAdapterState] = useState<AdapterOption>(loadAdapter)
+
+  const setAdapter = useCallback((newAdapter: AdapterOption) => {
+    setAdapterState(newAdapter)
+    saveAdapter(newAdapter)
+  }, [])
+
+  return { adapter, setAdapter }
+}

--- a/sdk-app/src/useAdapterModeContext.ts
+++ b/sdk-app/src/useAdapterModeContext.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react'
+import { AdapterModeContext } from './AdapterModeContext'
+import type { AdapterModeContextValue } from './AdapterModeContext'
+import { resolveAdapterComponents } from './design/component-adapters/resolveAdapter'
+
+export function useAdapterModeContext(): AdapterModeContextValue {
+  return useContext(AdapterModeContext)
+}
+
+export function useAdapterComponents() {
+  const { adapter } = useContext(AdapterModeContext)
+  return resolveAdapterComponents(adapter)
+}


### PR DESCRIPTION
## Summary
- Adds a component adapter infrastructure to the SDK Dev App that allows swapping SDK components with gws-flows equivalents (Bootstrap-based) at runtime via a top-bar switcher
- Implements GWS adapter components for Box, Button, ButtonIcon, Heading, Table, Tabs, and Text — enabling side-by-side visual comparison between the SDK design system and gws-flows rendering
- Wires the adapter into both the component renderer and design layout views through the existing `GustoProvider` `components` prop

## Test plan
- [ ] Run `npm run sdk-app` and verify the adapter switcher appears in the top bar
- [ ] Toggle between "Default" and "GWS" modes and confirm components re-render with the appropriate styling
- [ ] Navigate to the Contractor List design prototype and verify the table renders correctly in both adapter modes
- [ ] Verify the adapter preference persists across page refreshes (localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)