### PR TITLE
fix: add icons to Holiday policy detail action buttons

### DIFF
--- a/src/components/UNSTABLE_TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.test.tsx
@@ -95,6 +95,20 @@ describe('HolidayPolicyDetail', () => {
       expect(screen.getByText('Add employees')).toBeInTheDocument()
       expect(screen.getByText('Edit policy')).toBeInTheDocument()
     })
+
+    it('renders icons on the Add employees and Edit policy buttons', async () => {
+      renderWithProviders(<HolidayPolicyDetail {...defaultProps} defaultTab="holidays" />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Add employees')).toBeInTheDocument()
+      })
+
+      const addButton = screen.getByRole('button', { name: /add employees/i })
+      const editButton = screen.getByRole('button', { name: /edit policy/i })
+
+      expect(addButton.querySelector('svg')).toBeInTheDocument()
+      expect(editButton.querySelector('svg')).toBeInTheDocument()
+    })
   })
 
   describe('employees tab', () => {

--- a/src/components/UNSTABLE_TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.tsx
+++ b/src/components/UNSTABLE_TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.tsx
@@ -18,6 +18,8 @@ import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentCon
 import { useI18n } from '@/i18n'
 import { firstLastName } from '@/helpers/formattedStrings'
 import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
+import EditIcon from '@/assets/icons/edit-02.svg?react'
+import PlusCircleIcon from '@/assets/icons/plus-circle.svg?react'
 
 export interface HolidayPolicyDetailProps extends BaseComponentInterface {
   companyId: string
@@ -134,10 +136,20 @@ function Root({ companyId, defaultTab = 'holidays' }: HolidayPolicyDetailProps) 
   }
 
   const actions = [
-    <Button key="add" variant="secondary" onClick={handleAddEmployees}>
+    <Button
+      key="add"
+      variant="secondary"
+      icon={<PlusCircleIcon aria-hidden />}
+      onClick={handleAddEmployees}
+    >
       {t('show.addEmployeesCta')}
     </Button>,
-    <Button key="edit" variant="secondary" onClick={handleEditPolicy}>
+    <Button
+      key="edit"
+      variant="secondary"
+      icon={<EditIcon aria-hidden />}
+      onClick={handleEditPolicy}
+    >
       {t('show.editPolicyCta')}
     </Button>,
   ]


### PR DESCRIPTION
## Summary
- Add employees and Edit policy on the Holiday policy detail screen rendered without icons, while the equivalent buttons on the regular `TimeOffPolicyDetail` had `PlusCircleIcon` and `EditIcon`. Mirror that treatment so the two policy detail surfaces feel consistent.
- Adds a regression test asserting both buttons render an `<svg>` child.

This is PR 5 in the time-off bug-fix slate captured in `~/.claude/plans/ok-i-want-to-partitioned-balloon.md`.

## Test plan
- [x] `npm run test -- --run src/components/UNSTABLE_TimeOff/HolidayPolicyDetail/` — 8/8 passing (added 1 new icon-presence assertion)
- [ ] Storybook `HolidayPolicyDetail` — confirm both buttons show their icon
- [ ] Visually compare with `TimeOffPolicyDetail` story to confirm consistent treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)