### PR TITLE
fix: add isWithinBox support to DataCards

### DIFF
--- a/sdk-app/src/design/prototypes/component-showcase/index.tsx
+++ b/sdk-app/src/design/prototypes/component-showcase/index.tsx
@@ -1,11 +1,31 @@
 import { useState } from 'react'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
-import { Flex, Grid } from '@/components/Common'
+import { DataView, Flex, Grid, useDataView } from '@/components/Common'
+
+const teamMembers = [
+  {
+    name: 'Alice Chen',
+    role: 'Software Engineer',
+    department: 'Engineering',
+    startDate: '2024-01-15',
+  },
+  { name: 'Bob Martinez', role: 'Product Designer', department: 'Design', startDate: '2023-06-01' },
+]
 
 export function ComponentShowcase() {
   const Components = useComponentContext()
   const [textValue, setTextValue] = useState('')
   const [selectValue, setSelectValue] = useState('')
+
+  const dataViewProps = useDataView({
+    data: teamMembers,
+    columns: [
+      { key: 'name' as const, title: 'Name' },
+      { key: 'role' as const, title: 'Role' },
+      { key: 'department' as const, title: 'Department' },
+      { key: 'startDate' as const, title: 'Start Date' },
+    ],
+  })
 
   return (
     <Grid gap={32}>
@@ -108,6 +128,13 @@ export function ComponentShowcase() {
         <Components.Text size="md">Text — Medium</Components.Text>
         <Components.Text size="sm">Text — Small</Components.Text>
         <Components.Text size="xs">Text — Extra Small</Components.Text>
+      </Flex>
+
+      <Flex flexDirection="column" gap={12}>
+        <Components.Heading as="h2">Data View</Components.Heading>
+        <Components.Box withPadding={false} header={<Components.BoxHeader title="Team Members" />}>
+          <DataView label="Team members" {...dataViewProps} isWithinBox />
+        </Components.Box>
       </Flex>
     </Grid>
   )

--- a/src/components/Common/DataView/DataCards/DataCards.module.scss
+++ b/src/components/Common/DataView/DataCards/DataCards.module.scss
@@ -1,3 +1,23 @@
+.root {
+  &[data-within-box] {
+    .selectAllRow {
+      border-bottom: 1px solid var(--g-colorBorderSecondary);
+    }
+
+    [data-testid='data-card'] {
+      border: none;
+      border-radius: 0;
+      box-shadow: none;
+      margin-bottom: 0;
+      border-bottom: 1px solid var(--g-colorBorderSecondary);
+    }
+
+    [role='list'] [role='listitem']:last-child [data-testid='data-card'] {
+      border-bottom: none;
+    }
+  }
+}
+
 .selectAllRow {
   padding: toRem(8) toRem(16);
 }

--- a/src/components/Common/DataView/DataCards/DataCards.module.scss
+++ b/src/components/Common/DataView/DataCards/DataCards.module.scss
@@ -1,10 +1,10 @@
 .root {
-  &[data-within-box] {
+  &.withinBox {
     .selectAllRow {
       border-bottom: 1px solid var(--g-colorBorderSecondary);
     }
 
-    [data-testid='data-card'] {
+    .flushCard {
       border: none;
       border-radius: 0;
       box-shadow: none;
@@ -12,7 +12,7 @@
       border-bottom: 1px solid var(--g-colorBorderSecondary);
     }
 
-    [role='list'] [role='listitem']:last-child [data-testid='data-card'] {
+    [role='list'] [role='listitem']:last-child .flushCard {
       border-bottom: none;
     }
   }

--- a/src/components/Common/DataView/DataCards/DataCards.test.tsx
+++ b/src/components/Common/DataView/DataCards/DataCards.test.tsx
@@ -124,19 +124,19 @@ describe('DataCards', () => {
   })
 
   describe('isWithinBox', () => {
-    test('does not add data-within-box attribute by default', () => {
-      renderCards()
-      expect(screen.getByTestId('data-cards')).not.toHaveAttribute('data-within-box')
-    })
-
-    test('adds data-within-box attribute when isWithinBox is true', () => {
+    test('renders without data-within-box attribute', () => {
       renderCards({ isWithinBox: true })
-      expect(screen.getByTestId('data-cards')).toHaveAttribute('data-within-box')
+      expect(screen.getByTestId('data-cards')).not.toHaveAttribute('data-within-box')
     })
 
-    test('does not add data-within-box attribute when isWithinBox is false', () => {
-      renderCards({ isWithinBox: false })
-      expect(screen.getByTestId('data-cards')).not.toHaveAttribute('data-within-box')
+    test('applies withinBox class when isWithinBox is true', () => {
+      renderCards({ isWithinBox: true })
+      expect(screen.getByTestId('data-cards').className).toMatch(/withinBox/)
+    })
+
+    test('does not apply withinBox class by default', () => {
+      renderCards()
+      expect(screen.getByTestId('data-cards').className).not.toMatch(/withinBox/)
     })
   })
 

--- a/src/components/Common/DataView/DataCards/DataCards.test.tsx
+++ b/src/components/Common/DataView/DataCards/DataCards.test.tsx
@@ -123,6 +123,23 @@ describe('DataCards', () => {
     expect(screen.getByText('No data available')).toBeInTheDocument()
   })
 
+  describe('isWithinBox', () => {
+    test('does not add data-within-box attribute by default', () => {
+      renderCards()
+      expect(screen.getByTestId('data-cards')).not.toHaveAttribute('data-within-box')
+    })
+
+    test('adds data-within-box attribute when isWithinBox is true', () => {
+      renderCards({ isWithinBox: true })
+      expect(screen.getByTestId('data-cards')).toHaveAttribute('data-within-box')
+    })
+
+    test('does not add data-within-box attribute when isWithinBox is false', () => {
+      renderCards({ isWithinBox: false })
+      expect(screen.getByTestId('data-cards')).not.toHaveAttribute('data-within-box')
+    })
+  })
+
   test('should render footer when provided', () => {
     const footer = () => ({
       name: <strong>Total Records:</strong>,

--- a/src/components/Common/DataView/DataCards/DataCards.tsx
+++ b/src/components/Common/DataView/DataCards/DataCards.tsx
@@ -2,6 +2,7 @@ import { useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import styles from './DataCards.module.scss'
 import type { useDataViewPropReturn, SelectionMode } from '@/components/Common/DataView/useDataView'
+import type { TableProps } from '@/components/Common/UI/Table/TableTypes'
 import { useSelectionState } from '@/components/Common/DataView/useSelectionState'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
@@ -17,6 +18,7 @@ export type DataCardsProps<T> = {
   emptyState?: useDataViewPropReturn<T>['emptyState']
   footer?: useDataViewPropReturn<T>['footer']
   selectionMode?: SelectionMode
+  isWithinBox?: TableProps['isWithinBox']
 }
 
 export const DataCards = <T,>({
@@ -30,6 +32,7 @@ export const DataCards = <T,>({
   emptyState,
   footer,
   selectionMode = 'multiple',
+  isWithinBox,
 }: DataCardsProps<T>) => {
   const Components = useComponentContext()
   const { t } = useTranslation('common')
@@ -68,7 +71,11 @@ export const DataCards = <T,>({
   }
 
   return (
-    <div data-testid="data-cards">
+    <div
+      className={styles.root}
+      data-testid="data-cards"
+      data-within-box={isWithinBox || undefined}
+    >
       {onSelect && getIsItemSelected && selectionMode === 'multiple' && data.length > 0 && (
         <div className={styles.selectAllRow}>
           <Components.Checkbox

--- a/src/components/Common/DataView/DataCards/DataCards.tsx
+++ b/src/components/Common/DataView/DataCards/DataCards.tsx
@@ -1,4 +1,5 @@
 import { useId } from 'react'
+import cn from 'classnames'
 import { useTranslation } from 'react-i18next'
 import styles from './DataCards.module.scss'
 import type { useDataViewPropReturn, SelectionMode } from '@/components/Common/DataView/useDataView'
@@ -71,11 +72,7 @@ export const DataCards = <T,>({
   }
 
   return (
-    <div
-      className={styles.root}
-      data-testid="data-cards"
-      data-within-box={isWithinBox || undefined}
-    >
+    <div className={cn(styles.root, isWithinBox && styles.withinBox)} data-testid="data-cards">
       {onSelect && getIsItemSelected && selectionMode === 'multiple' && data.length > 0 && (
         <div className={styles.selectAllRow}>
           <Components.Checkbox
@@ -88,12 +85,18 @@ export const DataCards = <T,>({
       <div role="list" aria-label={label}>
         {data.length === 0 && emptyState && (
           <div role="listitem">
-            <Components.Card>{emptyState()}</Components.Card>
+            <Components.Card className={isWithinBox ? styles.flushCard : undefined}>
+              {emptyState()}
+            </Components.Card>
           </div>
         )}
         {data.map((item, index) => (
           <div role="listitem" key={index}>
-            <Components.Card menu={itemMenu && itemMenu(item)} action={renderAction(item, index)}>
+            <Components.Card
+              menu={itemMenu && itemMenu(item)}
+              action={renderAction(item, index)}
+              className={isWithinBox ? styles.flushCard : undefined}
+            >
               {columns.map((column, colIndex) => (
                 <Flex key={colIndex} flexDirection="column" gap={0}>
                   {column.title && <h5 className={styles.columnTitle}>{column.title}</h5>}
@@ -108,7 +111,7 @@ export const DataCards = <T,>({
         ))}
         {footer && (
           <div role="listitem">
-            <Components.Card>
+            <Components.Card className={isWithinBox ? styles.flushCard : undefined}>
               {(() => {
                 const footerContent = footer()
 

--- a/src/components/Common/UI/Box/Box.module.scss
+++ b/src/components/Common/UI/Box/Box.module.scss
@@ -6,6 +6,7 @@
   box-shadow: var(--g-shadowResting);
   border-radius: var(--g-boxRadius);
   border: 1px solid var(--g-colorBorderSecondary);
+  overflow: hidden;
 }
 
 .header {


### PR DESCRIPTION
## Summary
- Adds `isWithinBox` prop to `DataCards`, matching the existing pattern in `DataTable`
- When inside a Box, cards strip their border, border-radius, and box-shadow, and render divider lines between items instead
- Adds `overflow: hidden` to Box so card content respects the Box border-radius

## Demo

**Before**
<img width="539" height="398" alt="Screenshot 2026-04-28 at 4 29 00 PM" src="https://github.com/user-attachments/assets/78b04eea-4a97-4449-91af-8031128f4a25" />

**After**

<img width="421" height="652" alt="Screenshot 2026-04-28 at 4 42 33 PM" src="https://github.com/user-attachments/assets/08192814-b94e-4adc-b618-de2c27487178" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)