### PR TITLE
fix: remove duplicate holiday add-employees transition in state machine

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -481,17 +481,6 @@ export const timeOffMachine = {
       ),
     ),
     transition(
-      componentEvents.TIME_OFF_HOLIDAY_ADD_EMPLOYEES,
-      'addEmployeesHoliday',
-      reduce(
-        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
-          ...ctx,
-          component: AddEmployeesHolidayContextual,
-          alerts: undefined,
-        }),
-      ),
-    ),
-    transition(
       componentEvents.TIME_OFF_EDIT_HOLIDAY_POLICY,
       'editHolidaySelectionForm',
       reduce(


### PR DESCRIPTION
## Summary
- The `viewHolidayEmployees` state in the time-off state machine had the `TIME_OFF_HOLIDAY_ADD_EMPLOYEES` transition defined twice with identical targets and reducers
- In robot3, only the first matching transition is used, so the duplicate was unreachable dead code
- Removed the duplicate to reduce confusion and maintenance burden

## Test plan
- [x] All 64 state machine tests pass
- [x] No behavioral change expected (duplicate was unreachable)