### PR TITLE
fix: wire holiday policy edit and add-employees flows

### DIFF
--- a/docs/reference/endpoint-inventory.json
+++ b/docs/reference/endpoint-inventory.json
@@ -1380,6 +1380,10 @@
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
+          "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
+        },
+        {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/time_off_policies"
         },
@@ -1442,6 +1446,10 @@
         },
         {
           "method": "POST",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
@@ -1521,6 +1529,10 @@
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
+          "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
+        },
+        {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/time_off_policies"
         },
@@ -1583,6 +1595,10 @@
         },
         {
           "method": "POST",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
@@ -1651,6 +1667,10 @@
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
+          "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
+        },
+        {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/time_off_policies"
         },
@@ -1713,6 +1733,10 @@
         },
         {
           "method": "POST",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
@@ -1781,6 +1805,10 @@
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
+          "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
+        },
+        {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/time_off_policies"
         },
@@ -1843,6 +1871,10 @@
         },
         {
           "method": "POST",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
@@ -1911,6 +1943,10 @@
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
+          "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
+        },
+        {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/time_off_policies"
         },
@@ -1976,6 +2012,10 @@
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
+          "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
+        },
+        {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/time_off_policies"
         },
@@ -2038,6 +2078,10 @@
         },
         {
           "method": "POST",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
@@ -2127,6 +2171,10 @@
         },
         {
           "method": "POST",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {

--- a/docs/reference/endpoint-reference.md
+++ b/docs/reference/endpoint-reference.md
@@ -263,6 +263,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
@@ -277,6 +278,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
@@ -292,6 +294,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
@@ -306,6 +309,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
@@ -320,6 +324,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
@@ -334,6 +339,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
@@ -348,6 +354,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
@@ -362,6 +369,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
@@ -376,6 +384,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
@@ -390,6 +399,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
@@ -404,6 +414,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
@@ -422,6 +433,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |

--- a/src/components/UNSTABLE_TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.tsx
+++ b/src/components/UNSTABLE_TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.tsx
@@ -128,11 +128,11 @@ function Root({ companyId, defaultTab = 'holidays' }: HolidayPolicyDetailProps) 
   }
 
   const handleAddEmployees = () => {
-    onEvent(componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE)
+    onEvent(componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES)
   }
 
   const handleEditPolicy = () => {
-    onEvent(componentEvents.TIME_OFF_VIEW_HOLIDAY_SCHEDULE)
+    onEvent(componentEvents.TIME_OFF_EDIT_HOLIDAY_POLICY)
   }
 
   const actions = [

--- a/src/components/UNSTABLE_TimeOff/HolidaySelectionForm/HolidaySelectionForm.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/HolidaySelectionForm/HolidaySelectionForm.test.tsx
@@ -193,4 +193,103 @@ describe('HolidaySelectionForm', () => {
       })
     })
   })
+
+  describe('edit mode', () => {
+    const editProps = { ...defaultProps, mode: 'edit' as const }
+
+    const existingPolicy = {
+      version: 'policy-version-1',
+      company_uuid: 'company-123',
+      federal_holidays: {
+        new_years_day: { selected: true },
+        mlk_day: { selected: false },
+        presidents_day: { selected: true },
+        memorial_day: { selected: false },
+        juneteenth: { selected: false },
+        independence_day: { selected: true },
+        labor_day: { selected: false },
+        columbus_day: { selected: false },
+        veterans_day: { selected: false },
+        thanksgiving: { selected: true },
+        christmas_day: { selected: true },
+      },
+      employees: [],
+    }
+
+    beforeEach(() => {
+      server.use(
+        http.get(`${API_BASE_URL}/v1/companies/:companyUuid/holiday_pay_policy`, () => {
+          return HttpResponse.json(existingPolicy)
+        }),
+      )
+    })
+
+    it('prefills checkboxes from existing policy selections', async () => {
+      renderWithProviders(<HolidaySelectionForm {...editProps} />)
+
+      await waitFor(() => {
+        expect(screen.getByText("New Year's Day")).toBeInTheDocument()
+      })
+
+      const headerCheckbox = screen.getByRole('checkbox', { name: 'Select all rows' })
+      const rowCheckboxes = screen
+        .getAllByRole('checkbox')
+        .filter(cb => cb !== headerCheckbox) as HTMLInputElement[]
+
+      const checkedCount = rowCheckboxes.filter(cb => cb.checked).length
+      expect(checkedCount).toBe(5)
+    })
+
+    it('calls PUT and emits HOLIDAY_SELECTION_EDIT_DONE on Continue', async () => {
+      let putCalled = false
+      let putBody: Record<string, unknown> | null = null
+      server.use(
+        http.put(
+          `${API_BASE_URL}/v1/companies/:companyUuid/holiday_pay_policy`,
+          async ({ request }) => {
+            putCalled = true
+            putBody = (await request.json()) as Record<string, unknown>
+            return HttpResponse.json(existingPolicy)
+          },
+        ),
+      )
+
+      renderWithProviders(<HolidaySelectionForm {...editProps} />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+      await waitFor(() => {
+        expect(onEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_HOLIDAY_SELECTION_EDIT_DONE)
+      })
+
+      expect(putCalled).toBe(true)
+      expect(putBody).toMatchObject({ version: 'policy-version-1' })
+    })
+
+    it('does not emit the create-flow DONE event in edit mode', async () => {
+      server.use(
+        http.put(`${API_BASE_URL}/v1/companies/:companyUuid/holiday_pay_policy`, () => {
+          return HttpResponse.json(existingPolicy)
+        }),
+      )
+
+      renderWithProviders(<HolidaySelectionForm {...editProps} />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+      await waitFor(() => {
+        expect(onEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_HOLIDAY_SELECTION_EDIT_DONE)
+      })
+
+      expect(onEvent).not.toHaveBeenCalledWith(componentEvents.TIME_OFF_HOLIDAY_SELECTION_DONE)
+    })
+  })
 })

