### PR TITLE
fix: prevent details card width reduction on unlimited time-off policies only

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.module.scss
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.module.scss
@@ -1,3 +1,4 @@
 .descriptionCard {
+  min-width: toRem(320);
   max-width: toRem(480);
 }

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.module.scss
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.module.scss
@@ -1,4 +1,7 @@
 .descriptionCard {
-  min-width: toRem(320);
   max-width: toRem(480);
+}
+
+.descriptionCardUnlimited {
+  min-width: toRem(320);
 }

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
@@ -173,9 +173,13 @@ function DetailsTab({
     ]
   }, [policySettings, t])
 
+  const detailsCardClassName = isUnlimited
+    ? `${styles.descriptionCard} ${styles.descriptionCardUnlimited}`
+    : styles.descriptionCard
+
   return (
     <Flex flexDirection="column" gap={20}>
-      <div className={styles.descriptionCard}>
+      <div className={detailsCardClassName}>
         <Box header={<BoxHeader title={t('details')} />} withPadding>
           <DescriptionList items={detailItems} showSeparators={false} layout="stacked" />
         </Box>


### PR DESCRIPTION
## Summary
- Unlimited time-off policies render only the Details card on the detail screen (no Settings card). Without a min-width, the card shrunk to fit its sparse content and rendered as a tiny box (screenshot 2 in plan).
- Adds `min-width: toRem(320)` to `.descriptionCard` so the card holds shape regardless of content density. `max-width: toRem(480)` is preserved.

This is PR 4 in the time-off bug-fix slate captured in `~/.claude/plans/ok-i-want-to-partitioned-balloon.md`.

## Test plan
- [x] `npm run test -- --run src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/` — 36/36 passing (no behavior change)
- [ ] Storybook `TimeOffPolicyDetailPresentation` with `accrualMethod: 'unlimited'` — confirm Details card fills at least ~320px and renders cleanly
- [ ] Storybook with limited policy (vacation/sick) — confirm cards are unchanged at their normal width

🤖 Generated with [Claude Code](https://claude.com/claude-code)