### PR TITLE
fix(SDK-426): add empty state to RecoveryCasesList

### DIFF
--- a/src/components/Payroll/RecoveryCases/RecoveryCasesList/RecoveryCasesList.test.tsx
+++ b/src/components/Payroll/RecoveryCases/RecoveryCasesList/RecoveryCasesList.test.tsx
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
+import { HttpResponse } from 'msw'
+import { RecoveryCasesList } from './RecoveryCasesList'
+import { server } from '@/test/mocks/server'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import {
+  getEmptyRecoveryCases,
+  handleGetRecoveryCases,
+  mockRecoveryCases,
+} from '@/test/mocks/apis/recovery_cases'
+
+vi.mock('@/hooks/useContainerBreakpoints/useContainerBreakpoints', async () => {
+  const actual = await vi.importActual('@/hooks/useContainerBreakpoints/useContainerBreakpoints')
+  return {
+    ...actual,
+    default: () => ['base', 'small', 'medium'],
+    useContainerBreakpoints: () => ['base', 'small', 'medium'],
+  }
+})
+
+describe('RecoveryCasesList', () => {
+  const onEvent = vi.fn()
+  const defaultProps = {
+    companyId: 'company-123',
+    onEvent,
+  }
+
+  beforeEach(() => {
+    setupApiTestMocks()
+    onEvent.mockClear()
+  })
+
+  it('renders table with description when recovery cases exist', async () => {
+    server.use(handleGetRecoveryCases(() => HttpResponse.json(mockRecoveryCases)))
+    renderWithProviders(<RecoveryCasesList {...defaultProps} />)
+
+    await screen.findByText('Recovery cases')
+    const loader = screen.getByLabelText('Loading component...')
+    await waitForElementToBeRemoved(loader)
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Recovery cases')
+    expect(screen.getByText(/One or more payments.*/)).toBeInTheDocument()
+
+    // Each recovery case's original debit date is the header for that row
+    const rowHeaderLabels = screen.getAllByRole('rowheader').map($el => $el.textContent)
+    expect(rowHeaderLabels).toEqual(['2024-01-05', '2024-01-10', '-'])
+  })
+
+  it('renders empty table without description when no recovery cases', async () => {
+    server.use(getEmptyRecoveryCases)
+
+    renderWithProviders(<RecoveryCasesList {...defaultProps} />)
+
+    await screen.findByText('Recovery cases')
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Recovery cases')
+    expect(screen.queryByText(/One or more payments.*/)).not.toBeInTheDocument()
+
+    expect(screen.getByRole('rowheader')).toHaveTextContent(/No recovery cases.*/)
+  })
+})

--- a/src/components/Payroll/RecoveryCases/RecoveryCasesList/RecoveryCasesList.tsx
+++ b/src/components/Payroll/RecoveryCases/RecoveryCasesList/RecoveryCasesList.tsx
@@ -11,7 +11,7 @@ import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentCon
 import { useComponentDictionary, useI18n } from '@/i18n'
 import { DataView } from '@/components/Common/DataView/DataView'
 import { useDataView } from '@/components/Common/DataView/useDataView'
-import { Flex, FlexItem } from '@/components/Common'
+import { EmptyData, Flex, FlexItem } from '@/components/Common'
 import { recoveryCasesEvents } from '@/shared/constants'
 import type { BadgeProps } from '@/components/Common/UI/Badge/BadgeTypes'
 import { formatNumberAsCurrency } from '@/helpers/formattedStrings'
@@ -116,6 +116,9 @@ function Root({ companyId, dictionary, onEvent }: RecoveryCasesListProps) {
 
   const dataViewProps = useDataView({
     data: recoveryCases,
+    emptyState: () => (
+      <EmptyData title={t('emptyTableTitle')} description={t('emptyTableDescription')} />
+    ),
     columns: [
       {
         key: 'originalDebitDate',
@@ -169,7 +172,7 @@ function Root({ companyId, dictionary, onEvent }: RecoveryCasesListProps) {
           <Heading as="h2" styledAs="h4">
             {t('title')}
           </Heading>
-          <Text>{t('description')}</Text>
+          {recoveryCases.length > 0 && <Text>{t('description')}</Text>}
         </Flex>
 
         <DataView {...dataViewProps} label={t('title')} />

--- a/src/i18n/en/Payroll.RecoveryCasesList.json
+++ b/src/i18n/en/Payroll.RecoveryCasesList.json
@@ -1,6 +1,8 @@
 {
   "title": "Recovery cases",
   "description": "One or more payments couldn't be processed due to a bank error. Resolve open recovery cases to continue running payroll.",
+  "emptyTableTitle": "No recovery cases",
+  "emptyTableDescription": "There are no recovery cases that need your response at this time.",
   "labels": {
     "noLatestErrorCode": "—",
     "noLatestErrorCodeAriaLabel": "No error code available"

--- a/src/test/mocks/apis/recovery_cases.ts
+++ b/src/test/mocks/apis/recovery_cases.ts
@@ -53,6 +53,10 @@ const getRecoveryCases = handleGetRecoveryCases(() => {
   return HttpResponse.json(mockRecoveryCases)
 })
 
+export const getEmptyRecoveryCases = handleGetRecoveryCases(() => {
+  return HttpResponse.json([])
+})
+
 const redebitRecoveryCase = handleRedebitRecoveryCase(() => {
   return new HttpResponse(null, { status: 202 })
 })

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -3020,6 +3020,8 @@ export interface PayrollPayrollReceipts{
 export interface PayrollRecoveryCasesList{
 "title":string;
 "description":string;
+"emptyTableTitle":string;
+"emptyTableDescription":string;
 "labels":{
 "noLatestErrorCode":string;
 "noLatestErrorCodeAriaLabel":string;


### PR DESCRIPTION
## Summary

Make the empty state for recovery cases more visually consistent with information requests.

## Changes

**Before:** `RecoveryCasesList` showed an empty table when there were no active cases
<img width="1624" height="1061" alt="Screenshot 2026-04-28 at 8 12 36 AM" src="https://github.com/user-attachments/assets/4f93118a-ed6b-4bdd-ad63-1228d92df1d1" />

**Now:** `RecoveryCasesList` shows the same empty state as the `InformationRequestsList` and hides the description since it's not relevant
<img width="1624" height="1061" alt="Screenshot 2026-04-28 at 8 16 21 AM" src="https://github.com/user-attachments/assets/f481cf6f-4f3a-4429-a96e-0cd96453fa53" />


## Related

- Jira ticket: [SDK-426](https://gustohq.atlassian.net/browse/SDK-426)

## Testing

- `npm run test -- RecoveryCasesList`
- `npm run sdk-app`
  - http://localhost:5200/payroll/RecoveryCases compared to http://localhost:5200/informationrequests/InformationRequestList

[SDK-426]: https://gustohq.atlassian.net/browse/SDK-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