--- a/src/components/UNSTABLE_TimeOff/HolidaySelectionForm/HolidaySelectionForm.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/HolidaySelectionForm/HolidaySelectionForm.test.tsx
@@ -1,12 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
+import { QueryClient } from '@tanstack/react-query'
+import { queryKeyHolidayPayPoliciesGet } from '@gusto/embedded-api/react-query/holidayPayPoliciesGet'
 import { HolidaySelectionForm } from './HolidaySelectionForm'
 import { server } from '@/test/mocks/server'
 import { componentEvents } from '@/shared/constants'
 import { setupApiTestMocks } from '@/test/mocks/apiServer'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import { GustoTestProvider } from '@/test/GustoTestApiProvider'
 import { API_BASE_URL } from '@/test/constants'
 
 describe('HolidaySelectionForm', () => {
@@ -192,6 +195,50 @@ describe('HolidaySelectionForm', () => {
         expect(onEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_HOLIDAY_SELECTION_DONE)
       })
     })
+
+    it('seeds the GET cache with the created policy so the next mount sees it', async () => {
+      const createdPolicy = {
+        version: 'fresh-version',
+        company_uuid: 'company-123',
+        federal_holidays: { new_years_day: { selected: true } },
+        employees: [],
+      }
+      server.use(
+        http.post(`${API_BASE_URL}/v1/companies/:companyUuid/holiday_pay_policy`, () =>
+          HttpResponse.json(createdPolicy),
+        ),
+      )
+
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      // Pre-populate the cache with `{ holidayPayPolicy: undefined }` to mirror
+      // the production scenario where PolicyList's non-suspense GET ran before
+      // any policy existed. Without seeding from the create response, the next
+      // SelectEmployeesHoliday StandaloneLoader would read this stale undefined
+      // via Suspense and throw "Unexpected response: missing holidayPayPolicy".
+      queryClient.setQueryData(queryKeyHolidayPayPoliciesGet('company-123', {}), {
+        holidayPayPolicy: undefined,
+      })
+
+      render(
+        <GustoTestProvider queryClient={queryClient}>
+          <HolidaySelectionForm {...defaultProps} />
+        </GustoTestProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
+      })
+      await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+      await waitFor(() => {
+        expect(onEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_HOLIDAY_SELECTION_DONE)
+      })
+
+      const cached = queryClient.getQueryData<{ holidayPayPolicy?: { version?: string } }>(
+        queryKeyHolidayPayPoliciesGet('company-123', {}),
+      )
+      expect(cached?.holidayPayPolicy?.version).toBe('fresh-version')
+    })
   })
 
   describe('edit mode', () => {
@@ -290,6 +337,45 @@ describe('HolidaySelectionForm', () => {
       })
 
       expect(onEvent).not.toHaveBeenCalledWith(componentEvents.TIME_OFF_HOLIDAY_SELECTION_DONE)
+    })
+
+    it('seeds the GET cache with the updated policy', async () => {
+      const updatedPolicy = { ...existingPolicy, version: 'updated-version' }
+      // Replace the GET handler too so the post-invalidate refetch (which fires
+      // because HolidaySelectionForm is still mounted in this test) returns the
+      // updated policy rather than overwriting our seed with the stale one.
+      server.use(
+        http.get(`${API_BASE_URL}/v1/companies/:companyUuid/holiday_pay_policy`, () =>
+          HttpResponse.json(updatedPolicy),
+        ),
+        http.put(`${API_BASE_URL}/v1/companies/:companyUuid/holiday_pay_policy`, () =>
+          HttpResponse.json(updatedPolicy),
+        ),
+      )
+
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+      render(
+        <GustoTestProvider queryClient={queryClient}>
+          <HolidaySelectionForm {...editProps} />
+        </GustoTestProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
+      })
+      await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+      await waitFor(() => {
+        expect(onEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_HOLIDAY_SELECTION_EDIT_DONE)
+      })
+
+      await waitFor(() => {
+        const cached = queryClient.getQueryData<{ holidayPayPolicy?: { version?: string } }>(
+          queryKeyHolidayPayPoliciesGet('company-123', {}),
+        )
+        expect(cached?.holidayPayPolicy?.version).toBe('updated-version')
+      })
     })
   })
 })

--- a/src/components/UNSTABLE_TimeOff/HolidaySelectionForm/HolidaySelectionForm.tsx
+++ b/src/components/UNSTABLE_TimeOff/HolidaySelectionForm/HolidaySelectionForm.tsx
@@ -4,9 +4,12 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useHolidayPayPoliciesCreateMutation } from '@gusto/embedded-api/react-query/holidayPayPoliciesCreate'
 import {
   useHolidayPayPoliciesGetSuspense,
+  queryKeyHolidayPayPoliciesGet,
   invalidateAllHolidayPayPoliciesGet,
+  type HolidayPayPoliciesGetQueryData,
 } from '@gusto/embedded-api/react-query/holidayPayPoliciesGet'
 import { useHolidayPayPoliciesUpdateMutation } from '@gusto/embedded-api/react-query/holidayPayPoliciesUpdate'
