### PR TITLE
feat(3/5): add SelectEmployees container for time-off/sick policies (SDK-565)

### DIFF
--- a/docs/reference/endpoint-inventory.json
+++ b/docs/reference/endpoint-inventory.json
@@ -1398,6 +1398,10 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         }
       ],
       "variables": [
@@ -1443,6 +1447,10 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         }
       ],
       "variables": [
@@ -1499,6 +1507,10 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         }
       ],
       "variables": [
@@ -1544,6 +1556,10 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         }
       ],
       "variables": [
@@ -1589,6 +1605,10 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         }
       ],
       "variables": [
@@ -1634,6 +1654,10 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         }
       ],
       "variables": [
@@ -1679,6 +1703,10 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         }
       ],
       "variables": [
@@ -1724,6 +1752,10 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         }
       ],
       "variables": [
@@ -1769,6 +1801,10 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         }
       ],
       "variables": [
@@ -1814,6 +1850,10 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         }
       ],
       "variables": [
@@ -1859,6 +1899,10 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         }
       ],
       "variables": [

--- a/docs/reference/endpoint-reference.md
+++ b/docs/reference/endpoint-reference.md
@@ -268,6 +268,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | POST | `/v1/companies/:companyUuid/time_off_policies` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
 | **UNSTABLE_TimeOff.PolicyTypeSelector** | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
@@ -277,6 +278,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | POST | `/v1/companies/:companyUuid/time_off_policies` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
 | **UNSTABLE_TimeOff.PolicyConfigurationForm** | POST | `/v1/companies/:companyUuid/time_off_policies` |
 | **UNSTABLE_TimeOff.PolicySettingsPresentation** | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
@@ -287,6 +289,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | POST | `/v1/companies/:companyUuid/time_off_policies` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
 | **UNSTABLE_TimeOff.AddEmployeesToPolicy** | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
@@ -296,6 +299,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | POST | `/v1/companies/:companyUuid/time_off_policies` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
 | **UNSTABLE_TimeOff.ViewPolicyDetails** | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
@@ -305,6 +309,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | POST | `/v1/companies/:companyUuid/time_off_policies` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
 | **UNSTABLE_TimeOff.ViewPolicyEmployees** | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
@@ -314,6 +319,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | POST | `/v1/companies/:companyUuid/time_off_policies` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
 | **UNSTABLE_TimeOff.HolidaySelectionForm** | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
@@ -323,6 +329,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | POST | `/v1/companies/:companyUuid/time_off_policies` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
 | **UNSTABLE_TimeOff.AddEmployeesHoliday** | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
@@ -332,6 +339,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | POST | `/v1/companies/:companyUuid/time_off_policies` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
 | **UNSTABLE_TimeOff.ViewHolidayEmployees** | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
@@ -341,6 +349,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | POST | `/v1/companies/:companyUuid/time_off_policies` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
 | **UNSTABLE_TimeOff.ViewHolidaySchedule** | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
@@ -350,6 +359,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | POST | `/v1/companies/:companyUuid/time_off_policies` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
 | **UNSTABLE_TimeOff.TimeOffFlow** | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
@@ -359,6 +369,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | POST | `/v1/companies/:companyUuid/time_off_policies` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
 
 ## Flows
 

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.stories.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.stories.tsx
@@ -148,7 +148,9 @@ function StoryWrapper({
       selectedUuids={selectedUuids}
       searchValue={searchValue}
       onSearchChange={setSearchValue}
-      onSearchClear={() => { setSearchValue(''); }}
+      onSearchClear={() => {
+        setSearchValue('')
+      }}
       onSelect={handleSelect}
       onBack={onBack}
       onContinue={onContinue}
@@ -188,7 +190,9 @@ export const SearchFiltered = () => {
       selectedUuids={new Set(['1'])}
       searchValue={searchValue}
       onSearchChange={setSearchValue}
-      onSearchClear={() => { setSearchValue(''); }}
+      onSearchClear={() => {
+        setSearchValue('')
+      }}
       onSelect={fn()}
       onBack={onBack}
       onContinue={onContinue}

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.stories.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.stories.tsx
@@ -1,0 +1,216 @@
+import { useState } from 'react'
+import { fn } from 'storybook/test'
+import { SelectEmployeesPresentation } from './SelectEmployeesPresentation'
+import type { EmployeeItem } from './SelectEmployeesPresentationTypes'
+import type { PaginationControlProps } from '@/components/Common/PaginationControl/PaginationControlTypes'
+import { useI18n } from '@/i18n'
+
+function I18nLoader({ children }: { children: React.ReactNode }) {
+  useI18n('Company.TimeOff.SelectEmployees')
+  return <>{children}</>
+}
+
+export default {
+  title: 'Domain/TimeOff/SelectEmployees',
+  parameters: {
+    layout: 'padded',
+  },
+  decorators: [
+    (Story: React.ComponentType) => (
+      <I18nLoader>
+        <div style={{ width: '100%', minWidth: '640px' }}>
+          <Story />
+        </div>
+      </I18nLoader>
+    ),
+  ],
+}
+
+const mockEmployees: EmployeeItem[] = [
+  {
+    uuid: '1',
+    firstName: 'Alejandro',
+    lastName: 'Kuhic',
+    jobTitle: 'Marketing Director',
+    department: 'Brand & Marketing',
+  },
+  {
+    uuid: '2',
+    firstName: 'Alexander',
+    lastName: 'Hamilton',
+    jobTitle: 'Engineer',
+    department: 'Product & Engineering',
+  },
+  {
+    uuid: '3',
+    firstName: 'Arthur',
+    lastName: 'Schopenhauer',
+    jobTitle: 'Engineer',
+    department: 'Product & Engineering',
+  },
+  {
+    uuid: '4',
+    firstName: 'Friedrich',
+    lastName: 'Nietzsche',
+    jobTitle: 'Engineer',
+    department: 'Product & Engineering',
+  },
+  {
+    uuid: '5',
+    firstName: 'Hannah',
+    lastName: 'Arendt',
+    jobTitle: 'Account Manager',
+    department: 'Sales',
+  },
+  {
+    uuid: '6',
+    firstName: 'Immanuel',
+    lastName: 'Kant',
+    jobTitle: 'Client Support Manager',
+    department: 'CX',
+  },
+  {
+    uuid: '7',
+    firstName: 'Isaiah',
+    lastName: 'Berlin',
+    jobTitle: 'Client Support Manager',
+    department: 'CX',
+  },
+  {
+    uuid: '8',
+    firstName: 'Patricia',
+    lastName: 'Churchland',
+    jobTitle: 'Chief Editor',
+    department: 'Brand & Marketing',
+  },
+  {
+    uuid: '9',
+    firstName: 'Regina',
+    lastName: 'Spektor',
+    jobTitle: 'Account Director',
+    department: 'Sales',
+  },
+  {
+    uuid: '10',
+    firstName: 'Soren',
+    lastName: 'Kierkegaard',
+    jobTitle: 'Office Administrator',
+    department: 'Administration',
+  },
+]
+
+const mockPagination: PaginationControlProps = {
+  currentPage: 1,
+  totalPages: 10,
+  totalCount: 100,
+  itemsPerPage: 10,
+  handleFirstPage: fn().mockName('handleFirstPage'),
+  handlePreviousPage: fn().mockName('handlePreviousPage'),
+  handleNextPage: fn().mockName('handleNextPage'),
+  handleLastPage: fn().mockName('handleLastPage'),
+  handleItemsPerPageChange: fn().mockName('handleItemsPerPageChange'),
+}
+
+const onBack = fn().mockName('onBack')
+const onContinue = fn().mockName('onContinue')
+
+function StoryWrapper({
+  initialSelected = new Set<string>(),
+  showReassignmentWarning = false,
+  employees = mockEmployees,
+  pagination,
+}: {
+  initialSelected?: Set<string>
+  showReassignmentWarning?: boolean
+  employees?: EmployeeItem[]
+  pagination?: PaginationControlProps
+}) {
+  const [searchValue, setSearchValue] = useState('')
+  const [selectedUuids, setSelectedUuids] = useState(initialSelected)
+  const [balances, setBalances] = useState<Record<string, string>>({})
+
+  const handleSelect = (item: EmployeeItem, checked: boolean) => {
+    setSelectedUuids(prev => {
+      const next = new Set(prev)
+      if (checked) next.add(item.uuid)
+      else next.delete(item.uuid)
+      return next
+    })
+  }
+
+  const handleBalanceChange = (uuid: string, value: string) => {
+    setBalances(prev => ({ ...prev, [uuid]: value }))
+  }
+
+  return (
+    <SelectEmployeesPresentation
+      employees={employees}
+      selectedUuids={selectedUuids}
+      searchValue={searchValue}
+      onSearchChange={setSearchValue}
+      onSearchClear={() => { setSearchValue(''); }}
+      onSelect={handleSelect}
+      onBack={onBack}
+      onContinue={onContinue}
+      showReassignmentWarning={showReassignmentWarning}
+      balances={balances}
+      onBalanceChange={handleBalanceChange}
+      pagination={pagination}
+    />
+  )
+}
+
+export const Default = () => <StoryWrapper />
+
+export const PartialSelection = () => <StoryWrapper initialSelected={new Set(['1', '3', '5'])} />
+
+export const AllSelected = () => (
+  <StoryWrapper initialSelected={new Set(mockEmployees.map(e => e.uuid))} />
+)
+
+export const WithReassignmentWarning = () => <StoryWrapper showReassignmentWarning />
+
+export const WithoutReassignmentWarning = () => <StoryWrapper />
+
+export const WithPagination = () => (
+  <StoryWrapper initialSelected={new Set(['1', '4', '6'])} pagination={mockPagination} />
+)
+
+export const SearchFiltered = () => {
+  const [searchValue, setSearchValue] = useState('alex')
+  const filtered = mockEmployees.filter(e =>
+    `${e.firstName} ${e.lastName}`.toLowerCase().includes(searchValue.toLowerCase()),
+  )
+
+  return (
+    <SelectEmployeesPresentation
+      employees={filtered}
+      selectedUuids={new Set(['1'])}
+      searchValue={searchValue}
+      onSearchChange={setSearchValue}
+      onSearchClear={() => { setSearchValue(''); }}
+      onSelect={fn()}
+      onBack={onBack}
+      onContinue={onContinue}
+      showReassignmentWarning={false}
+      balances={{}}
+      onBalanceChange={fn()}
+    />
+  )
+}
+
+export const EmptySearchResults = () => (
+  <SelectEmployeesPresentation
+    employees={[]}
+    selectedUuids={new Set()}
+    searchValue="nonexistent employee"
+    onSearchChange={fn()}
+    onSearchClear={fn()}
+    onSelect={fn()}
+    onBack={onBack}
+    onContinue={onContinue}
+    showReassignmentWarning={false}
+    balances={{}}
+    onBalanceChange={fn()}
+  />
+)

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.test.tsx
@@ -136,10 +136,12 @@ describe('SelectEmployeesPresentation', () => {
     expect(onSearchChange).toHaveBeenCalledWith('A')
   })
 
-  test('calls onSearchClear when clear button is clicked', async () => {
+  test('calls onSearchChange and onSearchClear when input is cleared', async () => {
+    const onSearchChange = vi.fn()
     const onSearchClear = vi.fn()
-    renderPresentation({ searchValue: 'alice', onSearchClear })
-    await userEvent.click(screen.getByLabelText('clearSearch'))
+    renderPresentation({ searchValue: 'alice', onSearchChange, onSearchClear })
+    await userEvent.clear(screen.getByRole('searchbox'))
+    expect(onSearchChange).toHaveBeenCalledWith('')
     expect(onSearchClear).toHaveBeenCalledOnce()
   })
 

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen } from '@testing-library/react'
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { userEvent } from '@testing-library/user-event'
+import { SelectEmployeesPresentation } from './SelectEmployeesPresentation'
+import type { SelectEmployeesPresentationProps } from './SelectEmployeesPresentationTypes'
+import { ThemeProvider } from '@/contexts/ThemeProvider'
+import { ComponentsProvider } from '@/contexts/ComponentAdapter/ComponentsProvider'
+import { defaultComponents } from '@/contexts/ComponentAdapter/adapters/defaultComponentAdapter'
+import { mockUseContainerBreakpoints } from '@/test/setup'
+
+vi.mock('@/i18n/I18n', () => ({
+  useI18n: vi.fn(),
+}))
+
+const mockEmployees = [
+  {
+    uuid: '1',
+    firstName: 'Alice',
+    lastName: 'Smith',
+    jobTitle: 'Engineer',
+    department: 'Engineering',
+  },
+  { uuid: '2', firstName: 'Bob', lastName: 'Jones', jobTitle: 'Designer', department: 'Design' },
+]
+
+const defaultProps: SelectEmployeesPresentationProps = {
+  employees: mockEmployees,
+  selectedUuids: new Set<string>(),
+  searchValue: '',
+  onSelect: vi.fn(),
+  onSearchChange: vi.fn(),
+  onSearchClear: vi.fn(),
+  onBack: vi.fn(),
+  onContinue: vi.fn(),
+  showReassignmentWarning: false,
+}
+
+function renderPresentation(overrides: Partial<SelectEmployeesPresentationProps> = {}) {
+  return render(
+    <ThemeProvider>
+      <ComponentsProvider value={defaultComponents}>
+        <SelectEmployeesPresentation {...defaultProps} {...overrides} />
+      </ComponentsProvider>
+    </ThemeProvider>,
+  )
+}
+
+describe('SelectEmployeesPresentation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseContainerBreakpoints.mockReturnValue(['base', 'small', 'medium', 'large'])
+  })
+
+  test('renders heading', () => {
+    renderPresentation()
+    expect(screen.getByText('title')).toBeInTheDocument()
+  })
+
+  test('renders holidayDescription when showReassignmentWarning is false', () => {
+    renderPresentation({ showReassignmentWarning: false })
+    expect(screen.getByText('holidayDescription')).toBeInTheDocument()
+    expect(screen.queryByText('description')).not.toBeInTheDocument()
+  })
+
+  test('renders description when showReassignmentWarning is true', () => {
+    renderPresentation({ showReassignmentWarning: true })
+    expect(screen.getByText('description')).toBeInTheDocument()
+    expect(screen.queryByText('holidayDescription')).not.toBeInTheDocument()
+  })
+
+  test('does not render reassignment warning Alert when showReassignmentWarning is false', () => {
+    renderPresentation({ showReassignmentWarning: false })
+    expect(screen.queryByText('reassignmentWarning')).not.toBeInTheDocument()
+  })
+
+  test('renders reassignment warning Alert when showReassignmentWarning is true', () => {
+    renderPresentation({ showReassignmentWarning: true })
+    expect(screen.getByText('reassignmentWarning')).toBeInTheDocument()
+  })
+
+  test('renders Department column header and values', () => {
+    renderPresentation()
+    expect(screen.getByText('departmentColumn')).toBeInTheDocument()
+    expect(screen.getByText('Engineering')).toBeInTheDocument()
+    expect(screen.getByText('Design')).toBeInTheDocument()
+  })
+
+  test('renders employee names', () => {
+    renderPresentation()
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument()
+  })
+
+  test('renders Back and Continue buttons', () => {
+    renderPresentation()
+    expect(screen.getByRole('button', { name: 'backCta' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'continueCta' })).toBeInTheDocument()
+  })
+
+  test('calls onBack when Back button is clicked', async () => {
+    const onBack = vi.fn()
+    renderPresentation({ onBack })
+    await userEvent.click(screen.getByRole('button', { name: 'backCta' }))
+    expect(onBack).toHaveBeenCalledOnce()
+  })
+
+  test('calls onContinue when Continue button is clicked', async () => {
+    const onContinue = vi.fn()
+    renderPresentation({ onContinue })
+    await userEvent.click(screen.getByRole('button', { name: 'continueCta' }))
+    expect(onContinue).toHaveBeenCalledOnce()
+  })
+
+  test('calls onSelect with item and checked=true when a checkbox is clicked', async () => {
+    const onSelect = vi.fn()
+    renderPresentation({ onSelect })
+    // checkboxes[0] is the select-all header; checkboxes[1] is first employee
+    const checkboxes = screen.getAllByRole('checkbox')
+    await userEvent.click(checkboxes[1] as Element)
+    expect(onSelect).toHaveBeenCalledWith(mockEmployees[0], true)
+  })
+
+  test('renders selected state for checked employees', () => {
+    renderPresentation({ selectedUuids: new Set(['1']) })
+    // checkboxes[0] = select-all header, checkboxes[1] = Alice (uuid '1'), checkboxes[2] = Bob (uuid '2')
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes[1]).toBeChecked()
+    expect(checkboxes[2]).not.toBeChecked()
+  })
+
+  test('calls onSearchChange when user types in search input', async () => {
+    const onSearchChange = vi.fn()
+    renderPresentation({ onSearchChange })
+    const input = screen.getByPlaceholderText('searchPlaceholder')
+    await userEvent.type(input, 'A')
+    expect(onSearchChange).toHaveBeenCalledWith('A')
+  })
+
+  test('calls onSearchClear when clear button is clicked', async () => {
+    const onSearchClear = vi.fn()
+    renderPresentation({ searchValue: 'alice', onSearchClear })
+    await userEvent.click(screen.getByLabelText('clearSearch'))
+    expect(onSearchClear).toHaveBeenCalledOnce()
+  })
+
+  test('shows empty search results state when no employees match', () => {
+    renderPresentation({ employees: [], searchValue: 'nonexistent' })
+    expect(screen.getByText('noSearchResults')).toBeInTheDocument()
+  })
+
+  test('renders pagination when pagination prop is provided', () => {
+    renderPresentation({
+      pagination: {
+        currentPage: 1,
+        totalPages: 3,
+        totalCount: 30,
+        itemsPerPage: 10,
+        handleFirstPage: vi.fn(),
+        handlePreviousPage: vi.fn(),
+        handleNextPage: vi.fn(),
+        handleLastPage: vi.fn(),
+        handleItemsPerPageChange: vi.fn(),
+      },
+    })
+    expect(screen.getByTestId('pagination-control')).toBeInTheDocument()
+  })
+})

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
@@ -68,7 +68,9 @@ export function SelectEmployeesPresentation({
                       shouldVisuallyHideLabel
                       aria-labelledby={`employee-name-${employee.uuid} ${balanceColHeaderId}`}
                       value={balances?.[employee.uuid] ?? ''}
-                      onChange={(value: string) => { onBalanceChange(employee.uuid, value); }}
+                      onChange={(value: string) => {
+                        onBalanceChange(employee.uuid, value)
+                      }}
                       placeholder="0"
                     />
                   ),

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
@@ -1,0 +1,91 @@
+import { useId } from 'react'
+import { useTranslation } from 'react-i18next'
+import { EmployeeTable } from '../../shared/EmployeeTable/EmployeeTable'
+import type {
+  EmployeeItem,
+  SelectEmployeesPresentationProps,
+} from './SelectEmployeesPresentationTypes'
+import { ActionsLayout, Flex } from '@/components/Common'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { useI18n } from '@/i18n'
+
+export function SelectEmployeesPresentation({
+  employees,
+  selectedUuids,
+  searchValue,
+  onSelect,
+  onSearchChange,
+  onSearchClear,
+  onBack,
+  onContinue,
+  showReassignmentWarning,
+  balances,
+  onBalanceChange,
+  pagination,
+  isFetching,
+}: SelectEmployeesPresentationProps) {
+  useI18n('Company.TimeOff.SelectEmployees')
+  const { t } = useTranslation('Company.TimeOff.SelectEmployees')
+  const Components = useComponentContext()
+  const { Heading, Text, Button, Alert } = Components
+  const balanceColHeaderId = useId()
+
+  return (
+    <Flex flexDirection="column" alignItems="stretch" gap={32}>
+      <Flex flexDirection="column" gap={4}>
+        <Heading as="h2">{t('title')}</Heading>
+        <Text variant="supporting">
+          {showReassignmentWarning ? t('description') : t('holidayDescription')}
+        </Text>
+      </Flex>
+
+      {showReassignmentWarning && <Alert status="warning" label={t('reassignmentWarning')} />}
+
+      <EmployeeTable<EmployeeItem>
+        data={employees}
+        searchValue={searchValue}
+        onSearchChange={onSearchChange}
+        onSearchClear={onSearchClear}
+        selectionMode="multiple"
+        onSelect={onSelect}
+        getIsItemSelected={item => selectedUuids.has(item.uuid)}
+        isFetching={isFetching}
+        pagination={pagination}
+        additionalColumns={[
+          {
+            key: 'department' as keyof EmployeeItem,
+            title: t('departmentColumn'),
+          },
+          ...(onBalanceChange
+            ? [
+                {
+                  key: 'balance' as keyof EmployeeItem,
+                  title: <span id={balanceColHeaderId}>{t('startingBalanceColumn')}</span>,
+                  render: (employee: EmployeeItem) => (
+                    <Components.TextInput
+                      name={`balance-${employee.uuid}`}
+                      label={t('startingBalanceColumn')}
+                      shouldVisuallyHideLabel
+                      aria-labelledby={`employee-name-${employee.uuid} ${balanceColHeaderId}`}
+                      value={balances?.[employee.uuid] ?? ''}
+                      onChange={(value: string) => { onBalanceChange(employee.uuid, value); }}
+                      placeholder="0"
+                    />
+                  ),
+                },
+              ]
+            : []),
+        ]}
+      />
+
+      <ActionsLayout>
+        <Button variant="secondary" onClick={onBack}>
+          {t('backCta')}
+        </Button>
+        <Button variant="primary" onClick={onContinue}>
+          {t('continueCta')}
+        </Button>
+      </ActionsLayout>
+    </Flex>
+  )
+}

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentationTypes.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentationTypes.ts
@@ -1,0 +1,26 @@
+import type { PaginationControlProps } from '@/components/Common/PaginationControl/PaginationControlTypes'
+
+export interface EmployeeItem {
+  uuid: string
+  firstName?: string | null
+  lastName?: string | null
+  jobTitle?: string | null
+  department?: string | null
+  balance?: string | null
+}
+
+export interface SelectEmployeesPresentationProps {
+  employees: EmployeeItem[]
+  selectedUuids: Set<string>
+  searchValue: string
+  onSelect: (item: EmployeeItem, checked: boolean) => void
+  onSearchChange: (value: string) => void
+  onSearchClear: () => void
+  onBack: () => void
+  onContinue: () => void
+  showReassignmentWarning: boolean
+  balances?: Record<string, string>
+  onBalanceChange?: (uuid: string, value: string) => void
+  pagination?: PaginationControlProps
+  isFetching?: boolean
+}

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
@@ -81,7 +81,7 @@ describe('SelectEmployeesTimeOff', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUseContainerBreakpoints.mockReturnValue(['base', 'small', 'medium', 'large'])
-    mockAddEmployees.mockResolvedValue({})
+    mockAddEmployees.mockResolvedValue({ timeOffPolicy: { uuid: 'policy-456' } })
   })
 
   it('renders employee names from API data', async () => {
@@ -161,7 +161,9 @@ describe('SelectEmployeesTimeOff', () => {
       })
 
       await waitFor(() => {
-        expect(mockOnEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE)
+        expect(mockOnEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE, {
+          uuid: 'policy-456',
+        })
       })
     })
 

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SelectEmployeesTimeOff } from './SelectEmployeesTimeOff'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import { componentEvents } from '@/shared/constants'
+import { mockUseContainerBreakpoints } from '@/test/setup'
+
+vi.mock('@/i18n/I18n', () => ({
+  useI18n: vi.fn(),
+}))
+
+const mockAddEmployees = vi.fn()
+const mockOnEvent = vi.fn()
+
+const mockEmployees = [
+  {
+    uuid: '1',
+    firstName: 'Alice',
+    lastName: 'Smith',
+    jobs: [{ primary: true, title: 'Engineer' }],
+    department: 'Engineering',
+  },
+  {
+    uuid: '2',
+    firstName: 'Bob',
+    lastName: 'Jones',
+    jobs: [{ primary: true, title: 'Designer' }],
+    department: 'Design',
+  },
+]
+
+vi.mock('@gusto/embedded-api/react-query/employeesList', () => ({
+  useEmployeesListSuspense: () => ({
+    data: {
+      showEmployees: mockEmployees,
+      httpMeta: { response: { headers: new Headers() } },
+    },
+    isFetching: false,
+  }),
+}))
+
+vi.mock('@gusto/embedded-api/react-query/timeOffPoliciesAddEmployees', () => ({
+  useTimeOffPoliciesAddEmployeesMutation: () => ({
+    mutateAsync: mockAddEmployees,
+    isPending: false,
+  }),
+}))
+
+vi.mock('@/components/Base/useBase', () => ({
+  useBase: () => ({
+    onEvent: mockOnEvent,
+    baseSubmitHandler: vi.fn(async (_, fn: () => Promise<void>) => fn()),
+    setError: vi.fn(),
+    error: null,
+    LoadingIndicator: () => null,
+  }),
+}))
+
+vi.mock('@/hooks/usePagination/usePagination', () => ({
+  usePagination: () => ({
+    currentPage: 1,
+    itemsPerPage: 25,
+    getPaginationProps: vi.fn().mockReturnValue(undefined),
+    resetPage: vi.fn(),
+  }),
+}))
+
+function renderComponent(props: Partial<{ mode: 'standalone' | 'wizard' }> = {}) {
+  return renderWithProviders(
+    <SelectEmployeesTimeOff companyId="company-123" policyId="policy-456" {...props} />,
+  )
+}
+
+// DataTable renders a select-all header checkbox (index 0) when selectionMode="multiple"
+// and getIsItemSelected is provided. Employee checkboxes start at index 1.
+const FIRST_EMPLOYEE_CHECKBOX = 1
+const SECOND_EMPLOYEE_CHECKBOX = 2
+
+describe('SelectEmployeesTimeOff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseContainerBreakpoints.mockReturnValue(['base', 'small', 'medium', 'large'])
+    mockAddEmployees.mockResolvedValue({})
+  })
+
+  it('renders employee names from API data', async () => {
+    renderComponent()
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument()
+  })
+
+  it('renders department column values', async () => {
+    renderComponent()
+    await waitFor(() => {
+      expect(screen.getByText('Engineering')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Design')).toBeInTheDocument()
+  })
+
+  it('shows reassignment warning alert', async () => {
+    renderComponent()
+    await waitFor(() => {
+      expect(screen.getByText('reassignmentWarning')).toBeInTheDocument()
+    })
+  })
+
+  it('filters employees by search value', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    })
+
+    const input = screen.getByPlaceholderText('searchPlaceholder')
+    await user.type(input, 'alice')
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
+  })
+
+  it('fires CANCEL when Back is clicked', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'backCta' })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('button', { name: 'backCta' }))
+    expect(mockOnEvent).toHaveBeenCalledWith(componentEvents.CANCEL)
+  })
+
+  describe('standalone mode', () => {
+    it('calls mutation with selected employee UUID and fires TIME_OFF_ADD_EMPLOYEES_DONE', async () => {
+      const user = userEvent.setup()
+      renderComponent({ mode: 'standalone' })
+
+      // Wait for employee checkboxes (header select-all at [0] + 2 employee rows = 3 total)
+      await waitFor(() => {
+        expect(screen.getAllByRole('checkbox').length).toBeGreaterThan(1)
+      })
+
+      await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
+      await user.click(screen.getByRole('button', { name: 'continueCta' }))
+
+      await waitFor(() => {
+        expect(mockAddEmployees).toHaveBeenCalledWith({
+          request: {
+            timeOffPolicyUuid: 'policy-456',
+            requestBody: {
+              employees: [{ uuid: '1' }],
+            },
+          },
+        })
+      })
+
+      await waitFor(() => {
+        expect(mockOnEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE)
+      })
+    })
+
+    it('calls mutation with multiple selected UUIDs', async () => {
+      const user = userEvent.setup()
+      renderComponent({ mode: 'standalone' })
+
+      // 1 select-all header + 2 employees = 3 checkboxes
+      await waitFor(() => {
+        expect(screen.getAllByRole('checkbox').length).toBe(3)
+      })
+
+      const checkboxes = screen.getAllByRole('checkbox')
+      await user.click(checkboxes[FIRST_EMPLOYEE_CHECKBOX] as Element)
+      await user.click(checkboxes[SECOND_EMPLOYEE_CHECKBOX] as Element)
+      await user.click(screen.getByRole('button', { name: 'continueCta' }))
+
+      await waitFor(() => {
+        expect(mockAddEmployees).toHaveBeenCalledWith({
+          request: {
+            timeOffPolicyUuid: 'policy-456',
+            requestBody: {
+              employees: expect.arrayContaining([{ uuid: '1' }, { uuid: '2' }]),
+            },
+          },
+        })
+      })
+    })
+  })
+
+  describe('wizard mode', () => {
+    it('fires TIME_OFF_ADD_EMPLOYEES_DONE with employeeUuids and does NOT call mutation', async () => {
+      const user = userEvent.setup()
+      renderComponent({ mode: 'wizard' })
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('checkbox').length).toBeGreaterThan(1)
+      })
+
+      await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
+      await user.click(screen.getByRole('button', { name: 'continueCta' }))
+
+      await waitFor(() => {
+        expect(mockOnEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE, {
+          employeeUuids: ['1'],
+        })
+      })
+
+      expect(mockAddEmployees).not.toHaveBeenCalled()
+    })
+
+    it('includes all selected UUIDs in wizard event payload', async () => {
+      const user = userEvent.setup()
+      renderComponent({ mode: 'wizard' })
+
+      // 1 select-all header + 2 employees = 3 checkboxes
+      await waitFor(() => {
+        expect(screen.getAllByRole('checkbox').length).toBe(3)
+      })
+
+      const checkboxes = screen.getAllByRole('checkbox')
+      await user.click(checkboxes[FIRST_EMPLOYEE_CHECKBOX] as Element)
+      await user.click(checkboxes[SECOND_EMPLOYEE_CHECKBOX] as Element)
+      await user.click(screen.getByRole('button', { name: 'continueCta' }))
+
+      await waitFor(() => {
+        expect(mockOnEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE, {
+          employeeUuids: expect.arrayContaining(['1', '2']),
+        })
+      })
+    })
+  })
+})

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useEmployeesListSuspense } from '@gusto/embedded-api/react-query/employeesList'
+import { useTimeOffPoliciesAddEmployeesMutation } from '@gusto/embedded-api/react-query/timeOffPoliciesAddEmployees'
+import { SelectEmployeesPresentation } from './SelectEmployeesPresentation'
+import type { EmployeeItem } from './SelectEmployeesPresentationTypes'
+import { useBase } from '@/components/Base/useBase'
+import { usePagination } from '@/hooks/usePagination/usePagination'
+import { componentEvents } from '@/shared/constants'
+
+interface SelectEmployeesTimeOffProps {
+  companyId: string
+  policyId: string
+  mode?: 'standalone' | 'wizard'
+}
+
+export function SelectEmployeesTimeOff({
+  companyId,
+  policyId,
+  mode = 'standalone',
+}: SelectEmployeesTimeOffProps) {
+  const { onEvent, baseSubmitHandler } = useBase()
+  const [selectedUuids, setSelectedUuids] = useState(new Set<string>())
+  const [searchValue, setSearchValue] = useState('')
+  const [balances, setBalances] = useState<Record<string, string>>({})
+  const { currentPage, itemsPerPage, getPaginationProps, resetPage } = usePagination()
+
+  const { data: employeesData, isFetching } = useEmployeesListSuspense({
+    companyId,
+    terminated: false,
+    page: currentPage,
+    per: itemsPerPage,
+  })
+
+  const employees = useMemo<EmployeeItem[]>(
+    () =>
+      (employeesData.showEmployees ?? []).map(e => ({
+        uuid: e.uuid,
+        firstName: e.firstName,
+        lastName: e.lastName,
+        jobTitle: e.jobs?.find(job => job.primary)?.title ?? null,
+        department: e.department ?? null,
+      })),
+    [employeesData.showEmployees],
+  )
+
+  const filteredEmployees = useMemo(() => {
+    if (!searchValue) return employees
+    const lower = searchValue.toLowerCase()
+    return employees.filter(e =>
+      `${e.firstName ?? ''} ${e.lastName ?? ''}`.toLowerCase().includes(lower),
+    )
+  }, [employees, searchValue])
+
+  const pagination = useMemo(
+    () => getPaginationProps(employeesData.httpMeta.response.headers, isFetching),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [employeesData.httpMeta.response.headers, isFetching, currentPage, itemsPerPage],
+  )
+
+  const { mutateAsync: addEmployees } = useTimeOffPoliciesAddEmployeesMutation()
+
+  const handleSelect = useCallback((item: EmployeeItem, checked: boolean) => {
+    setSelectedUuids(prev => {
+      const next = new Set(prev)
+      if (checked) next.add(item.uuid)
+      else next.delete(item.uuid)
+      return next
+    })
+  }, [])
+
+  const handleBalanceChange = useCallback((uuid: string, value: string) => {
+    setBalances(prev => ({ ...prev, [uuid]: value }))
+  }, [])
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchValue(value)
+      resetPage()
+    },
+    [resetPage],
+  )
+
+  const handleContinue = useCallback(async () => {
+    if (mode === 'wizard') {
+      onEvent(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE, {
+        employeeUuids: [...selectedUuids],
+      })
+      return
+    }
+
+    await baseSubmitHandler({}, async () => {
+      await addEmployees({
+        request: {
+          timeOffPolicyUuid: policyId,
+          requestBody: {
+            employees: [...selectedUuids].map(uuid => ({
+              uuid,
+              ...(balances[uuid] !== undefined && { balance: balances[uuid] }),
+            })),
+          },
+        },
+      })
+      onEvent(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE)
+    })
+  }, [mode, baseSubmitHandler, addEmployees, policyId, selectedUuids, onEvent])
+
+  const handleBack = useCallback(() => {
+    onEvent(componentEvents.CANCEL)
+  }, [onEvent])
+
+  return (
+    <SelectEmployeesPresentation
+      employees={filteredEmployees}
+      selectedUuids={selectedUuids}
+      searchValue={searchValue}
+      onSelect={handleSelect}
+      onSearchChange={handleSearchChange}
+      onSearchClear={() => {
+        setSearchValue('')
+        resetPage()
+      }}
+      onBack={handleBack}
+      onContinue={handleContinue}
+      showReassignmentWarning
+      balances={balances}
+      onBalanceChange={handleBalanceChange}
+      pagination={pagination}
+      isFetching={isFetching}
+    />
+  )
+}

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
@@ -51,11 +51,7 @@ export function SelectEmployeesTimeOff({
     )
   }, [employees, searchValue])
 
