### PR TITLE
fix: wire up Add Employee screen

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
@@ -343,6 +343,36 @@ describe('timeOffStateMachine', () => {
       expect(service.machine.current).toBe('viewTimeOffPolicyDetail')
       expect(service.context.policyId).toBe('policy-existing')
     })
+
+    it('transitions to policyDetailsForm on TIME_OFF_EDIT_POLICY', () => {
+      const service = createService()
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'policy-existing',
+        policyType: 'vacation',
+      })
+      expect(service.machine.current).toBe('viewTimeOffPolicyDetail')
+
+      send(service, componentEvents.TIME_OFF_EDIT_POLICY, { policyId: 'policy-existing' })
+
+      expect(service.machine.current).toBe('policyDetailsForm')
+      expect(service.context.policyId).toBe('policy-existing')
+      expect(service.context.alerts).toBeUndefined()
+    })
+
+    it('transitions to policySettings on TIME_OFF_CHANGE_SETTINGS', () => {
+      const service = createService()
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'policy-existing',
+        policyType: 'vacation',
+      })
+      expect(service.machine.current).toBe('viewTimeOffPolicyDetail')
+
+      send(service, componentEvents.TIME_OFF_CHANGE_SETTINGS, { policyId: 'policy-existing' })
+
+      expect(service.machine.current).toBe('policySettings')
+      expect(service.context.policyId).toBe('policy-existing')
+      expect(service.context.alerts).toBeUndefined()
+    })
   })
 
   describe('back to list', () => {

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
@@ -310,6 +310,41 @@ describe('timeOffStateMachine', () => {
     })
   })
 
