### PR TITLE
fix: dedupe identical bullets on submission error alerts

### DIFF
--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -7,6 +7,7 @@ import { QueryErrorResetBoundary } from '@tanstack/react-query'
 import { FadeIn } from '../Common/FadeIn/FadeIn'
 import { BaseContext, type OnEventType } from './useBase'
 import { useBaseSubmit } from './useBaseSubmit'
+import { dedupeFieldErrorMessages } from './dedupeFieldErrorMessages'
 import { componentEvents, type EventType } from '@/shared/constants'
 import { InternalError } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
@@ -93,16 +94,19 @@ function SingleErrorContent({ error }: { error: SDKError }) {
   const Components = useComponentContext()
   const { t } = useTranslation()
   const hasFieldErrors = error.fieldErrors.length > 0
+  const dedupedFieldErrors = dedupeFieldErrorMessages(
+    error.fieldErrors.map(fieldError => fieldError.message),
+  )
 
   return (
     <Components.Alert label={t('status.errorEncountered')} status="error">
       {hasFieldErrors && (
         <Components.UnorderedList
-          items={error.fieldErrors
-            .filter(fieldError => fieldError.message)
-            .map(fieldError => (
-              <span key={fieldError.field}>{fieldError.message}</span>
-            ))}
+          items={dedupedFieldErrors.map(({ message, count }) => (
+            <span key={message}>
+              {count > 1 ? t('status.duplicateErrorCount', { message, count }) : message}
+            </span>
+          ))}
         />
       )}
       {!hasFieldErrors && error.category === 'validation_error' && (
@@ -138,12 +142,18 @@ function MultipleErrorsContent({ errors }: { errors: SDKError[] }) {
               return <span key={index}>{error.message || t('errors.unknownError')}</span>
             }
 
+            const dedupedFieldErrors = dedupeFieldErrorMessages(
+              visibleFieldErrors.map(fieldError => fieldError.message),
+            )
+
             return (
               <span key={index}>
                 {error.message || t('errors.unknownError')}
                 <Components.UnorderedList
-                  items={visibleFieldErrors.map(fieldError => (
-                    <span key={fieldError.field}>{fieldError.message}</span>
+                  items={dedupedFieldErrors.map(({ message, count }) => (
+                    <span key={message}>
+                      {count > 1 ? t('status.duplicateErrorCount', { message, count }) : message}
+                    </span>
                   ))}
                 />
               </span>

--- a/src/components/Base/dedupeFieldErrorMessages.test.ts
+++ b/src/components/Base/dedupeFieldErrorMessages.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { dedupeFieldErrorMessages } from './dedupeFieldErrorMessages'
+
+describe('dedupeFieldErrorMessages', () => {
+  it('returns each distinct message with count 1', () => {
+    expect(dedupeFieldErrorMessages(['a', 'b', 'c'])).toEqual([
+      { message: 'a', count: 1 },
+      { message: 'b', count: 1 },
+      { message: 'c', count: 1 },
+    ])
+  })
+
+  it('collapses exact duplicates into one entry with the count', () => {
+    expect(dedupeFieldErrorMessages(['a', 'a', 'a'])).toEqual([{ message: 'a', count: 3 }])
+  })
+
+  it('preserves order of first occurrence when mixing duplicates and uniques', () => {
+    expect(dedupeFieldErrorMessages(['x', 'y', 'x', 'z', 'y', 'x'])).toEqual([
+      { message: 'x', count: 3 },
+      { message: 'y', count: 2 },
+      { message: 'z', count: 1 },
+    ])
+  })
+
+  it('skips empty strings', () => {
+    expect(dedupeFieldErrorMessages(['', 'a', '', 'a'])).toEqual([{ message: 'a', count: 2 }])
+  })
+
+  it('returns an empty array for an empty input', () => {
+    expect(dedupeFieldErrorMessages([])).toEqual([])
+  })
+
+  it('treats whitespace-only differences as distinct', () => {
+    expect(dedupeFieldErrorMessages(['a', 'a ', 'a'])).toEqual([
+      { message: 'a', count: 2 },
+      { message: 'a ', count: 1 },
+    ])
+  })
+})

--- a/src/components/Base/dedupeFieldErrorMessages.ts
+++ b/src/components/Base/dedupeFieldErrorMessages.ts
@@ -1,0 +1,30 @@
+/**
+ * Collapses identical error messages into a single entry with a count.
+ *
+ * The Gusto API returns one field error per offending record (e.g. one per
+ * employee in a bulk operation). When all the records fail the same way, the
+ * UI rendered N copies of the same string. This preserves order of first
+ * occurrence and aggregates exact-match duplicates.
+ */
+export interface DedupedErrorMessage {
+  message: string
+  count: number
+}
+
+export function dedupeFieldErrorMessages(messages: string[]): DedupedErrorMessage[] {
+  const indexByMessage = new Map<string, number>()
+  const result: DedupedErrorMessage[] = []
+
+  for (const message of messages) {
+    if (!message) continue
+    const existingIndex = indexByMessage.get(message)
+    if (existingIndex === undefined) {
+      indexByMessage.set(message, result.length)
+      result.push({ message, count: 1 })
+    } else {
+      result[existingIndex]!.count += 1
+    }
+  }
+
+  return result
+}

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -4,7 +4,8 @@
     "loadingOptions": "Loading options...",
     "requiredField": "is a required field",
     "errorEncountered": "There was a problem with your submission",
-    "multipleErrorsEncountered": "There were multiple problems with your submission"
+    "multipleErrorsEncountered": "There were multiple problems with your submission",
+    "duplicateErrorCount": "{{message}} (×{{count}})"
   },
   "optionalLabel": "(optional)",
   "progressBarLabel": "You are on step {{currentStep}} of {{totalSteps}}",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -3231,6 +3231,7 @@ export interface common{
 "requiredField":string;
 "errorEncountered":string;
 "multipleErrorsEncountered":string;
+"duplicateErrorCount":string;
 };
 "optionalLabel":string;
 "progressBarLabel":string;


### PR DESCRIPTION
## Summary
- Bulk operations (e.g. removing N employees from a policy) commonly return one field error per offending record with the same message. The submission-error alert rendered N copies of the same text, making it look like there were N distinct problems when there was effectively one (screenshot 4 in plan).
- Adds a tiny `dedupeFieldErrorMessages` helper that collapses exact duplicates while preserving order of first occurrence. Applied to both `SingleErrorContent` and `MultipleErrorsContent`. When the same bullet would repeat, the alert now shows `<message> (×N)` once.

### Scope note: per-employee attribution deferred

The plan also calls for prefixing each bullet with the offending employee's name (e.g. `"<Employee>: <message>"`). Doing that requires reasoning about API field-path encoding (`employees.{i}.uuid`) and threading a UUID-to-name map down to the alert-rendering layer in Base. That's a meaningful extra surface and a different abstraction concern than the dedupe, so I'm leaving it as a follow-up. The dedupe alone removes the immediate "wall of identical bullets" symptom.

This is PR 2 in the time-off bug-fix slate captured in `~/.claude/plans/ok-i-want-to-partitioned-balloon.md`.

## Test plan
- [x] `npm run test -- --run src/components/Base/dedupeFieldErrorMessages.test.ts` — 6/6 passing (new helper)
- [x] `npm run test -- --run` — full suite 2467/2467 passing
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: bulk-remove 3+ employees with the same blocker (e.g. pending time-off request) — confirm alert shows one bullet with `(×N)` instead of N identical bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)