### PR TITLE
chore: Update README with missing docs and fix stale links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,7 +304,7 @@ Following types are currently defined:
 
 ## Documentation
 
-You can find documentation on building with the Gusto Embedded React SDK [in the `docs` directory within this repo here](./docs/01/what-is-the-gep-react-sdk.md). [Documentation is also hosted live alongside the Gusto Embedded API docs here](https://docs.gusto.com/embedded-payroll/docs/what-is-the-gep-react-sdk).
+You can find documentation on building with the Gusto Embedded React SDK [in the `docs` directory within this repo](./docs/).
 
 ## Cutting a new release
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,19 @@ To install:
 npm add @gusto/embedded-react-sdk
 ```
 
-Examples at:
+## SDK Dev App
 
-https://codesandbox.io/p/sandbox/gusto-embedded-sdk-demo-employeelist-nzpslw
+A standalone development application for building and testing SDK components with live API data is available in [`sdk-app/`](sdk-app/). To get started:
+
+```bash
+npm run sdk-app              # Demo environment (default)
+npm run sdk-app:staging      # Staging environment
+```
+
+See the [SDK Dev App README](sdk-app/README.md) for full setup and usage details.
 
 ## Documentation
 
-Live documentation is available at: https://docs.gusto.com/embedded-payroll/docs/what-is-the-gep-react-sdk
-
-- [What is the GEP React SDK](docs/what-is-the-gep-react-sdk.md)
 - [Deciding to build with the SDK](docs/deciding-to-build-with-the-sdk/deciding-to-build-with-the-sdk.md)
   - [Build Pathways - SDK, Flows & APIs](docs/deciding-to-build-with-the-sdk/build-pathways-sdk-flows-api.md)
   - [Component Types](docs/deciding-to-build-with-the-sdk/component-types.md)
@@ -33,6 +37,8 @@ Live documentation is available at: https://docs.gusto.com/embedded-payroll/docs
   - [Routing](docs/integration-guide/routing.md)
   - [Request Interceptors](docs/integration-guide/request-interceptors.md)
   - [Customizing SDK UI](docs/integration-guide/customizing-sdk-ui.md)
+  - [Observability](docs/integration-guide/observability.md)
+  - [Observability Examples](docs/integration-guide/observability-examples.md)
 - [Theming](docs/theming/theming.md)
   - [Theming Guide](docs/theming/theming-guide.md)
   - [Theme Variables](docs/theming/theme-variables.md)
@@ -42,11 +48,19 @@ Live documentation is available at: https://docs.gusto.com/embedded-payroll/docs
   - [Setting up your Component Adapter](docs/component-adapter/setting-up-your-component-adapter.md)
   - [Component Inventory](docs/component-adapter/component-inventory.md)
   - [Component Adapter FAQ](docs/component-adapter/component-adapter-faq.md)
+- [Reference](docs/reference/endpoint-reference.md)
+  - [Endpoint Reference](docs/reference/endpoint-reference.md)
+  - [Jobs and Compensations](docs/reference/jobs-and-compensations.md)
+  - [Proxy Examples](docs/reference/proxy-examples.md)
 - [Workflows Overview](docs/workflows-overview/workflows-overview.md)
   - [Company Onboarding](docs/workflows-overview/company-onboarding.md)
   - [Contractor Onboarding](docs/workflows-overview/contractor-onboarding.md)
+  - [Contractor Payments](docs/workflows-overview/contractor-payments.md)
   - [Employee Onboarding](docs/workflows-overview/employee-onboarding/employee-onboarding.md)
     - [Employee Self-Onboarding](docs/workflows-overview/employee-onboarding/employee-self-onboarding.md)
+  - [Employee Dashboard](docs/workflows-overview/employee-dashboard.md)
+  - [Employee Termination](docs/workflows-overview/employee-termination.md)
+  - [Information Requests](docs/workflows-overview/information-requests.md)
   - [Run Payroll](docs/workflows-overview/run-payroll.md)
   - [Off-Cycle Payroll (Bonus & Correction)](docs/workflows-overview/off-cycle-payroll.md)
   - [Dismissal Payroll](docs/workflows-overview/dismissal-payroll.md)
@@ -54,4 +68,8 @@ Live documentation is available at: https://docs.gusto.com/embedded-payroll/docs
 - [Hooks (Experimental)](docs/hooks/hooks.md)
   - [useEmployeeDetailsForm](docs/hooks/useEmployeeDetailsForm.md)
   - [useCompensationForm](docs/hooks/useCompensationForm.md)
+  - [useFederalTaxesForm](docs/hooks/useFederalTaxesForm.md)
+  - [usePayScheduleForm](docs/hooks/usePayScheduleForm.md)
+  - [useSignCompanyForm](docs/hooks/useSignCompanyForm.md)
+  - [useSignEmployeeForm](docs/hooks/useSignEmployeeForm.md)
   - [useWorkAddressForm](docs/hooks/useWorkAddressForm.md)


### PR DESCRIPTION
## Summary
- Add 14 missing doc entries to the README documentation index (reference section, observability guides, new workflow docs, new hooks)
- Remove outdated CodeSandbox link and stale `docs.gusto.com` link that pointed to the old `what-is-the-gep-react-sdk` slug
- Add SDK Dev App section pointing to `sdk-app/` with quick start commands
- Remove `docs/what-is-the-gep-react-sdk.md` from the repo and README (content now lives at `docs.gusto.com/embedded-payroll/docs/react-sdk`)

## Added docs
**Reference** (new section): `endpoint-reference.md`, `jobs-and-compensations.md`, `proxy-examples.md`

**Integration Guide**: `observability.md`, `observability-examples.md`

**Workflows Overview**: `contractor-payments.md`, `employee-dashboard.md`, `employee-termination.md`, `information-requests.md`

**Hooks**: `useFederalTaxesForm.md`, `usePayScheduleForm.md`, `useSignCompanyForm.md`, `useSignEmployeeForm.md`

## Test plan
- [ ] Verify all doc links in README resolve to existing files in the repo