### PR TITLE
fix: hide deactivated policies from time-off policy list

### DIFF
--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.test.tsx
@@ -173,6 +173,35 @@ describe('PolicyList', () => {
         expect(screen.getByRole('button', { name: 'Finish setup' })).toBeInTheDocument()
       })
     })
+
+    it('omits deactivated policies from the list', async () => {
+      server.use(
+        http.get(`${API_BASE_URL}/v1/companies/:companyUuid/time_off_policies`, () => {
+          return HttpResponse.json([
+            ...mockPolicies,
+            {
+              uuid: 'policy-deactivated',
+              company_uuid: 'company-123',
+              name: 'Deactivated Policy',
+              policy_type: 'vacation',
+              accrual_method: 'per_pay_period',
+              accrual_rate: '40.0',
+              is_active: false,
+              complete: true,
+              employees: [],
+            },
+          ])
+        }),
+      )
+
+      renderWithProviders(<PolicyList {...defaultProps} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Vacation')).toBeInTheDocument()
+      })
+      expect(screen.getByText('Sick Leave')).toBeInTheDocument()
+      expect(screen.queryByText('Deactivated Policy')).not.toBeInTheDocument()
+    })
   })
 
   describe('empty state', () => {

--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.tsx
@@ -54,7 +54,7 @@ function Root({ companyId, onEvent }: PolicyListProps) {
   const { data: policiesData } = useTimeOffPoliciesGetAllSuspense({
     companyUuid: companyId,
   })
-  const timeOffPolicies = policiesData.timeOffPolicies ?? []
+  const timeOffPolicies = (policiesData.timeOffPolicies ?? []).filter(policy => policy.isActive)
 
   const holidayQuery = useHolidayPayPoliciesGet(
     { companyUuid: companyId },


### PR DESCRIPTION
## Summary
- Deleting a regular time-off policy from the kabob menu deactivates it server-side, but the list endpoint still returns it. The row lingered (and re-ordered to the bottom because the backend ordering shifted).
- Filter `policiesData.timeOffPolicies` on `policy.isActive` before mapping into list items. We're filtering client-side because `GET /v1/companies/{uuid}/time_off_policies` does not accept an `active`/`status` query param — the OpenAPI-generated request type only takes `companyUuid` + version header, so there is no way to ask the backend to exclude deactivated policies.
- Holiday deletion goes through a different mutation that 404s/204s the subsequent fetch, so no analogous filter is needed for the holiday row.

This is PR 1 in the time-off bug-fix slate captured in `~/.claude/plans/ok-i-want-to-partitioned-balloon.md`.

## Test plan
- [x] `npm run test -- --run src/components/UNSTABLE_TimeOff/PolicyList/` — 22/22 passing (added 1 new test for the filter)
- [ ] Manual: create a sick policy, delete from kabob menu, confirm row disappears immediately and does not reappear on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)