### PR TITLE
feat: add create-demo-data Claude Code skill

### DIFF
--- a/.claude/commands/create-demo-data/SKILL.md
+++ b/.claude/commands/create-demo-data/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: create-demo-data
+description: Create test data (employees, contractors, time off policies, etc.) in the Gusto demo environment via API. Use this skill whenever the user wants to create, add, or seed records for their current demo company — even if they just say "add an employee" or "I need a contractor to test with". Also triggers for requests like "set up test data", "create some records", or "I need a company with X".
+---
+
+# Create Demo Data
+
+Create records in the current Gusto demo company by making API calls directly to the GWS Flows demo environment. This is for testing the SDK against realistic data states without needing ZenPayroll running locally.
+
+The demo company is always pre-provisioned — this skill only creates entities within the existing company.
+
+## Step 1 — Load environment
+
+Read the env file at `sdk-app/env/.env.demo` and extract:
+
+- `GWS_FLOWS_HOST` — the base URL (should be `https://flows.gusto-demo.com`)
+- `FLOW_TOKEN` — auth token embedded in URL path
+- `VITE_COMPANY_ID` — the current demo company UUID
+
+If the file doesn't exist or is empty, tell the user to run `npm run sdk-app` first to provision a demo company.
+
+Construct the base URL for all API calls:
+
+```
+{GWS_FLOWS_HOST}/fe_sdk/{FLOW_TOKEN}
+```
+
+## Step 2 — Understand what the user wants
+
+Ask the user what entity they want to create. Supported entity types:
+
+| Entity             | Clarifying questions to ask                                    |
+| ------------------ | -------------------------------------------------------------- |
+| Employee           | Self-onboarding or admin-entered? Any specific name/email?     |
+| Contractor         | Individual or Business? Hourly or Fixed wage? Self-onboarding? |
+| Time off policy    | Vacation or sick? What accrual method?                         |
+| Location           | What address?                                                  |
+| Pay schedule       | What frequency?                                                |
+| Contractor payment | Which contractor? Amount?                                      |
+
+For each entity type, ask only the questions that meaningfully change the outcome. Use sensible defaults for everything else:
+
+- Names: generate realistic fake names (e.g., "Sarah Chen", "Marcus Rivera")
+- Emails: use `{first}.{last}-{random4digits}@example.com`
+- Dates: use today's date for start dates
+- Addresses: use `123 Main St, San Francisco, CA 94105`
+- Wage rates: use `"50.00"` for hourly contractors
+
+If the user gives a vague request like "add an employee", create one with reasonable defaults and report what was created. Don't over-ask.
+
+## Step 3 — Verify connectivity
+
+Before the first API call, verify the token is still valid:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}' '{base_url}/v1/companies/{company_id}/employees'
+```
+
+If this returns anything other than 200, tell the user their token has likely expired and suggest running `npm run sdk-app:setup` to re-provision.
+
+## Step 4 — Make the API call
+
+Read `references/api-endpoints.md` for the exact endpoint, method, and request body schema for the entity type.
+
+Use curl with:
+
+- `Content-Type: application/json`
+- The constructed base URL from Step 1
+- Snake_case field names in the JSON body
+
+Example:
+
+```bash
+curl -s -X POST '{base_url}/v1/companies/{company_id}/employees' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "first_name": "Sarah",
+    "last_name": "Chen",
+    "email": "sarah.chen-4821@example.com",
+    "self_onboarding": false
+  }'
+```
+
+Capture the full response. On success (2xx), extract the `uuid` from the response.
+
+On failure (4xx), read the error response body and:
+
+- If 422: show the validation errors and ask the user how to fix
+- If 401/403: token is likely expired, suggest re-provisioning
+- If 404: endpoint may not be available in demo, explain this
+
+## Step 5 — Report results
+
+After a successful creation, report:
+
+- Entity type and key identifiers (name, UUID)
+- Any useful details from the response (status, onboarding state)
+- If the user might want to do follow-up operations (e.g., "Want me to also add a home address and bank account for this employee?")
+
+## Step 6 — Batch creation
+
+If the user asks for multiple records (e.g., "create 3 employees"), create them sequentially and report a summary table at the end.
+
+If the user asks for a specific state (e.g., "employee with missing bank info"), create the employee but skip the optional setup steps that would complete that state.
+
+## Handling common scenarios
+
+These map user requests to the specific data states needed to test each SDK flow.
+
+### Employee Onboarding Flow (admin-led)
+
+The Employee Onboarding Flow (`src/components/Employee/OnboardingFlow/`) walks an admin through setting up a new employee: profile → compensation → taxes → payment method → deductions → documents → summary.
+
+**"I need to test admin employee onboarding"**
+→ Create an employee with `self_onboarding: false` and minimal fields (first_name, last_name). This gives an employee in `admin_onboarding_incomplete` status — the earliest state where the admin fills in everything.
+
+**"I need an employee partway through onboarding"**
+→ Create the employee with `self_onboarding: false`, then add a home address and job to simulate partial completion. The flow uses smart guards to detect which steps are already done.
+
+**"I need a fully onboarded employee"**
+→ Create the employee with all fields populated (name, email, DOB, SSN), then create a home address, bank account, and job. This puts them in `onboarding_completed` status.
+
+### Employee Self-Onboarding Flow
+
+The Self-Onboarding Flow (`src/components/Employee/SelfOnboardingFlow/`) is the employee-facing experience: profile → taxes → payment method → documents → summary.
+
+**"I need to test employee self-onboarding"**
+→ Create an employee with `self_onboarding: true` and an email address. This puts them in `self_onboarding_pending_invite` status initially, which transitions to `self_onboarding_invited` once the invite is sent — the entry point for the self-onboarding flow.
+
+**"I need a self-onboarding employee who started but hasn't finished"**
+→ This status (`self_onboarding_invited_started`) is set by the backend when the employee begins. Create with `self_onboarding: true` — the user can advance the state by partially completing the flow in the SDK.
+
+### Contractor Onboarding Flow
+
+The Contractor Onboarding Flow (`src/components/Contractor/OnboardingFlow/`) walks through: profile → address → payment method → new hire report → submit. If self-onboarding, the address step is skipped.
+
+**"I need to test contractor onboarding"**
+→ Create an Individual contractor with `self_onboarding: false`, `wage_type: "Hourly"`, `hourly_rate: "50.00"`, and a start_date of today. This gives `admin_onboarding_incomplete` status.
+
+**"I need a self-onboarding contractor"**
+→ Create with `self_onboarding: true` and an email. The flow skips the address step and goes profile → payment → new hire report → submit.
+
+**"I need a contractor who finished onboarding"**
+→ Create with all fields: name, email, SSN, work_state, wage details. Add a bank account afterward. This results in `onboarding_completed` status.
+
+**"I need a Business-type contractor"**
+→ Create with `type: "Business"`, `business_name`, and optionally `ein`. Individual-only fields (first_name, last_name, ssn) are ignored.
+
+### Contractor Payment Flow
+
+The Contractor Payment Flow (`src/components/Contractor/Payments/PaymentFlow/`) manages creating payments, viewing history, and handling RFIs.
+
+**"I need to test contractor payments"**
+→ First ensure an onboarded contractor exists (create one if needed). Then create a contractor payment with a date, amount, and payment method.
+
+### Contractor Profile Management
+
+The Contractor Profile Management flow (`sdk-app/src/design/prototypes/contractor-management/`) allows viewing and editing an existing contractor's details: address, payment method, basic info, and compensation.
+
+**"I need to test contractor profile editing"**
+→ Create a fully onboarded contractor (all fields populated + bank account). The profile flow expects an existing contractor with data to display and edit.
+
+### Time Off Policies
+
+**"Set up a time off policy"**
+→ Ask: vacation or sick? Then ask about accrual method. Default to `unlimited` if they don't have a preference. Set `complete: true` to mark it as fully configured.
+
+**"I need a PTO policy with accrual"**
+→ Create with `policy_type: "vacation"`, `accrual_method: "per_pay_period"`, `accrual_rate: "3.08"` (80 hours/year ÷ 26 pay periods). Set reasonable limits like `max_hours: "160.0"` and `carryover_limit_hours: "40.0"`.
+
+**"I need an unlimited PTO policy"**
+→ Create with `accrual_method: "unlimited"`. Leave accrual_rate, max_hours, carryover_limit_hours, max_accrual_hours_per_year, AND accrual_waiting_period_days all blank/absent (they must be null or omitted for unlimited — the API rejects even `0` for these fields).
+
+### Entity lists
+
+**"I need to test the employee list"**
+→ The Employee Onboarding Flow starts with an employee list (Index state). Create several employees in different onboarding states so the list shows variety. Include at least one `admin_onboarding_incomplete` (self_onboarding: false), one `self_onboarding_pending_invite` (self_onboarding: true + email), and one fully onboarded.
+
+**"I need to test the contractor list"**
+→ Same approach: create contractors in different states. Include at least one admin-onboarding incomplete, one self-onboarding invited, and one fully onboarded.
+
+### Mixed scenarios
+
+**"I need a company with a mix of employees and contractors"**
+→ Create 2-3 employees in different states (one admin-onboarding, one self-onboarding, one fully onboarded) and 1-2 contractors (one Individual hourly, one fully onboarded). Report all UUIDs in a summary table.

--- a/.claude/commands/create-demo-data/SKILL.md
+++ b/.claude/commands/create-demo-data/SKILL.md
@@ -27,16 +27,51 @@ Construct the base URL for all API calls:
 
 ## Step 2 — Understand what the user wants
 
-Ask the user what entity they want to create. Supported entity types:
+Ask the user what entity they want to create. Present only the top-level entity options initially:
 
-| Entity             | Clarifying questions to ask                                    |
-| ------------------ | -------------------------------------------------------------- |
-| Employee           | Self-onboarding or admin-entered? Any specific name/email?     |
-| Contractor         | Individual or Business? Hourly or Fixed wage? Self-onboarding? |
-| Time off policy    | Vacation or sick? What accrual method?                         |
-| Location           | What address?                                                  |
-| Pay schedule       | What frequency?                                                |
-| Contractor payment | Which contractor? Amount?                                      |
+- Employee
+- Contractor
+- Time off policy
+- Location
+- Pay schedule
+- Contractor payment
+
+Tell the user: if they want more than one, just say so.
+
+### Narrowing down — progressive clarification
+
+Only ask follow-up questions when the user's request doesn't already specify what you need. If the user gives a description that maps directly to a known scenario (see "Handling common scenarios" below), skip clarification and execute immediately.
+
+**If the user says "employee"** → ask what onboarding state:
+
+| State                       | Description                                         |
+| --------------------------- | --------------------------------------------------- |
+| Admin onboarding incomplete | Brand new, admin fills in everything                |
+| Self-onboarding invited     | Received invite, hasn't started yet                 |
+| Partially onboarded         | Some steps done (e.g., address but no bank account) |
+| Fully onboarded             | All steps complete, active employee                 |
+
+**If the user says "contractor"** → ask what onboarding state, and whether Individual or Business:
+
+| State                            | Description                                    |
+| -------------------------------- | ---------------------------------------------- |
+| Admin onboarding incomplete      | Brand new, admin fills in everything           |
+| Self-onboarding invited          | Received invite, hasn't started                |
+| Self-onboarding ready for review | Completed self-onboarding, admin review needed |
+| Fully onboarded                  | All steps complete, active contractor          |
+
+**If the user says "a self-onboarding contractor"** → they've already narrowed the path. Ask only the remaining ambiguity: Invited? Ready for review? Individual or Business?
+
+**If the user says "a contractor that has completed self-onboarding ready for review"** → that maps exactly to a known state. Execute it.
+
+**Other entities:**
+
+| Entity             | Clarifying questions to ask            |
+| ------------------ | -------------------------------------- |
+| Time off policy    | Vacation or sick? What accrual method? |
+| Location           | What address?                          |
+| Pay schedule       | What frequency?                        |
+| Contractor payment | Which contractor? Amount?              |
 
 For each entity type, ask only the questions that meaningfully change the outcome. Use sensible defaults for everything else:
 
@@ -48,19 +83,13 @@ For each entity type, ask only the questions that meaningfully change the outcom
 
 If the user gives a vague request like "add an employee", create one with reasonable defaults and report what was created. Don't over-ask.
 
-## Step 3 — Verify connectivity
-
-Before the first API call, verify the token is still valid:
-
-```bash
-curl -s -o /dev/null -w '%{http_code}' '{base_url}/v1/companies/{company_id}/employees'
-```
-
-If this returns anything other than 200, tell the user their token has likely expired and suggest running `npm run sdk-app:setup` to re-provision.
-
-## Step 4 — Make the API call
+## Step 3 — Verify connectivity and make API calls (single Bash call)
 
 Read `references/api-endpoints.md` for the exact endpoint, method, and request body schema for the entity type.
+
+### IMPORTANT: Chain everything into one Bash call
+
+**All API work for a single entity — connectivity check, creation, and any follow-up calls — must be chained into a single Bash command using `&&`.** This minimizes permission prompts to just 1 per entity.
 
 Use curl with:
 
@@ -68,9 +97,13 @@ Use curl with:
 - The constructed base URL from Step 1
 - Snake_case field names in the JSON body
 
-Example:
+When follow-up calls need the UUID from the creation response, extract it inline with `python3 -c` or `jq`.
+
+### Example — simple entity (no follow-up)
 
 ```bash
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' '{base_url}/v1/companies/{company_id}/employees') && \
+if [ "$STATUS" != "200" ]; then echo "Token expired (got $STATUS)"; exit 1; fi && \
 curl -s -X POST '{base_url}/v1/companies/{company_id}/employees' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -81,6 +114,32 @@ curl -s -X POST '{base_url}/v1/companies/{company_id}/employees' \
   }'
 ```
 
+### Example — entity with follow-up calls
+
+```bash
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' '{base_url}/v1/companies/{company_id}/contractors') && \
+if [ "$STATUS" != "200" ]; then echo "Token expired (got $STATUS)"; exit 1; fi && \
+RESULT=$(curl -s -X POST '{base_url}/v1/companies/{company_id}/contractors' \
+  -H 'Content-Type: application/json' \
+  -d '{...}') && \
+echo "Create response: $RESULT" && \
+UUID=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['uuid'])") && \
+echo "Created contractor: $UUID" && \
+curl -s -X PUT "{base_url}/v1/contractors/$UUID/address" \
+  -H 'Content-Type: application/json' \
+  -d '{...}' && \
+curl -s -X POST "{base_url}/v1/contractors/$UUID/bank_accounts" \
+  -H 'Content-Type: application/json' \
+  -d '{...}' && \
+curl -s -X PUT "{base_url}/v1/contractors/$UUID/onboarding_status" \
+  -H 'Content-Type: application/json' \
+  -d '{"onboarding_status": "onboarding_completed"}'
+```
+
+**Goal: 1 permission prompt per entity, regardless of how many API calls are needed.**
+
+### Error handling
+
 Capture the full response. On success (2xx), extract the `uuid` from the response.
 
 On failure (4xx), read the error response body and:
@@ -89,7 +148,7 @@ On failure (4xx), read the error response body and:
 - If 401/403: token is likely expired, suggest re-provisioning
 - If 404: endpoint may not be available in demo, explain this
 
-## Step 5 — Report results
+## Step 4 — Report results
 
 After a successful creation, report:
 
@@ -97,7 +156,7 @@ After a successful creation, report:
 - Any useful details from the response (status, onboarding state)
 - If the user might want to do follow-up operations (e.g., "Want me to also add a home address and bank account for this employee?")
 
-## Step 6 — Batch creation
+## Step 5 — Batch creation
 
 If the user asks for multiple records (e.g., "create 3 employees"), create them sequentially and report a summary table at the end.
 

--- a/.claude/commands/create-demo-data/evals/evals.json
+++ b/.claude/commands/create-demo-data/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "create-demo-data",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I need a contractor to test with",
+      "expected_output": "Should ask clarifying questions (Individual vs Business, wage type), then create a contractor via POST to the demo API using env config from sdk-app/env/.env.demo",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Create 3 employees in different onboarding states so I can test the employee list",
+      "expected_output": "Should create one admin_onboarding_incomplete employee (self_onboarding: false), one self_onboarding_invited (self_onboarding: true + email), and one fully onboarded employee. Should report all UUIDs in a summary table.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Set up an unlimited PTO policy for my company",
+      "expected_output": "Should create a time off policy with policy_type vacation, accrual_method unlimited, and complete: true. Should NOT set accrual_rate, max_hours, or carryover_limit_hours (must be null for unlimited).",
+      "files": []
+    }
+  ]
+}

--- a/.claude/commands/create-demo-data/references/api-endpoints.md
+++ b/.claude/commands/create-demo-data/references/api-endpoints.md
@@ -100,23 +100,67 @@ POST /v1/employees/{employee_id}/bank_accounts
 POST /v1/companies/{company_uuid}/contractors
 ```
 
