### PR TITLE
feat(sdk-app): replace entity ID inputs with searchable selects

### DIFF
--- a/sdk-app/src/App.tsx
+++ b/sdk-app/src/App.tsx
@@ -6,6 +6,7 @@ import { Sidebar } from './Sidebar'
 import { DemoSettingsPanel } from './DemoSettingsPanel'
 import { TokenExpiredOverlay } from './TokenExpiredOverlay'
 import { useEntities } from './useEntities'
+import { useEntityCatalog } from './useEntityCatalog'
 import { useDemoManager } from './useDemoManager'
 import { useAppMode } from './useAppMode'
 import { useThemeMode } from './useThemeMode'
@@ -16,6 +17,7 @@ export function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [searchQuery, setSearchQuery] = useState('')
   const { entities, updateEntity, replaceEntities, resetToDefaults } = useEntities()
+  const entityCatalog = useEntityCatalog(entities.companyId)
   const demoManager = useDemoManager()
   const mode = useAppMode()
   const themeMode = useThemeMode()
@@ -77,6 +79,7 @@ export function App() {
           proxyMode={demoManager.proxyMode}
           onCreateNewDemo={handleCreateNewDemo}
           onRefreshToken={demoManager.refreshToken}
+          entityCatalog={entityCatalog}
         />
         {demoManager.tokenStatus === 'expired' && (
           <TokenExpiredOverlay

--- a/sdk-app/src/DemoSettingsPanel.module.scss
+++ b/sdk-app/src/DemoSettingsPanel.module.scss
@@ -170,9 +170,10 @@
 .copyRow {
   display: flex;
   gap: 0.5rem;
-  align-items: stretch;
+  align-items: flex-start;
 
-  input {
+  > input,
+  > .selectWrapper {
     flex: 1;
     min-width: 0;
   }
@@ -187,49 +188,51 @@
   position: relative;
 }
 
-.selectButton {
-  width: 100%;
+.comboboxInputWrapper {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+
+  input {
+    flex: 1;
+    padding-right: 2rem;
+  }
+}
+
+.comboboxChevron {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 2rem;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.5rem 0.625rem;
-  border: 0.0625rem solid var(--color-border);
-  border-radius: 0.375rem;
-  background: var(--color-bg);
-  color: var(--color-text);
-  font-size: 0.8125rem;
+  justify-content: center;
+  background: transparent;
+  border: none;
   cursor: pointer;
-  text-align: left;
-
-  &:focus {
-    outline: none;
-    border-color: var(--color-active);
-    box-shadow: 0 0 0 0.125rem var(--color-focus-ring);
-  }
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-}
-
-.selectButtonContent {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  flex: 1;
-}
-
-.selectPlaceholder {
-  color: var(--color-text-muted);
-  flex: 1;
-}
-
-.selectChevron {
   color: var(--color-text-muted);
   font-size: 0.75rem;
-  flex-shrink: 0;
+  padding: 0;
+}
+
+.helperLine {
+  margin-top: 0.25rem;
+  font-size: 0.6875rem;
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.helperLineHidden {
+  visibility: hidden;
+}
+
+.selectStatus {
+  padding: 0.5rem 0.625rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
 }
 
 .selectMenu {

--- a/sdk-app/src/DemoSettingsPanel.module.scss
+++ b/sdk-app/src/DemoSettingsPanel.module.scss
@@ -166,3 +166,124 @@
   gap: 0.5rem;
   margin-top: 0.5rem;
 }
+
+.copyRow {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+
+  input {
+    flex: 1;
+    min-width: 0;
+  }
+}
+
+.readOnly {
+  background: var(--color-badge-bg);
+  cursor: default;
+}
+
+.selectWrapper {
+  position: relative;
+}
+
+.selectButton {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
+  border: 0.0625rem solid var(--color-border);
+  border-radius: 0.375rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  text-align: left;
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-active);
+    box-shadow: 0 0 0 0.125rem var(--color-focus-ring);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.selectButtonContent {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.selectPlaceholder {
+  color: var(--color-text-muted);
+  flex: 1;
+}
+
+.selectChevron {
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.selectMenu {
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  right: 0;
+  z-index: 10;
+  margin: 0;
+  padding: 0.25rem;
+  list-style: none;
+  background: var(--color-bg);
+  border: 0.0625rem solid var(--color-border);
+  border-radius: 0.375rem;
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.12);
+  max-height: 16rem;
+  overflow-y: auto;
+}
+
+.selectOption {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 0.5rem 0.625rem;
+  background: transparent;
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  text-align: left;
+  color: var(--color-text);
+
+  &:hover {
+    background: var(--color-hover-bg);
+  }
+}
+
+.selectOptionActive {
+  background: var(--color-hover-bg);
+}
+
+.optionPrimary {
+  font-size: 0.8125rem;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.optionSecondary {
+  font-size: 0.6875rem;
+  font-family: monospace;
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/sdk-app/src/DemoSettingsPanel.tsx
+++ b/sdk-app/src/DemoSettingsPanel.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react'
 import type { EntityIds } from './useEntities'
 import type { TokenStatus } from './useDemoManager'
+import type { EntityCatalog } from './useEntityCatalog'
+import type { EntityOption } from './entityFormatters'
 import styles from './DemoSettingsPanel.module.scss'
 
 interface DemoSettingsPanelProps {
@@ -15,6 +17,7 @@ interface DemoSettingsPanelProps {
   proxyMode: string
   onCreateNewDemo: (demoType: string) => Promise<unknown>
   onRefreshToken: () => Promise<unknown>
+  entityCatalog: EntityCatalog
 }
 
 const TEXT_FIELDS: { key: keyof EntityIds; label: string }[] = [
@@ -22,94 +25,85 @@ const TEXT_FIELDS: { key: keyof EntityIds; label: string }[] = [
   { key: 'formId', label: 'Form ID' },
 ]
 
-interface EntityOption {
-  value: string
-  primary: string
-  secondary: string
-}
-
-interface EntityLists {
-  employees: EntityOption[]
-  contractors: EntityOption[]
-  payrolls: EntityOption[]
-}
-
-interface RawEmployee {
-  uuid?: string
-  first_name?: string | null
-  last_name?: string | null
-}
-
-interface RawContractor {
-  uuid?: string
-  type?: string
-  first_name?: string | null
-  last_name?: string | null
-  business_name?: string | null
-}
-
-interface RawPayroll {
-  uuid?: string
-  payroll_uuid?: string
-  check_date?: string
-  pay_period?: { start_date?: string; end_date?: string }
-}
-
-function formatPayPeriod(payroll: RawPayroll): string {
-  const start = payroll.pay_period?.start_date
-  const end = payroll.pay_period?.end_date
-  if (start && end) return `${start} – ${end}`
-  if (payroll.check_date) return `Check date ${payroll.check_date}`
-  return 'Payroll'
-}
-
-function formatContractor(contractor: RawContractor): string {
-  if (contractor.type === 'Business') {
-    return contractor.business_name || 'Business contractor'
-  }
-  const name = [contractor.first_name, contractor.last_name].filter(Boolean).join(' ').trim()
-  return name || 'Contractor'
-}
-
-function formatEmployee(employee: RawEmployee): string {
-  const name = [employee.first_name, employee.last_name].filter(Boolean).join(' ').trim()
-  return name || 'Employee'
-}
-
-async function fetchList<T>(path: string): Promise<T[]> {
-  try {
-    const res = await fetch(path)
-    if (!res.ok) return []
-    const data = (await res.json()) as unknown
-    return Array.isArray(data) ? (data as T[]) : []
-  } catch {
-    return []
-  }
-}
-
-interface EntitySelectProps {
+interface EntityComboboxProps {
   label: string
   value: string
   options: EntityOption[]
   isLoading: boolean
   placeholder: string
-  fallbackPlaceholder: string
   useFallback: boolean
   onChange: (value: string) => void
+  trailing?: ReactNode
 }
 
-function EntitySelect({
+function filterOptions(options: EntityOption[], query: string): EntityOption[] {
+  const trimmed = query.trim().toLowerCase()
+  if (!trimmed) return options
+  return options.filter(
+    option =>
+      option.primary.toLowerCase().includes(trimmed) ||
+      option.secondary.toLowerCase().includes(trimmed),
+  )
+}
+
+interface CopyIdButtonProps {
+  value: string
+  ariaLabel: string
+}
+
+function CopyIdButton({ value, ariaLabel }: CopyIdButtonProps) {
+  const [status, setStatus] = useState<'idle' | 'copied'>('idle')
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    },
+    [],
+  )
+
+  const handleClick = useCallback(async () => {
+    if (!value) return
+    try {
+      await navigator.clipboard.writeText(value)
+      setStatus('copied')
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => {
+        setStatus('idle')
+      }, 1500)
+    } catch {
+      // Clipboard unavailable
+    }
+  }, [value])
+
+  return (
+    <button
+      type="button"
+      className={styles.btn}
+      onClick={handleClick}
+      disabled={!value}
+      aria-label={ariaLabel}
+    >
+      {status === 'copied' ? 'Copied' : 'Copy ID'}
+    </button>
+  )
+}
+
+function EntityCombobox({
   label,
   value,
   options,
   isLoading,
   placeholder,
-  fallbackPlaceholder,
   useFallback,
   onChange,
-}: EntitySelectProps) {
+  trailing,
+}: EntityComboboxProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const [query, setQuery] = useState('')
   const wrapperRef = useRef<HTMLDivElement | null>(null)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const inputId = `entity-${label.toLowerCase().replace(/\s+/g, '-')}-input`
 
   useEffect(() => {
     if (!isOpen) return
@@ -119,7 +113,10 @@ function EntitySelect({
       }
     }
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsOpen(false)
+      if (e.key === 'Escape') {
+        setIsOpen(false)
+        inputRef.current?.blur()
+      }
     }
     document.addEventListener('mousedown', handleClick)
     document.addEventListener('keydown', handleKey)
@@ -129,78 +126,134 @@ function EntitySelect({
     }
   }, [isOpen])
 
+  const matched = useMemo(() => options.find(option => option.value === value), [options, value])
+  const filtered = useMemo(() => filterOptions(options, query), [options, query])
+
   if (useFallback) {
     return (
       <div className={styles.field}>
-        <label>{label}</label>
-        <input
-          type="text"
-          value={value}
-          onChange={e => {
-            onChange(e.target.value)
-          }}
-          placeholder={fallbackPlaceholder}
-        />
+        <label htmlFor={inputId}>{label}</label>
+        <div className={styles.copyRow}>
+          <input
+            id={inputId}
+            type="text"
+            value={value}
+            onChange={e => {
+              onChange(e.target.value)
+            }}
+            placeholder={placeholder}
+          />
+          {trailing}
+        </div>
       </div>
     )
   }
 
-  const selected = options.find(option => option.value === value)
-  const hasOptions = options.length > 0
+  const handleInputChange = (next: string) => {
+    setQuery(next)
+    onChange(next)
+    if (!isOpen) setIsOpen(true)
+  }
+
+  const handleSelect = (option: EntityOption) => {
+    onChange(option.value)
+    setQuery('')
+    setIsOpen(false)
+    inputRef.current?.blur()
+  }
 
   return (
     <div className={styles.field}>
-      <label id={`${label}-label`}>{label}</label>
-      <div className={styles.selectWrapper} ref={wrapperRef}>
-        <button
-          type="button"
-          className={styles.selectButton}
-          onClick={() => {
-            setIsOpen(open => !open)
-          }}
-          disabled={isLoading || !hasOptions}
-          aria-haspopup="listbox"
-          aria-expanded={isOpen}
-          aria-labelledby={`${label}-label`}
-        >
-          {selected ? (
-            <span className={styles.selectButtonContent}>
-              <span className={styles.optionPrimary}>{selected.primary}</span>
-              <span className={styles.optionSecondary}>{selected.secondary}</span>
-            </span>
-          ) : (
-            <span className={styles.selectPlaceholder}>
-              {isLoading ? 'Loading...' : hasOptions ? placeholder : 'No options available'}
-            </span>
-          )}
-          <span className={styles.selectChevron} aria-hidden="true">
-            ▾
-          </span>
-        </button>
+      <label htmlFor={inputId}>{label}</label>
+      <div className={styles.copyRow}>
+        <div className={styles.selectWrapper} ref={wrapperRef}>
+          <div className={styles.comboboxInputWrapper}>
+            <input
+              id={inputId}
+              ref={inputRef}
+              type="text"
+              value={isOpen ? query : value}
+              placeholder={value ? '' : placeholder}
+              onFocus={() => {
+                setQuery('')
+              }}
+              onMouseDown={() => {
+                setIsOpen(open => !open)
+              }}
+              onChange={e => {
+                handleInputChange(e.target.value)
+              }}
+              role="combobox"
+              aria-expanded={isOpen}
+              aria-controls={`${inputId}-listbox`}
+              aria-autocomplete="list"
+              autoComplete="off"
+              spellCheck={false}
+              data-1p-ignore="true"
+              data-lpignore="true"
+            />
+            <button
+              type="button"
+              className={styles.comboboxChevron}
+              tabIndex={-1}
+              aria-label={isOpen ? 'Close options' : 'Open options'}
+              onClick={() => {
+                setIsOpen(open => !open)
+                if (!isOpen) inputRef.current?.focus()
+              }}
+            >
+              ▾
+            </button>
+          </div>
 
-        {isOpen && hasOptions && (
-          <ul className={styles.selectMenu} role="listbox" aria-labelledby={`${label}-label`}>
-            {options.map(option => {
-              const isSelected = option.value === value
-              return (
-                <li key={option.value} role="option" aria-selected={isSelected}>
-                  <button
-                    type="button"
-                    className={`${styles.selectOption} ${isSelected ? styles.selectOptionActive : ''}`}
-                    onClick={() => {
-                      onChange(option.value)
-                      setIsOpen(false)
-                    }}
-                  >
-                    <span className={styles.optionPrimary}>{option.primary}</span>
-                    <span className={styles.optionSecondary}>{option.secondary}</span>
-                  </button>
+          {isOpen && (
+            <ul
+              id={`${inputId}-listbox`}
+              className={styles.selectMenu}
+              role="listbox"
+              aria-label={label}
+            >
+              {isLoading && options.length === 0 ? (
+                <li className={styles.selectStatus}>Loading…</li>
+              ) : filtered.length === 0 ? (
+                <li className={styles.selectStatus}>
+                  {options.length === 0 ? 'No options available' : 'No matches'}
                 </li>
-              )
-            })}
-          </ul>
-        )}
+              ) : (
+                filtered.map(option => {
+                  const isSelected = option.value === value
+                  return (
+                    <li key={option.value} role="option" aria-selected={isSelected}>
+                      <button
+                        type="button"
+                        className={`${styles.selectOption} ${isSelected ? styles.selectOptionActive : ''}`}
+                        onMouseDown={e => {
+                          e.preventDefault()
+                        }}
+                        onClick={() => {
+                          handleSelect(option)
+                        }}
+                      >
+                        <span className={styles.optionPrimary}>{option.primary}</span>
+                        <span className={styles.optionSecondary}>{option.secondary}</span>
+                      </button>
+                    </li>
+                  )
+                })
+              )}
+            </ul>
+          )}
+        </div>
+        {trailing}
       </div>
+      {matched && (
+        <div
+          className={`${styles.helperLine} ${isOpen ? styles.helperLineHidden : ''}`}
+          aria-hidden={isOpen}
+        >
+          {matched.primary}
+        </div>
+      )}
     </div>
   )
 }
@@ -217,17 +270,11 @@ export function DemoSettingsPanel({
   proxyMode,
   onCreateNewDemo,
   onRefreshToken,
+  entityCatalog,
 }: DemoSettingsPanelProps) {
   const currentDemoType = import.meta.env.VITE_DEMO_TYPE || 'react_sdk_demo_company_onboarded'
   const [selectedDemoType, setSelectedDemoType] = useState(currentDemoType)
   const confirmedSnapshot = useRef(entities)
-  const [lists, setLists] = useState<EntityLists>({
-    employees: [],
-    contractors: [],
-    payrolls: [],
-  })
-  const [listsLoading, setListsLoading] = useState(false)
-  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied'>('idle')
 
   useEffect(() => {
     if (!isOpen) {
@@ -240,76 +287,12 @@ export function DemoSettingsPanel({
   const mode = typeof __SDK_APP_PROXY_MODE__ !== 'undefined' ? __SDK_APP_PROXY_MODE__ : proxyMode
 
   const isFlowTokenMode = mode === 'flow-token'
-  const companyId = entities.companyId
-
-  useEffect(() => {
-    if (!isOpen || !isFlowTokenMode || !companyId) return
-
-    let cancelled = false
-    const load = async () => {
-      setListsLoading(true)
-      const base = `/api/v1/companies/${companyId}`
-      const [employees, contractors, payrolls] = await Promise.all([
-        fetchList<RawEmployee>(`${base}/employees`),
-        fetchList<RawContractor>(`${base}/contractors`),
-        fetchList<RawPayroll>(`${base}/payrolls`),
-      ])
-
-      if (cancelled) return
-
-      setLists({
-        employees: employees
-          .filter(e => !!e.uuid)
-          .map(e => ({
-            value: e.uuid as string,
-            primary: formatEmployee(e),
-            secondary: e.uuid as string,
-          })),
-        contractors: contractors
-          .filter(c => !!c.uuid)
-          .map(c => ({
-            value: c.uuid as string,
-            primary: formatContractor(c),
-            secondary: c.uuid as string,
-          })),
-        payrolls: payrolls
-          .filter(p => !!(p.payroll_uuid || p.uuid))
-          .map(p => {
-            const id = (p.payroll_uuid || p.uuid) as string
-            return {
-              value: id,
-              primary: formatPayPeriod(p),
-              secondary: id,
-            }
-          }),
-      })
-      setListsLoading(false)
-    }
-
-    void load()
-    return () => {
-      cancelled = true
-    }
-  }, [isOpen, isFlowTokenMode, companyId])
 
   const hasChanges =
     entities.employeeId !== confirmedSnapshot.current.employeeId ||
     entities.contractorId !== confirmedSnapshot.current.contractorId ||
     entities.payrollId !== confirmedSnapshot.current.payrollId ||
     TEXT_FIELDS.some(({ key }) => entities[key] !== confirmedSnapshot.current[key])
-
-  const handleCopyCompanyId = useCallback(async () => {
-    if (!companyId) return
-    try {
-      await navigator.clipboard.writeText(companyId)
-      setCopyStatus('copied')
-      setTimeout(() => {
-        setCopyStatus('idle')
-      }, 1500)
-    } catch {
-      // Clipboard unavailable
-    }
-  }, [companyId])
 
   if (!isOpen) return null
 
@@ -410,69 +393,69 @@ export function DemoSettingsPanel({
                 readOnly
                 className={styles.readOnly}
               />
-              <button
-                className={styles.btn}
-                onClick={handleCopyCompanyId}
-                disabled={!entities.companyId}
-                type="button"
-              >
-                {copyStatus === 'copied' ? 'Copied' : 'Copy'}
-              </button>
+              <CopyIdButton value={entities.companyId} ariaLabel="Copy company ID" />
             </div>
           </div>
 
-          <EntitySelect
+          <EntityCombobox
             label="Employee"
             value={entities.employeeId}
-            options={lists.employees}
-            isLoading={listsLoading}
-            placeholder="Select an employee..."
-            fallbackPlaceholder="Enter employee id..."
+            options={entityCatalog.employees}
+            isLoading={entityCatalog.isLoading}
+            placeholder="Search or paste an employee id..."
             useFallback={!isFlowTokenMode}
             onChange={value => {
               onUpdateEntity('employeeId', value)
             }}
+            trailing={<CopyIdButton value={entities.employeeId} ariaLabel="Copy employee ID" />}
           />
 
-          <EntitySelect
+          <EntityCombobox
             label="Contractor"
             value={entities.contractorId}
-            options={lists.contractors}
-            isLoading={listsLoading}
-            placeholder="Select a contractor..."
-            fallbackPlaceholder="Enter contractor id..."
+            options={entityCatalog.contractors}
+            isLoading={entityCatalog.isLoading}
+            placeholder="Search or paste a contractor id..."
             useFallback={!isFlowTokenMode}
             onChange={value => {
               onUpdateEntity('contractorId', value)
             }}
+            trailing={<CopyIdButton value={entities.contractorId} ariaLabel="Copy contractor ID" />}
           />
 
-          <EntitySelect
+          <EntityCombobox
             label="Payroll"
             value={entities.payrollId}
-            options={lists.payrolls}
-            isLoading={listsLoading}
-            placeholder="Select a payroll..."
-            fallbackPlaceholder="Enter payroll id..."
+            options={entityCatalog.payrolls}
+            isLoading={entityCatalog.isLoading}
+            placeholder="Search or paste a payroll id..."
             useFallback={!isFlowTokenMode}
             onChange={value => {
               onUpdateEntity('payrollId', value)
             }}
+            trailing={<CopyIdButton value={entities.payrollId} ariaLabel="Copy payroll ID" />}
           />
 
-          {TEXT_FIELDS.map(({ key, label }) => (
-            <div key={key} className={styles.field}>
-              <label>{label}</label>
-              <input
-                type="text"
-                value={entities[key]}
-                onChange={e => {
-                  onUpdateEntity(key, e.target.value)
-                }}
-                placeholder={`Enter ${label.toLowerCase()}...`}
-              />
-            </div>
-          ))}
+          {TEXT_FIELDS.map(({ key, label }) => {
+            const inputId = `entity-${key}-input`
+            return (
+              <div key={key} className={styles.field}>
+                <label htmlFor={inputId}>{label}</label>
+                <div className={styles.copyRow}>
+                  <input
+                    id={inputId}
+                    type="text"
+                    value={entities[key]}
+                    onChange={e => {
+                      onUpdateEntity(key, e.target.value)
+                    }}
+                    placeholder={`Enter ${label.toLowerCase()}...`}
+                  />
+                  <CopyIdButton value={entities[key]} ariaLabel={`Copy ${label.toLowerCase()}`} />
+                </div>
+              </div>
+            )
+          })}
 
           <div className={styles.actions}>
             {hasChanges && (

--- a/sdk-app/src/DemoSettingsPanel.tsx
+++ b/sdk-app/src/DemoSettingsPanel.tsx
@@ -1,4 +1,12 @@
-import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react'
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+} from 'react'
 import type { EntityIds } from './useEntities'
 import type { TokenStatus } from './useDemoManager'
 import type { EntityCatalog } from './useEntityCatalog'
@@ -101,9 +109,12 @@ function EntityCombobox({
 }: EntityComboboxProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [query, setQuery] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
+  const optionRefs = useRef<Array<HTMLLIElement | null>>([])
   const inputId = `entity-${label.toLowerCase().replace(/\s+/g, '-')}-input`
+  const optionId = (index: number) => `${inputId}-option-${index}`
 
   useEffect(() => {
     if (!isOpen) return
@@ -129,6 +140,24 @@ function EntityCombobox({
   const matched = useMemo(() => options.find(option => option.value === value), [options, value])
   const filtered = useMemo(() => filterOptions(options, query), [options, query])
 
+  useEffect(() => {
+    if (!isOpen) return
+    const selectedIdx = filtered.findIndex(option => option.value === value)
+    setActiveIndex(selectedIdx >= 0 ? selectedIdx : 0)
+  }, [isOpen]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    setActiveIndex(idx => {
+      if (filtered.length === 0) return 0
+      return Math.min(Math.max(idx, 0), filtered.length - 1)
+    })
+  }, [filtered.length])
+
+  useEffect(() => {
+    if (!isOpen) return
+    optionRefs.current[activeIndex]?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex, isOpen])
+
   if (useFallback) {
     return (
       <div className={styles.field}>
@@ -152,6 +181,7 @@ function EntityCombobox({
   const handleInputChange = (next: string) => {
     setQuery(next)
     onChange(next)
+    setActiveIndex(0)
     if (!isOpen) setIsOpen(true)
   }
 
@@ -160,6 +190,37 @@ function EntityCombobox({
     setQuery('')
     setIsOpen(false)
     inputRef.current?.blur()
+  }
+
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      if (!isOpen) {
+        setIsOpen(true)
+        return
+      }
+      if (filtered.length === 0) return
+      setActiveIndex(idx => (idx + 1) % filtered.length)
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      if (!isOpen) {
+        setIsOpen(true)
+        return
+      }
+      if (filtered.length === 0) return
+      setActiveIndex(idx => (idx - 1 + filtered.length) % filtered.length)
+    } else if (e.key === 'Enter') {
+      if (isOpen && filtered[activeIndex]) {
+        e.preventDefault()
+        handleSelect(filtered[activeIndex])
+      }
+    } else if (e.key === 'Home' && isOpen) {
+      e.preventDefault()
+      setActiveIndex(0)
+    } else if (e.key === 'End' && isOpen) {
+      e.preventDefault()
+      setActiveIndex(Math.max(filtered.length - 1, 0))
+    }
   }
 
   return (
@@ -183,9 +244,13 @@ function EntityCombobox({
               onChange={e => {
                 handleInputChange(e.target.value)
               }}
+              onKeyDown={handleKeyDown}
               role="combobox"
               aria-expanded={isOpen}
               aria-controls={`${inputId}-listbox`}
+              aria-activedescendant={
+                isOpen && filtered[activeIndex] ? optionId(activeIndex) : undefined
+              }
               aria-autocomplete="list"
               autoComplete="off"
               spellCheck={false}
@@ -220,15 +285,27 @@ function EntityCombobox({
                   {options.length === 0 ? 'No options available' : 'No matches'}
                 </li>
               ) : (
-                filtered.map(option => {
+                filtered.map((option, index) => {
                   const isSelected = option.value === value
+                  const isActive = index === activeIndex
                   return (
-                    <li key={option.value} role="option" aria-selected={isSelected}>
+                    <li
+                      key={option.value}
+                      id={optionId(index)}
+                      ref={el => {
+                        optionRefs.current[index] = el
+                      }}
+                      role="option"
+                      aria-selected={isSelected}
+                    >
                       <button
                         type="button"
-                        className={`${styles.selectOption} ${isSelected ? styles.selectOptionActive : ''}`}
+                        className={`${styles.selectOption} ${isActive ? styles.selectOptionActive : ''}`}
                         onMouseDown={e => {
                           e.preventDefault()
+                        }}
+                        onMouseEnter={() => {
+                          setActiveIndex(index)
                         }}
                         onClick={() => {
                           handleSelect(option)

--- a/sdk-app/src/DemoSettingsPanel.tsx
+++ b/sdk-app/src/DemoSettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import type { EntityIds } from './useEntities'
 import type { TokenStatus } from './useDemoManager'
 import styles from './DemoSettingsPanel.module.scss'
@@ -17,14 +17,193 @@ interface DemoSettingsPanelProps {
   onRefreshToken: () => Promise<unknown>
 }
 
-const ENTITY_FIELDS: { key: keyof EntityIds; label: string }[] = [
-  { key: 'companyId', label: 'Company ID' },
-  { key: 'employeeId', label: 'Employee ID' },
-  { key: 'contractorId', label: 'Contractor ID' },
-  { key: 'payrollId', label: 'Payroll ID' },
+const TEXT_FIELDS: { key: keyof EntityIds; label: string }[] = [
   { key: 'requestId', label: 'Request ID' },
   { key: 'formId', label: 'Form ID' },
 ]
+
+interface EntityOption {
+  value: string
+  primary: string
+  secondary: string
+}
+
+interface EntityLists {
+  employees: EntityOption[]
+  contractors: EntityOption[]
+  payrolls: EntityOption[]
+}
+
+interface RawEmployee {
+  uuid?: string
+  first_name?: string | null
+  last_name?: string | null
+}
+
+interface RawContractor {
+  uuid?: string
+  type?: string
+  first_name?: string | null
+  last_name?: string | null
+  business_name?: string | null
+}
+
+interface RawPayroll {
+  uuid?: string
+  payroll_uuid?: string
+  check_date?: string
+  pay_period?: { start_date?: string; end_date?: string }
+}
+
+function formatPayPeriod(payroll: RawPayroll): string {
+  const start = payroll.pay_period?.start_date
+  const end = payroll.pay_period?.end_date
+  if (start && end) return `${start} – ${end}`
+  if (payroll.check_date) return `Check date ${payroll.check_date}`
+  return 'Payroll'
+}
+
+function formatContractor(contractor: RawContractor): string {
+  if (contractor.type === 'Business') {
+    return contractor.business_name || 'Business contractor'
+  }
+  const name = [contractor.first_name, contractor.last_name].filter(Boolean).join(' ').trim()
+  return name || 'Contractor'
+}
+
+function formatEmployee(employee: RawEmployee): string {
+  const name = [employee.first_name, employee.last_name].filter(Boolean).join(' ').trim()
+  return name || 'Employee'
+}
+
+async function fetchList<T>(path: string): Promise<T[]> {
+  try {
+    const res = await fetch(path)
+    if (!res.ok) return []
+    const data = (await res.json()) as unknown
+    return Array.isArray(data) ? (data as T[]) : []
+  } catch {
+    return []
+  }
+}
+
+interface EntitySelectProps {
+  label: string
+  value: string
+  options: EntityOption[]
+  isLoading: boolean
+  placeholder: string
+  fallbackPlaceholder: string
+  useFallback: boolean
+  onChange: (value: string) => void
+}
+
+function EntitySelect({
+  label,
+  value,
+  options,
+  isLoading,
+  placeholder,
+  fallbackPlaceholder,
+  useFallback,
+  onChange,
+}: EntitySelectProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleClick = (e: MouseEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [isOpen])
+
+  if (useFallback) {
+    return (
+      <div className={styles.field}>
+        <label>{label}</label>
+        <input
+          type="text"
+          value={value}
+          onChange={e => {
+            onChange(e.target.value)
+          }}
+          placeholder={fallbackPlaceholder}
+        />
+      </div>
+    )
+  }
+
+  const selected = options.find(option => option.value === value)
+  const hasOptions = options.length > 0
+
+  return (
+    <div className={styles.field}>
+      <label id={`${label}-label`}>{label}</label>
+      <div className={styles.selectWrapper} ref={wrapperRef}>
+        <button
+          type="button"
+          className={styles.selectButton}
+          onClick={() => {
+            setIsOpen(open => !open)
+          }}
+          disabled={isLoading || !hasOptions}
+          aria-haspopup="listbox"
+          aria-expanded={isOpen}
+          aria-labelledby={`${label}-label`}
+        >
+          {selected ? (
+            <span className={styles.selectButtonContent}>
+              <span className={styles.optionPrimary}>{selected.primary}</span>
+              <span className={styles.optionSecondary}>{selected.secondary}</span>
+            </span>
+          ) : (
+            <span className={styles.selectPlaceholder}>
+              {isLoading ? 'Loading...' : hasOptions ? placeholder : 'No options available'}
+            </span>
+          )}
+          <span className={styles.selectChevron} aria-hidden="true">
+            ▾
+          </span>
+        </button>
+
+        {isOpen && hasOptions && (
+          <ul className={styles.selectMenu} role="listbox" aria-labelledby={`${label}-label`}>
+            {options.map(option => {
+              const isSelected = option.value === value
+              return (
+                <li key={option.value} role="option" aria-selected={isSelected}>
+                  <button
+                    type="button"
+                    className={`${styles.selectOption} ${isSelected ? styles.selectOptionActive : ''}`}
+                    onClick={() => {
+                      onChange(option.value)
+                      setIsOpen(false)
+                    }}
+                  >
+                    <span className={styles.optionPrimary}>{option.primary}</span>
+                    <span className={styles.optionSecondary}>{option.secondary}</span>
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
 
 export function DemoSettingsPanel({
   isOpen,
@@ -42,6 +221,13 @@ export function DemoSettingsPanel({
   const currentDemoType = import.meta.env.VITE_DEMO_TYPE || 'react_sdk_demo_company_onboarded'
   const [selectedDemoType, setSelectedDemoType] = useState(currentDemoType)
   const confirmedSnapshot = useRef(entities)
+  const [lists, setLists] = useState<EntityLists>({
+    employees: [],
+    contractors: [],
+    payrolls: [],
+  })
+  const [listsLoading, setListsLoading] = useState(false)
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied'>('idle')
 
   useEffect(() => {
     if (!isOpen) {
@@ -49,17 +235,84 @@ export function DemoSettingsPanel({
     }
   }, [isOpen, entities])
 
-  const hasChanges = ENTITY_FIELDS.some(
-    ({ key }) => entities[key] !== confirmedSnapshot.current[key],
-  )
-
   const env = typeof __SDK_APP_ENV__ !== 'undefined' ? __SDK_APP_ENV__ : 'demo'
   const build = typeof __SDK_APP_BUILD__ !== 'undefined' ? __SDK_APP_BUILD__ : 'dev'
   const mode = typeof __SDK_APP_PROXY_MODE__ !== 'undefined' ? __SDK_APP_PROXY_MODE__ : proxyMode
 
+  const isFlowTokenMode = mode === 'flow-token'
+  const companyId = entities.companyId
+
+  useEffect(() => {
+    if (!isOpen || !isFlowTokenMode || !companyId) return
+
+    let cancelled = false
+    const load = async () => {
+      setListsLoading(true)
+      const base = `/api/v1/companies/${companyId}`
+      const [employees, contractors, payrolls] = await Promise.all([
+        fetchList<RawEmployee>(`${base}/employees`),
+        fetchList<RawContractor>(`${base}/contractors`),
+        fetchList<RawPayroll>(`${base}/payrolls`),
+      ])
+
+      if (cancelled) return
+
+      setLists({
+        employees: employees
+          .filter(e => !!e.uuid)
+          .map(e => ({
+            value: e.uuid as string,
+            primary: formatEmployee(e),
+            secondary: e.uuid as string,
+          })),
+        contractors: contractors
+          .filter(c => !!c.uuid)
+          .map(c => ({
+            value: c.uuid as string,
+            primary: formatContractor(c),
+            secondary: c.uuid as string,
+          })),
+        payrolls: payrolls
+          .filter(p => !!(p.payroll_uuid || p.uuid))
+          .map(p => {
+            const id = (p.payroll_uuid || p.uuid) as string
+            return {
+              value: id,
+              primary: formatPayPeriod(p),
+              secondary: id,
+            }
+          }),
+      })
+      setListsLoading(false)
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [isOpen, isFlowTokenMode, companyId])
+
+  const hasChanges =
+    entities.employeeId !== confirmedSnapshot.current.employeeId ||
+    entities.contractorId !== confirmedSnapshot.current.contractorId ||
+    entities.payrollId !== confirmedSnapshot.current.payrollId ||
+    TEXT_FIELDS.some(({ key }) => entities[key] !== confirmedSnapshot.current[key])
+
+  const handleCopyCompanyId = useCallback(async () => {
+    if (!companyId) return
+    try {
+      await navigator.clipboard.writeText(companyId)
+      setCopyStatus('copied')
+      setTimeout(() => {
+        setCopyStatus('idle')
+      }, 1500)
+    } catch {
+      // Clipboard unavailable
+    }
+  }, [companyId])
+
   if (!isOpen) return null
 
-  const isFlowTokenMode = mode === 'flow-token'
   const displayEnv = env === 'localzp' ? 'local' : env
 
   return (
@@ -146,7 +399,68 @@ export function DemoSettingsPanel({
 
         <div className={styles.section}>
           <h3>Entity IDs</h3>
-          {ENTITY_FIELDS.map(({ key, label }) => (
+
+          <div className={styles.field}>
+            <label htmlFor="company-id-input">Company ID</label>
+            <div className={styles.copyRow}>
+              <input
+                id="company-id-input"
+                type="text"
+                value={entities.companyId}
+                readOnly
+                className={styles.readOnly}
+              />
+              <button
+                className={styles.btn}
+                onClick={handleCopyCompanyId}
+                disabled={!entities.companyId}
+                type="button"
+              >
+                {copyStatus === 'copied' ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+          </div>
+
+          <EntitySelect
+            label="Employee"
+            value={entities.employeeId}
+            options={lists.employees}
+            isLoading={listsLoading}
+            placeholder="Select an employee..."
+            fallbackPlaceholder="Enter employee id..."
+            useFallback={!isFlowTokenMode}
+            onChange={value => {
+              onUpdateEntity('employeeId', value)
+            }}
+          />
+
+          <EntitySelect
+            label="Contractor"
+            value={entities.contractorId}
+            options={lists.contractors}
+            isLoading={listsLoading}
+            placeholder="Select a contractor..."
+            fallbackPlaceholder="Enter contractor id..."
+            useFallback={!isFlowTokenMode}
+            onChange={value => {
+              onUpdateEntity('contractorId', value)
+            }}
+          />
+
+          <EntitySelect
+            label="Payroll"
+            value={entities.payrollId}
+            options={lists.payrolls}
+            isLoading={listsLoading}
+            placeholder="Select a payroll..."
+            fallbackPlaceholder="Enter payroll id..."
+            useFallback={!isFlowTokenMode}
+            onChange={value => {
+              onUpdateEntity('payrollId', value)
+            }}
+          />
+
+          {TEXT_FIELDS.map(({ key, label }) => (
             <div key={key} className={styles.field}>
               <label>{label}</label>
               <input

--- a/sdk-app/src/entityFormatters.ts
+++ b/sdk-app/src/entityFormatters.ts
@@ -1,0 +1,47 @@
+export interface RawEmployee {
+  uuid?: string
+  first_name?: string | null
+  last_name?: string | null
+}
+
+export interface RawContractor {
+  uuid?: string
+  type?: string
+  first_name?: string | null
+  last_name?: string | null
+  business_name?: string | null
+}
+
+export interface RawPayroll {
+  uuid?: string
+  payroll_uuid?: string
+  check_date?: string
+  pay_period?: { start_date?: string; end_date?: string }
+}
+
+export interface EntityOption {
+  value: string
+  primary: string
+  secondary: string
+}
+
+export function formatPayPeriod(payroll: RawPayroll): string {
+  const start = payroll.pay_period?.start_date
+  const end = payroll.pay_period?.end_date
+  if (start && end) return `${start} – ${end}`
+  if (payroll.check_date) return `Check date ${payroll.check_date}`
+  return 'Payroll'
+}
+
+export function formatContractor(contractor: RawContractor): string {
+  if (contractor.type === 'Business') {
+    return contractor.business_name || 'Business contractor'
+  }
+  const name = [contractor.first_name, contractor.last_name].filter(Boolean).join(' ').trim()
+  return name || 'Contractor'
+}
+
+export function formatEmployee(employee: RawEmployee): string {
+  const name = [employee.first_name, employee.last_name].filter(Boolean).join(' ').trim()
+  return name || 'Employee'
+}

--- a/sdk-app/src/useEntityCatalog.ts
+++ b/sdk-app/src/useEntityCatalog.ts
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react'
+import {
+  type EntityOption,
+  type RawContractor,
+  type RawEmployee,
+  type RawPayroll,
+  formatContractor,
+  formatEmployee,
+  formatPayPeriod,
+} from './entityFormatters'
+
+export interface EntityCatalog {
+  employees: EntityOption[]
+  contractors: EntityOption[]
+  payrolls: EntityOption[]
+  isLoading: boolean
+}
+
+const EMPTY_CATALOG: EntityCatalog = {
+  employees: [],
+  contractors: [],
+  payrolls: [],
+  isLoading: false,
+}
+
+async function fetchList<T>(path: string, signal: AbortSignal): Promise<T[]> {
+  try {
+    const res = await fetch(path, { signal })
+    if (!res.ok) return []
+    const data = (await res.json()) as unknown
+    return Array.isArray(data) ? (data as T[]) : []
+  } catch {
+    return []
+  }
+}
+
+export function useEntityCatalog(companyId: string): EntityCatalog {
+  const [catalog, setCatalog] = useState<EntityCatalog>(EMPTY_CATALOG)
+
+  const proxyMode = typeof __SDK_APP_PROXY_MODE__ !== 'undefined' ? __SDK_APP_PROXY_MODE__ : 'none'
+  const isFlowTokenMode = proxyMode === 'flow-token'
+
+  useEffect(() => {
+    if (!isFlowTokenMode || !companyId) {
+      setCatalog(EMPTY_CATALOG)
+      return
+    }
+
+    const controller = new AbortController()
+    setCatalog(prev => ({ ...prev, isLoading: true }))
+
+    const load = async () => {
+      const base = `/api/v1/companies/${companyId}`
+      const [employees, contractors, payrolls] = await Promise.all([
+        fetchList<RawEmployee>(`${base}/employees`, controller.signal),
+        fetchList<RawContractor>(`${base}/contractors`, controller.signal),
+        fetchList<RawPayroll>(`${base}/payrolls`, controller.signal),
+      ])
+
+      if (controller.signal.aborted) return
+
+      setCatalog({
+        employees: employees
+          .filter(e => !!e.uuid)
+          .map(e => ({
+            value: e.uuid as string,
+            primary: formatEmployee(e),
+            secondary: e.uuid as string,
+          })),
+        contractors: contractors
+          .filter(c => !!c.uuid)
+          .map(c => ({
+            value: c.uuid as string,
+            primary: formatContractor(c),
+            secondary: c.uuid as string,
+          })),
+        payrolls: payrolls
+          .filter(p => !!(p.payroll_uuid || p.uuid))
+          .map(p => {
+            const id = (p.payroll_uuid || p.uuid) as string
+            return {
+              value: id,
+              primary: formatPayPeriod(p),
+              secondary: id,
+            }
+          }),
+        isLoading: false,
+      })
+    }
+
+    void load()
+
+    return () => {
+      controller.abort()
+    }
+  }, [companyId, isFlowTokenMode])
+
+  return catalog
+}


### PR DESCRIPTION
## Summary

Updates the SDK dev app's demo settings panel so users no longer need to know UUIDs to switch the active employee, contractor, or payroll. The entity ID text inputs are replaced with searchable two-line comboboxes populated from the API, and every entity row gains a Copy ID button.

## Changes

- Employee, Contractor, and Payroll IDs are now searchable comboboxes listing entities for the current company. Each option shows a primary label (employee/contractor name or payroll period) and the UUID below it in a muted monospace style.
- Lists are fetched on panel open from `/api/v1/companies/{companyId}/{employees,contractors,payrolls}` when the proxy is in `flow-token` mode. When the proxy is unavailable, each combobox gracefully falls back to a plain text input.
- Company ID becomes a read-only field.
- Every entity row (Company, Employee, Contractor, Payroll, Request ID, Form ID) gets a Copy ID button with a "Copied" confirmation state.
- Adds combobox/helper-line/copy-row styles to `DemoSettingsPanel.module.scss`.
- New helpers extracted to `entityFormatters.ts` (label formatting) and `useEntityCatalog.ts` (fetching/caching the entity lists).

### Open/close behavior

- Clicking the input toggles the menu open and closed.
- Clicking anywhere outside the input (label, copy button, panel background, other fields) closes the menu.
- The selected entity name stays in the DOM (hidden via `visibility` while the menu is open) so opening the menu does not shift content below.
- The menu anchors flush below the input rather than below the helper line.

## Demo

<!-- Add a screenshot or recording of the updated panel -->

## Testing

- `npm run sdk-app`
- Open the demo settings panel and verify:
  - Company ID is read-only and the Copy button copies the UUID (shows "Copied" briefly).
  - Employee, Contractor, and Payroll fields show comboboxes with two-line options (name/period + UUID).
  - Selecting an option updates the active entity ID and the Update button appears.
  - Every entity row (including Request ID and Form ID) has a working Copy ID button.
  - Clicking the input toggles the menu; clicking anywhere outside (label, copy button, etc.) closes it.
  - Pressing Escape closes the menu.
  - Opening/closing the menu does not shift the fields below.
  - When running without a flow token, the three combobox fields gracefully fall back to text inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)