### PR TITLE
fix: rename Settings card title on time-off policy detail

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.test.tsx
@@ -104,7 +104,7 @@ describe('TimeOffPolicyDetail', () => {
       renderComponent()
 
       await waitFor(() => {
-        expect(screen.getByText('Settings')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument()
       })
       expect(screen.getByText('240 hour(s)')).toBeInTheDocument()
     })
@@ -116,7 +116,7 @@ describe('TimeOffPolicyDetail', () => {
       await waitFor(() => {
         expect(screen.getByText('Details')).toBeInTheDocument()
       })
-      expect(screen.queryByText('Settings')).not.toBeInTheDocument()
+      expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument()
     })
 
     it('renders action buttons', async () => {

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.test.tsx
@@ -104,7 +104,7 @@ describe('TimeOffPolicyDetail', () => {
       renderComponent()
 
       await waitFor(() => {
-        expect(screen.getByText('Policy settings')).toBeInTheDocument()
+        expect(screen.getByText('Settings')).toBeInTheDocument()
       })
       expect(screen.getByText('240 hour(s)')).toBeInTheDocument()
     })
@@ -116,7 +116,7 @@ describe('TimeOffPolicyDetail', () => {
       await waitFor(() => {
         expect(screen.getByText('Details')).toBeInTheDocument()
       })
-      expect(screen.queryByText('Policy settings')).not.toBeInTheDocument()
+      expect(screen.queryByText('Settings')).not.toBeInTheDocument()
     })
 
     it('renders action buttons', async () => {

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.test.tsx
@@ -150,7 +150,7 @@ describe('TimeOffPolicyDetailPresentation', () => {
       renderComponent({ policySettings: fullPolicySettings })
 
       await waitFor(() => {
-        expect(screen.getByText('Policy settings')).toBeInTheDocument()
+        expect(screen.getByText('Settings')).toBeInTheDocument()
       })
       expect(screen.getByText('Accrual maximum')).toBeInTheDocument()
       expect(screen.getByText('100 hour(s) per year')).toBeInTheDocument()
@@ -167,7 +167,7 @@ describe('TimeOffPolicyDetailPresentation', () => {
       renderComponent()
 
       await waitFor(() => {
-        expect(screen.getByText('Policy settings')).toBeInTheDocument()
+        expect(screen.getByText('Settings')).toBeInTheDocument()
       })
       expect(screen.getByText('No maximum')).toBeInTheDocument()
       expect(screen.getByText('No carry over limit')).toBeInTheDocument()
@@ -198,7 +198,7 @@ describe('TimeOffPolicyDetailPresentation', () => {
         expect(screen.getByText('Details')).toBeInTheDocument()
       })
       expect(screen.getByText('Unlimited')).toBeInTheDocument()
-      expect(screen.queryByText('Policy settings')).not.toBeInTheDocument()
+      expect(screen.queryByText('Settings')).not.toBeInTheDocument()
     })
   })
 

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.test.tsx
@@ -150,7 +150,7 @@ describe('TimeOffPolicyDetailPresentation', () => {
       renderComponent({ policySettings: fullPolicySettings })
 
       await waitFor(() => {
-        expect(screen.getByText('Settings')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument()
       })
       expect(screen.getByText('Accrual maximum')).toBeInTheDocument()
       expect(screen.getByText('100 hour(s) per year')).toBeInTheDocument()
@@ -167,7 +167,7 @@ describe('TimeOffPolicyDetailPresentation', () => {
       renderComponent()
 
       await waitFor(() => {
-        expect(screen.getByText('Settings')).toBeInTheDocument()
+        expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument()
       })
       expect(screen.getByText('No maximum')).toBeInTheDocument()
       expect(screen.getByText('No carry over limit')).toBeInTheDocument()
@@ -198,7 +198,7 @@ describe('TimeOffPolicyDetailPresentation', () => {
         expect(screen.getByText('Details')).toBeInTheDocument()
       })
       expect(screen.getByText('Unlimited')).toBeInTheDocument()
-      expect(screen.queryByText('Settings')).not.toBeInTheDocument()
+      expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument()
     })
   })
 

--- a/src/i18n/en/Company.TimeOff.TimeOffPolicyDetails.json
+++ b/src/i18n/en/Company.TimeOff.TimeOffPolicyDetails.json
@@ -46,7 +46,7 @@
     "perHourPaidNoOvertime": "{{accrualRate}} hour(s) for every {{accrualRateUnit}} hour(s) worked and all paid hours, excluding overtime"
   },
   "resetDate": "Reset date",
-  "policySettingsTitle": "Policy settings",
+  "policySettingsTitle": "Settings",
   "changeSettingsCta": "Change",
   "maxAccrualHoursPerYear": {
     "label": "Accrual maximum",


### PR DESCRIPTION
## Summary
- Card on the Time Off Policy Detail page that lists accrual maximum, balance maximum, carry over limit, etc. now reads "Settings" instead of "Policy settings". The page is already titled with the policy name, so the longer label was redundant.
- Updates the `policySettingsTitle` value in `Company.TimeOff.TimeOffPolicyDetails.json` and the matching unit-test assertions; ran `npm run i18n:generate` (no type changes since the value remains a string).

This is PR 3 in the time-off bug-fix slate captured in `~/.claude/plans/ok-i-want-to-partitioned-balloon.md`.

## Test plan
- [x] `npm run test -- --run src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/` — 36/36 passing
- [ ] Storybook `TimeOffPolicyDetailPresentation` — verify the second card on the Details tab reads "Settings"
- [ ] Manual: open a sick/vacation policy detail in the dev app and confirm the card title

🤖 Generated with [Claude Code](https://claude.com/claude-code)