### PR TITLE
fix: hide holiday pay option when company already has a policy

### DIFF
--- a/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelector.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelector.tsx
@@ -21,10 +21,7 @@ export function PolicyTypeSelector(props: PolicyTypeSelectorProps) {
 function Root({ companyId, defaultPolicyType }: PolicyTypeSelectorProps) {
   const { onEvent } = useBase()
 
-  const holidayQuery = useHolidayPayPoliciesGet(
-    { companyUuid: companyId },
-    { throwOnError: () => false },
-  )
+  const holidayQuery = useHolidayPayPoliciesGet({ companyUuid: companyId })
   const holidayPolicyExists = Boolean(holidayQuery.data?.holidayPayPolicy)
 
   const handleContinue = (policyType: PolicyType) => {

--- a/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelector.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelector.tsx
@@ -1,3 +1,4 @@
+import { useHolidayPayPoliciesGet } from '@gusto/embedded-api/react-query/holidayPayPoliciesGet'
 import { PolicyTypeSelectorPresentation } from './PolicyTypeSelectorPresentation'
 import type { PolicyType } from './PolicyTypeSelectorTypes'
 import { BaseComponent, type BaseComponentInterface } from '@/components/Base'
@@ -17,8 +18,14 @@ export function PolicyTypeSelector(props: PolicyTypeSelectorProps) {
   )
 }
 
-function Root({ defaultPolicyType }: PolicyTypeSelectorProps) {
+function Root({ companyId, defaultPolicyType }: PolicyTypeSelectorProps) {
   const { onEvent } = useBase()
+
+  const holidayQuery = useHolidayPayPoliciesGet(
+    { companyUuid: companyId },
+    { throwOnError: () => false },
+  )
+  const holidayPolicyExists = Boolean(holidayQuery.data?.holidayPayPolicy)
 
   const handleContinue = (policyType: PolicyType) => {
     onEvent(componentEvents.TIME_OFF_POLICY_TYPE_SELECTED, {
@@ -35,6 +42,7 @@ function Root({ defaultPolicyType }: PolicyTypeSelectorProps) {
       onContinue={handleContinue}
       onCancel={handleCancel}
       defaultPolicyType={defaultPolicyType}
+      holidayPolicyExists={holidayPolicyExists}
     />
   )
 }

--- a/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelectorPresentation.stories.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelectorPresentation.stories.tsx
@@ -48,3 +48,7 @@ export const SickLeaveSelected = () => (
     defaultPolicyType="sick"
   />
 )
+
+export const HolidayPolicyAlreadyExists = () => (
+  <PolicyTypeSelectorPresentation onContinue={onContinue} onCancel={onCancel} holidayPolicyExists />
+)

--- a/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelectorPresentation.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelectorPresentation.test.tsx
@@ -1,10 +1,14 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
 import { PolicyTypeSelector } from './PolicyTypeSelector'
 import { PolicyTypeSelectorPresentation } from './PolicyTypeSelectorPresentation'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
 import { componentEvents } from '@/shared/constants'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { server } from '@/test/mocks/server'
+import { API_BASE_URL } from '@/test/constants'
 
 describe('PolicyTypeSelectorPresentation', () => {
   const defaultProps = {
@@ -214,6 +218,32 @@ describe('PolicyTypeSelectorPresentation', () => {
     })
   })
 
+  describe('holidayPolicyExists', () => {
+    it('hides the Holiday pay option when a holiday policy already exists', async () => {
+      renderWithProviders(<PolicyTypeSelectorPresentation {...defaultProps} holidayPolicyExists />)
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('radio')).toHaveLength(2)
+      })
+
+      expect(screen.queryByLabelText('Holiday pay')).not.toBeInTheDocument()
+      expect(screen.getByLabelText('Time off')).toBeInTheDocument()
+      expect(screen.getByLabelText('Sick leave')).toBeInTheDocument()
+    })
+
+    it('shows all three options when no holiday policy exists', async () => {
+      renderWithProviders(
+        <PolicyTypeSelectorPresentation {...defaultProps} holidayPolicyExists={false} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('radio')).toHaveLength(3)
+      })
+
+      expect(screen.getByLabelText('Holiday pay')).toBeInTheDocument()
+    })
+  })
+
   describe('accessibility', () => {
     it('has a radio group with correct role', async () => {
       renderWithProviders(<PolicyTypeSelectorPresentation {...defaultProps} />)
@@ -243,11 +273,26 @@ describe('PolicyTypeSelectorPresentation', () => {
   })
 })
 
+const mockHolidayPayPolicy = {
+  version: '1b37938b017c7fd7116bada007072290',
+  company_uuid: 'company-123',
+  federal_holidays: {
+    new_years_day: { selected: true, name: "New Year's Day", date: 'January 1' },
+  },
+  employees: [],
+}
+
 describe('PolicyTypeSelector', () => {
   const onEvent = vi.fn()
 
   beforeEach(() => {
+    setupApiTestMocks()
     onEvent.mockClear()
+    server.use(
+      http.get(`${API_BASE_URL}/v1/companies/:companyUuid/holiday_pay_policy`, () => {
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
   })
 
   it('fires TIME_OFF_POLICY_TYPE_SELECTED with vacation on submit', async () => {
@@ -340,5 +385,22 @@ describe('PolicyTypeSelector', () => {
     await waitFor(() => {
       expect(onEvent).not.toHaveBeenCalled()
     })
+  })
+
+  it('hides Holiday pay option when the company already has a holiday policy', async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/v1/companies/:companyUuid/holiday_pay_policy`, () => {
+        return HttpResponse.json(mockHolidayPayPolicy)
+      }),
+    )
+
+    renderWithProviders(<PolicyTypeSelector onEvent={onEvent} companyId="company-123" />)
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Holiday pay')).not.toBeInTheDocument()
+    })
+
+    expect(screen.getByLabelText('Time off')).toBeInTheDocument()
+    expect(screen.getByLabelText('Sick leave')).toBeInTheDocument()
   })
 })

--- a/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelectorPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelectorPresentation.tsx
@@ -15,6 +15,7 @@ export function PolicyTypeSelectorPresentation({
   onContinue,
   onCancel,
   defaultPolicyType,
+  holidayPolicyExists = false,
 }: PolicyTypeSelectorPresentationProps) {
   useI18n('Company.TimeOff.SelectPolicyType')
   const { t } = useTranslation('Company.TimeOff.SelectPolicyType')
@@ -26,26 +27,29 @@ export function PolicyTypeSelectorPresentation({
     },
   })
 
-  const policyTypeOptions = useMemo(
-    () => [
-      {
-        value: 'holiday' as PolicyType,
+  const policyTypeOptions = useMemo(() => {
+    const options: Array<{ value: PolicyType; label: string; description: string }> = []
+    if (!holidayPolicyExists) {
+      options.push({
+        value: 'holiday',
         label: t('holidayLabel'),
         description: t('holidayHint'),
-      },
+      })
+    }
+    options.push(
       {
-        value: 'vacation' as PolicyType,
+        value: 'vacation',
         label: t('timeOffLabel'),
         description: t('timeOffHint'),
       },
       {
-        value: 'sick' as PolicyType,
+        value: 'sick',
         label: t('sickLeaveLabel'),
         description: t('sickLeaveHint'),
       },
-    ],
-    [t],
-  )
+    )
+    return options
+  }, [t, holidayPolicyExists])
 
   const handleSubmit = (data: PolicyTypeSelectorFormData) => {
     onContinue(data.policyType)

--- a/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelectorTypes.ts
+++ b/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelectorTypes.ts
@@ -4,4 +4,5 @@ export interface PolicyTypeSelectorPresentationProps {
   onContinue: (policyType: PolicyType) => void
   onCancel: () => void
   defaultPolicyType?: PolicyType
+  holidayPolicyExists?: boolean
 }


### PR DESCRIPTION
## Summary

- A Gusto company can have **only one** holiday pay policy at a time. The API rejects `POST /companies/{id}/holiday_pay_policy` when one already exists. Today the `PolicyTypeSelector` radio always offers Holiday pay as a third option, so users with an existing policy can pick it, submit, and hit the API error.
- Match `gws-flows` ([app/views/company/time_off/time_off_management/new.html.erb#L12-L20](https://github.com/Gusto/gws-flows/blob/main/app/views/company/time_off/time_off_management/new.html.erb#L12-L20)) by completely omitting the radio option from the DOM when a holiday policy is already present. Detected via the existing `useHolidayPayPoliciesGet` query — same pattern `PolicyList` uses.
- Added presentation- and container-level tests, plus a `HolidayPolicyAlreadyExists` Storybook story.

## Test plan

- [x] `npm run test -- --run src/components/UNSTABLE_TimeOff/PolicyTypeSelector` (26/26 pass)
- [x] `npm run test -- --run src/components/UNSTABLE_TimeOff` (336/336 pass)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/components/UNSTABLE_TimeOff/PolicyTypeSelector` clean
- [ ] Storybook: `Domain/TimeOff/PolicyTypeSelector → HolidayPolicyAlreadyExists` shows only Time off / Sick leave
- [ ] sdk-app smoke: with an existing holiday policy, "Create policy" shows two options; after deleting the policy, three options return

🤖 Generated with [Claude Code](https://claude.com/claude-code)