+  describe('viewTimeOffPolicyDetail state', () => {
+    it('transitions to addEmployeesToPolicy on TIME_OFF_ADD_EMPLOYEES_TO_POLICY with policyId', () => {
+      const service = createService()
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'policy-existing',
+        policyType: 'vacation',
+      })
+      expect(service.machine.current).toBe('viewTimeOffPolicyDetail')
+
+      send(service, componentEvents.TIME_OFF_ADD_EMPLOYEES_TO_POLICY, {
+        policyId: 'policy-existing',
+      })
+
+      expect(service.machine.current).toBe('addEmployeesToPolicy')
+      expect(service.context.policyId).toBe('policy-existing')
+      expect(service.context.alerts).toBeUndefined()
+    })
+
+    it('returns to viewTimeOffPolicyDetail with the same policyId after adding employees', () => {
+      const service = createService()
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'policy-existing',
+        policyType: 'vacation',
+      })
+      send(service, componentEvents.TIME_OFF_ADD_EMPLOYEES_TO_POLICY, {
+        policyId: 'policy-existing',
+      })
+
+      send(service, componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE)
+
+      expect(service.machine.current).toBe('viewTimeOffPolicyDetail')
+      expect(service.context.policyId).toBe('policy-existing')
+    })
+  })
+
   describe('back to list', () => {
     it('returns to policyList from viewTimeOffPolicyDetail', () => {
       const service = createService()

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -20,6 +20,7 @@ type PolicyTypePayload = { policyType: 'sick' | 'vacation' | 'holiday' }
 type PolicyCreatedPayload = { policyId: string; accrualMethod?: string }
 type ErrorPayload = { alert?: TimeOffFlowAlert }
 type ViewPolicyPayload = { policyId: string; policyType: 'sick' | 'vacation' | 'holiday' }
+type AddEmployeesToPolicyPayload = { policyId: string }
 
 function isSickOrVacation(_ctx: TimeOffFlowContextInterface, ev: { payload: PolicyTypePayload }) {
   return ev.payload.policyType === 'sick' || ev.payload.policyType === 'vacation'
@@ -274,7 +275,24 @@ export const timeOffMachine = {
     cancelToPolicyList,
   ),
 
-  viewTimeOffPolicyDetail: state<MachineTransition>(backToListTransition),
+  viewTimeOffPolicyDetail: state<MachineTransition>(
+    transition(
+      componentEvents.TIME_OFF_ADD_EMPLOYEES_TO_POLICY,
+      'addEmployeesToPolicy',
+      reduce(
+        (
+          ctx: TimeOffFlowContextInterface,
+          ev: { payload: AddEmployeesToPolicyPayload },
+        ): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: AddEmployeesToPolicyContextual,
+          policyId: ev.payload.policyId,
+          alerts: undefined,
+        }),
+      ),
+    ),
+    backToListTransition,
+  ),
 
   holidaySelectionForm: state<MachineTransition>(
     transition(

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -20,7 +20,7 @@ type PolicyTypePayload = { policyType: 'sick' | 'vacation' | 'holiday' }
 type PolicyCreatedPayload = { policyId: string; accrualMethod?: string }
 type ErrorPayload = { alert?: TimeOffFlowAlert }
 type ViewPolicyPayload = { policyId: string; policyType: 'sick' | 'vacation' | 'holiday' }
-type AddEmployeesToPolicyPayload = { policyId: string }
+type PolicyIdPayload = { policyId: string }
 
 function isSickOrVacation(_ctx: TimeOffFlowContextInterface, ev: { payload: PolicyTypePayload }) {
   return ev.payload.policyType === 'sick' || ev.payload.policyType === 'vacation'
@@ -282,10 +282,40 @@ export const timeOffMachine = {
       reduce(
         (
           ctx: TimeOffFlowContextInterface,
-          ev: { payload: AddEmployeesToPolicyPayload },
+          ev: { payload: PolicyIdPayload },
         ): TimeOffFlowContextInterface => ({
           ...ctx,
           component: AddEmployeesToPolicyContextual,
+          policyId: ev.payload.policyId,
+          alerts: undefined,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.TIME_OFF_EDIT_POLICY,
+      'policyDetailsForm',
+      reduce(
+        (
+          ctx: TimeOffFlowContextInterface,
+          ev: { payload: PolicyIdPayload },
+        ): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: PolicyDetailsFormContextual,
+          policyId: ev.payload.policyId,
+          alerts: undefined,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.TIME_OFF_CHANGE_SETTINGS,
+      'policySettings',
+      reduce(
+        (
+          ctx: TimeOffFlowContextInterface,
+          ev: { payload: PolicyIdPayload },
+        ): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: PolicySettingsContextual,
           policyId: ev.payload.policyId,
           alerts: undefined,
         }),

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.stories.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.stories.tsx
@@ -120,16 +120,23 @@ function StoryWrapper({
   employees = mockEmployees,
   pagination,
   initialBalances = {},
+  originallyOnPolicyUuids,
+  originalBalances,
+  removeConfirmOpen = false,
 }: {
   initialSelected?: Set<string>
   showReassignmentWarning?: boolean
   employees?: EmployeeItem[]
   pagination?: PaginationControlProps
   initialBalances?: Record<string, string>
+  originallyOnPolicyUuids?: Set<string>
+  originalBalances?: Record<string, string>
+  removeConfirmOpen?: boolean
 }) {
   const [searchValue, setSearchValue] = useState('')
   const [selectedUuids, setSelectedUuids] = useState(initialSelected)
   const [balances, setBalances] = useState<Record<string, string>>(initialBalances)
+  const [confirmOpen, setConfirmOpen] = useState(removeConfirmOpen)
 
   const handleSelect = (item: EmployeeItem, checked: boolean) => {
     setSelectedUuids(prev => {
@@ -144,6 +151,10 @@ function StoryWrapper({
     setBalances(prev => ({ ...prev, [uuid]: value }))
   }
 
+  const removeCount = originallyOnPolicyUuids
+    ? [...originallyOnPolicyUuids].filter(uuid => !selectedUuids.has(uuid)).length
+    : 0
+
   return (
     <SelectEmployeesPresentation
       employees={employees}
@@ -155,11 +166,31 @@ function StoryWrapper({
       }}
       onSelect={handleSelect}
       onBack={onBack}
-      onContinue={onContinue}
+      onContinue={() => {
+        if (removeCount > 0) setConfirmOpen(true)
+        else onContinue()
+      }}
       showReassignmentWarning={showReassignmentWarning}
       balances={balances}
       onBalanceChange={handleBalanceChange}
       pagination={pagination}
+      originallyOnPolicyUuids={originallyOnPolicyUuids}
+      originalBalances={originalBalances}
+      removeConfirmDialog={
+        originallyOnPolicyUuids
+          ? {
+              isOpen: confirmOpen,
+              count: removeCount,
+              onConfirm: () => {
+                setConfirmOpen(false)
+                onContinue()
+              },
+              onClose: () => {
+                setConfirmOpen(false)
+              },
+            }
+          : undefined
+      }
     />
   )
 }
@@ -188,6 +219,35 @@ export const WithCarryOver = () => (
       '3': '8',
       '4': '0',
     }}
+    showReassignmentWarning
+  />
+)
+
+export const WithExistingAssignees = () => (
+  <StoryWrapper
+    initialSelected={new Set(['1', '3'])}
+    originallyOnPolicyUuids={new Set(['1', '3'])}
+    originalBalances={{ '1': '12', '3': '4.5' }}
+    showReassignmentWarning
+  />
+)
+
+export const ExistingAssigneesWithNewSelections = () => (
+  <StoryWrapper
+    initialSelected={new Set(['1', '3', '5'])}
+    originallyOnPolicyUuids={new Set(['1', '3'])}
+    originalBalances={{ '1': '12', '3': '4.5' }}
+    initialBalances={{ '5': '8' }}
+    showReassignmentWarning
+  />
+)
+
+export const RemoveConfirmDialogOpen = () => (
+  <StoryWrapper
+    initialSelected={new Set(['1'])}
+    originallyOnPolicyUuids={new Set(['1', '3', '5'])}
+    originalBalances={{ '1': '12', '3': '4.5', '5': '20' }}
+    removeConfirmOpen
     showReassignmentWarning
   />
 )

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
@@ -25,11 +25,14 @@ export function SelectEmployeesPresentation({
   onBalanceChange,
   pagination,
   isFetching,
+  originallyOnPolicyUuids,
+  originalBalances,
+  removeConfirmDialog,
 }: SelectEmployeesPresentationProps) {
   useI18n('Company.TimeOff.SelectEmployees')
   const { t } = useTranslation('Company.TimeOff.SelectEmployees')
   const Components = useComponentContext()
-  const { Heading, Text, Button, Alert } = Components
+  const { Heading, Text, Button, Alert, Dialog } = Components
   const balanceColHeaderId = useId()
 
   return (
@@ -66,19 +69,30 @@ export function SelectEmployeesPresentation({
                 {
                   key: 'balance' as keyof EmployeeItem,
                   title: <span id={balanceColHeaderId}>{t('startingBalanceColumn')}</span>,
-                  render: (employee: EmployeeItem) => (
-                    <Components.TextInput
-                      name={`balance-${employee.uuid}`}
-                      label={t('startingBalanceColumn')}
-                      shouldVisuallyHideLabel
-                      aria-labelledby={`employee-name-${employee.uuid} ${balanceColHeaderId}`}
-                      value={balances?.[employee.uuid] ?? ''}
-                      onChange={(value: string) => {
-                        onBalanceChange(employee.uuid, value)
-                      }}
-                      placeholder="0"
-                    />
-                  ),
+                  render: (employee: EmployeeItem) => {
+                    if (originallyOnPolicyUuids?.has(employee.uuid)) {
+                      return (
+                        <Text
+                          aria-labelledby={`employee-name-${employee.uuid} ${balanceColHeaderId}`}
+                        >
+                          {originalBalances?.[employee.uuid] ?? '0'}
+                        </Text>
+                      )
+                    }
+                    return (
+                      <Components.TextInput
+                        name={`balance-${employee.uuid}`}
+                        label={t('startingBalanceColumn')}
+                        shouldVisuallyHideLabel
+                        aria-labelledby={`employee-name-${employee.uuid} ${balanceColHeaderId}`}
+                        value={balances?.[employee.uuid] ?? ''}
+                        onChange={(value: string) => {
+                          onBalanceChange(employee.uuid, value)
+                        }}
+                        placeholder="0"
+                      />
+                    )
+                  },
                 },
               ]
             : []),
@@ -93,6 +107,21 @@ export function SelectEmployeesPresentation({
           {t('continueCta')}
         </Button>
       </ActionsLayout>
+
+      {removeConfirmDialog && (
+        <Dialog
+          isOpen={removeConfirmDialog.isOpen}
+          onClose={removeConfirmDialog.onClose}
+          onPrimaryActionClick={removeConfirmDialog.onConfirm}
+          isPrimaryActionLoading={removeConfirmDialog.isPending}
+          isDestructive
+          title={t('removeConfirmDialog.title', { count: removeConfirmDialog.count })}
+          primaryActionLabel={t('removeConfirmDialog.confirmCta')}
+          closeActionLabel={t('removeConfirmDialog.cancelCta')}
+        >
+          {t('removeConfirmDialog.description', { count: removeConfirmDialog.count })}
+        </Dialog>
+      )}
     </Flex>
   )
 }

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentationTypes.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentationTypes.ts
@@ -11,6 +11,14 @@ export interface EmployeeItem {
   eligiblePaidTimeOff?: PaidTimeOff[]
 }
 
+export interface RemoveConfirmDialogState {
+  isOpen: boolean
+  count: number
+  onConfirm: () => void
+  onClose: () => void
+  isPending?: boolean
+}
+
 export interface SelectEmployeesPresentationProps {
   employees: EmployeeItem[]
   selectedUuids: Set<string>
@@ -27,4 +35,10 @@ export interface SelectEmployeesPresentationProps {
   onBalanceChange?: (uuid: string, value: string) => void
   pagination?: PaginationControlProps
   isFetching?: boolean
+  /** UUIDs of employees already on the policy. These render with read-only balances and cannot have their balance edited from this screen. */
+  originallyOnPolicyUuids?: Set<string>
+  /** Current policy balances keyed by employee uuid. Used to render read-only balance text for originally-on-policy employees. */
+  originalBalances?: Record<string, string>
+  /** Optional confirm dialog shown before submitting when the user is about to remove employees from the policy. */
+  removeConfirmDialog?: RemoveConfirmDialogState
 }

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type * as ReactQuery from '@tanstack/react-query'
 import type { CreatableTimeOffPolicyType } from '../../TimeOffFlow/timeOffPolicyTypes'
 import { SelectEmployeesTimeOff } from './SelectEmployeesTimeOff'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
@@ -12,7 +13,10 @@ vi.mock('@/i18n/I18n', () => ({
 }))
 
 const mockAddEmployees = vi.fn()
+const mockRemoveEmployees = vi.fn()
 const mockOnEvent = vi.fn()
+const mockInvalidateQueries = vi.fn()
+let mockPolicyEmployees: Array<{ uuid: string; balance?: string }> = []
 
 const mockEmployees = [
   {
@@ -79,6 +83,27 @@ vi.mock('@gusto/embedded-api/react-query/timeOffPoliciesAddEmployees', () => ({
   }),
 }))
 
+vi.mock('@gusto/embedded-api/react-query/timeOffPoliciesRemoveEmployees', () => ({
+  useTimeOffPoliciesRemoveEmployeesMutation: () => ({
+    mutateAsync: mockRemoveEmployees,
+    isPending: false,
+  }),
+}))
+
+vi.mock('@gusto/embedded-api/react-query/timeOffPoliciesGet', () => ({
+  useTimeOffPoliciesGetSuspense: () => ({
+    data: { timeOffPolicy: { uuid: 'policy-456', employees: mockPolicyEmployees } },
+  }),
+}))
+
+vi.mock('@tanstack/react-query', async importActual => {
+  const actual = await importActual<typeof ReactQuery>()
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+  }
+})
+
 vi.mock('@/components/Base/useBase', () => ({
   useBase: () => ({
     onEvent: mockOnEvent,
@@ -124,6 +149,8 @@ describe('SelectEmployeesTimeOff', () => {
     vi.clearAllMocks()
     mockUseContainerBreakpoints.mockReturnValue(['base', 'small', 'medium', 'large'])
     mockAddEmployees.mockResolvedValue({ timeOffPolicy: { uuid: 'policy-456' } })
+    mockRemoveEmployees.mockResolvedValue({ timeOffPolicy: { uuid: 'policy-456' } })
+    mockPolicyEmployees = []
   })
 
   it('renders employee names from API data', async () => {
@@ -376,6 +403,129 @@ describe('SelectEmployeesTimeOff', () => {
         balance?: string
       }>
       expect(submitted.find(e => e.uuid === '1')).toEqual({ uuid: '1', balance: '40' })
+    })
+  })
+
+  describe('standalone mode with existing assignees', () => {
+    it('pre-selects employees that are already on the policy', async () => {
+      mockPolicyEmployees = [{ uuid: '1', balance: '12' }]
+      renderComponent({ mode: 'standalone' })
+      await waitFor(() => {
+        expect(screen.getAllByRole('checkbox').length).toBe(4)
+      })
+      const checkboxes = screen.getAllByRole('checkbox')
+      // Alice (uuid '1') is on the policy → pre-checked.
+      expect(checkboxes[FIRST_EMPLOYEE_CHECKBOX]).toBeChecked()
+      expect(checkboxes[SECOND_EMPLOYEE_CHECKBOX]).not.toBeChecked()
+    })
+
+    it("renders existing assignee's policy balance as read-only text", async () => {
+      mockPolicyEmployees = [{ uuid: '1', balance: '12' }]
+      renderComponent({ mode: 'standalone' })
+      await waitFor(() => {
+        expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+      })
+      // No editable input for Alice — her balance is rendered as plain text "12"
+      expect(screen.getByText('12')).toBeInTheDocument()
+      expect(screen.queryByDisplayValue('40')).not.toBeInTheDocument()
+    })
+
+    it('emits DONE without any mutation when nothing changed', async () => {
+      const user = userEvent.setup()
+      mockPolicyEmployees = [{ uuid: '1', balance: '12' }]
+      renderComponent({ mode: 'standalone' })
+      await waitFor(() => {
+        expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+      })
+      await user.click(screen.getByRole('button', { name: 'continueCta' }))
+      await waitFor(() => {
+        expect(mockOnEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE)
+      })
+      expect(mockAddEmployees).not.toHaveBeenCalled()
+      expect(mockRemoveEmployees).not.toHaveBeenCalled()
+    })
+
+    it('submits only newly-added employees when no removals are queued', async () => {
+      const user = userEvent.setup()
+      mockPolicyEmployees = [{ uuid: '1', balance: '12' }]
+      renderComponent({ mode: 'standalone' })
+      await waitFor(() => {
+        expect(screen.getByText('Bob Jones')).toBeInTheDocument()
+      })
+      // Add Bob — he is not yet on the policy
+      await user.click(screen.getAllByRole('checkbox')[SECOND_EMPLOYEE_CHECKBOX] as Element)
+      await user.click(screen.getByRole('button', { name: 'continueCta' }))
+      await waitFor(() => {
+        expect(mockAddEmployees).toHaveBeenCalledWith({
+          request: {
+            timeOffPolicyUuid: 'policy-456',
+            requestBody: { employees: [{ uuid: '2', balance: '0' }] },
+          },
+        })
+      })
+      // Alice was unchanged — must not be re-submitted
+      const submitted = mockAddEmployees.mock.calls[0]?.[0].request.requestBody.employees as Array<{
+        uuid: string
+      }>
+      expect(submitted.find(e => e.uuid === '1')).toBeUndefined()
+      expect(mockRemoveEmployees).not.toHaveBeenCalled()
+    })
+
+    it('opens confirm dialog when an existing assignee is unchecked', async () => {
+      const user = userEvent.setup()
+      mockPolicyEmployees = [{ uuid: '1', balance: '12' }]
+      renderComponent({ mode: 'standalone' })
+      await waitFor(() => {
+        expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+      })
+      // Uncheck Alice
+      await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
+      await user.click(screen.getByRole('button', { name: 'continueCta' }))
+      // Dialog should be visible — confirm/cancel buttons render with i18n keys
+      expect(
+        await screen.findByRole('button', { name: 'removeConfirmDialog.confirmCta' }),
+      ).toBeInTheDocument()
+      // No mutation has fired yet — gated on confirm
+      expect(mockRemoveEmployees).not.toHaveBeenCalled()
+      expect(mockAddEmployees).not.toHaveBeenCalled()
+    })
+
+    it('runs remove then add and invalidates the policy cache on confirm', async () => {
+      const user = userEvent.setup()
+      mockPolicyEmployees = [{ uuid: '1', balance: '12' }]
+      renderComponent({ mode: 'standalone' })
+      await waitFor(() => {
+        expect(screen.getByText('Bob Jones')).toBeInTheDocument()
+      })
+      // Uncheck Alice (uuid '1') and check Bob (uuid '2')
+      await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
+      await user.click(screen.getAllByRole('checkbox')[SECOND_EMPLOYEE_CHECKBOX] as Element)
+      await user.click(screen.getByRole('button', { name: 'continueCta' }))
+      const confirmBtn = await screen.findByRole('button', {
+        name: 'removeConfirmDialog.confirmCta',
+      })
+      await user.click(confirmBtn)
+      await waitFor(() => {
+        expect(mockRemoveEmployees).toHaveBeenCalledWith({
+          request: {
+            timeOffPolicyUuid: 'policy-456',
+            requestBody: { employees: [{ uuid: '1' }] },
+          },
+        })
+      })
+      expect(mockAddEmployees).toHaveBeenCalledWith({
+        request: {
+          timeOffPolicyUuid: 'policy-456',
+          requestBody: { employees: [{ uuid: '2', balance: '0' }] },
+        },
+      })
+      // remove must come before add
+      expect(mockRemoveEmployees.mock.invocationCallOrder[0]).toBeLessThan(
+        mockAddEmployees.mock.invocationCallOrder[0]!,
+      )
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['@gusto/embedded-api', 'timeOffPolicies', 'get'],
+      })
     })
   })
 

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useTimeOffPoliciesAddEmployeesMutation } from '@gusto/embedded-api/react-query/timeOffPoliciesAddEmployees'
+import { useTimeOffPoliciesRemoveEmployeesMutation } from '@gusto/embedded-api/react-query/timeOffPoliciesRemoveEmployees'
+import { useTimeOffPoliciesGetSuspense } from '@gusto/embedded-api/react-query/timeOffPoliciesGet'
+import { useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import type { CreatableTimeOffPolicyType } from '../../TimeOffFlow/timeOffPolicyTypes'
 import { SelectEmployeesPresentation } from './SelectEmployeesPresentation'
@@ -46,15 +49,63 @@ function deriveCarryOverBalances(
   return map
 }
 
-export function SelectEmployeesTimeOff({
+export function SelectEmployeesTimeOff(props: SelectEmployeesTimeOffProps) {
+  if (props.mode === 'wizard') {
+    return <SelectEmployeesTimeOffInner {...props} mode="wizard" />
+  }
+  return <StandaloneLoader {...props} />
+}
+
+function StandaloneLoader(props: SelectEmployeesTimeOffProps) {
+  const { data: policyResponse } = useTimeOffPoliciesGetSuspense({
+    timeOffPolicyUuid: props.policyId,
+  })
+  const policy = policyResponse.timeOffPolicy
+  if (!policy) throw new Error('Unexpected response: missing timeOffPolicy')
+
+  const originalUuids = useMemo(() => {
+    const set = new Set<string>()
+    for (const e of policy.employees) {
+      if (e.uuid) set.add(e.uuid)
+    }
+    return set
+  }, [policy.employees])
+
+  const originalBalances = useMemo(() => {
+    const map: Record<string, string> = {}
+    for (const e of policy.employees) {
+      if (e.uuid) map[e.uuid] = e.balance ?? '0'
+    }
+    return map
+  }, [policy.employees])
+
+  return (
+    <SelectEmployeesTimeOffInner
+      {...props}
+      mode="standalone"
+      originalUuids={originalUuids}
+      originalBalances={originalBalances}
+    />
+  )
+}
+
+interface InnerProps extends SelectEmployeesTimeOffProps {
+  originalUuids?: Set<string>
+  originalBalances?: Record<string, string>
+}
+
+function SelectEmployeesTimeOffInner({
   companyId,
   policyId,
   policyType,
   mode = 'standalone',
-}: SelectEmployeesTimeOffProps) {
+  originalUuids,
+  originalBalances,
+}: InnerProps) {
   useI18n('Company.TimeOff.SelectEmployees')
   const { t } = useTranslation('Company.TimeOff.SelectEmployees')
   const { onEvent, baseSubmitHandler } = useBase()
+  const queryClient = useQueryClient()
   const {
     filteredEmployees,
     selectedUuids,
@@ -65,7 +116,7 @@ export function SelectEmployeesTimeOff({
     handleSelectAll,
     handleSearchChange,
     handleSearchClear,
-  } = useSelectEmployeesData(companyId)
+  } = useSelectEmployeesData(companyId, originalUuids)
 
   // Captures the full Employee record at the moment a row is selected so
   // their carry-over balance is still available at submit time even if the
@@ -112,10 +163,69 @@ export function SelectEmployeesTimeOff({
   )
 
   const { mutateAsync: addEmployees } = useTimeOffPoliciesAddEmployeesMutation()
+  const { mutateAsync: removeEmployees, isPending: isRemovePending } =
+    useTimeOffPoliciesRemoveEmployeesMutation()
+
+  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false)
 
   const handleBalanceChange = useCallback((uuid: string, value: string) => {
     setBalances(prev => ({ ...prev, [uuid]: value }))
   }, [])
+
+  const buildAddPayload = useCallback(
+    (uuids: string[]) =>
+      uuids.map(uuid => {
+        const userValue = balances[uuid]
+        const carryOver = extractCarryOverBalance(
+          selectedEmployeesRef.current.get(uuid),
+          policyType,
+        )
+        // Per design review: do not zero out balances accidentally.
+        // Prefer user input → fall back to carry-over → omit `balance`
+        // entirely (backend defaults the row to 0) when neither is set.
+        const balance = userValue && userValue.length > 0 ? userValue : carryOver
+        return balance ? { uuid, balance } : { uuid }
+      }),
+    [balances, policyType],
+  )
+
+  const submitDiff = useCallback(
+    async (toAdd: string[], toRemove: string[]) => {
+      await baseSubmitHandler({}, async () => {
+        if (toRemove.length > 0) {
+          await removeEmployees({
+            request: {
+              timeOffPolicyUuid: policyId,
+              requestBody: { employees: toRemove.map(uuid => ({ uuid })) },
+            },
+          })
+        }
+        let policyResult: unknown
+        if (toAdd.length > 0) {
+          const response = await addEmployees({
+            request: {
+              timeOffPolicyUuid: policyId,
+              requestBody: { employees: buildAddPayload(toAdd) },
+            },
+          })
+          policyResult = response.timeOffPolicy
+        }
+        void queryClient.invalidateQueries({
+          queryKey: ['@gusto/embedded-api', 'timeOffPolicies', 'get'],
+        })
+        onEvent(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE, policyResult)
+      })
+    },
+    [
+      baseSubmitHandler,
+      removeEmployees,
+      addEmployees,
+      buildAddPayload,
+      policyId,
+      queryClient,
+      onEvent,
+    ],
+  )
 
   const handleContinue = useCallback(async () => {
     if (mode === 'wizard') {
@@ -125,38 +235,37 @@ export function SelectEmployeesTimeOff({
       return
     }
 
-    await baseSubmitHandler({}, async () => {
-      const response = await addEmployees({
-        request: {
-          timeOffPolicyUuid: policyId,
-          requestBody: {
-            employees: [...selectedUuids].map(uuid => {
-              const userValue = balances[uuid]
-              const carryOver = extractCarryOverBalance(
-                selectedEmployeesRef.current.get(uuid),
-                policyType,
-              )
-              // Per design review: do not zero out balances accidentally.
-              // Prefer user input → fall back to carry-over → omit `balance`
-              // entirely (backend defaults the row to 0) when neither is set.
-              const balance = userValue && userValue.length > 0 ? userValue : carryOver
-              return balance ? { uuid, balance } : { uuid }
-            }),
-          },
-        },
-      })
-      onEvent(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE, response.timeOffPolicy)
-    })
-  }, [
-    mode,
-    baseSubmitHandler,
-    addEmployees,
-    policyId,
-    selectedUuids,
-    balances,
-    policyType,
-    onEvent,
-  ])
+    const original = originalUuids ?? new Set<string>()
+    const toAdd = [...selectedUuids].filter(uuid => !original.has(uuid))
+    const toRemove = [...original].filter(uuid => !selectedUuids.has(uuid))
+
+    if (toAdd.length === 0 && toRemove.length === 0) {
+      onEvent(componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE)
+      return
+    }
+
+    if (toRemove.length > 0) {
+      setConfirmRemoveOpen(true)
+      return
+    }
+
+    await submitDiff(toAdd, toRemove)
+  }, [mode, originalUuids, selectedUuids, onEvent, submitDiff])
+
+  const handleConfirmRemove = useCallback(async () => {
+    const original = originalUuids ?? new Set<string>()
+    const toAdd = [...selectedUuids].filter(uuid => !original.has(uuid))
+    const toRemove = [...original].filter(uuid => !selectedUuids.has(uuid))
+    setConfirmRemoveOpen(false)
+    await submitDiff(toAdd, toRemove)
+  }, [originalUuids, selectedUuids, submitDiff])
+
+  const removeCount = useMemo(() => {
+    if (!originalUuids) return 0
+    let count = 0
+    for (const uuid of originalUuids) if (!selectedUuids.has(uuid)) count += 1
+    return count
+  }, [originalUuids, selectedUuids])
 
   const handleBack = useCallback(() => {
     onEvent(componentEvents.CANCEL)
@@ -179,6 +288,23 @@ export function SelectEmployeesTimeOff({
       onBalanceChange={handleBalanceChange}
       pagination={pagination}
       isFetching={isFetching}
+      originallyOnPolicyUuids={originalUuids}
+      originalBalances={originalBalances}
+      removeConfirmDialog={
+        mode === 'standalone'
+          ? {
+              isOpen: confirmRemoveOpen,
+              count: removeCount,
+              onConfirm: () => {
+                void handleConfirmRemove()
+              },
+              onClose: () => {
+                setConfirmRemoveOpen(false)
+              },
+              isPending: isRemovePending,
+            }
+          : undefined
+      }
     />
   )
 }

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/useSelectEmployeesData.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/useSelectEmployeesData.ts
@@ -5,8 +5,10 @@ import type { PaidTimeOff } from '@gusto/embedded-api/models/components/paidtime
 import type { EmployeeItem } from './SelectEmployeesPresentationTypes'
 import { usePagination } from '@/hooks/usePagination/usePagination'
 
-export function useSelectEmployeesData(companyId: string) {
-  const [selectedUuids, setSelectedUuids] = useState(new Set<string>())
+export function useSelectEmployeesData(companyId: string, initialSelectedUuids?: Set<string>) {
+  const [selectedUuids, setSelectedUuids] = useState<Set<string>>(
+    () => new Set(initialSelectedUuids ?? []),
+  )
   const [searchValue, setSearchValue] = useState('')
   const { currentPage, itemsPerPage, getPaginationProps, resetPage } = usePagination()
 

--- a/src/i18n/en/Company.TimeOff.SelectEmployees.json
+++ b/src/i18n/en/Company.TimeOff.SelectEmployees.json
@@ -8,5 +8,13 @@
   "departmentColumn": "Department",
   "startingBalanceColumn": "Starting balance (hrs)",
   "backCta": "Back",
-  "continueCta": "Continue"
+  "continueCta": "Continue",
+  "removeConfirmDialog": {
+    "title_one": "Remove {{count}} employee from this policy?",
+    "title_other": "Remove {{count}} employees from this policy?",
+    "description_one": "This employee's balance for this policy will be removed. They can be re-added later.",
+    "description_other": "These employees' balances for this policy will be removed. They can be re-added later.",
+    "confirmCta": "Remove and save",
+    "cancelCta": "Cancel"
+  }
 }

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -583,6 +583,14 @@ export interface CompanyTimeOffSelectEmployees{
 "startingBalanceColumn":string;
 "backCta":string;
 "continueCta":string;
+"removeConfirmDialog":{
+"title_one":string;
+"title_other":string;
+"description_one":string;
+"description_other":string;
+"confirmCta":string;
+"cancelCta":string;
+};
 };
 export interface CompanyTimeOffSelectPolicyType{
 "title":string;


### PR DESCRIPTION
## Summary

Reworks the Add Employees screen reached from a Time-Off policy detail page so a single round-trip can manage the policy's roster end-to-end. Previously the user landed on a list of every non-terminated employee with no indication of who was already on the policy — re-submitting an existing assignee was easy and removing one was a separate flow on the detail page.

Two parts:

1. **State machine wiring** (already on this branch): `viewTimeOffPolicyDetail` now transitions to `addEmployeesToPolicy` on `TIME_OFF_ADD_EMPLOYEES_TO_POLICY`, reducing the payload's `policyId` into context. Round-trip back via the existing `TIME_OFF_ADD_EMPLOYEES_DONE` transition.
2. **Manage-membership UX** (new): the Add Employees screen now pre-selects existing assignees, shows their current balance read-only, diffs the selection at submit time, and gates removals behind a destructive confirm dialog.

Behavior details on (2):
- `useSelectEmployeesData` accepts `initialSelectedUuids` to seed the selection set.
- For originally-on-policy rows, the balance cell renders as read-only text (their current saved balance). Editable balance + carry-over pre-fill remains for newly-added rows.
- At submit, compute the diff against `policy.employees`. `toAdd` calls `useTimeOffPoliciesAddEmployeesMutation`; `toRemove` calls `useTimeOffPoliciesRemoveEmployeesMutation`. Unchanged rows are skipped — balances for existing assignees are owned by the dedicated edit-balance flow on the detail page.
- When `toRemove.length > 0` a destructive confirm dialog gates the submit. On confirm, run remove first, then add, then invalidate the policy cache.
- Empty diff is a pure no-op: emits `TIME_OFF_ADD_EMPLOYEES_DONE` without an API call so navigation still works.
- Wizard mode is unchanged (no policy fetched, still emits `employeeUuids`).

This is PR 9 in the time-off bug-fix slate captured in `~/.claude/plans/ok-i-want-to-partitioned-balloon.md`. Plan for the membership UX work: `~/.claude/plans/we-were-just-working-memoized-island.md`.

## Test plan

- [x] `npm run test -- --run src/components/UNSTABLE_TimeOff` — 305/305 passing (added 6 new tests covering pre-select, read-only balance, no-op diff, add-only path, dialog-gated submit, remove-then-add ordering, cache invalidation)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [ ] Storybook: verify `WithExistingAssignees`, `ExistingAssigneesWithNewSelections`, and `RemoveConfirmDialogOpen` render correctly (`npm run storybook`)
- [ ] Manual e2e via SDK dev app (`npm run sdk-app`):
  - [ ] Open a Time-Off policy detail page that already has assignees → click "Add employees" → existing assignees appear pre-selected with their balance shown read-only
  - [ ] Uncheck one existing assignee, check one new employee → click Continue → confirm dialog appears → confirm → roster reflects both add and remove
  - [ ] Open the same screen and click Continue without changing anything → no API call, navigation returns to the detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)