### PR TITLE
fix(SDK-464): validate integer percentages in payment method split

### DIFF
--- a/src/components/Employee/PaymentMethod/PaymentMethod.test.tsx
+++ b/src/components/Employee/PaymentMethod/PaymentMethod.test.tsx
@@ -116,6 +116,46 @@ describe('PaymentMethod - Percentage Split Validation', () => {
       expect(result.success).toBe(false)
     })
 
+    it('should reject decimal percentages', () => {
+      const invalidData = {
+        type: 'Direct Deposit' as const,
+        isSplit: true as const,
+        hasBankPayload: false as const,
+        splitBy: 'Percentage' as const,
+        splitAmount: {
+          'account-1': 80.001,
+          'account-2': 19.9,
+        },
+        priority: {
+          'account-1': 1,
+          'account-2': 2,
+        },
+      }
+
+      const result = CombinedSchema.safeParse(invalidData)
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0]?.code).toEqual('invalid_union')
+
+      if (!result.success && result.error.issues[0]?.code === 'invalid_union') {
+        expect(result.error.issues[0].errors).toContainEqual([
+          {
+            code: 'invalid_type',
+            expected: 'int',
+            format: 'safeint',
+            message: 'Invalid input: expected int, received number',
+            path: ['splitAmount', 'account-1'],
+          },
+          {
+            code: 'invalid_type',
+            expected: 'int',
+            format: 'safeint',
+            message: 'Invalid input: expected int, received number',
+            path: ['splitAmount', 'account-2'],
+          },
+        ])
+      }
+    })
+
     it('should reject percentages over 100 for individual accounts', () => {
       const invalidData = {
         type: 'Direct Deposit' as const,

--- a/src/components/Employee/PaymentMethod/Split.tsx
+++ b/src/components/Employee/PaymentMethod/Split.tsx
@@ -224,8 +224,9 @@ function PercentageField({
         })}
         format="percent"
         min={0}
+        maximumFractionDigits={0}
         isRequired
-        errorMessage={t('validations.amountError')}
+        errorMessage={t('validations.percentageAmountError')}
         onChange={onChange}
       />
     </Fragment>

--- a/src/components/Employee/PaymentMethod/usePaymentMethod.ts
+++ b/src/components/Employee/PaymentMethod/usePaymentMethod.ts
@@ -23,15 +23,17 @@ export const CombinedSchema = z.union([
       isSplit: z.literal(true),
       hasBankPayload: z.literal(false),
       splitBy: z.literal('Percentage'),
-      splitAmount: z.record(z.string(), z.number().max(100).min(0)).superRefine((input, ctx) => {
-        const total = Object.values(input).reduce((acc, curr) => acc + curr, 0)
-        if (total !== 100) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: `percentage_split_total_error:${total}`,
-          })
-        }
-      }),
+      splitAmount: z
+        .record(z.string(), z.number().int().max(100).min(0))
+        .superRefine((input, ctx) => {
+          const total = Object.values(input).reduce((acc, curr) => acc + curr, 0)
+          if (total !== 100) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `percentage_split_total_error:${total}`,
+            })
+          }
+        }),
       priority: z.record(z.string(), z.number()),
     }),
     z.object({

--- a/src/i18n/en/Employee.PaymentMethod.json
+++ b/src/i18n/en/Employee.PaymentMethod.json
@@ -45,6 +45,7 @@
   "validations": {
     "percentageError": "If payment method amount is split by Percentage, all split amounts must add up to exactly 100.",
     "percentageErrorWithTotal": "Splits must total 100%. Currently {{total}}%.",
+    "percentageAmountError": "Percentage should be a whole number between 0 and 100",
     "amountError": "Please enter valid amount",
     "accountName": "Account name is required",
     "routingNumber": "Routing number should be a number (9 digits)",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1961,6 +1961,7 @@ export interface EmployeePaymentMethod{
 "validations":{
 "percentageError":string;
 "percentageErrorWithTotal":string;
+"percentageAmountError":string;
 "amountError":string;
 "accountName":string;
 "routingNumber":string;


### PR DESCRIPTION
## Summary

Improve client-side validation of percentage splits for employee payment method.

## Changes

**Before:** Splitting an employee payment method by percentage allowed you to input decimal values; the server replied with a 422 and requested integers.

<img width="1066" height="646" alt="Screenshot 2026-04-27 at 12 51 49 PM" src="https://github.com/user-attachments/assets/4f262e30-7a54-483c-82a8-74f3a5a011f9" />

Error message at top of form, no inline validation:

> There was a problem with your submission.
> - If the payment amount is split by Percentage, split amount must be an integer.

---

**Now:** Client-side validation prevents you from typing or pasting a decimal in the percentage input. If you _do_ manage to use an invalid number (possibly via the hook?) we give a more descriptive error message.

<img width="1219" height="564" alt="Screenshot 2026-04-27 at 1 56 27 PM" src="https://github.com/user-attachments/assets/47d3f5ca-119d-4a11-b366-609a820b4392" />

Error message inline, below individual field marked as invalid:
> Percentage should be a whole number between 0 and 100

## Related

- Jira ticket: [SDK-464](https://gustohq.atlassian.net/browse/SDK-464)

## Testing

- `npm run test PaymentMethod`
- `npm run sdk-app`
  - http://localhost:5200/employee/PaymentMethod
  - Add a second bank account
  - Split paycheck by percentage
  - Attempt to type or paste a decimal; should round to nearest integer
  - Attempt to submit with an invalid integer (e.g. 101); should show more descriptive error message

[SDK-464]: https://gustohq.atlassian.net/browse/SDK-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