### PR TITLE
fix: hide Edit balance menu item for unlimited time-off policies

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.test.tsx
@@ -214,6 +214,35 @@ describe('TimeOffPolicyDetail', () => {
     })
   })
 
+  describe('unlimited policy menu', () => {
+    it('does not show Edit balance in the overflow menu for unlimited policies', async () => {
+      mockPolicyData = { ...basePolicyData, accrualMethod: 'unlimited' }
+      const user = userEvent.setup()
+      renderComponent()
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Vacation Policy' })).toBeInTheDocument()
+      })
+
+      const tabSelect = screen.getByRole('button', { name: /Vacation Policy/i })
+      await user.click(tabSelect)
+      const employeesOption = await screen.findByRole('option', { name: 'Employees' })
+      await user.click(employeesOption)
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('button', { name: /actions/i }).length).toBeGreaterThan(0)
+      })
+
+      const hamburgerButtons = screen.getAllByRole('button', { name: /actions/i })
+      await user.click(hamburgerButtons[0]!)
+
+      await waitFor(() => {
+        expect(screen.getByText('Remove employee')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('Edit balance')).not.toBeInTheDocument()
+    })
+  })
+
   describe('accessibility', () => {
     it('should not have accessibility violations on details tab', async () => {
       const { container } = renderComponent()

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.tsx
@@ -245,36 +245,43 @@ function Root({ policyId }: TimeOffPolicyDetailProps) {
     ]
   }, [Button, onEvent, policyId, t, isEditable])
 
+  const isUnlimited = policy.accrualMethod === 'unlimited'
+
   const itemMenu = useCallback(
     (employee: TimeOffPolicyDetailEmployee) => {
       const employeeName = `${employee.firstName ?? ''} ${employee.lastName ?? ''}`.trim()
+      const items = [
+        ...(!isUnlimited
+          ? [
+              {
+                label: t('employeeTable.editBalance'),
+                icon: <EditIcon aria-hidden />,
+                onClick: () => {
+                  setEditBalanceState({
+                    employeeUuid: employee.uuid,
+                    employeeName,
+                    currentBalance: employee.balance ?? 0,
+                  })
+                },
+              },
+            ]
+          : []),
+        {
+          label: t('employeeTable.removeEmployee'),
+          icon: <TrashCanSvg aria-hidden />,
+          onClick: () => {
+            setRemoveTarget({ uuid: employee.uuid, name: employeeName })
+          },
+        },
+      ]
       return (
         <HamburgerMenu
-          items={[
-            {
-              label: t('employeeTable.editBalance'),
-              icon: <EditIcon aria-hidden />,
-              onClick: () => {
-                setEditBalanceState({
-                  employeeUuid: employee.uuid,
-                  employeeName,
-                  currentBalance: employee.balance ?? 0,
-                })
-              },
-            },
-            {
-              label: t('employeeTable.removeEmployee'),
-              icon: <TrashCanSvg aria-hidden />,
-              onClick: () => {
-                setRemoveTarget({ uuid: employee.uuid, name: employeeName })
-              },
-            },
-          ]}
+          items={items}
           triggerLabel={`${t('employeeTable.actions')} ${employeeName}`}
         />
       )
     },
-    [t],
+    [t, isUnlimited],
   )
 
   const discriminatedProps =


### PR DESCRIPTION
## Summary
- The per-employee overflow menu in `TimeOffPolicyDetail` showed "Edit balance" for unlimited policies, even though balances are not applicable
- Gates the menu item on `accrualMethod !== 'unlimited'` so only "Remove employee" appears for unlimited policies
- Adds a test asserting the unlimited policy menu behavior

## Test plan
- [x] Unit test added: verifies "Edit balance" is absent from the menu for unlimited policies
- [x] Existing tests continue to pass (10/10)
- [ ] Manual: Create an unlimited PTO policy, view detail, check per-employee overflow menu