### PR TITLE
fix: workers comp rate inputs submit typed values (SDK-798)

### DIFF
--- a/src/components/Common/TaxInputs/TaxInputs.tsx
+++ b/src/components/Common/TaxInputs/TaxInputs.tsx
@@ -149,7 +149,7 @@ export function NumberInput({
       name={key}
       label={label}
       description={description ?? wcDescription}
-      defaultValue={typeof value !== 'undefined' ? Number(value) : undefined}
+      defaultValue={value !== undefined && value !== null ? Number(value) : undefined}
       format={isCurrency ? 'currency' : isPercent ? 'percent' : 'decimal'}
       isDisabled={isDisabled}
       maximumFractionDigits={isPercent ? 4 : undefined}

--- a/src/components/Company/StateTaxes/StateTaxesForm/Form.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesForm/Form.tsx
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { useTranslation } from 'react-i18next'
 import { Fragment } from 'react/jsx-runtime'
 import { useStateTaxesForm } from './context'
+import { toRhfKey } from './rhfKey'
 import { QuestionInput } from '@/components/Common/TaxInputs/TaxInputs'
 import { useLocaleDateFormatter } from '@/contexts/LocaleProvider/useLocale'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
@@ -32,7 +33,7 @@ export function Form() {
             <QuestionInput
               requirement={{
                 ...requirement,
-                key: `${key}.${requirement.key as string}`,
+                key: `${key}.${toRhfKey(requirement.key as string)}`,
               }}
               questionType={requirement.metadata?.type ?? 'Text'}
               key={requirement.key}

--- a/src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.test.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.test.tsx
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
 import { StateTaxesForm } from './StateTaxesForm'
 import { setupApiTestMocks } from '@/test/mocks/apiServer'
 import { componentEvents } from '@/shared/constants'
 import { GustoTestProvider } from '@/test/GustoTestApiProvider'
+import { server } from '@/test/mocks/server'
+import { API_BASE_URL } from '@/test/constants'
 
 vi.mock('@/hooks/useContainerBreakpoints/useContainerBreakpoints', async () => {
   const actual = await vi.importActual('@/hooks/useContainerBreakpoints/useContainerBreakpoints')
@@ -102,6 +105,47 @@ describe('StateTaxesForm', () => {
       await waitFor(() => {
         expect(onEvent).toHaveBeenCalledWith(componentEvents.COMPANY_STATE_TAX_UPDATED)
       })
+    })
+
+    it('submits workers compensation rate values entered by the user', async () => {
+      let capturedBody: unknown = null
+      server.use(
+        http.put(
+          `${API_BASE_URL}/v1/companies/:company_id/tax_requirements/:state`,
+          async ({ request }) => {
+            capturedBody = await request.json()
+            return HttpResponse.json({})
+          },
+        ),
+      )
+
+      const hourlyRateInput = await screen.findByLabelText(/Hourly Rate/i)
+      await user.type(hourlyRateInput, '5.25')
+
+      const employeeWithholdingInput = await screen.findByLabelText(/Employee Withholding/i)
+      await user.type(employeeWithholdingInput, '0.5')
+
+      const submitButton = await screen.findByRole('button', { name: /Save/i })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(onEvent).toHaveBeenCalledWith(componentEvents.COMPANY_STATE_TAX_UPDATED)
+      })
+
+      const body = capturedBody as {
+        requirement_sets: Array<{
+          key: string
+          requirements: Array<{ key: string; value: string }>
+        }>
+      }
+      const wcSet = body.requirement_sets.find(rs => rs.key === 'workerscompensationrates')
+      expect(wcSet).toBeDefined()
+      expect(wcSet?.requirements).toEqual(
+        expect.arrayContaining([
+          { key: 'wa_wc_hourly_rate|010103', value: '5.25' },
+          { key: 'wa_wc_employee_withholding|010103', value: '0.5' },
+        ]),
+      )
     })
   })
 })

--- a/src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.tsx
@@ -9,6 +9,7 @@ import { Head } from './Head'
 import { StateTaxesFormProvider } from './context'
 import { Form } from './Form'
 import { Actions } from './Actions'
+import { fromRhfKey, toRhfKey } from './rhfKey'
 import type { BaseComponentInterface, CommonComponentInterface } from '@/components/Base/Base'
 import { BaseComponent } from '@/components/Base/Base'
 import { useI18n } from '@/i18n/I18n'
