### PR TITLE
feat: time off policy detail presentational component

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.module.scss
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.module.scss
@@ -1,0 +1,3 @@
+.descriptionCard {
+  max-width: toRem(480);
+}

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.stories.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.stories.tsx
@@ -1,0 +1,417 @@
+import { Suspense, useState } from 'react'
+import { fn } from 'storybook/test'
+import { TimeOffPolicyDetailPresentation } from './TimeOffPolicyDetailPresentation'
+import type {
+  TimeOffPolicyDetailEmployee,
+  PolicyDetails,
+  PolicySettingsDisplay,
+} from './TimeOffPolicyDetailTypes'
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import PlusCircleIcon from '@/assets/icons/plus-circle.svg?react'
+import EditIcon from '@/assets/icons/edit-02.svg?react'
+import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
+
+export default {
+  title: 'Domain/TimeOff/TimeOffPolicyDetail',
+  decorators: [
+    (Story: React.ComponentType) => (
+      <Suspense fallback={<div>Loading translations...</div>}>
+        <Story />
+      </Suspense>
+    ),
+  ],
+}
+
+const mockLimitedPolicyDetails: PolicyDetails = {
+  policyType: 'vacation',
+  accrualMethod: 'perHourWorked',
+  accrualRate: 2.0,
+  accrualRateUnit: 20.0,
+  resetDate: 'January 1',
+}
+
+const mockUnlimitedPolicyDetails: PolicyDetails = {
+  policyType: 'vacation',
+  accrualMethod: 'unlimited',
+}
+
+const mockSickPolicyDetails: PolicyDetails = {
+  policyType: 'sick',
+  accrualMethod: 'perCalendarYear',
+  accrualRate: 40,
+  resetDate: 'January 1',
+}
+
+const mockPolicySettings: PolicySettingsDisplay = {
+  maxAccrualHoursPerYear: null,
+  maxHours: 240,
+  carryoverLimitHours: null,
+  accrualWaitingPeriodDays: null,
+  paidOutOnTermination: true,
+}
+
+const mockEmployees: TimeOffPolicyDetailEmployee[] = [
+  {
+    uuid: '1',
+    firstName: 'Alejandro',
+    lastName: 'Kuhic',
+    jobTitle: 'Marketing Director',
+    balance: 80,
+  },
+  { uuid: '2', firstName: 'Alexander', lastName: 'Hamilton', jobTitle: 'Engineer', balance: 120.5 },
+  { uuid: '3', firstName: 'Arthur', lastName: 'Schopenhauer', jobTitle: 'Engineer', balance: 40 },
+  { uuid: '4', firstName: 'Friedrich', lastName: 'Nietzsche', jobTitle: 'Engineer', balance: 0 },
+  { uuid: '5', firstName: 'Hannah', lastName: 'Arendt', jobTitle: 'Account Manager', balance: 160 },
+  {
+    uuid: '6',
+    firstName: 'Immanuel',
+    lastName: 'Kant',
+    jobTitle: 'Client Support Manager',
+    balance: null,
+  },
+]
+
+const onBack = fn().mockName('onBack')
+const onTabChange = fn().mockName('onTabChange')
+const onDismissAlert = fn().mockName('onDismissAlert')
+const onRemoveConfirm = fn().mockName('onRemoveConfirm')
+const onRemoveClose = fn().mockName('onRemoveClose')
+const onChangeSettings = fn().mockName('onChangeSettings')
+
+function useSearchState() {
+  const [searchValue, setSearchValue] = useState('')
+  return {
+    searchValue,
+    onSearchChange: setSearchValue,
+    onSearchClear: () => {
+      setSearchValue('')
+    },
+  }
+}
+
+function usePolicyActions() {
+  const { Button } = useComponentContext()
+
+  return [
+    <Button key="add" variant="secondary" icon={<PlusCircleIcon aria-hidden />} onClick={fn()}>
+      Add employees
+    </Button>,
+    <Button key="edit" variant="secondary" icon={<EditIcon aria-hidden />} onClick={fn()}>
+      Edit policy
+    </Button>,
+  ]
+}
+
+const closedRemoveDialog = {
+  isOpen: false,
+  employeeName: '',
+  onConfirm: onRemoveConfirm,
+  onClose: onRemoveClose,
+  isPending: false,
+}
+
+function makeItemMenu(employee: TimeOffPolicyDetailEmployee) {
+  return (
+    <HamburgerMenu
+      items={[
+        {
+          label: 'Edit balance',
+          icon: <EditIcon aria-hidden />,
+          onClick: fn().mockName(`edit-balance-${employee.firstName}`),
+        },
+        {
+          label: 'Remove',
+          icon: <TrashCanSvg aria-hidden />,
+          onClick: fn().mockName(`remove-${employee.firstName}`),
+        },
+      ]}
+      triggerLabel={`Actions for ${employee.firstName} ${employee.lastName}`}
+    />
+  )
+}
+
+export const DetailsTabLimited = () => {
+  const [selectedTabId, setSelectedTabId] = useState('details')
+  const search = useSearchState()
+  const actions = usePolicyActions()
+
+  return (
+    <TimeOffPolicyDetailPresentation
+      title="Awesome Time Off Policy"
+      subtitle="Paid time off policy"
+      onBack={onBack}
+      backLabel="Back"
+      actions={actions}
+      policyDetails={mockLimitedPolicyDetails}
+      policySettings={mockPolicySettings}
+      onChangeSettings={onChangeSettings}
+      selectedTabId={selectedTabId}
+      onTabChange={id => {
+        setSelectedTabId(id)
+        onTabChange(id)
+      }}
+      employees={{
+        data: mockEmployees,
+        ...search,
+        itemMenu: makeItemMenu,
+        selectionMode: 'multiple',
+        onSelect: fn().mockName('onSelect'),
+        getIsItemSelected: () => false,
+      }}
+      removeDialog={closedRemoveDialog}
+    />
+  )
+}
+
+export const DetailsTabSick = () => {
+  const [selectedTabId, setSelectedTabId] = useState('details')
+  const search = useSearchState()
+  const actions = usePolicyActions()
+
+  return (
+    <TimeOffPolicyDetailPresentation
+      title="Sick Leave Policy"
+      subtitle="Sick leave"
+      onBack={onBack}
+      backLabel="Back"
+      actions={actions}
+      policyDetails={mockSickPolicyDetails}
+      policySettings={{
+        ...mockPolicySettings,
+        maxAccrualHoursPerYear: 100,
+        accrualWaitingPeriodDays: 30,
+      }}
+      onChangeSettings={onChangeSettings}
+      selectedTabId={selectedTabId}
+      onTabChange={id => {
+        setSelectedTabId(id)
+        onTabChange(id)
+      }}
+      employees={{
+        data: mockEmployees,
+        ...search,
+        itemMenu: makeItemMenu,
+        selectionMode: 'multiple',
+        onSelect: fn().mockName('onSelect'),
+        getIsItemSelected: () => false,
+      }}
+      removeDialog={closedRemoveDialog}
+    />
+  )
+}
+
+export const DetailsTabUnlimited = () => {
+  const [selectedTabId, setSelectedTabId] = useState('details')
+  const search = useSearchState()
+  const actions = usePolicyActions()
+
+  return (
+    <TimeOffPolicyDetailPresentation
+      title="Unlimited PTO"
+      subtitle="Paid time off policy"
+      onBack={onBack}
+      backLabel="Back"
+      actions={actions}
+      policyDetails={mockUnlimitedPolicyDetails}
+      selectedTabId={selectedTabId}
+      onTabChange={id => {
+        setSelectedTabId(id)
+        onTabChange(id)
+      }}
+      employees={{
+        data: mockEmployees,
+        ...search,
+        itemMenu: makeItemMenu,
+        selectionMode: 'multiple',
+        onSelect: fn().mockName('onSelect'),
+        getIsItemSelected: () => false,
+      }}
+      removeDialog={closedRemoveDialog}
+    />
+  )
+}
+
+export const EmployeesTab = () => {
+  const [selectedTabId, setSelectedTabId] = useState('employees')
+  const search = useSearchState()
+  const actions = usePolicyActions()
+
+  return (
+    <TimeOffPolicyDetailPresentation
+      title="Awesome Time Off Policy"
+      subtitle="Paid time off policy"
+      onBack={onBack}
+      backLabel="Back"
+      actions={actions}
+      policyDetails={mockLimitedPolicyDetails}
+      policySettings={mockPolicySettings}
+      onChangeSettings={onChangeSettings}
+      selectedTabId={selectedTabId}
+      onTabChange={id => {
+        setSelectedTabId(id)
+        onTabChange(id)
+      }}
+      employees={{
+        data: mockEmployees,
+        ...search,
+        itemMenu: makeItemMenu,
+        selectionMode: 'multiple',
+        onSelect: fn().mockName('onSelect'),
+        getIsItemSelected: () => false,
+      }}
+      removeDialog={closedRemoveDialog}
+    />
+  )
+}
+
+export const BulkRemoveSelected = () => {
+  const [selectedTabId, setSelectedTabId] = useState('employees')
+  const search = useSearchState()
+  const actions = usePolicyActions()
+
+  return (
+    <TimeOffPolicyDetailPresentation
+      title="Awesome Time Off Policy"
+      subtitle="Paid time off policy"
+      onBack={onBack}
+      backLabel="Back"
+      actions={actions}
+      policyDetails={mockLimitedPolicyDetails}
+      policySettings={mockPolicySettings}
+      onChangeSettings={onChangeSettings}
+      selectedTabId={selectedTabId}
+      onTabChange={id => {
+        setSelectedTabId(id)
+        onTabChange(id)
+      }}
+      employees={{
+        data: mockEmployees,
+        ...search,
+        itemMenu: makeItemMenu,
+        selectionMode: 'multiple',
+        onSelect: fn().mockName('onSelect'),
+        getIsItemSelected: employee => employee.uuid === '1' || employee.uuid === '3',
+        footer: () => ({
+          name: null,
+          jobTitle: null,
+          balance: null,
+        }),
+      }}
+      removeDialog={closedRemoveDialog}
+      bulkRemoveDialog={{
+        isOpen: false,
+        count: 2,
+        onConfirm: fn().mockName('bulkRemoveConfirm'),
+        onClose: fn().mockName('bulkRemoveClose'),
+        isPending: false,
+      }}
+    />
+  )
+}
+
+export const WithSuccessAlert = () => {
+  const [selectedTabId, setSelectedTabId] = useState('employees')
+  const search = useSearchState()
+  const actions = usePolicyActions()
+
+  return (
+    <TimeOffPolicyDetailPresentation
+      title="Awesome Time Off Policy"
+      subtitle="Paid time off policy"
+      onBack={onBack}
+      backLabel="Back"
+      actions={actions}
+      policyDetails={mockLimitedPolicyDetails}
+      policySettings={mockPolicySettings}
+      onChangeSettings={onChangeSettings}
+      selectedTabId={selectedTabId}
+      onTabChange={id => {
+        setSelectedTabId(id)
+        onTabChange(id)
+      }}
+      employees={{
+        data: mockEmployees,
+        ...search,
+        itemMenu: makeItemMenu,
+        selectionMode: 'multiple',
+        onSelect: fn().mockName('onSelect'),
+        getIsItemSelected: () => false,
+      }}
+      removeDialog={closedRemoveDialog}
+      successAlert="Alejandro Kuhic has been removed from the policy."
+      onDismissAlert={onDismissAlert}
+    />
+  )
+}
+
+export const RemoveDialogOpen = () => {
+  const [selectedTabId, setSelectedTabId] = useState('employees')
+  const search = useSearchState()
+  const actions = usePolicyActions()
+
+  return (
+    <TimeOffPolicyDetailPresentation
+      title="Awesome Time Off Policy"
+      subtitle="Paid time off policy"
+      onBack={onBack}
+      backLabel="Back"
+      actions={actions}
+      policyDetails={mockLimitedPolicyDetails}
+      policySettings={mockPolicySettings}
+      onChangeSettings={onChangeSettings}
+      selectedTabId={selectedTabId}
+      onTabChange={id => {
+        setSelectedTabId(id)
+        onTabChange(id)
+      }}
+      employees={{
+        data: mockEmployees,
+        ...search,
+        itemMenu: makeItemMenu,
+        selectionMode: 'multiple',
+        onSelect: fn().mockName('onSelect'),
+        getIsItemSelected: () => false,
+      }}
+      removeDialog={{
+        isOpen: true,
+        employeeName: 'Alejandro Kuhic',
+        onConfirm: onRemoveConfirm,
+        onClose: onRemoveClose,
+        isPending: false,
+      }}
+    />
+  )
+}
+
+export const EmptyEmployees = () => {
+  const [selectedTabId, setSelectedTabId] = useState('employees')
+  const search = useSearchState()
+  const actions = usePolicyActions()
+
+  return (
+    <TimeOffPolicyDetailPresentation
+      title="Awesome Time Off Policy"
+      subtitle="Paid time off policy"
+      onBack={onBack}
+      backLabel="Back"
+      actions={actions}
+      policyDetails={mockLimitedPolicyDetails}
+      policySettings={mockPolicySettings}
+      onChangeSettings={onChangeSettings}
+      selectedTabId={selectedTabId}
+      onTabChange={id => {
+        setSelectedTabId(id)
+        onTabChange(id)
+      }}
+      employees={{
+        data: [],
+        ...search,
+        selectionMode: 'multiple',
+        onSelect: fn().mockName('onSelect'),
+        getIsItemSelected: () => false,
+      }}
+      removeDialog={closedRemoveDialog}
+    />
+  )
+}

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
@@ -1,0 +1,199 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { PolicyDetailLayout } from '../shared/PolicyDetailLayout'
+import type {
+  TimeOffPolicyDetailPresentationProps,
+  TimeOffPolicyDetailEmployee,
+  PolicyDetails,
+  PolicySettingsDisplay,
+} from './TimeOffPolicyDetailTypes'
+import styles from './TimeOffPolicyDetail.module.scss'
+import { Flex } from '@/components/Common'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { useI18n } from '@/i18n'
+
+const DETAILS_TAB_ID = 'details'
+
+export function TimeOffPolicyDetailPresentation({
+  title,
+  subtitle,
+  onBack,
+  backLabel,
+  actions,
+  policyDetails,
+  policySettings,
+  onChangeSettings,
+  selectedTabId,
+  onTabChange,
+  employees,
+  removeDialog,
+  bulkRemoveDialog,
+  successAlert,
+  onDismissAlert,
+}: TimeOffPolicyDetailPresentationProps) {
+  useI18n('Company.TimeOff.TimeOffPolicyDetails')
+  const { t } = useTranslation('Company.TimeOff.TimeOffPolicyDetails')
+
+  const balanceColumn = useMemo(
+    () => [
+      {
+        key: 'balance' as keyof TimeOffPolicyDetailEmployee,
+        title: t('employeeTable.balance'),
+        render: (item: TimeOffPolicyDetailEmployee) => item.balance ?? '-',
+      },
+    ],
+    [t],
+  )
+
+  const detailsTabContent = (
+    <DetailsTab
+      policyDetails={policyDetails}
+      policySettings={policySettings}
+      onChangeSettings={onChangeSettings}
+    />
+  )
+
+  return (
+    <PolicyDetailLayout
+      title={title}
+      subtitle={subtitle}
+      onBack={onBack}
+      backLabel={backLabel}
+      actions={actions}
+      firstTab={{
+        id: DETAILS_TAB_ID,
+        label: t('tabs.policyDetails'),
+        content: detailsTabContent,
+      }}
+      selectedTabId={selectedTabId}
+      onTabChange={onTabChange}
+      employees={{
+        ...employees,
+        additionalColumns: balanceColumn,
+      }}
+      removeDialog={removeDialog}
+      bulkRemoveDialog={bulkRemoveDialog}
+      successAlert={successAlert}
+      onDismissAlert={onDismissAlert}
+    />
+  )
+}
+
+function DetailsTab({
+  policyDetails,
+  policySettings,
+  onChangeSettings,
+}: {
+  policyDetails: PolicyDetails
+  policySettings?: PolicySettingsDisplay
+  onChangeSettings?: () => void
+}) {
+  useI18n('Company.TimeOff.TimeOffPolicyDetails')
+  const { t } = useTranslation('Company.TimeOff.TimeOffPolicyDetails')
+  const { Box, BoxHeader, DescriptionList, Button } = useComponentContext()
+
+  const isUnlimited = policyDetails.accrualMethod === 'unlimited'
+
+  const detailItems = useMemo(() => {
+    const accrualMethodKey = policyDetails.accrualMethod
+    const items = [
+      {
+        term: t('accrualMethod.label'),
+        description: t(`accrualMethod.${accrualMethodKey}`),
+      },
+      {
+        term: t('accrualRate.label'),
+        description: t(`accrualRate.${accrualMethodKey}`, {
+          accrualRate: policyDetails.accrualRate,
+          accrualRateUnit: policyDetails.accrualRateUnit,
+        }),
+      },
+    ]
+
+    if (policyDetails.resetDate) {
+      items.push({
+        term: t('resetDate'),
+        description: policyDetails.resetDate,
+      })
+    }
+
+    return items
+  }, [policyDetails, t])
+
+  const settingsItems = useMemo(() => {
+    if (!policySettings) return []
+
+    return [
+      {
+        term: t('maxAccrualHoursPerYear.label'),
+        description:
+          policySettings.maxAccrualHoursPerYear != null
+            ? t('maxAccrualHoursPerYear.withMaximum', {
+                count: policySettings.maxAccrualHoursPerYear,
+              })
+            : t('maxAccrualHoursPerYear.noMaximum'),
+      },
+      {
+        term: t('maxHours.label'),
+        description:
+          policySettings.maxHours != null
+            ? t('maxHours.withMaximum', { count: policySettings.maxHours })
+            : t('maxHours.noMaximum'),
+      },
+      {
+        term: t('carryoverLimitHours.label'),
+        description:
+          policySettings.carryoverLimitHours != null
+            ? t('carryoverLimitHours.withLimit', { count: policySettings.carryoverLimitHours })
+            : t('carryoverLimitHours.noLimit'),
+      },
+      {
+        term: t('accrualWaitingPeriodDays.label'),
+        description:
+          policySettings.accrualWaitingPeriodDays != null
+            ? t('accrualWaitingPeriodDays.withPeriod', {
+                count: policySettings.accrualWaitingPeriodDays,
+              })
+            : t('accrualWaitingPeriodDays.noPeriod'),
+      },
+      {
+        term: t('paidOutOnTermination.label'),
+        description: policySettings.paidOutOnTermination
+          ? t('paidOutOnTermination.yes')
+          : t('paidOutOnTermination.no'),
+      },
+    ]
+  }, [policySettings, t])
+
+  return (
+    <Flex flexDirection="column" gap={20}>
+      <div className={styles.descriptionCard}>
+        <Box header={<BoxHeader title={t('details')} />} withPadding>
+          <DescriptionList items={detailItems} showSeparators={false} layout="stacked" />
+        </Box>
+      </div>
+
+      {!isUnlimited && policySettings && (
+        <div className={styles.descriptionCard}>
+          <Box
+            header={
+              <BoxHeader
+                title={t('policySettingsTitle')}
+                action={
+                  onChangeSettings && (
+                    <Button variant="secondary" onClick={onChangeSettings}>
+                      {t('changeSettingsCta')}
+                    </Button>
+                  )
+                }
+              />
+            }
+            withPadding
+          >
+            <DescriptionList items={settingsItems} showSeparators={false} layout="stacked" />
+          </Box>
+        </div>
+      )}
+    </Flex>
+  )
+}

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
@@ -95,26 +95,28 @@ function DetailsTab({
   const isUnlimited = policyDetails.accrualMethod === 'unlimited'
 
   const detailItems = useMemo(() => {
-    const accrualMethodKey = policyDetails.accrualMethod
-    const items = [
+    const items: { term: string; description: string }[] = [
       {
         term: t('accrualMethod.label'),
-        description: t(`accrualMethod.${accrualMethodKey}`),
-      },
-      {
-        term: t('accrualRate.label'),
-        description: t(`accrualRate.${accrualMethodKey}`, {
-          accrualRate: policyDetails.accrualRate,
-          accrualRateUnit: policyDetails.accrualRateUnit,
-        }),
+        description: t(`accrualMethod.${policyDetails.accrualMethod}`),
       },
     ]
 
-    if (policyDetails.resetDate) {
+    if (policyDetails.accrualMethod !== 'unlimited') {
       items.push({
-        term: t('resetDate'),
-        description: policyDetails.resetDate,
+        term: t('accrualRate.label'),
+        description: t(`accrualRate.${policyDetails.accrualMethod}`, {
+          accrualRate: policyDetails.accrualRate,
+          accrualRateUnit: policyDetails.accrualRateUnit,
+        }),
       })
+
+      if (policyDetails.resetDate) {
+        items.push({
+          term: t('resetDate'),
+          description: policyDetails.resetDate,
+        })
+      }
     }
 
     return items

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailTypes.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailTypes.ts
@@ -49,16 +49,12 @@ export interface PolicySettingsDisplay {
   paidOutOnTermination: boolean
 }
 
-export interface TimeOffPolicyDetailPresentationProps {
+interface TimeOffPolicyDetailPresentationBaseProps {
   title: string
   subtitle?: string
   onBack: () => void
   backLabel: string
   actions?: ReactNode[]
-
-  policyDetails: PolicyDetails
-  policySettings?: PolicySettingsDisplay
-  onChangeSettings?: () => void
 
   selectedTabId: string
   onTabChange: (id: string) => void
@@ -85,3 +81,17 @@ export interface TimeOffPolicyDetailPresentationProps {
   successAlert?: string
   onDismissAlert?: () => void
 }
+
+export type TimeOffPolicyDetailPresentationProps = TimeOffPolicyDetailPresentationBaseProps &
+  (
+    | {
+        policyDetails: UnlimitedPolicyDetails
+        policySettings?: never
+        onChangeSettings?: never
+      }
+    | {
+        policyDetails: RateBasedPolicyDetails
+        policySettings: PolicySettingsDisplay
+        onChangeSettings?: () => void
+      }
+  )

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailTypes.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailTypes.ts
@@ -8,15 +8,12 @@ import type {
   BulkRemoveDialogState,
 } from '../shared/PolicyDetailLayout/PolicyDetailLayoutTypes'
 
-export type { BulkRemoveDialogState }
-
 export interface TimeOffPolicyDetailEmployee extends EmployeeTableItem {
   uuid: string
   balance: number | null
 }
 
-export type AccrualMethodKey =
-  | 'unlimited'
+export type RateBasedAccrualMethod =
   | 'perPayPeriod'
   | 'perCalendarYear'
   | 'perAnniversaryYear'
@@ -25,15 +22,24 @@ export type AccrualMethodKey =
   | 'perHourPaid'
   | 'perHourPaidNoOvertime'
 
+export type AccrualMethodKey = 'unlimited' | RateBasedAccrualMethod
+
 export type PolicyTypeKey = 'vacation' | 'sick'
 
-export interface PolicyDetails {
+interface UnlimitedPolicyDetails {
   policyType: PolicyTypeKey
-  accrualMethod: AccrualMethodKey
-  accrualRate?: number
+  accrualMethod: 'unlimited'
+}
+
+interface RateBasedPolicyDetails {
+  policyType: PolicyTypeKey
+  accrualMethod: RateBasedAccrualMethod
+  accrualRate: number
   accrualRateUnit?: number
   resetDate?: string
 }
+
+export type PolicyDetails = UnlimitedPolicyDetails | RateBasedPolicyDetails
 
 export interface PolicySettingsDisplay {
   maxAccrualHoursPerYear: number | null

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailTypes.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailTypes.ts
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react'
+import type {
+  EmployeeTableItem,
+  EmployeeTableProps,
+} from '../shared/EmployeeTable/EmployeeTableTypes'
+import type {
+  RemoveDialogState,
+  BulkRemoveDialogState,
+} from '../shared/PolicyDetailLayout/PolicyDetailLayoutTypes'
+
+export type { BulkRemoveDialogState }
+
+export interface TimeOffPolicyDetailEmployee extends EmployeeTableItem {
+  uuid: string
+  balance: number | null
+}
+
+export type AccrualMethodKey =
+  | 'unlimited'
+  | 'perPayPeriod'
+  | 'perCalendarYear'
+  | 'perAnniversaryYear'
+  | 'perHourWorked'
+  | 'perHourWorkedNoOvertime'
+  | 'perHourPaid'
+  | 'perHourPaidNoOvertime'
+
+export type PolicyTypeKey = 'vacation' | 'sick'
+
+export interface PolicyDetails {
+  policyType: PolicyTypeKey
+  accrualMethod: AccrualMethodKey
+  accrualRate?: number
+  accrualRateUnit?: number
+  resetDate?: string
+}
+
+export interface PolicySettingsDisplay {
+  maxAccrualHoursPerYear: number | null
+  maxHours: number | null
+  carryoverLimitHours: number | null
+  accrualWaitingPeriodDays: number | null
+  paidOutOnTermination: boolean
+}
+
+export interface TimeOffPolicyDetailPresentationProps {
+  title: string
+  subtitle?: string
+  onBack: () => void
+  backLabel: string
+  actions?: ReactNode[]
+
+  policyDetails: PolicyDetails
+  policySettings?: PolicySettingsDisplay
+  onChangeSettings?: () => void
+
+  selectedTabId: string
+  onTabChange: (id: string) => void
+
+  employees: Pick<
+    EmployeeTableProps<TimeOffPolicyDetailEmployee>,
+    | 'data'
+    | 'searchValue'
+    | 'onSearchChange'
+    | 'onSearchClear'
+    | 'searchPlaceholder'
+    | 'itemMenu'
+    | 'pagination'
+    | 'isFetching'
+    | 'emptyState'
+    | 'selectionMode'
+    | 'onSelect'
+    | 'getIsItemSelected'
+    | 'footer'
+  >
+
+  removeDialog: RemoveDialogState
+  bulkRemoveDialog?: BulkRemoveDialogState
+  successAlert?: string
+  onDismissAlert?: () => void
+}

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/index.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/index.ts
@@ -1,0 +1,8 @@
+export { TimeOffPolicyDetailPresentation } from './TimeOffPolicyDetailPresentation'
+export type {
+  TimeOffPolicyDetailPresentationProps,
+  TimeOffPolicyDetailEmployee,
+  PolicyDetails,
+  PolicySettingsDisplay,
+  BulkRemoveDialogState,
+} from './TimeOffPolicyDetailTypes'

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/index.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/index.ts
@@ -4,5 +4,4 @@ export type {
   TimeOffPolicyDetailEmployee,
   PolicyDetails,
   PolicySettingsDisplay,
-  BulkRemoveDialogState,
 } from './TimeOffPolicyDetailTypes'

--- a/src/components/UNSTABLE_TimeOff/index.ts
+++ b/src/components/UNSTABLE_TimeOff/index.ts
@@ -26,5 +26,12 @@ export type {
   HolidayPolicyDetailPresentationProps,
   HolidayPolicyDetailEmployee,
 } from './HolidayPolicyDetail'
+export { TimeOffPolicyDetailPresentation } from './TimeOffPolicyDetail'
+export type {
+  TimeOffPolicyDetailPresentationProps,
+  TimeOffPolicyDetailEmployee,
+  PolicyDetails,
+  PolicySettingsDisplay,
+} from './TimeOffPolicyDetail'
 export { TimeOffFlow } from './TimeOffFlow/TimeOffFlow'
 export type { TimeOffFlowProps } from './TimeOffFlow/TimeOffFlowComponents'

--- a/src/components/UNSTABLE_TimeOff/shared/PolicyDetailLayout/PolicyDetailLayout.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/shared/PolicyDetailLayout/PolicyDetailLayout.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from '@testing-library/react'
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { userEvent } from '@testing-library/user-event'
+import type { EmployeeTableItem } from '../EmployeeTable/EmployeeTableTypes'
+import { PolicyDetailLayout } from './PolicyDetailLayout'
+import type { PolicyDetailLayoutProps } from './PolicyDetailLayoutTypes'
+import { ThemeProvider } from '@/contexts/ThemeProvider'
+import { ComponentsProvider } from '@/contexts/ComponentAdapter/ComponentsProvider'
+import { defaultComponents } from '@/contexts/ComponentAdapter/adapters/defaultComponentAdapter'
+import { mockUseContainerBreakpoints } from '@/test/setup'
+
+vi.mock('@/i18n/I18n', () => ({
+  useI18n: vi.fn(),
+}))
+
+interface TestEmployee extends EmployeeTableItem {
+  uuid: string
+}
+
+const testEmployees: TestEmployee[] = [
+  { uuid: '1', firstName: 'Alice', lastName: 'Smith', jobTitle: 'Engineer' },
+  { uuid: '2', firstName: 'Bob', lastName: 'Jones', jobTitle: 'Designer' },
+]
+
+function buildProps(
+  overrides: Partial<PolicyDetailLayoutProps<TestEmployee>> = {},
+): PolicyDetailLayoutProps<TestEmployee> {
+  return {
+    title: 'Test Policy',
+    onBack: vi.fn(),
+    backLabel: 'Back',
+    firstTab: { id: 'details', label: 'Details', content: <div>Details content</div> },
+    selectedTabId: 'details',
+    onTabChange: vi.fn(),
+    employees: {
+      data: testEmployees,
+      searchValue: '',
+      onSearchChange: vi.fn(),
+      onSearchClear: vi.fn(),
+    },
+    removeDialog: {
+      isOpen: false,
+      employeeName: '',
+      onConfirm: vi.fn(),
+      onClose: vi.fn(),
+      isPending: false,
+    },
+    ...overrides,
+  }
+}
+
+function renderLayout(overrides: Partial<PolicyDetailLayoutProps<TestEmployee>> = {}) {
+  return render(
+    <ThemeProvider>
+      <ComponentsProvider value={defaultComponents}>
+        <PolicyDetailLayout<TestEmployee> {...buildProps(overrides)} />
+      </ComponentsProvider>
+    </ThemeProvider>,
+  )
+}
+
+describe('PolicyDetailLayout bulkRemoveDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseContainerBreakpoints.mockReturnValue(['base', 'small', 'medium', 'large'])
+  })
+
+  test('does not render bulk remove dialog when bulkRemoveDialog is undefined', () => {
+    renderLayout()
+
+    expect(screen.queryByText('bulkRemoveDialog.title')).not.toBeInTheDocument()
+  })
+
+  test('does not render bulk remove dialog when isOpen is false', () => {
+    renderLayout({
+      bulkRemoveDialog: {
+        isOpen: false,
+        count: 3,
+        onConfirm: vi.fn(),
+        onClose: vi.fn(),
+        isPending: false,
+      },
+    })
+
+    const dialogs = document.querySelectorAll('dialog')
+    const bulkDialog = Array.from(dialogs).find(d =>
+      d.textContent.includes('bulkRemoveDialog.title'),
+    )
+    expect(bulkDialog).toBeDefined()
+    expect(bulkDialog!.hasAttribute('open')).toBe(false)
+  })
+
+  test('renders bulk remove dialog with correct title and buttons when isOpen is true', () => {
+    renderLayout({
+      bulkRemoveDialog: {
+        isOpen: true,
+        count: 2,
+        onConfirm: vi.fn(),
+        onClose: vi.fn(),
+        isPending: false,
+      },
+    })
+
+    expect(screen.getByText('bulkRemoveDialog.title')).toBeInTheDocument()
+    expect(screen.getByText('bulkRemoveDialog.description')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'bulkRemoveDialog.confirmCta' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'bulkRemoveDialog.cancelCta' })).toBeInTheDocument()
+  })
+
+  test('calls onConfirm when confirm button is clicked', async () => {
+    const onConfirm = vi.fn()
+    renderLayout({
+      bulkRemoveDialog: {
+        isOpen: true,
+        count: 2,
+        onConfirm,
+        onClose: vi.fn(),
+        isPending: false,
+      },
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'bulkRemoveDialog.confirmCta' }))
+
+    expect(onConfirm).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/UNSTABLE_TimeOff/shared/PolicyDetailLayout/PolicyDetailLayout.tsx
+++ b/src/components/UNSTABLE_TimeOff/shared/PolicyDetailLayout/PolicyDetailLayout.tsx
@@ -19,6 +19,7 @@ export function PolicyDetailLayout<T extends EmployeeTableItem>({
   onTabChange,
   employees,
   removeDialog,
+  bulkRemoveDialog,
   successAlert,
   onDismissAlert,
 }: PolicyDetailLayoutProps<T>) {
@@ -48,6 +49,10 @@ export function PolicyDetailLayout<T extends EmployeeTableItem>({
             isFetching={employees.isFetching}
             emptyState={employees.emptyState}
             additionalColumns={employees.additionalColumns}
+            selectionMode={employees.selectionMode}
+            onSelect={employees.onSelect}
+            getIsItemSelected={employees.getIsItemSelected}
+            footer={employees.footer}
           />
         </Box>
       ),
@@ -81,6 +86,21 @@ export function PolicyDetailLayout<T extends EmployeeTableItem>({
       >
         {t('removeEmployeeDialog.description', { name: removeDialog.employeeName })}
       </Dialog>
+
+      {bulkRemoveDialog && (
+        <Dialog
+          isOpen={bulkRemoveDialog.isOpen}
+          onClose={bulkRemoveDialog.onClose}
+          onPrimaryActionClick={bulkRemoveDialog.onConfirm}
+          isPrimaryActionLoading={bulkRemoveDialog.isPending}
+          isDestructive
+          title={t('bulkRemoveDialog.title', { count: bulkRemoveDialog.count })}
+          primaryActionLabel={t('bulkRemoveDialog.confirmCta')}
+          closeActionLabel={t('bulkRemoveDialog.cancelCta')}
+        >
+          {t('bulkRemoveDialog.description')}
+        </Dialog>
+      )}
     </>
   )
 }

--- a/src/components/UNSTABLE_TimeOff/shared/PolicyDetailLayout/PolicyDetailLayoutTypes.ts
+++ b/src/components/UNSTABLE_TimeOff/shared/PolicyDetailLayout/PolicyDetailLayoutTypes.ts
@@ -9,6 +9,14 @@ export interface RemoveDialogState {
   isPending: boolean
 }
 
+export interface BulkRemoveDialogState {
+  isOpen: boolean
+  count: number
+  onConfirm: () => void
+  onClose: () => void
+  isPending: boolean
+}
+
 export interface PolicyDetailLayoutProps<T extends EmployeeTableItem> {
   title: string
   subtitle?: string
@@ -36,9 +44,14 @@ export interface PolicyDetailLayoutProps<T extends EmployeeTableItem> {
     | 'isFetching'
     | 'emptyState'
     | 'additionalColumns'
+    | 'selectionMode'
+    | 'onSelect'
+    | 'getIsItemSelected'
+    | 'footer'
   >
 
   removeDialog: RemoveDialogState
+  bulkRemoveDialog?: BulkRemoveDialogState
   successAlert?: string
   onDismissAlert?: () => void
 }

--- a/src/components/UNSTABLE_TimeOff/shared/PolicyDetailLayout/index.ts
+++ b/src/components/UNSTABLE_TimeOff/shared/PolicyDetailLayout/index.ts
@@ -1,2 +1,6 @@
 export { PolicyDetailLayout } from './PolicyDetailLayout'
-export type { PolicyDetailLayoutProps, RemoveDialogState } from './PolicyDetailLayoutTypes'
+export type {
+  PolicyDetailLayoutProps,
+  RemoveDialogState,
+  BulkRemoveDialogState,
+} from './PolicyDetailLayoutTypes'

--- a/src/i18n/en/Company.TimeOff.PolicyDetail.json
+++ b/src/i18n/en/Company.TimeOff.PolicyDetail.json
@@ -8,5 +8,11 @@
     "description": "Are you sure you want to remove {{name}} from this policy?",
     "confirmCta": "Remove",
     "cancelCta": "Cancel"
+  },
+  "bulkRemoveDialog": {
+    "title": "Remove {{count}} employee(s) from policy?",
+    "description": "When you remove an employee from a policy, any existing balance is removed.",
+    "confirmCta": "Remove employees",
+    "cancelCta": "Cancel"
   }
 }

--- a/src/i18n/en/Company.TimeOff.TimeOffPolicyDetails.json
+++ b/src/i18n/en/Company.TimeOff.TimeOffPolicyDetails.json
@@ -86,11 +86,8 @@
   },
   "editBalanceModal": {
     "title": "Edit {{name}} time off balance",
-    "balanceLabel": "Balance (hrs)",
     "currentBalance": "Current balance",
-    "hoursUnit": "hours",
-    "cancelCta": "Cancel",
-    "updateCta": "Update balance"
+    "hoursUnit": "hours"
   },
   "removeEmployeeModal": {
     "title": "Remove {{name}} from policy?",

--- a/src/i18n/en/Company.TimeOff.TimeOffPolicyDetails.json
+++ b/src/i18n/en/Company.TimeOff.TimeOffPolicyDetails.json
@@ -47,6 +47,7 @@
   },
   "resetDate": "Reset date",
   "policySettingsTitle": "Policy settings",
+  "changeSettingsCta": "Change",
   "maxAccrualHoursPerYear": {
     "label": "Accrual maximum",
     "noMaximum": "No maximum",
@@ -85,8 +86,11 @@
   },
   "editBalanceModal": {
     "title": "Edit {{name}} time off balance",
+    "balanceLabel": "Balance (hrs)",
     "currentBalance": "Current balance",
-    "hoursUnit": "hours"
+    "hoursUnit": "hours",
+    "cancelCta": "Cancel",
+    "updateCta": "Update balance"
   },
   "removeEmployeeModal": {
     "title": "Remove {{name}} from policy?",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -722,11 +722,8 @@ export interface CompanyTimeOffTimeOffPolicyDetails{
 };
 "editBalanceModal":{
 "title":string;
-"balanceLabel":string;
 "currentBalance":string;
 "hoursUnit":string;
-"cancelCta":string;
-"updateCta":string;
 };
 "removeEmployeeModal":{
 "title":string;

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -565,6 +565,12 @@ export interface CompanyTimeOffPolicyDetail{
 "confirmCta":string;
 "cancelCta":string;
 };
+"bulkRemoveDialog":{
+"title":string;
+"description":string;
+"confirmCta":string;
+"cancelCta":string;
+};
 };
 export interface CompanyTimeOffSelectEmployees{
 "title":string;
@@ -677,6 +683,7 @@ export interface CompanyTimeOffTimeOffPolicyDetails{
 };
 "resetDate":string;
 "policySettingsTitle":string;
+"changeSettingsCta":string;
 "maxAccrualHoursPerYear":{
 "label":string;
 "noMaximum":string;
@@ -715,8 +722,11 @@ export interface CompanyTimeOffTimeOffPolicyDetails{
 };
 "editBalanceModal":{
 "title":string;
+"balanceLabel":string;
 "currentBalance":string;
 "hoursUnit":string;
+"cancelCta":string;
+"updateCta":string;
 };
 "removeEmployeeModal":{
 "title":string;


### PR DESCRIPTION
## Problem / Why

Partners need to view and manage time-off policy details within the embedded SDK. Currently the `ViewPolicyDetails` and `ViewPolicyEmployees` components are stubs with no real UI. This PR builds the stateless presentational layer for the consolidated policy detail view, enabling partners to see policy configuration (type, accrual rate, settings) and enrolled employees with balances in a single tabbed component.

SDK-585

## Summary

- Adds stateless `TimeOffPolicyDetailPresentation` component at `UNSTABLE_TimeOff/TimeOffPolicyDetail/`
- Details tab renders policy details (type, rate, reset date) and settings (accrual max, balance max, carry over, waiting period, termination payout) in description list cards
- Employees tab leverages shared `PolicyDetailLayout` with additional Balance column, selection mode, and item menu (edit balance, remove)
- Extends shared `PolicyDetailLayout` to support `selectionMode`, `onSelect`, `getIsItemSelected`, `footer`, and `bulkRemoveDialog`
- Storybook stories for all states: limited/unlimited/sick details, employees tab, bulk remove, success alert, remove dialog, empty employees

## Test plan

- [x] Verify all stories render correctly in Storybook
- [x] Limited policy shows both Details and Settings cards
- [x] Unlimited policy shows only Details card (no Settings)
- [x] Employees tab shows Balance column
- [x] Remove dialog renders with employee name
- [x] Success alert renders and dismisses
- [x] Existing PolicyDetailLayout consumers (HolidayPolicyDetail) remain unaffected
- Automated unit tests with accessibility checks are in the follow-up PR #1658