### PR TITLE
fix: emit SDK event on time off policy deletion

### DIFF
--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.test.tsx
@@ -391,6 +391,50 @@ describe('PolicyList', () => {
       })
     })
 
+    it('emits TIME_OFF_DELETE_POLICY_DONE event after successful deletion', async () => {
+      server.use(
+        http.put(`${API_BASE_URL}/v1/time_off_policies/:timeOffPolicyUuid/deactivate`, () => {
+          return HttpResponse.json({
+            uuid: 'policy-1',
+            company_uuid: 'company-123',
+            name: 'Vacation',
+            policy_type: 'vacation',
+            accrual_method: 'per_pay_period',
+            is_active: false,
+            employees: [],
+          })
+        }),
+      )
+
+      renderWithProviders(<PolicyList {...defaultProps} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Vacation')).toBeInTheDocument()
+      })
+
+      const menuButtons = screen.getAllByRole('button', { name: 'Open menu' })
+      await user.click(menuButtons[0]!)
+
+      await waitFor(() => {
+        expect(screen.getByRole('menuitem', { name: 'Delete policy' })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('menuitem', { name: 'Delete policy' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+
+      const dialog = screen.getByRole('dialog')
+      await user.click(within(dialog).getByRole('button', { name: 'Delete policy' }))
+
+      await waitFor(() => {
+        expect(onEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_DELETE_POLICY_DONE, {
+          policyId: 'policy-1',
+        })
+      })
+    })
+
     it('closes dialog when cancel is clicked', async () => {
       renderWithProviders(<PolicyList {...defaultProps} />)
 
@@ -545,6 +589,46 @@ describe('PolicyList', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Holiday pay policy deleted successfully')).toBeInTheDocument()
+      })
+    })
+
+    it('emits TIME_OFF_DELETE_POLICY_DONE event after holiday policy deletion', async () => {
+      server.use(
+        http.get(`${API_BASE_URL}/v1/companies/:companyUuid/holiday_pay_policy`, () => {
+          return HttpResponse.json(mockHolidayPayPolicy)
+        }),
+        http.delete(`${API_BASE_URL}/v1/companies/:companyUuid/holiday_pay_policy`, () => {
+          return new HttpResponse(null, { status: 204 })
+        }),
+      )
+
+      renderWithProviders(<PolicyList {...defaultProps} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Holiday pay policy')).toBeInTheDocument()
+      })
+
+      const menuButtons = screen.getAllByRole('button', { name: 'Open menu' })
+      const holidayMenuButton = menuButtons[menuButtons.length - 1]!
+      await user.click(holidayMenuButton)
+
+      await waitFor(() => {
+        expect(screen.getByRole('menuitem', { name: 'Delete policy' })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('menuitem', { name: 'Delete policy' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+
+      const dialog = screen.getByRole('dialog')
+      await user.click(within(dialog).getByRole('button', { name: 'Delete policy' }))
+
+      await waitFor(() => {
+        expect(onEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_DELETE_POLICY_DONE, {
+          policyId: 'company-123',
+        })
       })
     })
   })

--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.tsx
@@ -143,6 +143,7 @@ function Root({ companyId, onEvent }: PolicyListProps) {
         await invalidateAllTimeOffPoliciesGetAll(queryClient)
         setDeleteSuccessAlert(t('flash.policyDeleted', { name: policy.name }))
       }
+      onEvent(componentEvents.TIME_OFF_DELETE_POLICY_DONE, { policyId: policy.uuid })
     })
     setIsDeletingPolicyId(null)
   }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -256,6 +256,7 @@ export const timeOffEvents = {
   TIME_OFF_HOLIDAY_ADD_EMPLOYEES: 'timeOff/holidayAddEmployees',
   TIME_OFF_EDIT_HOLIDAY_POLICY: 'timeOff/editHolidayPolicy',
   TIME_OFF_HOLIDAY_SELECTION_EDIT_DONE: 'timeOff/holidaySelection/editDone',
+  TIME_OFF_DELETE_POLICY_DONE: 'timeOff/deletePolicy/done',
 } as const
 
 export const componentEvents = {


### PR DESCRIPTION
## Summary

- Policy deletion in `PolicyList` performed the mutation and showed a success alert but never emitted an SDK event, giving partners no way to react programmatically
- Adds `TIME_OFF_DELETE_POLICY_DONE` event constant emitted after both regular policy deactivation and holiday policy deletion

## Test plan

- [x] Integration test verifies `onEvent` called with `TIME_OFF_DELETE_POLICY_DONE` and `{ policyId }` after non-holiday deletion
- [x] Integration test verifies the same for holiday policy deletion
- [ ] Manual: Delete a time-off policy, observe `timeOff/deletePolicy/done` in onEvent console logs