### PR TITLE
fix: send complete: false when creating non-unlimited time off policies

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationForm.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationForm.test.tsx
@@ -488,6 +488,7 @@ describe('PolicyConfigurationForm', () => {
             accrualMethod: 'per_hour_worked_no_overtime',
             accrualRate: '1',
             accrualRateUnit: '40',
+            complete: false,
           }),
         },
       })
@@ -526,6 +527,7 @@ describe('PolicyConfigurationForm', () => {
             accrualMethod: 'per_hour_paid',
             accrualRate: '2',
             accrualRateUnit: '30',
+            complete: false,
           }),
         },
       })
@@ -562,6 +564,7 @@ describe('PolicyConfigurationForm', () => {
             policyType: 'vacation',
             accrualMethod: 'per_pay_period',
             accrualRate: '120',
+            complete: false,
           }),
         },
       })
@@ -597,6 +600,7 @@ describe('PolicyConfigurationForm', () => {
             accrualMethod: 'per_calendar_year',
             accrualRate: '80',
             policyResetDate: '01-01',
+            complete: false,
           }),
         },
       })
@@ -631,6 +635,7 @@ describe('PolicyConfigurationForm', () => {
           timeOffPolicyRequest: expect.objectContaining({
             accrualMethod: 'per_anniversary_year',
             accrualRate: '60',
+            complete: false,
           }),
         },
       })

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationForm.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationForm.tsx
@@ -78,6 +78,7 @@ function buildCreateRequestBody(
       accrualRate: data.accrualRate != null ? String(data.accrualRate) : undefined,
       accrualRateUnit: data.accrualRateUnit != null ? String(data.accrualRateUnit) : undefined,
       policyResetDate,
+      complete: false,
     }
   }
 
@@ -85,6 +86,7 @@ function buildCreateRequestBody(
     ...base,
     accrualRate: data.accrualRate != null ? String(data.accrualRate) : undefined,
     policyResetDate,
+    complete: false,
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixes 422 error ("Time off type is required") when creating PTO/sick policies with non-unlimited accrual methods
- The backend's V2 time off adapter interprets a missing `complete` field as `true`, triggering immediate policy activation during creation. For non-unlimited policies, creation is just the first step in a multi-step flow (create -> settings -> add employees -> activate), so the policy must not be activated at creation time.
- Adds `complete: false` to the create request body for all non-unlimited accrual methods, matching how gws-flows handles policy creation

## Test plan

- [x] Existing `PolicyConfigurationForm` tests updated to assert `complete: false` is included for hourly and fixed accrual methods
- [x] All 28 tests pass
- [x] Manually verify creating a PTO policy no longer returns the "Time off type is required" 422 error