+import type { HolidayPayPolicy } from '@gusto/embedded-api/models/components/holidaypaypolicy'
 import {
   getDefaultHolidayItems,
   buildFederalHolidaysPayload,
@@ -69,10 +72,26 @@ function useHolidaySelection(initialKeys: Set<string>) {
   return { selectedUuids, handleSelectionChange, handleSelectAll }
 }
 
+function seedPolicyCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  companyId: string,
+  policy: HolidayPayPolicy | undefined,
+) {
+  if (!policy) return
+  queryClient.setQueryData<HolidayPayPoliciesGetQueryData>(
+    queryKeyHolidayPayPoliciesGet(companyId, {}),
+    prev =>
+      prev
+        ? { ...prev, holidayPayPolicy: policy }
+        : (undefined as unknown as HolidayPayPoliciesGetQueryData),
+  )
+}
+
 function CreateRoot({ companyId }: RootProps) {
   useI18n('Company.TimeOff.HolidayPolicy')
   const { t } = useTranslation('Company.TimeOff.HolidayPolicy')
   const { onEvent, baseSubmitHandler } = useBase()
+  const queryClient = useQueryClient()
 
   const holidays = useMemo(() => getDefaultHolidayItems(t), [t])
   const allKeys = useMemo(() => new Set(FEDERAL_HOLIDAY_KEYS), [])
@@ -82,7 +101,7 @@ function CreateRoot({ companyId }: RootProps) {
 
   const handleContinue = useCallback(async () => {
     await baseSubmitHandler({}, async () => {
-      await createPolicy({
+      const response = await createPolicy({
         request: {
           companyUuid: companyId,
           holidayPayPolicyRequest: {
@@ -90,9 +109,15 @@ function CreateRoot({ companyId }: RootProps) {
           },
         },
       })
+      // Seed the GET cache so the next mount of SelectEmployeesHoliday's
+      // StandaloneLoader (in addEmployeesHoliday state) reads the freshly
+      // created policy instead of a stale `{ holidayPayPolicy: undefined }`
+      // left over from PolicyList's pre-create GET.
+      seedPolicyCache(queryClient, companyId, response.holidayPayPolicy)
+      await invalidateAllHolidayPayPoliciesGet(queryClient)
       onEvent(componentEvents.TIME_OFF_HOLIDAY_SELECTION_DONE)
     })
-  }, [baseSubmitHandler, createPolicy, companyId, selectedUuids, onEvent])
+  }, [baseSubmitHandler, createPolicy, companyId, selectedUuids, queryClient, onEvent])
 
   const handleBack = useCallback(() => {
     onEvent(componentEvents.CANCEL)
@@ -140,7 +165,7 @@ function EditRoot({ companyId }: RootProps) {
 
   const handleContinue = useCallback(async () => {
     await baseSubmitHandler({}, async () => {
-      await updatePolicy({
+      const response = await updatePolicy({
         request: {
           companyUuid: companyId,
           requestBody: {
@@ -149,6 +174,7 @@ function EditRoot({ companyId }: RootProps) {
           },
         },
       })
+      seedPolicyCache(queryClient, companyId, response.holidayPayPolicy)
       await invalidateAllHolidayPayPoliciesGet(queryClient)
       onEvent(componentEvents.TIME_OFF_HOLIDAY_SELECTION_EDIT_DONE)
     })

--- a/src/components/UNSTABLE_TimeOff/HolidaySelectionForm/HolidaySelectionForm.tsx
+++ b/src/components/UNSTABLE_TimeOff/HolidaySelectionForm/HolidaySelectionForm.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useQueryClient } from '@tanstack/react-query'
 import { useHolidayPayPoliciesCreateMutation } from '@gusto/embedded-api/react-query/holidayPayPoliciesCreate'
+import {
+  useHolidayPayPoliciesGetSuspense,
+  invalidateAllHolidayPayPoliciesGet,
+} from '@gusto/embedded-api/react-query/holidayPayPoliciesGet'
+import { useHolidayPayPoliciesUpdateMutation } from '@gusto/embedded-api/react-query/holidayPayPoliciesUpdate'
 import {
   getDefaultHolidayItems,
   buildFederalHolidaysPayload,
@@ -15,26 +21,27 @@ import { useI18n } from '@/i18n'
 
 export interface HolidaySelectionFormProps extends BaseComponentInterface {
   companyId: string
+  mode?: 'create' | 'edit'
 }
 
 export function HolidaySelectionForm(props: HolidaySelectionFormProps) {
   return (
     <BaseComponent {...props}>
-      <Root companyId={props.companyId} />
+      {props.mode === 'edit' ? (
+        <EditRoot companyId={props.companyId} />
+      ) : (
+        <CreateRoot companyId={props.companyId} />
+      )}
     </BaseComponent>
   )
 }
 
-function Root({ companyId }: { companyId: string }) {
-  useI18n('Company.TimeOff.HolidayPolicy')
-  const { t } = useTranslation('Company.TimeOff.HolidayPolicy')
-  const { onEvent, baseSubmitHandler } = useBase()
+interface RootProps {
+  companyId: string
+}
 
-  const holidays = useMemo(() => getDefaultHolidayItems(t), [t])
-  const allKeys = useMemo(() => new Set(FEDERAL_HOLIDAY_KEYS), [])
-  const [selectedUuids, setSelectedUuids] = useState(allKeys)
-
-  const { mutateAsync: createPolicy } = useHolidayPayPoliciesCreateMutation()
+function useHolidaySelection(initialKeys: Set<string>) {
+  const [selectedUuids, setSelectedUuids] = useState(initialKeys)
 
   const handleSelectionChange = useCallback((item: HolidayItem, selected: boolean) => {
     setSelectedUuids(prev => {
@@ -59,6 +66,20 @@ function Root({ companyId }: { companyId: string }) {
     })
   }, [])
 
+  return { selectedUuids, handleSelectionChange, handleSelectAll }
+}
+
+function CreateRoot({ companyId }: RootProps) {
+  useI18n('Company.TimeOff.HolidayPolicy')
+  const { t } = useTranslation('Company.TimeOff.HolidayPolicy')
+  const { onEvent, baseSubmitHandler } = useBase()
+
+  const holidays = useMemo(() => getDefaultHolidayItems(t), [t])
+  const allKeys = useMemo(() => new Set(FEDERAL_HOLIDAY_KEYS), [])
+  const { selectedUuids, handleSelectionChange, handleSelectAll } = useHolidaySelection(allKeys)
+
+  const { mutateAsync: createPolicy } = useHolidayPayPoliciesCreateMutation()
+
   const handleContinue = useCallback(async () => {
     await baseSubmitHandler({}, async () => {
       await createPolicy({
@@ -72,6 +93,74 @@ function Root({ companyId }: { companyId: string }) {
       onEvent(componentEvents.TIME_OFF_HOLIDAY_SELECTION_DONE)
     })
   }, [baseSubmitHandler, createPolicy, companyId, selectedUuids, onEvent])
+
+  const handleBack = useCallback(() => {
+    onEvent(componentEvents.CANCEL)
+  }, [onEvent])
+
+  return (
+    <HolidaySelectionFormPresentation
+      holidays={holidays}
+      selectedHolidayUuids={selectedUuids}
+      onSelectionChange={handleSelectionChange}
+      onSelectAll={handleSelectAll}
+      onContinue={handleContinue}
+      onBack={handleBack}
+    />
+  )
+}
+
+function EditRoot({ companyId }: RootProps) {
+  useI18n('Company.TimeOff.HolidayPolicy')
+  const { t } = useTranslation('Company.TimeOff.HolidayPolicy')
+  const { onEvent, baseSubmitHandler } = useBase()
+  const queryClient = useQueryClient()
+
+  const { data } = useHolidayPayPoliciesGetSuspense({ companyUuid: companyId })
+  const policy = data.holidayPayPolicy!
+
+  const holidays = useMemo(() => getDefaultHolidayItems(t), [t])
+
+  const initialSelected = useMemo(() => {
+    const next = new Set<string>()
+    const federal = policy.federalHolidays
+    for (const key of FEDERAL_HOLIDAY_KEYS) {
+      const entry = federal[key as keyof typeof federal]
+      if (entry?.selected === true) {
+        next.add(key)
+      }
+    }
+    return next
+  }, [policy.federalHolidays])
+
+  const { selectedUuids, handleSelectionChange, handleSelectAll } =
+    useHolidaySelection(initialSelected)
+
+  const { mutateAsync: updatePolicy } = useHolidayPayPoliciesUpdateMutation()
+
+  const handleContinue = useCallback(async () => {
+    await baseSubmitHandler({}, async () => {
+      await updatePolicy({
+        request: {
+          companyUuid: companyId,
+          requestBody: {
+            version: policy.version!,
+            federalHolidays: buildFederalHolidaysPayload(selectedUuids),
+          },
+        },
+      })
+      await invalidateAllHolidayPayPoliciesGet(queryClient)
+      onEvent(componentEvents.TIME_OFF_HOLIDAY_SELECTION_EDIT_DONE)
+    })
+  }, [
+    baseSubmitHandler,
+    updatePolicy,
+    companyId,
+    policy.version,
+    selectedUuids,
+    queryClient,
+    onEvent,
+  ])
 
   const handleBack = useCallback(() => {
     onEvent(componentEvents.CANCEL)

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/TimeOffFlowComponents.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/TimeOffFlowComponents.tsx
@@ -142,7 +142,23 @@ export function HolidaySelectionFormContextual() {
           {alert.content}
         </Alert>
       ))}
-      <HolidaySelectionForm onEvent={onEvent} companyId={ensureRequired(companyId)} />
+      <HolidaySelectionForm onEvent={onEvent} companyId={ensureRequired(companyId)} mode="create" />
+    </Flex>
+  )
+}
+
+export function EditHolidaySelectionFormContextual() {
+  const { onEvent, companyId, alerts } = useFlow<TimeOffFlowContextInterface>()
+  const { Alert } = useComponentContext()
+
+  return (
+    <Flex flexDirection="column" gap={8}>
+      {alerts?.map((alert, index) => (
+        <Alert key={index} status={alert.type} label={alert.title}>
+          {alert.content}
+        </Alert>
+      ))}
+      <HolidaySelectionForm onEvent={onEvent} companyId={ensureRequired(companyId)} mode="edit" />
     </Flex>
   )
 }

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
@@ -13,6 +13,7 @@ type TimeOffState =
   | 'addEmployeesToPolicy'
   | 'viewTimeOffPolicyDetail'
   | 'holidaySelectionForm'
+  | 'editHolidaySelectionForm'
   | 'addEmployeesHoliday'
   | 'viewHolidayEmployees'
   | 'viewHolidaySchedule'
@@ -424,6 +425,112 @@ describe('timeOffStateMachine', () => {
       send(service, componentEvents.TIME_OFF_POLICY_SETTINGS_DONE)
 
       expect(service.machine.current).toBe('addEmployeesToPolicy')
+    })
+  })
+
+  describe('viewHolidayEmployees state', () => {
+    function toViewHolidayEmployees(service: ReturnType<typeof createService>) {
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'holiday-policy',
+        policyType: 'holiday',
+      })
+      expect(service.machine.current).toBe('viewHolidayEmployees')
+    }
+
+    it('transitions to addEmployeesHoliday on TIME_OFF_HOLIDAY_ADD_EMPLOYEES', () => {
+      const service = createService()
+      toViewHolidayEmployees(service)
+
+      send(service, componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES)
+
+      expect(service.machine.current).toBe('addEmployeesHoliday')
+      expect(service.context.policyId).toBe('holiday-policy')
+      expect(service.context.alerts).toBeUndefined()
+    })
+
+    it('transitions to editHolidaySelectionForm on TIME_OFF_EDIT_HOLIDAY_POLICY', () => {
+      const service = createService()
+      toViewHolidayEmployees(service)
+
+      send(service, componentEvents.TIME_OFF_EDIT_HOLIDAY_POLICY)
+
+      expect(service.machine.current).toBe('editHolidaySelectionForm')
+      expect(service.context.policyId).toBe('holiday-policy')
+      expect(service.context.alerts).toBeUndefined()
+    })
+
+    it('returns to viewHolidayEmployees with same policyId after add-employees DONE', () => {
+      const service = createService()
+      toViewHolidayEmployees(service)
+      send(service, componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES)
+
+      send(service, componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE)
+
+      expect(service.machine.current).toBe('viewHolidayEmployees')
+      expect(service.context.policyId).toBe('holiday-policy')
+    })
+
+    it('returns to viewHolidayEmployees with same policyId after edit DONE', () => {
+      const service = createService()
+      toViewHolidayEmployees(service)
+      send(service, componentEvents.TIME_OFF_EDIT_HOLIDAY_POLICY)
+
+      send(service, componentEvents.TIME_OFF_HOLIDAY_SELECTION_EDIT_DONE)
+
+      expect(service.machine.current).toBe('viewHolidayEmployees')
+      expect(service.context.policyId).toBe('holiday-policy')
+    })
+
+    it('cancels from editHolidaySelectionForm to policyList', () => {
+      const service = createService()
+      toViewHolidayEmployees(service)
+      send(service, componentEvents.TIME_OFF_EDIT_HOLIDAY_POLICY)
+
+      send(service, componentEvents.CANCEL)
+
+      expect(service.machine.current).toBe('policyList')
+    })
+
+    it('does not route TIME_OFF_HOLIDAY_SELECTION_DONE in the edit flow into the create flow', () => {
+      const service = createService()
+      toViewHolidayEmployees(service)
+      send(service, componentEvents.TIME_OFF_EDIT_HOLIDAY_POLICY)
+
+      send(service, componentEvents.TIME_OFF_HOLIDAY_SELECTION_DONE)
+
+      // edit state only handles SELECTION_EDIT_DONE; the create-flow event is ignored
+      expect(service.machine.current).toBe('editHolidaySelectionForm')
+    })
+  })
+
+  describe('viewHolidaySchedule state', () => {
+    function toViewHolidaySchedule(service: ReturnType<typeof createService>) {
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'holiday-policy',
+        policyType: 'holiday',
+      })
+      send(service, componentEvents.TIME_OFF_VIEW_HOLIDAY_SCHEDULE)
+      expect(service.machine.current).toBe('viewHolidaySchedule')
+    }
+
+    it('transitions to addEmployeesHoliday on TIME_OFF_HOLIDAY_ADD_EMPLOYEES', () => {
+      const service = createService()
+      toViewHolidaySchedule(service)
+
+      send(service, componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES)
+
+      expect(service.machine.current).toBe('addEmployeesHoliday')
+      expect(service.context.policyId).toBe('holiday-policy')
+    })
+
+    it('transitions to editHolidaySelectionForm on TIME_OFF_EDIT_HOLIDAY_POLICY', () => {
+      const service = createService()
+      toViewHolidaySchedule(service)
+
+      send(service, componentEvents.TIME_OFF_EDIT_HOLIDAY_POLICY)
+
+      expect(service.machine.current).toBe('editHolidaySelectionForm')
+      expect(service.context.policyId).toBe('holiday-policy')
     })
   })
 

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -7,6 +7,7 @@ import {
   AddEmployeesToPolicyContextual,
   TimeOffPolicyDetailContextual,
   HolidaySelectionFormContextual,
+  EditHolidaySelectionFormContextual,
   AddEmployeesHolidayContextual,
   ViewHolidayEmployeesContextual,
   ViewHolidayScheduleContextual,
@@ -420,6 +421,28 @@ export const timeOffMachine = {
         }),
       ),
     ),
+    transition(
+      componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES,
+      'addEmployeesHoliday',
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: AddEmployeesHolidayContextual,
+          alerts: undefined,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.TIME_OFF_EDIT_HOLIDAY_POLICY,
+      'editHolidaySelectionForm',
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: EditHolidaySelectionFormContextual,
+          alerts: undefined,
+        }),
+      ),
+    ),
     backToListTransition,
   ),
 
@@ -434,7 +457,61 @@ export const timeOffMachine = {
         }),
       ),
     ),