-| Field                | Type    | Required | Notes                                                     |
-| -------------------- | ------- | -------- | --------------------------------------------------------- |
-| type                 | string  | yes      | "Individual" or "Business"                                |
-| wage_type            | string  | yes      | "Hourly" or "Fixed"                                       |
-| start_date           | string  | yes      | Format: YYYY-MM-DD                                        |
-| first_name           | string  | yes\*    | Required for Individual, ignored for Business             |
-| last_name            | string  | yes\*    | Required for Individual, ignored for Business             |
-| middle_initial       | string  | no       | Individual only                                           |
-| email                | string  | no       | Required if self_onboarding is true                       |
-| hourly_rate          | string  | no       | Required if wage_type is "Hourly" (e.g., "50.00")         |
-| self_onboarding      | boolean | no       | Recommended true so contractors get Gusto accounts        |
-| file_new_hire_report | boolean | no       | Individual only                                           |
-| work_state           | string  | no       | Two-letter code. Required if file_new_hire_report is true |
-| ssn                  | string  | no       | Individual only, for 1099 filing                          |
-| business_name        | string  | yes\*    | Required for Business type                                |
-| ein                  | string  | no       | Business type only                                        |
-| is_active            | boolean | no       |                                                           |
+| Field                | Type    | Required | Notes                                                                                     |
+| -------------------- | ------- | -------- | ----------------------------------------------------------------------------------------- |
+| type                 | string  | yes      | "Individual" or "Business"                                                                |
+| wage_type            | string  | yes      | "Hourly" or "Fixed"                                                                       |
+| start_date           | string  | yes      | Format: YYYY-MM-DD                                                                        |
+| first_name           | string  | yes\*    | Required for Individual, ignored for Business                                             |
+| last_name            | string  | yes\*    | Required for Individual, ignored for Business                                             |
+| middle_initial       | string  | no       | Individual only                                                                           |
+| email                | string  | no       | Required if self_onboarding is true                                                       |
+| hourly_rate          | string  | no       | Required if wage_type is "Hourly" (e.g., "50.00")                                         |
+| self_onboarding      | boolean | no       | Recommended true so contractors get Gusto accounts                                        |
+| file_new_hire_report | boolean | no       | Individual only                                                                           |
+| work_state           | string  | no       | Two-letter code. Required if file_new_hire_report is true                                 |
+| ssn                  | string  | no       | Individual only, for 1099 filing                                                          |
+| business_name        | string  | yes\*    | Required for Business type                                                                |
+| ein                  | string  | no       | Business type only. **Format: 9 digits, no hyphen** (e.g., `123456789`, NOT `12-3456789`) |
+| is_active            | boolean | no       |                                                                                           |
+
+### Update Contractor Address
+
+```
+PUT /v1/contractors/{contractor_uuid}/address
+```
+
+| Field    | Type   | Required | Notes                 |
+| -------- | ------ | -------- | --------------------- |
+| street_1 | string | yes      |                       |
+| street_2 | string | no       |                       |
+| city     | string | yes      |                       |
+| state    | string | yes      | Two-letter state code |
+| zip      | string | yes      |                       |
+
+### Update Contractor Onboarding Status
+
+```
+PUT /v1/contractors/{contractor_uuid}/onboarding_status
+```
+
+| Field             | Type   | Required | Notes                 |
+| ----------------- | ------ | -------- | --------------------- |
+| onboarding_status | string | yes      | See transitions below |
+
+**Valid transitions:**
+
+| Action                     | Current status                                                 | New status                    |
+| :------------------------- | :------------------------------------------------------------- | :---------------------------- |
+| Mark as self-onboarding    | `admin_onboarding_incomplete`                                  | `self_onboarding_not_invited` |
+| Invite to self-onboard     | `admin_onboarding_incomplete` or `self_onboarding_not_invited` | `self_onboarding_invited`     |
+| Cancel self-onboarding     | `self_onboarding_invited` or `self_onboarding_not_invited`     | `admin_onboarding_incomplete` |
+| Review self-onboarded info | `self_onboarding_started`                                      | `self_onboarding_review`      |
+| Finish onboarding          | `admin_onboarding_review` or `self_onboarding_review`          | `onboarding_completed`        |
+
+**Note:** Inviting a contractor with populated data may auto-advance to `self_onboarding_started`. All required onboarding steps (basic_details, add_address, compensation_details) must be completed before transitioning to `self_onboarding_review`.
+
+### Get Contractor Onboarding Status
+
+```
+GET /v1/contractors/{contractor_uuid}/onboarding_status
+```
+
+Returns the current `onboarding_status` and `onboarding_steps` array showing which steps are completed.
 
 ### Terminate Contractor
 

