### PR TITLE
fix: wire TIME_OFF_EDIT_POLICY and TIME_OFF_CHANGE_SETTINGS transitions

### DIFF
--- a/src/components/UNSTABLE_TimeOff/PolicySettings/PolicySettings.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicySettings/PolicySettings.tsx
@@ -2,6 +2,7 @@ import { useTimeOffPoliciesGetSuspense } from '@gusto/embedded-api/react-query/t
 import { useTimeOffPoliciesUpdateMutation } from '@gusto/embedded-api/react-query/timeOffPoliciesUpdate'
 import type { PutV1TimeOffPoliciesTimeOffPolicyUuidRequestBody } from '@gusto/embedded-api/models/operations/putv1timeoffpoliciestimeoffpolicyuuid'
 import type { TimeOffPolicy } from '@gusto/embedded-api/models/components/timeoffpolicy'
+import { useQueryClient } from '@tanstack/react-query'
 import { PolicySettingsPresentation } from './PolicySettingsPresentation'
 import type { PolicySettingsFormData, PolicySettingsAccrualMethod } from './PolicySettingsTypes'
 import { BaseComponent, type BaseComponentInterface } from '@/components/Base'
@@ -89,6 +90,7 @@ function buildUpdateRequestBody(
 
 function Root({ policyId }: PolicySettingsProps) {
   const { onEvent, baseSubmitHandler } = useBase()
+  const queryClient = useQueryClient()
 
   const { data: policyResponse } = useTimeOffPoliciesGetSuspense({
     timeOffPolicyUuid: policyId,
@@ -111,6 +113,9 @@ function Root({ policyId }: PolicySettingsProps) {
         },
       })
 
+      void queryClient.invalidateQueries({
+        queryKey: ['@gusto/embedded-api', 'timeOffPolicies', 'get'],
+      })
       onEvent(componentEvents.TIME_OFF_POLICY_SETTINGS_DONE, timeOffPolicy)
     })
   }

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
@@ -9,6 +9,7 @@ type TimeOffState =
   | 'policyTypeSelector'
   | 'policyDetailsForm'
   | 'policySettings'
+  | 'editPolicySettings'
   | 'addEmployeesToPolicy'
   | 'viewTimeOffPolicyDetail'
   | 'holidaySelectionForm'
@@ -329,14 +330,57 @@ describe('timeOffStateMachine', () => {
       expect(service.context.policyId).toBe('policy-existing')
     })
 
-    it('transitions to policySettings on TIME_OFF_CHANGE_SETTINGS with policyId', () => {
+    it('transitions to editPolicySettings on TIME_OFF_CHANGE_SETTINGS with policyId', () => {
       const service = createService()
       toViewPolicyDetail(service)
 
       send(service, componentEvents.TIME_OFF_CHANGE_SETTINGS, { policyId: 'policy-existing' })
 
-      expect(service.machine.current).toBe('policySettings')
+      expect(service.machine.current).toBe('editPolicySettings')
       expect(service.context.policyId).toBe('policy-existing')
+    })
+
+    it('returns to viewTimeOffPolicyDetail on TIME_OFF_POLICY_SETTINGS_DONE in the edit flow', () => {
+      const service = createService()
+      toViewPolicyDetail(service)
+      send(service, componentEvents.TIME_OFF_CHANGE_SETTINGS, { policyId: 'policy-existing' })
+
+      send(service, componentEvents.TIME_OFF_POLICY_SETTINGS_DONE)
+
+      expect(service.machine.current).toBe('viewTimeOffPolicyDetail')
+      // policyId is preserved so the detail view re-renders for the same policy
+      expect(service.context.policyId).toBe('policy-existing')
+    })
+
+    it('returns to viewTimeOffPolicyDetail on TIME_OFF_POLICY_SETTINGS_BACK in the edit flow', () => {
+      const service = createService()
+      toViewPolicyDetail(service)
+      send(service, componentEvents.TIME_OFF_CHANGE_SETTINGS, { policyId: 'policy-existing' })
+
+      send(service, componentEvents.TIME_OFF_POLICY_SETTINGS_BACK)
+
+      expect(service.machine.current).toBe('viewTimeOffPolicyDetail')
+      expect(service.context.policyId).toBe('policy-existing')
+    })
+
+    it('cancels from editPolicySettings to policyList', () => {
+      const service = createService()
+      toViewPolicyDetail(service)
+      send(service, componentEvents.TIME_OFF_CHANGE_SETTINGS, { policyId: 'policy-existing' })
+
+      send(service, componentEvents.CANCEL)
+
+      expect(service.machine.current).toBe('policyList')
+    })
+
+    it('does not route TIME_OFF_POLICY_SETTINGS_DONE in the create flow back to the detail view', () => {
+      // Guards against regression of the create flow when adding the edit-only state.
+      const service = createService()
+      toPolicySettings(service)
+
+      send(service, componentEvents.TIME_OFF_POLICY_SETTINGS_DONE)
+
+      expect(service.machine.current).toBe('addEmployeesToPolicy')
     })
   })
 

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
@@ -310,6 +310,36 @@ describe('timeOffStateMachine', () => {
     })
   })
 