+    transition(
+      componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES,
+      'addEmployeesHoliday',
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: AddEmployeesHolidayContextual,
+          alerts: undefined,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.TIME_OFF_EDIT_HOLIDAY_POLICY,
+      'editHolidaySelectionForm',
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: EditHolidaySelectionFormContextual,
+          alerts: undefined,
+        }),
+      ),
+    ),
     backToListTransition,
+  ),
+
+  // Distinct from `holidaySelectionForm` (the create-flow step) so that
+  // DONE returns to the holiday detail view instead of routing into
+  // `addEmployeesHoliday`.
+  editHolidaySelectionForm: state<MachineTransition>(
+    transition(
+      componentEvents.TIME_OFF_HOLIDAY_SELECTION_EDIT_DONE,
+      'viewHolidayEmployees',
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: ViewHolidayEmployeesContextual,
+          alerts: undefined,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.TIME_OFF_HOLIDAY_CREATE_ERROR,
+      'viewHolidayEmployees',
+      reduce(
+        (
+          ctx: TimeOffFlowContextInterface,
+          ev: { payload: ErrorPayload },
+        ): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: ViewHolidayEmployeesContextual,
+          alerts: ev.payload.alert ? [ev.payload.alert] : undefined,
+        }),
+      ),
+    ),
+    cancelToPolicyList,
   ),
 
   final: state<MachineTransition>(),

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.test.tsx
@@ -49,6 +49,12 @@ vi.mock('@gusto/embedded-api/react-query/holidayPayPoliciesGet', () => ({
     },
   }),
   invalidateAllHolidayPayPoliciesGet: vi.fn(),
