### PR TITLE
fix: render terminated employees on the time-off policy detail

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.test.tsx
@@ -40,16 +40,10 @@ vi.mock('@gusto/embedded-api/react-query/timeOffPoliciesGet', () => ({
   }),
 }))
 
+const mockUseEmployeesListSuspense = vi.fn()
+
 vi.mock('@gusto/embedded-api/react-query/employeesList', () => ({
-  useEmployeesListSuspense: () => ({
-    data: {
-      showEmployees: [
-        { uuid: 'emp-1', firstName: 'Alice', lastName: 'Smith', title: 'Engineer' },
-        { uuid: 'emp-2', firstName: 'Bob', lastName: 'Jones', title: 'Designer' },
-        { uuid: 'emp-3', firstName: 'Carol', lastName: 'Davis', title: null },
-      ],
-    },
-  }),
+  useEmployeesListSuspense: (args: unknown) => mockUseEmployeesListSuspense(args),
 }))
 
 vi.mock('@gusto/embedded-api/react-query/timeOffPoliciesRemoveEmployees', () => ({
@@ -74,6 +68,15 @@ describe('TimeOffPolicyDetail', () => {
     mockRemoveEmployees.mockResolvedValue({ timeOffPolicy: mockPolicyData })
     mockUpdateBalance.mockResolvedValue({ timeOffPolicy: mockPolicyData })
     mockPolicyData = { ...basePolicyData }
+    mockUseEmployeesListSuspense.mockReturnValue({
+      data: {
+        showEmployees: [
+          { uuid: 'emp-1', firstName: 'Alice', lastName: 'Smith', title: 'Engineer' },
+          { uuid: 'emp-2', firstName: 'Bob', lastName: 'Jones', title: 'Designer' },
+          { uuid: 'emp-3', firstName: 'Carol', lastName: 'Davis', title: null },
+        ],
+      },
+    })
   })
 
   function renderComponent(props = {}) {
@@ -126,6 +129,19 @@ describe('TimeOffPolicyDetail', () => {
         expect(screen.getByRole('button', { name: /add employee/i })).toBeInTheDocument()
       })
       expect(screen.getByRole('button', { name: /edit policy/i })).toBeInTheDocument()
+    })
+
+    it('fetches policy employees by uuid so terminated employees still appear', async () => {
+      renderComponent()
+
+      await waitFor(() => {
+        expect(mockUseEmployeesListSuspense).toHaveBeenCalled()
+      })
+      const args = mockUseEmployeesListSuspense.mock.calls[0]?.[0] as
+        | { uuids?: string[]; terminated?: boolean }
+        | undefined
+      expect(args?.uuids).toEqual(['emp-1', 'emp-2', 'emp-3'])
+      expect(args?.terminated).toBeUndefined()
     })
   })
 

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.tsx
@@ -143,9 +143,17 @@ function Root({ policyId }: TimeOffPolicyDetailProps) {
   const policy = policyResponse.timeOffPolicy
   if (!policy) throw new Error('Unexpected response: missing timeOffPolicy')
 
+  const policyEmployeeUuids = useMemo(
+    () => policy.employees.map(e => e.uuid).filter((uuid): uuid is string => Boolean(uuid)),
+    [policy.employees],
+  )
+
+  // Fetch by uuid rather than filtering by `terminated: false` — terminated
+  // employees can still be attached to a policy and we want their names/titles
+  // to render on the detail screen.
   const { data: employeesData } = useEmployeesListSuspense({
     companyId: policy.companyUuid,
-    terminated: false,
+    uuids: policyEmployeeUuids,
   })
 
   const [selectedTabId, setSelectedTabId] = useState('details')


### PR DESCRIPTION
## Summary
- The Employees tab on the time-off policy detail screen fetched its lookup data with `terminated: false`. Terminated employees can still be attached to a policy, so the map in `deriveEmployees` missed them and their rows rendered with empty names and job titles (screenshot 1 in plan).
- Refactored to fetch by `uuids` directly from `policy.employees`. We already know which employees the policy has, so we get exactly that set without filtering by termination state, and avoid over-fetching the full company roster just to enrich a handful of rows.
- Adds a regression test asserting the hook is called with `uuids` (the policy's attached employee uuids) and not `terminated: false`.

This is PR 8 in the time-off bug-fix slate captured in `~/.claude/plans/ok-i-want-to-partitioned-balloon.md`.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test -- --run src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/` — 37/37 passing
- [ ] Manual: attach an employee to a sick policy, dismiss them, reopen the policy detail Employees tab — confirm name and job title still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)