### PR TITLE
test(e2e): skip broken SelectEmployees time-off tests pending owner rewrite

### DIFF
--- a/e2e/tests/time-off.spec.ts
+++ b/e2e/tests/time-off.spec.ts
@@ -12,7 +12,14 @@ test.describe('TimeOffFlow', () => {
   })
 })
 
-test.describe('SelectEmployees - Add employees to time-off policy', () => {
+// The tests below were added in #1617 but assume a UI shape that doesn't exist:
+// they look for `getByRole('button').filter({ hasText: /vacation|sick|pto/i })`,
+// but PolicyListPresentation renders policy names as <Text> inside a DataView grid,
+// not as buttons. Reaching AddEmployeesToPolicy requires navigating the full
+// Create Policy flow (PolicyTypeSelector -> PolicyDetailsForm -> [PolicySettings ->]
+// AddEmployees). Skipping until the SelectEmployees feature owners can rewrite
+// these against the real flow with local validation.
+test.describe.skip('SelectEmployees - Add employees to time-off policy', () => {
   test('navigates to add employees step and displays employee table', async ({ page }) => {
     await page.goto('/?flow=time-off&companyId=123')
     await waitForLoadingComplete(page)
@@ -144,7 +151,8 @@ test.describe('SelectEmployees - Add employees to time-off policy', () => {
   })
 })
 
-test.describe('SelectEmployees - Add employees to holiday pay policy', () => {
+// Same root cause as the time-off describe above — selector mismatch with the actual UI.
+test.describe.skip('SelectEmployees - Add employees to holiday pay policy', () => {
   test('navigates to add holiday employees step', async ({ page, localConfig }) => {
     test.skip(
       !localConfig.isLocal,


### PR DESCRIPTION
## Summary

The two `SelectEmployees` describe blocks in `e2e/tests/time-off.spec.ts` (added in #1617) have been failing on every CI run since they landed. Skipping them with `test.describe.skip` and inline breadcrumbs so CI's e2e jobs go green again, until the SelectEmployees feature owners can rewrite them against the real flow.

## Why the tests fail

The entry selector used in every failing test is:

```ts
const policyLink = page.getByRole('button').filter({ hasText: /vacation|sick|pto/i }).first()
```

But [`PolicyListPresentation.tsx`](src/components/UNSTABLE_TimeOff/PolicyList/PolicyListPresentation.tsx) renders policy names as `<Text>` inside a DataView grid, not buttons. From the failed Playwright snapshot:

```yaml
- row "Vacation":
  - rowheader "Vacation":
    - paragraph: Vacation
  - gridcell "–":
  - gridcell "Finish setup Open menu":
    - button "Finish setup"
    - button "Open menu"
```

The only buttons on each row are `Finish setup` and `Open menu` — neither contains the policy name, so the selector never resolves.

## Why not just rewrite

There is no single-click path from `PolicyList` to `AddEmployeesToPolicy`. Reaching that state requires walking the full Create Policy flow:

```
PolicyList -> PolicyTypeSelector -> PolicyDetailsForm -> [PolicySettings ->] AddEmployees
```

That's a 3–4 step form interaction with i18n-translated labels (e.g., the "vacation" radio is labeled `t('timeOffLabel')` = "Time off") and validation that needs local e2e setup (gws-flows + ZenPayroll) to verify reliably. The e2e-demo job hits a real backend with different data, so a rewrite has to work in two environments.

Rather than push speculative selectors that pass review but break in subtle ways, this PR skips and hands off to the feature owner with breadcrumbs in the test file.

## Bonus finding (separate from this PR)

The Playwright snapshot also showed an alert on the page:

> Response validation failed ┌ 1 issue found: │ • [<root>.errors]: Required (invalid_type) Want: array Got: undefined

That's likely from the `holiday_pay_policy` 404 mock in [`src/test/mocks/apis/time_off_policies.ts`](src/test/mocks/apis/time_off_policies.ts) returning `{ message: 'Not found' }` while the SDK's error schema expects an `errors` array. Worth fixing but tangential — flagging here for visibility.

## Test plan

- [ ] `e2e` job goes green on this PR (passing test + skipped tests, no failures)
- [ ] `e2e-demo` job goes green on this PR
- [ ] All other CI jobs continue to pass
- [ ] Follow-up: SelectEmployees feature owners (cc whoever shipped #1611–#1617) rewrite the skipped tests against the real flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)