### PR TITLE
fix: filter time-off policy list to PTO, Sick, and Holiday only

### DIFF
--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.test.tsx
@@ -202,6 +202,45 @@ describe('PolicyList', () => {
       expect(screen.getByText('Sick Leave')).toBeInTheDocument()
       expect(screen.queryByText('Deactivated Policy')).not.toBeInTheDocument()
     })
+
+    it('omits non-PTO/sick policies (custom, bereavement, etc.) from the list', async () => {
+      server.use(
+        http.get(`${API_BASE_URL}/v1/companies/:companyUuid/time_off_policies`, () => {
+          return HttpResponse.json([
+            ...mockPolicies,
+            {
+              uuid: 'policy-custom',
+              company_uuid: 'company-123',
+              name: 'Custom Policy',
+              policy_type: 'custom',
+              accrual_method: 'unlimited',
+              is_active: true,
+              complete: true,
+              employees: [],
+            },
+            {
+              uuid: 'policy-bereavement',
+              company_uuid: 'company-123',
+              name: 'Bereavement',
+              policy_type: 'bereavement',
+              accrual_method: 'unlimited',
+              is_active: true,
+              complete: true,
+              employees: [],
+            },
+          ])
+        }),
+      )
+
+      renderWithProviders(<PolicyList {...defaultProps} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Vacation')).toBeInTheDocument()
+      })
+      expect(screen.getByText('Sick Leave')).toBeInTheDocument()
+      expect(screen.queryByText('Custom Policy')).not.toBeInTheDocument()
+      expect(screen.queryByText('Bereavement')).not.toBeInTheDocument()
+    })
   })
 
   describe('empty state', () => {

--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.tsx
@@ -15,6 +15,7 @@ import { useHolidayPayPoliciesDeleteMutation } from '@gusto/embedded-api/react-q
 import type { TimeOffPolicy } from '@gusto/embedded-api/models/components/timeoffpolicy'
 import { PolicyListPresentation } from './PolicyListPresentation'
 import type { PolicyListItem } from './PolicyListTypes'
+import { isListedTimeOffPolicyType } from '@/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffPolicyTypes'
 import { BaseBoundaries, BaseLayout, type BaseComponentInterface } from '@/components/Base'
 import { useBaseSubmit } from '@/components/Base/useBaseSubmit'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
@@ -53,7 +54,9 @@ function Root({ companyId, onEvent }: PolicyListProps) {
   const { data: policiesData } = useTimeOffPoliciesGetAllSuspense({
     companyUuid: companyId,
   })
-  const timeOffPolicies = (policiesData.timeOffPolicies ?? []).filter(policy => policy.isActive)
+  const timeOffPolicies = (policiesData.timeOffPolicies ?? []).filter(
+    policy => policy.isActive && isListedTimeOffPolicyType(policy.policyType),
+  )
 
   // Holiday pay policy is auxiliary to the main time-off list; never crash the
   // boundary on its failure. composeErrorHandler below surfaces the error as

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffPolicyTypes.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffPolicyTypes.ts
@@ -17,6 +17,19 @@ export function isEditableTimeOffPolicyType(
   return EDITABLE_TIME_OFF_POLICY_TYPES.includes(policyType as EditableTimeOffPolicyType)
 }
 
+// Subset of types the SDK surfaces from the time_off_policies endpoint.
+// Holiday lives on a separate endpoint and is merged into the list by the caller.
+export const LISTED_TIME_OFF_POLICY_TYPES = [
+  'sick',
+  'vacation',
+] as const satisfies readonly PolicyType[]
+
+export function isListedTimeOffPolicyType(
+  policyType: PolicyType | null | undefined,
+): policyType is CreatableTimeOffPolicyType {
+  return LISTED_TIME_OFF_POLICY_TYPES.includes(policyType as CreatableTimeOffPolicyType)
+}
+
 export function assertCreatablePolicyType(
   policyType: TimeOffPolicyType,
 ): asserts policyType is CreatableTimeOffPolicyType {


### PR DESCRIPTION
## Summary
- The Time Off policy list rendered every type returned by `GET /v1/companies/:companyUuid/time_off_policies` (custom, bereavement, floating_holiday, jury_duty, etc.), but the SDK only supports creating/editing PTO (`vacation`), Sick, and Holiday — these legacy types typically appear on companies migrated from gusto.com and exposed flows the SDK doesn't support.
- Adds `LISTED_TIME_OFF_POLICY_TYPES` + `isListedTimeOffPolicyType` in `timeOffPolicyTypes.ts` and applies the guard alongside the existing `isActive` filter in `PolicyList.tsx`. Holiday is unchanged since it comes from a separate `holidayPayPolicies` endpoint and is appended to the rendered list separately.
- The Speakeasy-generated `@gusto/embedded-api` request schema doesn't expose a `policy_type` filter, so this is necessarily a client-side filter.

## Test plan
- [x] `npm run test -- --run src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.test.tsx` (23/23 passing, including a new test that custom/bereavement policies are filtered out)
- [ ] Storybook smoke test: open the `PolicyList` story; confirm Vacation, Sick, and Holiday entries render and a `custom` policy in the mock does not
- [ ] Dev app (only if a seeded company has legacy types): `npm run sdk-app`, navigate to TimeOff policies, confirm only PTO/Sick/Holiday rows appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)