### PR TITLE
fix: wire Add Employees button on holiday policy detail to navigate to add employees page

### DIFF
--- a/src/components/UNSTABLE_TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.tsx
+++ b/src/components/UNSTABLE_TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.tsx
@@ -128,7 +128,7 @@ function Root({ companyId, defaultTab = 'holidays' }: HolidayPolicyDetailProps) 
   }
 
   const handleAddEmployees = () => {
-    onEvent(componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE)
+    onEvent(componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES)
   }
 
   const handleEditPolicy = () => {

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
@@ -325,6 +325,49 @@ describe('timeOffStateMachine', () => {
 
       expect(service.machine.current).toBe('viewHolidayEmployees')
     })
+
+    it('transitions from viewHolidayEmployees to addEmployeesHoliday on TIME_OFF_HOLIDAY_ADD_EMPLOYEES', () => {
+      const service = createService()
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'policy-123',
+        policyType: 'holiday',
+      })
+      expect(service.machine.current).toBe('viewHolidayEmployees')
+
+      send(service, componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES)
+
+      expect(service.machine.current).toBe('addEmployeesHoliday')
+      expect(service.context.alerts).toBeUndefined()
+    })
+
+    it('transitions from viewHolidaySchedule to addEmployeesHoliday on TIME_OFF_HOLIDAY_ADD_EMPLOYEES', () => {
+      const service = createService()
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'policy-123',
+        policyType: 'holiday',
+      })
+      send(service, componentEvents.TIME_OFF_VIEW_HOLIDAY_SCHEDULE)
+      expect(service.machine.current).toBe('viewHolidaySchedule')
+
+      send(service, componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES)
+
+      expect(service.machine.current).toBe('addEmployeesHoliday')
+      expect(service.context.alerts).toBeUndefined()
+    })
+
+    it('returns to viewHolidayEmployees after adding employees from detail view', () => {
+      const service = createService()
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'policy-123',
+        policyType: 'holiday',
+      })
+      send(service, componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES)
+      expect(service.machine.current).toBe('addEmployeesHoliday')
+
+      send(service, componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE)
+
+      expect(service.machine.current).toBe('viewHolidayEmployees')
+    })
   })
 
   describe('viewTimeOffPolicyDetail state', () => {

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -420,6 +420,17 @@ export const timeOffMachine = {
         }),
       ),
     ),
+    transition(
+      componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES,
+      'addEmployeesHoliday',
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: AddEmployeesHolidayContextual,
+          alerts: undefined,
+        }),
+      ),
+    ),
     backToListTransition,
   ),
 
@@ -431,6 +442,17 @@ export const timeOffMachine = {
         (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
           ...ctx,
           component: ViewHolidayEmployeesContextual,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES,
+      'addEmployeesHoliday',
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: AddEmployeesHolidayContextual,
+          alerts: undefined,
         }),
       ),
     ),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -249,6 +249,7 @@ export const timeOffEvents = {
   TIME_OFF_EDIT_POLICY: 'timeOff/editPolicy',
   TIME_OFF_CHANGE_SETTINGS: 'timeOff/changeSettings',
   TIME_OFF_ADD_EMPLOYEES_TO_POLICY: 'timeOff/addEmployeesToPolicy',
+  TIME_OFF_HOLIDAY_ADD_EMPLOYEES: 'timeOff/holidayAddEmployees',
 } as const
 
 export const componentEvents = {


### PR DESCRIPTION
## Summary
- The "Add Employees" button on the holiday policy detail page was firing `TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE` (the "finished adding" event) instead of an event to navigate to the add-employees step — so clicking it was a no-op
- Added a new `TIME_OFF_HOLIDAY_ADD_EMPLOYEES` event and wired transitions from both `viewHolidayEmployees` and `viewHolidaySchedule` states to `addEmployeesHoliday`, so the button works regardless of which tab the user is on

## Test plan
- [x] State machine unit tests pass (3 new tests added)
- [ ] Manual: navigate to a holiday policy detail page, click "Add Employees", verify it navigates to the add/edit employees page
- [ ] Manual: switch to the holiday schedule tab, click "Add Employees", verify same navigation works