--- a/.claude/commands/create-demo-data/references/api-endpoints.md
+++ b/.claude/commands/create-demo-data/references/api-endpoints.md
@@ -1,0 +1,279 @@
+# Gusto Demo API Endpoints Reference
+
+All requests use this URL pattern:
+
+```
+{GWS_FLOWS_HOST}/fe_sdk/{FLOW_TOKEN}/v1/{path}
+```
+
+All request bodies use **snake_case** field names. Set `Content-Type: application/json`.
+
+---
+
+## Employees
+
+### Create Employee
+
+```
+POST /v1/companies/{company_id}/employees
+```
+
+| Field                | Type    | Required | Notes                               |
+| -------------------- | ------- | -------- | ----------------------------------- |
+| first_name           | string  | yes      |                                     |
+| last_name            | string  | yes      |                                     |
+| middle_initial       | string  | no       |                                     |
+| email                | string  | no       | Required if self_onboarding is true |
+| work_email           | string  | no       |                                     |
+| date_of_birth        | string  | no       | Format: YYYY-MM-DD                  |
+| ssn                  | string  | no       | Format: XXX-XX-XXXX                 |
+| preferred_first_name | string  | no       |                                     |
+| self_onboarding      | boolean | no       | If true, employee self-onboards     |
+
+### Create Job for Employee
+
+```
+POST /v1/employees/{employee_id}/jobs
+```
+
+| Field       | Type   | Required | Notes              |
+| ----------- | ------ | -------- | ------------------ |
+| title       | string | yes      |                    |
+| hire_date   | string | yes      | Format: YYYY-MM-DD |
+| location_id | number | no       |                    |
+
+### Terminate Employee
+
+```
+POST /v1/employees/{employee_id}/terminations
+```
+
+| Field                   | Type    | Required | Notes              |
+| ----------------------- | ------- | -------- | ------------------ |
+| effective_date          | string  | yes      | Format: YYYY-MM-DD |
+| run_termination_payroll | boolean | no       |                    |
+
+### Rehire Employee
+
+```
+POST /v1/employees/{employee_id}/rehire
+```
+
+| Field          | Type   | Required | Notes              |
+| -------------- | ------ | -------- | ------------------ |
+| effective_date | string | yes      | Format: YYYY-MM-DD |
+
+### Create Home Address
+
+```
+POST /v1/employees/{employee_id}/home_addresses
+```
+
+| Field    | Type   | Required | Notes                 |
+| -------- | ------ | -------- | --------------------- |
+| street_1 | string | yes      |                       |
+| street_2 | string | no       |                       |
+| city     | string | yes      |                       |
+| state    | string | yes      | Two-letter state code |
+| zip      | string | yes      |                       |
+
+### Create Bank Account (Employee)
+
+```
+POST /v1/employees/{employee_id}/bank_accounts
+```
+
+| Field          | Type   | Required | Notes                   |
+| -------------- | ------ | -------- | ----------------------- |
+| name           | string | yes      | Account label           |
+| routing_number | string | yes      | 9 digits                |
+| account_number | string | yes      |                         |
+| account_type   | string | yes      | "Checking" or "Savings" |
+
+---
+
+## Contractors
+
+### Create Contractor
+
+```
+POST /v1/companies/{company_uuid}/contractors
+```
+
+| Field                | Type    | Required | Notes                                                     |
+| -------------------- | ------- | -------- | --------------------------------------------------------- |
+| type                 | string  | yes      | "Individual" or "Business"                                |
+| wage_type            | string  | yes      | "Hourly" or "Fixed"                                       |
+| start_date           | string  | yes      | Format: YYYY-MM-DD                                        |
+| first_name           | string  | yes\*    | Required for Individual, ignored for Business             |
+| last_name            | string  | yes\*    | Required for Individual, ignored for Business             |
+| middle_initial       | string  | no       | Individual only                                           |
+| email                | string  | no       | Required if self_onboarding is true                       |
+| hourly_rate          | string  | no       | Required if wage_type is "Hourly" (e.g., "50.00")         |
+| self_onboarding      | boolean | no       | Recommended true so contractors get Gusto accounts        |
+| file_new_hire_report | boolean | no       | Individual only                                           |
+| work_state           | string  | no       | Two-letter code. Required if file_new_hire_report is true |
+| ssn                  | string  | no       | Individual only, for 1099 filing                          |
+| business_name        | string  | yes\*    | Required for Business type                                |
+| ein                  | string  | no       | Business type only                                        |
+| is_active            | boolean | no       |                                                           |
+
+### Terminate Contractor
+
+```
+POST /v1/contractors/{contractor_uuid}/termination
+```
+
+| Field    | Type   | Required | Notes              |
+| -------- | ------ | -------- | ------------------ |
+| end_date | string | yes      | Format: YYYY-MM-DD |
+
+### Rehire Contractor
+
+```
+POST /v1/contractors/{contractor_uuid}/rehire
+```
+
+| Field      | Type   | Required | Notes              |
+| ---------- | ------ | -------- | ------------------ |
+| start_date | string | yes      | Format: YYYY-MM-DD |
+
+### Create Bank Account (Contractor)
+
+```
+POST /v1/contractors/{contractor_uuid}/bank_accounts
+```
+
+| Field          | Type   | Required | Notes                   |
+| -------------- | ------ | -------- | ----------------------- |
+| name           | string | yes      | Account label           |
+| routing_number | string | yes      | 9 digits                |
+| account_number | string | yes      |                         |
+| account_type   | string | yes      | "Checking" or "Savings" |
+
+---
+
+## Time Off Policies
+
+### Create Time Off Policy
+
+```
+POST /v1/companies/{company_uuid}/time_off_policies
+```
+
+| Field                       | Type    | Required | Notes                                                  |
+| --------------------------- | ------- | -------- | ------------------------------------------------------ |
+| name                        | string  | yes      | e.g., "Vacation", "Sick Leave"                         |
+| policy_type                 | string  | yes      | "vacation" or "sick"                                   |
+| accrual_method              | string  | yes      | See values below                                       |
+| accrual_rate                | string  | no       | Float as string, e.g., "40.0"                          |
+| accrual_rate_unit           | string  | no       | Hours per unit for hourly policies, e.g., "40.0"       |
+| paid_out_on_termination     | boolean | no       |                                                        |
+| accrual_waiting_period_days | number  | no       | Must be blank/null for unlimited; 0 for yearly methods |
+| carryover_limit_hours       | string  | no       | Must be blank for unlimited                            |
+| max_accrual_hours_per_year  | string  | no       | Must be blank for yearly/unlimited                     |
+| max_hours                   | string  | no       | Must be blank for unlimited                            |
+| policy_reset_date           | string  | no       | Format: MM-DD                                          |
+| complete                    | boolean | no       | Mark policy as fully configured                        |
+
+**Accrual methods:**
+
+- `unlimited` — no accrual tracking
+- `per_pay_period` — accrues each pay period
+- `per_calendar_year` — fixed annual accrual, resets on policy_reset_date
+- `per_anniversary_year` — fixed annual accrual, resets on hire date
+- `per_hour_worked` — accrues based on hours worked (including overtime)
+- `per_hour_worked_no_overtime` — accrues based on hours worked (excluding overtime)
+- `per_hour_paid` — accrues based on hours paid (including overtime)
+- `per_hour_paid_no_overtime` — accrues based on hours paid (excluding overtime)
+
+---
+
+## Company
+
+### Create Location
+
+```
+POST /v1/companies/{company_id}/locations
+```
+
+| Field        | Type   | Required | Notes                 |
+| ------------ | ------ | -------- | --------------------- |
+| street_1     | string | yes      |                       |
+| street_2     | string | no       |                       |
+| city         | string | yes      |                       |
+| state        | string | yes      | Two-letter state code |
+| zip          | string | yes      |                       |
+| phone_number | string | no       |                       |
+
+### Create Earning Type
+
+```
+POST /v1/companies/{company_id}/earning_types
+```
+
+| Field               | Type    | Required | Notes |
+| ------------------- | ------- | -------- | ----- |
+| name                | string  | yes      |       |
+| include_in_overtime | boolean | no       |       |
+
+---
+
+## Payroll
+
+### Create Pay Schedule
+
+```
+POST /v1/companies/{company_id}/pay_schedules
+```
+
+| Field                    | Type   | Required | Notes                                                          |
+| ------------------------ | ------ | -------- | -------------------------------------------------------------- |
+| frequency                | string | yes      | "Every week", "Every other week", "Twice per month", "Monthly" |
+| anchor_pay_date          | string | yes      | Format: YYYY-MM-DD                                             |
+| anchor_end_of_pay_period | string | yes      | Format: YYYY-MM-DD                                             |
+| day_1                    | number | no       | For "Twice per month" — first pay day (1-31)                   |
+| day_2                    | number | no       | For "Twice per month" — second pay day (1-31)                  |
+
+### Create Contractor Payment
+
+```
+POST /v1/companies/{company_id}/contractor_payments
+```
+
+| Field           | Type   | Required | Notes                       |
+| --------------- | ------ | -------- | --------------------------- |
+| contractor_uuid | string | yes      |                             |
+| date            | string | yes      | Format: YYYY-MM-DD          |
+| payment_method  | string | yes      | "Direct Deposit" or "Check" |
+| wage            | number | no       |                             |
+| hours           | number | no       |                             |
+| bonus           | number | no       |                             |
+| reimbursement   | number | no       |                             |
+
+---
+
+## Listing Entities (GET)
+
+Use these to discover existing records before creating new ones:
+
+```
+GET /v1/companies/{company_id}/employees
+GET /v1/companies/{company_id}/contractors
+GET /v1/companies/{company_id}/payrolls
+GET /v1/companies/{company_id}/locations
+GET /v1/companies/{company_id}/pay_schedules
+GET /v1/companies/{company_uuid}/time_off_policies
+GET /v1/companies/{company_id}/earning_types
+GET /v1/companies/{company_id}/forms
+```
+
+---
+
+## Notes
+
+- The `company_id` / `company_uuid` comes from the `VITE_COMPANY_ID` env var
+- Some endpoints use `company_id` and some use `company_uuid` — in practice they accept the same UUID
+- Responses include a `uuid` field on the created entity — capture this for follow-up operations
+- If a POST returns 422, the response body contains validation error details
+- The demo environment resets periodically; tokens expire and need re-provisioning via `npm run sdk-app:setup`


### PR DESCRIPTION
## Summary
- Adds a `/create-demo-data` Claude Code skill that creates test data (employees, contractors, time off policies, locations, pay schedules, contractor payments) in the Gusto demo environment via API
- Includes a reference file with all supported API endpoints and request schemas
- Allows testing the SDK in different data states without needing ZenPayroll running locally — just needs `sdk-app/env/.env.demo`

## Test plan
- [ ] Run `/create-demo-data` and ask it to create an employee
- [ ] Run `/create-demo-data` and ask it to create a contractor
- [ ] Run `/create-demo-data` and ask it to set up an unlimited PTO policy
- [ ] Verify it reads `sdk-app/env/.env.demo` correctly and makes valid API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)