### PR TITLE
chore: add empty sidebar categories for upcoming design prototypes

### DIFF
--- a/sdk-app/src/Sidebar.tsx
+++ b/sdk-app/src/Sidebar.tsx
@@ -39,7 +39,7 @@ function CategorySection({
     return items.filter(item => item.name.toLowerCase().includes(q))
   }, [items, searchQuery])
 
-  if (filteredItems.length === 0) return null
+  if (searchQuery && filteredItems.length === 0) return null
 
   const displayCategory =
     mode === 'preview' && category === 'InformationRequests' ? 'Info Requests' : category

--- a/sdk-app/src/design/registry.ts
+++ b/sdk-app/src/design/registry.ts
@@ -1,6 +1,6 @@
 export type Category = (typeof CATEGORIES)[number]
 
-export const CATEGORIES = ['Examples', 'Contractors'] as const
+export const CATEGORIES = ['Examples', 'Companies', 'Contractors', 'Employees', 'Payroll'] as const
 
 export interface PrototypeEntry {
   name: string
@@ -19,6 +19,7 @@ export const categorizedRegistry: CategorizedRegistry = {
         'A single page demonstrating SDK components like Button, TextInput, Select, Alert, and more.',
     },
   ],
+  Companies: [],
   Contractors: [
     {
       name: 'Contractor Management',
@@ -27,4 +28,6 @@ export const categorizedRegistry: CategorizedRegistry = {
         'A prototype flow for managing contractors — view the list and drill into individual profiles.',
     },
   ],
+  Employees: [],
+  Payroll: [],
 }


### PR DESCRIPTION
## Summary

Adds Companies, Employees, and Payroll as empty categories in the design sandbox sidebar so they're visible before prototypes are built.

## Changes

- Added Companies, Employees, and Payroll to the design registry as empty categories
- Updated sidebar to show category headers even when they have no items (previously hidden)

## Demo

N/A — sidebar categories render as headers with a count of 0.

## Related

N/A

## Testing

- Run `npm run sdk-app` and switch to Design mode
- Verify Companies, Employees, and Payroll appear in the sidebar with a count of 0
- Verify searching filters out empty categories that don't match