+  queryKeyHolidayPayPoliciesGet: (companyUuid: string) => [
+    '@gusto/embedded-api',
+    'holidayPayPolicies',
+    'get',
+    companyUuid,
+  ],
 }))
 
 vi.mock('@gusto/embedded-api/react-query/holidayPayPoliciesAddEmployees', () => ({

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.test.tsx
@@ -40,15 +40,27 @@ vi.mock('@gusto/embedded-api/react-query/employeesList', () => ({
   }),
 }))
 
+const mockHolidayPolicyEmployees: Array<{ uuid: string }> = []
+
 vi.mock('@gusto/embedded-api/react-query/holidayPayPoliciesGet', () => ({
   useHolidayPayPoliciesGetSuspense: () => ({
-    data: { holidayPayPolicy: { version: 'abc123' } },
+    data: {
+      holidayPayPolicy: { version: 'abc123', employees: mockHolidayPolicyEmployees },
+    },
   }),
+  invalidateAllHolidayPayPoliciesGet: vi.fn(),
 }))
 
 vi.mock('@gusto/embedded-api/react-query/holidayPayPoliciesAddEmployees', () => ({
   useHolidayPayPoliciesAddEmployeesMutation: () => ({
     mutateAsync: mockAddEmployees,
+    isPending: false,
+  }),
+}))
+
+vi.mock('@gusto/embedded-api/react-query/holidayPayPoliciesRemoveEmployees', () => ({
+  useHolidayPayPoliciesRemoveEmployeesMutation: () => ({
+    mutateAsync: vi.fn(),
     isPending: false,
   }),
 }))
@@ -201,6 +213,53 @@ describe('SelectEmployeesHoliday', () => {
           },
         })
       })
