### PR TITLE
fix(SDK-423): apply max length to information request text response

### DIFF
--- a/src/components/InformationRequests/InformationRequestForm/InformationRequestForm.tsx
+++ b/src/components/InformationRequests/InformationRequestForm/InformationRequestForm.tsx
@@ -31,6 +31,9 @@ const dompurifyConfig = {
   ALLOWED_ATTR: ['target', 'href', 'rel'],
 }
 
+/* API does not enforce an upper limit, so set a reasonable character max for a single-line input. */
+const MAX_TEXT_RESPONSE = 5000
+
 const InformationRequestFormSchema = z.record(
   z.string(),
   z.union([z.string().min(1), z.instanceof(File)]),
@@ -188,6 +191,7 @@ function Root({ companyId, requestId, dictionary }: InformationRequestFormProps)
               name={fieldName}
               label={t('fields.textAnswer.label')}
               placeholder={t('fields.textAnswer.placeholder')}
+              maxLength={MAX_TEXT_RESPONSE}
               isRequired
               errorMessage={t('validation.required')}
             />


### PR DESCRIPTION
## Summary

Add an upper limit to the text responses for information requests.

Original proposal included making this text input a text area, to allow for multiline comments. Based on the kinds of questions generated for RFIs, this seems unlikely as a use case. Neither the schema nor the API enforces a strict upper limit on characters, so use a reasonably high limit as a fallback.

## Demo

<img width="1765" height="1522" alt="Screenshot 2026-04-30 at 11 03 04 AM" src="https://github.com/user-attachments/assets/cbb15b7e-c3c2-49df-b5ae-d09f149cf9cc" />
<img width="1765" height="1522" alt="Screenshot 2026-04-30 at 11 03 19 AM" src="https://github.com/user-attachments/assets/59f24aa4-872d-4380-ad02-b92d3d269ca9" />

## Related

- Jira ticket: [SDK-423](https://gustohq.atlassian.net/browse/SDK-423)

## Testing

- `npm run sdk-app`
- Create a new request for information for your demo company
  + I can provide instructions via Slack if needed
- http://localhost:5200/informationrequests/InformationRequestsFlow
- Respond to the payroll request and attempt to paste more than 5000 characters; only the first 5k are allowed
  + I did this by copying an entire react component file, but you can use a [lorem ipsum generator](https://www.blindtextgenerator.com/lorem-ipsum) if you're fancy 

[SDK-423]: https://gustohq.atlassian.net/browse/SDK-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