-  const pagination = useMemo(
-    () => getPaginationProps(employeesData.httpMeta.response.headers, isFetching),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [employeesData.httpMeta.response.headers, isFetching, currentPage, itemsPerPage],
-  )
+  const pagination = getPaginationProps(employeesData.httpMeta.response.headers, isFetching)
 
   const { mutateAsync: addEmployees } = useTimeOffPoliciesAddEmployeesMutation()
 
@@ -80,7 +76,7 @@ export function SelectEmployeesTimeOff({
     [resetPage],
   )
 
-  const handleContinue = useCallback(async () => {
+  const handleContinue = async () => {
     if (mode === 'wizard') {
       onEvent(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE, {
         employeeUuids: [...selectedUuids],
@@ -89,7 +85,7 @@ export function SelectEmployeesTimeOff({
     }
 
     await baseSubmitHandler({}, async () => {
-      await addEmployees({
+      const response = await addEmployees({
         request: {
           timeOffPolicyUuid: policyId,
           requestBody: {
@@ -100,9 +96,9 @@ export function SelectEmployeesTimeOff({
           },
         },
       })
-      onEvent(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE)
+      onEvent(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE, response.timeOffPolicy)
     })
-  }, [mode, baseSubmitHandler, addEmployees, policyId, selectedUuids, onEvent])
+  }
 
   const handleBack = useCallback(() => {
     onEvent(componentEvents.CANCEL)


### PR DESCRIPTION
## Summary

- Add `SelectEmployeesTimeOff` container component for adding employees to time-off/sick policies
- Fetches active employees via `useEmployeesListSuspense`, manages selection/search/pagination state
- **Standalone mode**: calls `useTimeOffPoliciesAddEmployeesMutation` with selected UUIDs and optional per-employee starting balances
- **Wizard mode**: emits `TIME_OFF_ADD_EMPLOYEES_DONE` with selected UUIDs (no API call)
- Shows reassignment warning (employees can only be in one time-off policy)

Depends on: #1613

## Test plan

- [ ] `npm run test -- --run src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)