### PR TITLE
fix: filter policy detail settings display by accrual method category

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.test.tsx
@@ -13,6 +13,13 @@ const limitedPolicyDetails = {
   resetDate: 'January 1',
 }
 
+const fixedPolicyDetails = {
+  policyType: 'sick' as const,
+  accrualMethod: 'perCalendarYear' as const,
+  accrualRate: 40,
+  resetDate: 'January 1',
+}
+
 const unlimitedPolicyDetails = {
   policyType: 'vacation' as const,
   accrualMethod: 'unlimited' as const,
@@ -179,6 +186,24 @@ describe('TimeOffPolicyDetailPresentation', () => {
 
       await user.click(screen.getByRole('button', { name: 'Change' }))
       expect(onChangeSettings).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('details tab - fixed accrual policy', () => {
+    it('does not show Accrual maximum or Waiting period for fixed accrual', async () => {
+      renderComponent({
+        policyDetails: fixedPolicyDetails,
+        policySettings: fullPolicySettings,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Policy settings')).toBeInTheDocument()
+      })
+      expect(screen.getByText('Balance maximum')).toBeInTheDocument()
+      expect(screen.getByText('Carry over limit')).toBeInTheDocument()
+      expect(screen.getByText('Paid out on termination')).toBeInTheDocument()
+      expect(screen.queryByText('Accrual maximum')).not.toBeInTheDocument()
+      expect(screen.queryByText('Waiting period')).not.toBeInTheDocument()
     })
   })
 

--- a/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
@@ -97,6 +97,11 @@ function DetailsTab({
   const { Box, BoxHeader, DescriptionList, Button } = useComponentContext()
 
   const isUnlimited = policyDetails.accrualMethod === 'unlimited'
+  const isHoursWorked =
+    policyDetails.accrualMethod === 'perHourWorked' ||
+    policyDetails.accrualMethod === 'perHourWorkedNoOvertime' ||
+    policyDetails.accrualMethod === 'perHourPaid' ||
+    policyDetails.accrualMethod === 'perHourPaidNoOvertime'
 
   const detailItems = useMemo(() => {
     const items: { term: string; description: string }[] = [
@@ -129,8 +134,10 @@ function DetailsTab({
   const settingsItems = useMemo(() => {
     if (!policySettings) return []
 
-    return [
-      {
+    const items: { term: string; description: string }[] = []
+
+    if (isHoursWorked) {
+      items.push({
         term: t('maxAccrualHoursPerYear.label'),
         description:
           policySettings.maxAccrualHoursPerYear != null
@@ -138,7 +145,10 @@ function DetailsTab({
                 count: policySettings.maxAccrualHoursPerYear,
               })
             : t('maxAccrualHoursPerYear.noMaximum'),
-      },
+      })
+    }
+
+    items.push(
       {
         term: t('maxHours.label'),
         description:
@@ -153,7 +163,10 @@ function DetailsTab({
             ? t('carryoverLimitHours.withLimit', { count: policySettings.carryoverLimitHours })
             : t('carryoverLimitHours.noLimit'),
       },
-      {
+    )
+
+    if (isHoursWorked) {
+      items.push({
         term: t('accrualWaitingPeriodDays.label'),
         description:
           policySettings.accrualWaitingPeriodDays != null
@@ -161,15 +174,18 @@ function DetailsTab({
                 count: policySettings.accrualWaitingPeriodDays,
               })
             : t('accrualWaitingPeriodDays.noPeriod'),
-      },
-      {
-        term: t('paidOutOnTermination.label'),
-        description: policySettings.paidOutOnTermination
-          ? t('paidOutOnTermination.yes')
-          : t('paidOutOnTermination.no'),
-      },
-    ]
-  }, [policySettings, t])
+      })
+    }
+
+    items.push({
+      term: t('paidOutOnTermination.label'),
+      description: policySettings.paidOutOnTermination
+        ? t('paidOutOnTermination.yes')
+        : t('paidOutOnTermination.no'),
+    })
+
+    return items
+  }, [policySettings, t, isHoursWorked])
 
   const detailsCardClassName = isUnlimited
     ? `${styles.descriptionCard} ${styles.descriptionCardUnlimited}`


### PR DESCRIPTION
## Summary
- The settings card in the policy detail view showed all 5 settings rows (Accrual maximum, Balance maximum, Carry over limit, Waiting period, Payout on dismissal) regardless of accrual method
- For fixed-accrual policies (per_calendar_year, per_pay_period, per_anniversary_year), Accrual maximum and Waiting period were never configurable, so showing them was misleading
- Now conditionally renders these two fields only for hourly-accrual policies, matching the create/edit form behavior

## Test plan
- [x] Unit test added: verifies fixed-accrual detail view omits Accrual maximum and Waiting period
- [x] Existing tests pass (22/22), including hourly-accrual tests that still show all fields
- [ ] Manual: Open a fixed-accrual policy detail and verify only 3 settings rows appear