### PR TITLE
fix: reduce button padding and min-height to match input height

### DIFF
--- a/src/components/Common/UI/Button/Button.module.scss
+++ b/src/components/Common/UI/Button/Button.module.scss
@@ -14,11 +14,11 @@
     font-size: var(--g-fontSizeSmall);
     font-weight: var(--g-fontWeightSemibold);
     line-height: toRem(24);
-    min-height: toRem(42);
+    min-height: toRem(40);
     text-align: center;
     margin: 0;
     outline: none;
-    padding: toRem(8) toRem(16);
+    padding: toRem(6) toRem(16);
     text-decoration: none;
     text-transform: none;
     cursor: pointer;


### PR DESCRIPTION
## Summary

Reduces button `min-height` from 42px to 40px and vertical `padding` from 8px to 6px so that buttons have the same height as text inputs. When buttons and inputs appear side by side, there is no longer a height difference between them.

## Changes

- Reduced `min-height` from `toRem(42)` to `toRem(40)` in `Button.module.scss`
- Reduced vertical `padding` from `toRem(8)` to `toRem(6)`

## Demo

<!-- Before/after screenshots to be added -->

## Testing

- `npm run storybook` — check Button stories for visual correctness
- Inspect any layout where a Button sits next to a text input and confirm equal height

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)