+  describe('viewTimeOffPolicyDetail edit transitions', () => {
+    function toViewPolicyDetail(service: ReturnType<typeof createService>) {
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'policy-existing',
+        policyType: 'vacation',
+      })
+      expect(service.machine.current).toBe('viewTimeOffPolicyDetail')
+    }
+
+    it('transitions to policyDetailsForm on TIME_OFF_EDIT_POLICY with policyId', () => {
+      const service = createService()
+      toViewPolicyDetail(service)
+
+      send(service, componentEvents.TIME_OFF_EDIT_POLICY, { policyId: 'policy-existing' })
+
+      expect(service.machine.current).toBe('policyDetailsForm')
+      expect(service.context.policyId).toBe('policy-existing')
+    })
+
+    it('transitions to policySettings on TIME_OFF_CHANGE_SETTINGS with policyId', () => {
+      const service = createService()
+      toViewPolicyDetail(service)
+
+      send(service, componentEvents.TIME_OFF_CHANGE_SETTINGS, { policyId: 'policy-existing' })
+
+      expect(service.machine.current).toBe('policySettings')
+      expect(service.context.policyId).toBe('policy-existing')
+    })
+  })
+
   describe('back to list', () => {
     it('returns to policyList from viewTimeOffPolicyDetail', () => {
       const service = createService()

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -20,7 +20,7 @@ type PolicyTypePayload = { policyType: 'sick' | 'vacation' | 'holiday' }
 type PolicyCreatedPayload = { policyId: string; accrualMethod?: string }
 type ErrorPayload = { alert?: TimeOffFlowAlert }
 type ViewPolicyPayload = { policyId: string; policyType: 'sick' | 'vacation' | 'holiday' }
-type EditPolicyPayload = { policyId: string }
+type PolicyIdPayload = { policyId: string }
 
 function isSickOrVacation(_ctx: TimeOffFlowContextInterface, ev: { payload: PolicyTypePayload }) {
   return ev.payload.policyType === 'sick' || ev.payload.policyType === 'vacation'
@@ -282,7 +282,7 @@ export const timeOffMachine = {
       reduce(
         (
           ctx: TimeOffFlowContextInterface,
-          ev: { payload: EditPolicyPayload },
+          ev: { payload: PolicyIdPayload },
         ): TimeOffFlowContextInterface => ({
           ...ctx,
           component: PolicyDetailsFormContextual,
@@ -293,11 +293,11 @@ export const timeOffMachine = {
     ),
     transition(
       componentEvents.TIME_OFF_CHANGE_SETTINGS,
-      'policySettings',
+      'editPolicySettings',
       reduce(
         (
           ctx: TimeOffFlowContextInterface,
-          ev: { payload: EditPolicyPayload },
+          ev: { payload: PolicyIdPayload },
         ): TimeOffFlowContextInterface => ({
           ...ctx,
           component: PolicySettingsContextual,
@@ -307,6 +307,35 @@ export const timeOffMachine = {
       ),
     ),
     backToListTransition,
+  ),
+
+  // Distinct from `policySettings` (the create-flow step) so that DONE/BACK
+  // return to the policy detail view instead of routing into the create
+  // flow's add-employees / details-form steps.
+  editPolicySettings: state<MachineTransition>(
+    transition(
+      componentEvents.TIME_OFF_POLICY_SETTINGS_DONE,
+      'viewTimeOffPolicyDetail',
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: TimeOffPolicyDetailContextual,
+          alerts: undefined,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.TIME_OFF_POLICY_SETTINGS_BACK,
+      'viewTimeOffPolicyDetail',
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: TimeOffPolicyDetailContextual,
+          alerts: undefined,
+        }),
+      ),
+    ),
+    cancelToPolicyList,
   ),
 
   holidaySelectionForm: state<MachineTransition>(

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -20,6 +20,7 @@ type PolicyTypePayload = { policyType: 'sick' | 'vacation' | 'holiday' }
 type PolicyCreatedPayload = { policyId: string; accrualMethod?: string }
 type ErrorPayload = { alert?: TimeOffFlowAlert }
 type ViewPolicyPayload = { policyId: string; policyType: 'sick' | 'vacation' | 'holiday' }
+type EditPolicyPayload = { policyId: string }
 
 function isSickOrVacation(_ctx: TimeOffFlowContextInterface, ev: { payload: PolicyTypePayload }) {
   return ev.payload.policyType === 'sick' || ev.payload.policyType === 'vacation'
@@ -274,7 +275,39 @@ export const timeOffMachine = {
     cancelToPolicyList,
   ),
 
-  viewTimeOffPolicyDetail: state<MachineTransition>(backToListTransition),
+  viewTimeOffPolicyDetail: state<MachineTransition>(
+    transition(
+      componentEvents.TIME_OFF_EDIT_POLICY,
+      'policyDetailsForm',
+      reduce(
+        (
+          ctx: TimeOffFlowContextInterface,
+          ev: { payload: EditPolicyPayload },
+        ): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: PolicyDetailsFormContextual,
+          policyId: ev.payload.policyId,
+          alerts: undefined,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.TIME_OFF_CHANGE_SETTINGS,
+      'policySettings',
+      reduce(
+        (
+          ctx: TimeOffFlowContextInterface,
+          ev: { payload: EditPolicyPayload },
+        ): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: PolicySettingsContextual,
+          policyId: ev.payload.policyId,
+          alerts: undefined,
+        }),
+      ),
+    ),
+    backToListTransition,
+  ),
 
   holidaySelectionForm: state<MachineTransition>(
     transition(


### PR DESCRIPTION
## Summary

Wires up two missing transitions on `viewTimeOffPolicyDetail` and ensures the **Change settings** round-trip actually returns to the policy detail view.

- `TIME_OFF_EDIT_POLICY` → `policyDetailsForm` (reduces `policyId` into context)
- `TIME_OFF_CHANGE_SETTINGS` → `editPolicySettings` (reduces `policyId` into context)
- New `editPolicySettings` state whose `TIME_OFF_POLICY_SETTINGS_DONE` and `TIME_OFF_POLICY_SETTINGS_BACK` transitions return to `viewTimeOffPolicyDetail` with `policyId` preserved. The create-flow `policySettings` state and its outbound routing (DONE → `addEmployeesToPolicy`, BACK → `policyDetailsForm`) are unchanged.
- `PolicySettings` invalidates the policy cache after a successful update so the detail view re-renders with fresh data.
- Renamed `EditPolicyPayload` → `PolicyIdPayload` since the same payload shape is used by both edit-policy and change-settings transitions.

### Why a separate `editPolicySettings` state

The original wiring (PR initial commit) routed `TIME_OFF_CHANGE_SETTINGS` into the same `policySettings` state used by the create flow. That state's DONE and BACK transitions assume create-flow continuation: DONE → add-employees, BACK → create-policy form. So **Change settings** would dump the user into the add-employees flow on save and into the create form on back. Splitting the edit path into its own state keeps the create-flow wiring intact and gives the edit path the right round-trip without conditionals.

### Scope note: PolicyConfigurationForm edit-mode is still a follow-up

`PolicySettings` already supports edit mode (loads via `useTimeOffPoliciesGetSuspense`, saves via `useTimeOffPoliciesUpdateMutation`), so **Change settings now works end-to-end**.

`PolicyConfigurationForm` (the policy-details form) remains create-only. After this PR, **Edit policy** still navigates to that form, but the form will be empty and submit would attempt to create a new policy. The form's edit-mode (prefill via `useTimeOffPoliciesGetSuspense` + `useTimeOffPoliciesUpdateMutation` + return-to-detail on submit) is a follow-up — likely a parallel `editPolicyDetailsForm` state mirroring the pattern introduced here. Coordinate with Kristine before starting.

This is PR 10 in the time-off bug-fix slate captured in `~/.claude/plans/ok-i-want-to-partitioned-balloon.md`.

## Addresses Copilot review feedback

- Renamed `EditPolicyPayload` → `PolicyIdPayload` (Copilot, [timeOffStateMachine.ts:23](src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts#L23)).
- Fixed the `policySettings` round-trip routing for the edit flow by introducing `editPolicySettings` (Copilot, line 309 of the prior diff).
- Added round-trip coverage for the edit-from-detail path (Copilot, [timeOffStateMachine.test.ts:340](src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts#L340)).

## Test plan

- [x] `npm run test -- --run src/components/UNSTABLE_TimeOff/TimeOffFlow/ src/components/UNSTABLE_TimeOff/PolicySettings/` — 71/71 passing (added DONE/BACK/CANCEL round-trip tests + a regression test pinning the create-flow DONE behavior)
- [x] `npm run test -- --run src/components/UNSTABLE_TimeOff` — 303/303 passing (full TimeOff suite)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [ ] Manual: from a sick policy detail → click **Change** on the Settings card → form opens prefilled with the policy's current settings → save returns to the same policy detail with the updated values shown
- [ ] Manual: same flow, but click **Back** instead of save → returns to the same policy detail unchanged
- [ ] Manual (known limitation): from a sick policy detail → click **Edit policy** → verify the form is reached. Form will be empty and submit would create a duplicate policy — that is the deferred follow-up scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)