### PR TITLE
fix: improve contractor form layout and typography consistency

### DIFF
--- a/src/components/Contractor/Address/Address.tsx
+++ b/src/components/Contractor/Address/Address.tsx
@@ -94,7 +94,7 @@ function Root({ contractorId, defaultValues, children, className, dictionary }: 
       >
         <FormProvider {...formMethods}>
           <HtmlForm onSubmit={formMethods.handleSubmit(onSubmit)}>
-            <Flex flexDirection="column" gap={32}>
+            <Flex flexDirection="column" gap={32} alignItems="stretch">
               {children ? (
                 children
               ) : (

--- a/src/components/Contractor/Address/Head.tsx
+++ b/src/components/Contractor/Address/Head.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useAddress } from './useAddress'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common'
 
 export function Head() {
   const { t } = useTranslation('Contractor.Address')
@@ -9,14 +10,16 @@ export function Head() {
 
   return (
     <header>
-      <Components.Heading as="h2">
-        {contractorType === 'Business' ? t('businessAddressTitle') : t('homeAddressTitle')}
-      </Components.Heading>
-      <Components.Text>
-        {contractorType === 'Business'
-          ? t('businessAddressDescription')
-          : t('homeAddressDescription')}
-      </Components.Text>
+      <Flex flexDirection="column" gap={4}>
+        <Components.Heading as="h2">
+          {contractorType === 'Business' ? t('businessAddressTitle') : t('homeAddressTitle')}
+        </Components.Heading>
+        <Components.Text variant="supporting">
+          {contractorType === 'Business'
+            ? t('businessAddressDescription')
+            : t('homeAddressDescription')}
+        </Components.Text>
+      </Flex>
     </header>
   )
 }

--- a/src/components/Contractor/NewHireReport/NewHireReport.tsx
+++ b/src/components/Contractor/NewHireReport/NewHireReport.tsx
@@ -88,10 +88,12 @@ function Root({ contractorId, className, dictionary, selfOnboarding = false }: N
     <section className={className}>
       <FormProvider {...formMethods}>
         <Form onSubmit={formMethods.handleSubmit(onSubmit)}>
-          <Flex flexDirection={'column'}>
+          <Flex flexDirection="column" alignItems="stretch">
             <header>
-              <Components.Heading as="h2">{t('title')}</Components.Heading>
-              <Components.Text>{t('description')}</Components.Text>
+              <Flex flexDirection="column" gap={4}>
+                <Components.Heading as="h2">{t('title')}</Components.Heading>
+                <Components.Text variant="supporting">{t('description')}</Components.Text>
+              </Flex>
             </header>
             <RadioGroupField
               name="fileNewHireReport"

--- a/src/components/Contractor/PaymentMethod/BankAccountForm.tsx
+++ b/src/components/Contractor/PaymentMethod/BankAccountForm.tsx
@@ -1,12 +1,12 @@
 import { useTranslation } from 'react-i18next'
 import type { BankAccountFormProps } from './types'
-import { RadioGroupField, TextInputField } from '@/components/Common'
+import { Flex, RadioGroupField, TextInputField } from '@/components/Common'
 
 export function BankAccountForm({ bankAccount }: BankAccountFormProps) {
   const { t } = useTranslation('Contractor.PaymentMethod', { keyPrefix: 'bankAccountForm' })
 
   return (
-    <>
+    <Flex gap={20} flexDirection={'column'}>
       <TextInputField
         name="name"
         isRequired
@@ -38,6 +38,6 @@ export function BankAccountForm({ bankAccount }: BankAccountFormProps) {
           { value: 'Savings', label: t('accountTypeSavings') },
         ]}
       />
-    </>
+    </Flex>
   )
 }

--- a/src/components/Contractor/PaymentMethod/PaymentMethod.tsx
+++ b/src/components/Contractor/PaymentMethod/PaymentMethod.tsx
@@ -163,7 +163,6 @@ function Root({ contractorId, className, dictionary }: PaymentMethodProps) {
           <Flex gap={32} flexDirection={'column'}>
             <Components.Heading as="h2">{t('title')}</Components.Heading>
             <PaymentTypeForm />
-            <hr />
             {showBankAccountForm && <BankAccountForm bankAccount={bankAccount} />}
             <ActionsLayout>
               <Components.Button

--- a/src/components/Contractor/Profile/ContractorProfileForm.module.scss
+++ b/src/components/Contractor/Profile/ContractorProfileForm.module.scss
@@ -1,7 +1,0 @@
-.switchFieldContainer {
-  border: 1px solid var(--g-colorBorderSecondary);
-  border-radius: var(--g-cardRadius);
-  padding: toRem(20);
-  background-color: var(--g-colorBody);
-  box-shadow: var(--g-shadowResting);
-}

--- a/src/components/Contractor/Profile/ContractorProfileForm.tsx
+++ b/src/components/Contractor/Profile/ContractorProfileForm.tsx
@@ -2,7 +2,6 @@ import { FormProvider } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { type Contractor } from '@gusto/embedded-api/models/components/contractor'
 import type { useContractorProfile } from './useContractorProfile'
-import styles from './ContractorProfileForm.module.scss'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
 import { Form } from '@/components/Common/Form'
@@ -49,14 +48,16 @@ export function ContractorProfileForm({
     <section className={className}>
       <FormProvider {...formMethods}>
         <Form onSubmit={handleSubmit}>
-          <Grid gridTemplateColumns="1fr" gap={24} className="mb-8">
+          <Flex flexDirection="column" gap={20} alignItems="stretch">
             <header>
-              <Components.Heading as="h2">{t('title')}</Components.Heading>
-              <Components.Text>{t('subtitle')}</Components.Text>
+              <Flex flexDirection="column" gap={4}>
+                <Components.Heading as="h2">{t('title')}</Components.Heading>
+                <Components.Text variant="supporting">{t('subtitle')}</Components.Text>
+              </Flex>
             </header>
 
             {/* Invite Contractor Card */}
-            <div className={styles.switchFieldContainer}>
+            <Components.Box>
               <Grid gap={16}>
                 {/* Invite Contractor Toggle */}
                 <SwitchField
@@ -80,7 +81,7 @@ export function ContractorProfileForm({
                   />
                 )}
               </Grid>
-            </div>
+            </Components.Box>
 
             {/* Contractor Type */}
             <RadioGroupField
@@ -156,7 +157,7 @@ export function ContractorProfileForm({
               description={t('fields.startDate.description')}
               isRequired
             />
-          </Grid>
+          </Flex>
 
           {/* Actions */}
           <Flex gap={12} justifyContent="flex-end">

--- a/src/components/Contractor/Submit/SubmitDone.tsx
+++ b/src/components/Contractor/Submit/SubmitDone.tsx
@@ -13,9 +13,11 @@ export const SubmitDone = ({ onDone }: SubmitDoneProps) => {
   const { t } = useTranslation('Contractor.Submit')
 
   return (
-    <Flex flexDirection="column" alignItems="center">
-      <Heading as="h2">{t('doneTitle')}</Heading>
-      <Text>{t('doneDescription')}</Text>
+    <Flex flexDirection="column" gap={20} alignItems="center">
+      <Flex flexDirection="column" gap={4} alignItems="center">
+        <Heading as="h2">{t('doneTitle')}</Heading>
+        <Text variant="supporting">{t('doneDescription')}</Text>
+      </Flex>
       <Button variant="secondary" onClick={onDone}>
         {t('doneCta')}
       </Button>


### PR DESCRIPTION
## Summary

Standardize layout and typography across contractor form components to fix visual inconsistencies (e.g., narrow text wrapping in headers) and improve design consistency.

## Changes

- Replace Grid-based form layouts with Flex containers using `alignItems="stretch"` to fix header width issues
- Standardize heading/subtitle pairs with `Flex gap={4}` and `variant="supporting"` on subtitle text
- Replace custom SCSS card styling with `Components.Box` in contractor profile form
- Remove `<hr />` divider from payment method form
- Add consistent gap spacing across BankAccountForm and SubmitDone

## Demo

<img width="519" height="711" alt="Screenshot 2026-04-29 at 4 58 52 PM" src="https://github.com/user-attachments/assets/16892fe8-3d55-43dc-b87d-177fd72f01b3" />
<img width="519" height="611" alt="Screenshot 2026-04-29 at 4 58 44 PM" src="https://github.com/user-attachments/assets/f79edfa9-1478-4e43-a4e7-f50354477623" />
<img width="522" height="319" alt="Screenshot 2026-04-29 at 4 58 32 PM" src="https://github.com/user-attachments/assets/6e45253a-052d-40f2-ab17-1634cdfc0068" />
<img width="522" height="170" alt="Screenshot 2026-04-29 at 4 58 26 PM" src="https://github.com/user-attachments/assets/13de340f-cc16-4f88-afc4-770f2ef20916" />
<img width="510" height="659" alt="Screenshot 2026-04-29 at 4 58 18 PM" src="https://github.com/user-attachments/assets/f5249c83-6dcb-4ca9-a5f0-974cf7ff2edc" />


## Related

<!-- Link to relevant Jira ticket, Figma, or related PRs -->

## Testing

- `npm run storybook` → verify Contractor Profile, Address, New Hire Report, Payment Method, and Submit Done components
- Check that heading/subtitle text renders at full width (no narrow wrapping)
- Verify invite contractor card uses Box styling instead of custom SCSS

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)