+    })
+  })
+
+  describe('pre-selection', () => {
+    it('pre-selects employees already on the holiday policy', async () => {
+      mockHolidayPolicyEmployees.length = 0
+      mockHolidayPolicyEmployees.push({ uuid: '1' })
+
+      try {
+        renderComponent({ mode: 'standalone' })
+
+        await waitFor(() => {
+          expect(screen.getAllByRole('checkbox').length).toBe(3)
+        })
+
+        const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[]
+        expect(checkboxes[FIRST_EMPLOYEE_CHECKBOX]).toBeChecked()
+        expect(checkboxes[SECOND_EMPLOYEE_CHECKBOX]).not.toBeChecked()
+      } finally {
+        mockHolidayPolicyEmployees.length = 0
+      }
+    })
+
+    it('emits done event without calling mutations when nothing changed', async () => {
+      mockHolidayPolicyEmployees.length = 0
+      mockHolidayPolicyEmployees.push({ uuid: '1' })
+
+      try {
+        const user = userEvent.setup()
+        renderComponent({ mode: 'standalone' })
+
+        await waitFor(() => {
+          expect(screen.getByRole('button', { name: 'continueCta' })).toBeInTheDocument()
+        })
+
+        await user.click(screen.getByRole('button', { name: 'continueCta' }))
+
+        await waitFor(() => {
+          expect(mockOnEvent).toHaveBeenCalledWith(
+            componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE,
+          )
+        })
+
+        expect(mockAddEmployees).not.toHaveBeenCalled()
+      } finally {
+        mockHolidayPolicyEmployees.length = 0
+      }
     })
   })
 

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.tsx
@@ -4,8 +4,11 @@ import { useHolidayPayPoliciesAddEmployeesMutation } from '@gusto/embedded-api/r
 import { useHolidayPayPoliciesRemoveEmployeesMutation } from '@gusto/embedded-api/react-query/holidayPayPoliciesRemoveEmployees'
 import {
   useHolidayPayPoliciesGetSuspense,
+  queryKeyHolidayPayPoliciesGet,
   invalidateAllHolidayPayPoliciesGet,
+  type HolidayPayPoliciesGetQueryData,
 } from '@gusto/embedded-api/react-query/holidayPayPoliciesGet'
+import type { HolidayPayPolicy } from '@gusto/embedded-api/models/components/holidaypaypolicy'
 import { SelectEmployeesPresentation } from './SelectEmployeesPresentation'
 import { useSelectEmployeesData } from './useSelectEmployeesData'
 import { useBase } from '@/components/Base/useBase'