@@ -20,6 +21,14 @@ import { useBase } from '@/components/Base'
 interface StateTaxesFormProps extends CommonComponentInterface {
   companyId: string
   state: string
+}
+
+function stringifyRequirementValue(value: unknown): string {
+  if (value === undefined || value === null) return ''
+  if (typeof value === 'number') return isNaN(value) ? '' : String(value)
+  if (typeof value === 'string') return value
+  if (typeof value === 'boolean') return String(value)
+  return ''
 }
 
 export function StateTaxesForm(props: StateTaxesFormProps & BaseComponentInterface) {
@@ -57,13 +66,18 @@ function Root({ companyId, state, className, children }: StateTaxesFormProps) {
       requirementSet.requirements?.forEach(requirement => {
         if (!requirement.key) return
 
-        const requirementKey = requirement.key
+        const requirementKey = toRhfKey(requirement.key)
 
         const isPercentField =
           requirement.metadata?.type === 'tax_rate' || requirement.metadata?.type === 'percent'
 
         if (requirement.metadata?.type === 'radio') {
           requirementValues[requirementKey] = requirement.value ?? undefined
+        } else if (requirement.metadata?.type === 'workers_compensation_rate') {
+          requirementValues[requirementKey] =
+            requirement.value !== null && requirement.value !== undefined
+              ? Number(requirement.value)
+              : undefined
         } else {
           requirementValues[requirementKey] = requirement.value ? String(requirement.value) : ''
         }
@@ -86,6 +100,8 @@ function Root({ companyId, state, className, children }: StateTaxesFormProps) {
 
         if (requirement.metadata?.type === 'radio') {
           fieldSchema = z.boolean().optional()
+        } else if (requirement.metadata?.type === 'workers_compensation_rate') {
+          fieldSchema = z.number().optional()
         }
         requirementShape[requirementKey] = fieldSchema
         // --- End Schema Logic ---
@@ -127,8 +143,8 @@ function Root({ companyId, state, className, children }: StateTaxesFormProps) {
             key: requirementSetKey,
             effectiveFrom: requirementSet.effectiveFrom,
             requirements: Object.entries(payloadSet).map(([reqKey, value]) => ({
-              key: reqKey,
-              value: String(value),
+              key: fromRhfKey(reqKey),
+              value: stringifyRequirementValue(value),
             })),
           }
         })

--- a/src/components/Company/StateTaxes/StateTaxesForm/rhfKey.ts
+++ b/src/components/Company/StateTaxes/StateTaxesForm/rhfKey.ts
@@ -1,0 +1,8 @@
+// react-hook-form's path parser strips `|`, `"`, `'`, and `]` from field names
+// (see its stringToPath regex), which silently re-routes writes to a different
+// path than reads. Tax requirement keys like `wa_wc_hourly_rate|010103` need
+// the pipe replaced to round-trip through RHF state without losing values.
+const PIPE_PLACEHOLDER = '__PIPE__'
+
+export const toRhfKey = (key: string): string => key.replaceAll('|', PIPE_PLACEHOLDER)
+export const fromRhfKey = (key: string): string => key.replaceAll(PIPE_PLACEHOLDER, '|')


### PR DESCRIPTION
## Summary

- WA Workers Compensation Rate inputs (Hourly Rate / Employee Withholding) were always submitting empty strings to the tax requirements API. Typing a value did nothing — and entering anything would cause "should be a number" validation errors that blocked submission entirely.
- Two intertwined bugs: (1) the dynamic schema generator had no special case for `workers_compensation_rate` requirement metadata, so these fields used `z.string().optional()` while the `NumberInputField` writes `number` values; (2) the requirement keys (e.g. `wa_wc_hourly_rate|010103`) contain `|`, which `react-hook-form`'s path parser silently strips — causing typed values to land at `wa_wc_hourly_rate010103` (no pipe) while defaults stayed at `wa_wc_hourly_rate|010103` (with pipe), and Zod's resolver then discarded the typed values as unknown keys.
- Fix: sanitize `|` to a placeholder when registering with RHF (round-tripped via new `toRhfKey` / `fromRhfKey` helpers), add `z.number().optional()` schema and undefined-safe defaults for `workers_compensation_rate`, harden the submit handler against `undefined`/`NaN`, and stop seeding `NumberInput` with `Number(null) === 0` when the API returns `null`.
- Built TDD-first: new test types `5.25` / `0.5` into the WA workers comp inputs, captures the PUT body via an MSW override, and asserts the values arrive intact.

JIRA: [SDK-798](https://gustohq.atlassian.net/browse/SDK-798)

## Test plan

- [x] `npm run test -- --run src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.test.tsx` — 9/9 passing, including the new `submits workers compensation rate values entered by the user` case
- [x] `npm run test -- --run src/components/Company/StateTaxes/ src/components/Common/TaxInputs/` — 23/23 passing
- [x] `tsc --noEmit` clean
- [ ] Manual: WA `Company.OnboardingFlow → StateTaxes` with a company that has WA location + employee onboarded in 2026 with occupation code `45-2092`. Enter `5.25` in Hourly Rate, click Save, verify no inline validation errors and that the network PUT body contains `"value": "5.25"` for the `wa_wc_hourly_rate|...` requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-798]: https://gustohq.atlassian.net/browse/SDK-798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