### PR TITLE
fix(SDK-810): emit local calendar dates in DatePickerField string mode

### DIFF
--- a/src/helpers/dateFormatting.test.ts
+++ b/src/helpers/dateFormatting.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import {
   formatDateShortWithWeekday,
   formatDateShortWithWeekdayAndYear,
@@ -194,9 +194,10 @@ describe('Date Formatting Helpers', () => {
   })
 
   describe('normalizeDateToLocal', () => {
-    it('should normalize UTC dates to local midnight', () => {
-      const utcDate = new Date('2023-12-25T00:00:00.000Z')
-      const normalized = normalizeDateToLocal(utcDate)
+    it('returns a Date at local midnight reflecting the input\u2019s local calendar date', () => {
+      // Constructed in local time so the assertion is timezone-deterministic.
+      const localDate = new Date(2023, 11, 25)
+      const normalized = normalizeDateToLocal(localDate)
 
       expect(normalized).toBeInstanceOf(Date)
       expect(normalized?.getFullYear()).toBe(2023)
@@ -206,20 +207,95 @@ describe('Date Formatting Helpers', () => {
       expect(normalized?.getMinutes()).toBe(0)
     })
 
-    it('should normalize dates with time to midnight', () => {
-      const dateWithTime = new Date('2024-03-15T15:30:45.000Z')
+    it('zeros the time component while preserving the local calendar date', () => {
+      const dateWithTime = new Date(2024, 2, 15, 15, 30, 45)
       const normalized = normalizeDateToLocal(dateWithTime)
 
       expect(normalized?.getFullYear()).toBe(2024)
       expect(normalized?.getMonth()).toBe(2)
       expect(normalized?.getDate()).toBe(15)
       expect(normalized?.getHours()).toBe(0)
+      expect(normalized?.getMinutes()).toBe(0)
+      expect(normalized?.getSeconds()).toBe(0)
     })
 
     it('should return null for invalid inputs', () => {
       expect(normalizeDateToLocal(null)).toBeNull()
       expect(normalizeDateToLocal(new Date('invalid'))).toBeNull()
       expect(normalizeDateToLocal(new Date(NaN))).toBeNull()
+    })
+  })
+
+  describe.each([
+    { tz: 'UTC', label: 'UTC' },
+    { tz: 'America/Los_Angeles', label: 'UTC-8 (PST)' },
+    { tz: 'Asia/Kolkata', label: 'UTC+5:30 (IST)' },
+    { tz: 'Pacific/Kiritimati', label: 'UTC+14' },
+  ])('timezone behavior in $label', ({ tz }) => {
+    const originalTZ = process.env.TZ
+
+    beforeAll(() => {
+      process.env.TZ = tz
+    })
+
+    afterAll(() => {
+      process.env.TZ = originalTZ
+    })
+
+    describe('formatDateToStringDate', () => {
+      it('returns the local calendar date for a local-midnight Date', () => {
+        // `new Date(year, month, day)` creates a Date at LOCAL midnight regardless
+        // of host timezone. The formatter must return the same calendar date the
+        // user constructed, not the date's UTC interpretation.
+        expect(formatDateToStringDate(new Date(2024, 0, 15))).toBe('2024-01-15')
+      })
+
+      it('returns the local calendar date for a Date with an explicit time component', () => {
+        // 11:30 PM local on Jan 15 — in UTC- timezones this maps to a UTC instant
+        // on Jan 16, so any UTC-based formatter would emit the wrong calendar date.
+        expect(formatDateToStringDate(new Date(2024, 0, 15, 23, 30))).toBe('2024-01-15')
+      })
+
+      it('returns the local calendar date for an early-morning Date', () => {
+        // 1:00 AM local on Jan 16 — in UTC+ timezones this maps to a UTC instant
+        // on Jan 15, so any UTC-based formatter would emit the wrong calendar date.
+        expect(formatDateToStringDate(new Date(2024, 0, 16, 1, 0))).toBe('2024-01-16')
+      })
+    })
+
+    describe('normalizeDateToLocal', () => {
+      it('returns the same calendar date for a local-midnight Date (no-op)', () => {
+        const localMidnight = new Date(2024, 0, 15)
+        const normalized = normalizeDateToLocal(localMidnight)
+        expect(normalized?.getFullYear()).toBe(2024)
+        expect(normalized?.getMonth()).toBe(0)
+        expect(normalized?.getDate()).toBe(15)
+        expect(normalized?.getHours()).toBe(0)
+      })
+
+      it('zeros the time component while preserving the local calendar date', () => {
+        const lateAfternoon = new Date(2024, 0, 15, 17, 30, 45)
+        const normalized = normalizeDateToLocal(lateAfternoon)
+        expect(normalized?.getFullYear()).toBe(2024)
+        expect(normalized?.getMonth()).toBe(0)
+        expect(normalized?.getDate()).toBe(15)
+        expect(normalized?.getHours()).toBe(0)
+        expect(normalized?.getMinutes()).toBe(0)
+        expect(normalized?.getSeconds()).toBe(0)
+      })
+    })
+
+    describe('round trip: normalizeDateToLocal -> formatDateToStringDate', () => {
+      it('preserves the user-picked calendar date', () => {
+        // This mirrors what DatePickerField does in string mode: the underlying
+        // adapter (react-aria) hands us a local-midnight Date for the day the
+        // user clicked, and we round-trip through these two helpers to produce
+        // the YYYY-MM-DD string stored in the form. The picked date must survive.
+        const pickedDate = new Date(2024, 3, 16) // April 16 local midnight
+        const normalized = normalizeDateToLocal(pickedDate)
+        const stringForm = normalized ? formatDateToStringDate(normalized) : null
+        expect(stringForm).toBe('2024-04-16')
+      })
     })
   })
 

--- a/src/helpers/dateFormatting.ts
+++ b/src/helpers/dateFormatting.ts
@@ -168,11 +168,23 @@ export const formatPayPeriodRange = (
   return `${startFormatted}–${endFormatted}`
 }
 
+/**
+ * Formats a Date as a `YYYY-MM-DD` string using the date's *local* calendar
+ * date (year/month/day), so the output reflects the calendar date the user
+ * actually picked or stored regardless of the runtime timezone.
+ *
+ * Reading via `toISOString()` would shift the date by a day for users in
+ * UTC+ timezones, where local midnight falls before UTC midnight on the
+ * previous calendar day.
+ */
 export const formatDateToStringDate = (date: Date): string | null => {
   if (isNaN(date.getTime())) {
     return null
   }
-  return date.toISOString().split('T')[0] || null
+  const year = String(date.getFullYear()).padStart(4, '0')
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
 }
 
 /**
@@ -197,28 +209,19 @@ export const normalizeToISOString = (value?: string | null): string => {
 }
 
 /**
- * Normalizes Date to local midnight, handling timezone issues from any adapter.
+ * Returns a new Date at local midnight whose calendar year/month/day matches
+ * the input's *local* interpretation. Equivalent to zeroing the time component
+ * while preserving the local calendar date.
+ *
+ * Reading via `toISOString()` would shift the result by a day for users in
+ * UTC+ timezones whose local midnight lies on the previous UTC calendar day.
  */
 export const normalizeDateToLocal = (date: Date | null): Date | null => {
   if (!date || isNaN(date.getTime())) {
     return null
   }
 
-  const isoString = date.toISOString()
-  const [datePart] = isoString.split('T')
-  if (!datePart) return null
-
-  const parts = datePart.split('-')
-  if (parts.length !== 3) return null
-  const numbers = parts.map(Number)
-  const year = numbers[0]!
-  const month = numbers[1]!
-  const day = numbers[2]!
-  if (isNaN(year) || isNaN(month) || isNaN(day) || month < 1 || month > 12 || day < 1 || day > 31) {
-    return null
-  }
-
-  return new Date(year, month - 1, day)
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
 }
 
 export const MS_PER_HOUR = 1000 * 60 * 60


### PR DESCRIPTION
## Summary

* Fix `formatDateToStringDate` and `normalizeDateToLocal` to read local-time year / month / day instead of routing through `toISOString()`. In UTC+ timezones the UTC representation of a local-midnight Date sits on the previous calendar day, so the old implementations shifted the result back by a day each.
* Without this fix, `DatePickerField` in `isStringMode` chains both helpers, so the form value (and the date sent to the API) was **two days behind** what the user picked in calendars like UTC+5:30 (IST) or UTC+14 (Kiritimati).
* Pin the behavior with a parameterized test suite that re-runs the helper assertions in UTC, UTC-8 (PST), UTC+5:30 (IST), and UTC+14 (Kiritimati), including a round-trip test that mirrors what `DatePickerField` does in string mode.

## Why

The codebase already knows about this pitfall in two places — they just hadn't been generalized:

* `src/helpers/dateFormatting.ts` already had `normalizeToISOString`, with this docstring:
  > Unlike `formatDateToStringDate` (which reads UTC), this function reads the local year/month/day — safe for dates parsed from locale-format strings... or ISO strings, both of which `normalizeToDate` lands at local midnight.
* `src/components/Common/UI/DatePicker/DatePicker.tsx` has a private `dateToCalendarDate` helper (lines 29-42) with this comment:
  > `// Use local date parts to avoid UTC timezone shift from toISOString()`

This PR brings the two general-purpose helpers in line with that already-documented pattern.

## Bug trace (UTC+5:30, our react-aria adapter)

1. User clicks April 16 in the calendar.
2. `react-aria` emits `DateValue { year: 2024, month: 4, day: 16 }`.
3. `calendarDateValueToDate` converts to `new Date(2024, 3, 16)` = April 16 **local midnight** (= April 15 18:30 UTC).
4. `DatePickerField.handleChange`:
   1. `normalizeDateToLocal(value)` calls `value.toISOString()` → `"2024-04-15T18:30:00.000Z"` → builds `new Date(2024, 3, 15)` = **April 15 local midnight** (one day off).
   2. `formatDateToStringDate(...)` calls `.toISOString()` again on April 15 local → `"2024-04-14T18:30:00.000Z"` → returns `"2024-04-14"` (two days off).

The form ends up with `"2024-04-14"`. After this PR, the chain returns `"2024-04-16"` in every timezone tested.

## What changed

* `src/helpers/dateFormatting.ts`
  * `formatDateToStringDate` now builds the `YYYY-MM-DD` string from `getFullYear` / `getMonth` / `getDate` (with zero-padding) instead of `toISOString().split('T')[0]`.
  * `normalizeDateToLocal` now returns `new Date(date.getFullYear(), date.getMonth(), date.getDate())` instead of round-tripping through `toISOString()`.
  * Added doc comments explaining the local-time contract and the UTC pitfall.
* `src/helpers/dateFormatting.test.ts`
  * Replaced the two pre-existing `normalizeDateToLocal` tests that asserted UTC-input behavior with locale-deterministic equivalents (the old assertions were only correct in UTC and would fail elsewhere).
  * Added a `describe.each` block running in UTC, PST, IST, and UTC+14, exercising:
    1. `formatDateToStringDate` against local-midnight, late-evening, and early-morning Dates.
    2. `normalizeDateToLocal` no-op behavior on local-midnight Dates and time-zeroing on Dates with a time component.
    3. The string-mode round-trip (`normalizeDateToLocal` → `formatDateToStringDate`) preserving the user-picked calendar date.

## Behavior change for partner adapters

The new `normalizeDateToLocal` interprets its input in local time. For our default `react-aria` adapter (which already passes local-midnight Dates), this is a no-op and the user-visible bug is fixed. For a hypothetical partner adapter that passes UTC-midnight Dates, the result in UTC- timezones now shifts to the previous local calendar day (since UTC midnight there is `previous-day 16:00` local). This is consistent with the rest of the date pipeline now reading local — and the prior behavior was already broken for the much more common local-midnight adapter case in UTC+ timezones, so optimizing for the actually-shipped adapter is the right trade-off.

## Test plan

Automated:

- [x] New parameterized timezone tests cover the helpers and the round-trip in 4 timezones.
- [x] `npm run test -- --run` passes (2,340 / 2,340).
- [x] `npm run tsc` clean.
- [x] ESLint clean on changed files.

Manual:

- [ ] Run `TZ="Asia/Kolkata" npm run storybook` and pick a future date in any `DatePickerField` story (e.g. `Forms/DatePickerField`). Confirm the field's stored value matches what was clicked.
- [ ] Repeat in the SDK dev app for any flow that uses a `DatePickerField` (e.g. employee start date) and verify the date the API receives matches the picked date.

Made with [Cursor](https://cursor.com)