### PR TITLE
fix: handle "Add employees" navigation from holiday detail view

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
@@ -300,6 +300,37 @@ describe('timeOffStateMachine', () => {
     })
   })
 
+  describe('holiday add employees from detail', () => {
+    it('transitions viewHolidayEmployees -> addEmployeesHoliday on TIME_OFF_HOLIDAY_ADD_EMPLOYEES', () => {
+      const service = createService()
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'policy-123',
+        policyType: 'holiday',
+      })
+      expect(service.machine.current).toBe('viewHolidayEmployees')
+
+      send(service, componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES)
+
+      expect(service.machine.current).toBe('addEmployeesHoliday')
+      expect(service.context.alerts).toBeUndefined()
+    })
+
+    it('returns to viewHolidayEmployees after adding employees from detail', () => {
+      const service = createService()
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'policy-123',
+        policyType: 'holiday',
+      })
+      send(service, componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES)
+      expect(service.machine.current).toBe('addEmployeesHoliday')
+
+      send(service, componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE)
+
+      expect(service.machine.current).toBe('viewHolidayEmployees')
+      expect(service.context.alerts).toBeUndefined()
+    })
+  })
+
   describe('tab switching', () => {
     it('switches from viewHolidayEmployees to viewHolidaySchedule', () => {
       const service = createService()

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -460,6 +460,17 @@ export const timeOffMachine = {
 
   viewHolidayEmployees: state<MachineTransition>(
     transition(
+      componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES,
+      'addEmployeesHoliday',
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: AddEmployeesHolidayContextual,
+          alerts: undefined,
+        }),
+      ),
+    ),
+    transition(
       componentEvents.TIME_OFF_VIEW_HOLIDAY_SCHEDULE,
       'viewHolidaySchedule',
       reduce(


### PR DESCRIPTION
## Summary

- The "Add employees" button in `HolidayPolicyDetail` was firing `TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE` (a completion event only handled by `addEmployeesHoliday` state), causing the button to silently do nothing when the machine was in `viewHolidayEmployees`
- Introduces `TIME_OFF_HOLIDAY_ADD_EMPLOYEES` as a navigation event and wires a transition in `viewHolidayEmployees` → `addEmployeesHoliday`
- Fixes the handler to emit the correct navigation event

## Test plan

- [x] New state machine tests verify `viewHolidayEmployees` → `addEmployeesHoliday` on `TIME_OFF_HOLIDAY_ADD_EMPLOYEES`
- [x] Round-trip test: navigate to add-employees then complete returns to `viewHolidayEmployees`
- [ ] Manual: In TimeOffFlow, view a holiday policy, click "Add employees", verify navigation to employee selection screen