@@ -83,7 +86,7 @@ function SelectEmployeesHolidayInner({
     async (toAdd: string[], toRemove: string[]) => {
       await baseSubmitHandler({}, async () => {
         let currentVersion = version ?? ''
-        let policyResult: unknown
+        let latestPolicy: HolidayPayPolicy | undefined
         if (toRemove.length > 0) {
           const response = await removeEmployees({
             request: {
@@ -97,7 +100,7 @@ function SelectEmployeesHolidayInner({
           if (response.holidayPayPolicy?.version) {
             currentVersion = response.holidayPayPolicy.version
           }
-          policyResult = response.holidayPayPolicy
+          latestPolicy = response.holidayPayPolicy
         }
         if (toAdd.length > 0) {
           const response = await addEmployees({
@@ -109,10 +112,23 @@ function SelectEmployeesHolidayInner({
               },
             },
           })
-          policyResult = response.holidayPayPolicy
+          latestPolicy = response.holidayPayPolicy
+        }
+        // Seed the GET cache from the mutation response so that the next mount
+        // of HolidayPolicyDetail reads fresh data immediately. invalidateQueries
+        // alone only refetches *active* subscriptions, but we navigate away
+        // before the refetch can complete.
+        if (latestPolicy) {
+          queryClient.setQueryData<HolidayPayPoliciesGetQueryData>(
+            queryKeyHolidayPayPoliciesGet(companyId, {}),
+            prev =>
+              prev
+                ? { ...prev, holidayPayPolicy: latestPolicy }
+                : (undefined as unknown as HolidayPayPoliciesGetQueryData),
+          )
         }
         await invalidateAllHolidayPayPoliciesGet(queryClient)
-        onEvent(componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE, policyResult)
+        onEvent(componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE, latestPolicy)
       })
     },
     [baseSubmitHandler, removeEmployees, addEmployees, companyId, version, queryClient, onEvent],

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.tsx
@@ -1,6 +1,11 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { useHolidayPayPoliciesAddEmployeesMutation } from '@gusto/embedded-api/react-query/holidayPayPoliciesAddEmployees'
-import { useHolidayPayPoliciesGetSuspense } from '@gusto/embedded-api/react-query/holidayPayPoliciesGet'
+import { useHolidayPayPoliciesRemoveEmployeesMutation } from '@gusto/embedded-api/react-query/holidayPayPoliciesRemoveEmployees'
+import {
+  useHolidayPayPoliciesGetSuspense,
+  invalidateAllHolidayPayPoliciesGet,
+} from '@gusto/embedded-api/react-query/holidayPayPoliciesGet'
 import { SelectEmployeesPresentation } from './SelectEmployeesPresentation'
 import { useSelectEmployeesData } from './useSelectEmployeesData'
 import { useBase } from '@/components/Base/useBase'
@@ -11,11 +16,51 @@ interface SelectEmployeesHolidayProps {
   mode?: 'standalone' | 'wizard'
 }
 
-export function SelectEmployeesHoliday({
+export function SelectEmployeesHoliday(props: SelectEmployeesHolidayProps) {
+  if (props.mode === 'wizard') {
+    return <SelectEmployeesHolidayInner {...props} mode="wizard" />
+  }
+  return <StandaloneLoader {...props} />
+}
+
+function StandaloneLoader(props: SelectEmployeesHolidayProps) {
+  const { data: policyResponse } = useHolidayPayPoliciesGetSuspense({
+    companyUuid: props.companyId,
+  })
+  const policy = policyResponse.holidayPayPolicy
+  if (!policy) throw new Error('Unexpected response: missing holidayPayPolicy')
+
+  const originalUuids = useMemo(() => {
+    const set = new Set<string>()
+    for (const e of policy.employees) {
+      if (e.uuid) set.add(e.uuid)
+    }
+    return set
+  }, [policy.employees])
+
+  return (
+    <SelectEmployeesHolidayInner
+      {...props}
+      mode="standalone"
+      originalUuids={originalUuids}
+      version={policy.version}
+    />
+  )
+}
+
+interface InnerProps extends SelectEmployeesHolidayProps {
+  originalUuids?: Set<string>
+  version?: string
+}
+
+function SelectEmployeesHolidayInner({
   companyId,
   mode = 'standalone',
-}: SelectEmployeesHolidayProps) {
+  originalUuids,
+  version,
+}: InnerProps) {
   const { onEvent, baseSubmitHandler } = useBase()
+  const queryClient = useQueryClient()
   const {
     filteredEmployees,
     selectedUuids,
@@ -26,13 +71,52 @@ export function SelectEmployeesHoliday({
     handleSelectAll,
     handleSearchChange,
     handleSearchClear,
-  } = useSelectEmployeesData(companyId)
-
-  const { data: policyData } = useHolidayPayPoliciesGetSuspense({
-    companyUuid: companyId,
-  })
+  } = useSelectEmployeesData(companyId, originalUuids)
 
   const { mutateAsync: addEmployees } = useHolidayPayPoliciesAddEmployeesMutation()
+  const { mutateAsync: removeEmployees, isPending: isRemovePending } =
+    useHolidayPayPoliciesRemoveEmployeesMutation()
+
+  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false)
+
+  const submitDiff = useCallback(
+    async (toAdd: string[], toRemove: string[]) => {
+      await baseSubmitHandler({}, async () => {
+        let currentVersion = version ?? ''
+        let policyResult: unknown
+        if (toRemove.length > 0) {
+          const response = await removeEmployees({
+            request: {
+              companyUuid: companyId,
+              requestBody: {
+                version: currentVersion,
+                employees: toRemove.map(uuid => ({ uuid })),
+              },
+            },
+          })
+          if (response.holidayPayPolicy?.version) {
+            currentVersion = response.holidayPayPolicy.version
+          }
+          policyResult = response.holidayPayPolicy
+        }
+        if (toAdd.length > 0) {
+          const response = await addEmployees({
+            request: {
+              companyUuid: companyId,
+              requestBody: {
+                version: currentVersion,
+                employees: toAdd.map(uuid => ({ uuid })),
+              },
+            },
+          })
+          policyResult = response.holidayPayPolicy
+        }
+        await invalidateAllHolidayPayPoliciesGet(queryClient)
+        onEvent(componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE, policyResult)
+      })
+    },
+    [baseSubmitHandler, removeEmployees, addEmployees, companyId, version, queryClient, onEvent],
+  )
 
   const handleContinue = useCallback(async () => {
     if (mode === 'wizard') {
@@ -42,19 +126,37 @@ export function SelectEmployeesHoliday({
       return
     }
 
-    await baseSubmitHandler({}, async () => {
-      const result = await addEmployees({
-        request: {
-          companyUuid: companyId,
-          requestBody: {
-            version: policyData.holidayPayPolicy?.version ?? '',
-            employees: [...selectedUuids].map(uuid => ({ uuid })),
-          },
-        },
-      })
-      onEvent(componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE, result.holidayPayPolicy)
-    })
-  }, [mode, baseSubmitHandler, addEmployees, companyId, policyData, selectedUuids, onEvent])
+    const original = originalUuids ?? new Set<string>()
+    const toAdd = [...selectedUuids].filter(uuid => !original.has(uuid))
+    const toRemove = [...original].filter(uuid => !selectedUuids.has(uuid))
+
+    if (toAdd.length === 0 && toRemove.length === 0) {
+      onEvent(componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE)
+      return
+    }
+
+    if (toRemove.length > 0) {
+      setConfirmRemoveOpen(true)
+      return
+    }
+
+    await submitDiff(toAdd, toRemove)
+  }, [mode, originalUuids, selectedUuids, onEvent, submitDiff])
+
+  const handleConfirmRemove = useCallback(async () => {
+    const original = originalUuids ?? new Set<string>()
+    const toAdd = [...selectedUuids].filter(uuid => !original.has(uuid))
+    const toRemove = [...original].filter(uuid => !selectedUuids.has(uuid))
+    setConfirmRemoveOpen(false)
+    await submitDiff(toAdd, toRemove)
+  }, [originalUuids, selectedUuids, submitDiff])
+
+  const removeCount = useMemo(() => {
+    if (!originalUuids) return 0
+    let count = 0
+    for (const uuid of originalUuids) if (!selectedUuids.has(uuid)) count += 1
+    return count
+  }, [originalUuids, selectedUuids])
 
   const handleBack = useCallback(() => {
     onEvent(componentEvents.CANCEL)
@@ -74,6 +176,22 @@ export function SelectEmployeesHoliday({
       showReassignmentWarning={false}
       pagination={pagination}
       isFetching={isFetching}
+      originallyOnPolicyUuids={originalUuids}
+      removeConfirmDialog={
+        mode === 'standalone'
+          ? {
+              isOpen: confirmRemoveOpen,
+              count: removeCount,
+              onConfirm: () => {
+                void handleConfirmRemove()
+              },
+              onClose: () => {
+                setConfirmRemoveOpen(false)
+              },
+              isPending: isRemovePending,
+            }
+          : undefined
+      }
     />
   )
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -249,6 +249,9 @@ export const timeOffEvents = {
   TIME_OFF_EDIT_POLICY: 'timeOff/editPolicy',
   TIME_OFF_CHANGE_SETTINGS: 'timeOff/changeSettings',
   TIME_OFF_ADD_EMPLOYEES_TO_POLICY: 'timeOff/addEmployeesToPolicy',
+  TIME_OFF_HOLIDAY_ADD_EMPLOYEES: 'timeOff/holidayAddEmployees',
+  TIME_OFF_EDIT_HOLIDAY_POLICY: 'timeOff/editHolidayPolicy',
+  TIME_OFF_HOLIDAY_SELECTION_EDIT_DONE: 'timeOff/holidaySelection/editDone',
 } as const
 
 export const componentEvents = {


### PR DESCRIPTION
## Summary
- **State machine bug**: Add Employees and Edit Policy buttons on the holiday policy detail page fired events that no transition handled, so clicks just re-rendered the same screen. Add `TIME_OFF_HOLIDAY_ADD_EMPLOYEES` / `TIME_OFF_EDIT_HOLIDAY_POLICY` events with transitions on `viewHolidayEmployees` and `viewHolidaySchedule`, plus a new `editHolidaySelectionForm` state mirroring the `editPolicySettings` pattern (DONE returns to detail view, doesn't continue into create flow).
- **Edit mode**: `HolidaySelectionForm` now supports a `mode="edit"` branch that prefills selected holidays from the existing policy and saves via `holidayPayPoliciesUpdate` (firing the new `TIME_OFF_HOLIDAY_SELECTION_EDIT_DONE` event).
- **Pre-selection on Add Employees**: `SelectEmployeesHoliday` standalone mode now reads the existing policy's employees, pre-selects them, and submits a diff (add + remove with version reconciliation) — matching the non-holiday `AddEmployeesToPolicy` behavior. Toggling someone off now triggers the existing remove-confirmation dialog.

## Test plan
- [x] State machine tests cover both new transitions on `viewHolidayEmployees` and `viewHolidaySchedule`, edit-flow round-trip, and that the create-flow event isn't accepted in edit mode (`timeOffStateMachine.test.ts`)
- [x] HolidaySelectionForm edit-mode tests: prefill from existing selection, PUT request body includes correct `version`, fires `..._EDIT_DONE` (not the create event)
- [x] SelectEmployeesHoliday tests: pre-selects existing policy members, no-op submit when nothing changed
- [x] Full TimeOff suite: 330 passed
- [x] Full repo test suite: 2502 passed
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [ ] Manual end-to-end via `npm run sdk-app` against gws-flows + ZenPayroll: click Add Employees on the detail page → existing employees pre-checked, toggling off prompts confirm → save returns to detail. Click Edit Policy → selection form prefilled → toggle a holiday → Continue returns to detail with updated holidays tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)