### PR TITLE
fix: route cancel from edit-holiday form back to holiday detail

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
@@ -554,14 +554,15 @@ describe('timeOffStateMachine', () => {
       expect(service.context.policyId).toBe('holiday-policy')
     })
 
-    it('cancels from editHolidaySelectionForm to policyList', () => {
+    it('cancels from editHolidaySelectionForm back to viewHolidayEmployees', () => {
       const service = createService()
       toViewHolidayEmployees(service)
       send(service, componentEvents.TIME_OFF_EDIT_HOLIDAY_POLICY)
 
       send(service, componentEvents.CANCEL)
 
-      expect(service.machine.current).toBe('policyList')
+      expect(service.machine.current).toBe('viewHolidayEmployees')
+      expect(service.context.alerts).toBeUndefined()
     })
 
     it('does not route TIME_OFF_HOLIDAY_SELECTION_DONE in the edit flow into the create flow', () => {

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -570,7 +570,17 @@ export const timeOffMachine = {
         }),
       ),
     ),
-    cancelToPolicyList,
+    transition(
+      componentEvents.CANCEL,
+      'viewHolidayEmployees',
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: ViewHolidayEmployeesContextual,
+          alerts: undefined,
+        }),
+      ),
+    ),
   ),
 
   final: state<MachineTransition>(),


### PR DESCRIPTION
## Summary
- `editHolidaySelectionForm` reused the shared `cancelToPolicyList` transition, so cancelling from the edit-holiday form navigated all the way back to the policy list
- This was inconsistent with `editPolicyDetailsForm` which correctly returns to the detail view on cancel
- Now cancelling returns to `viewHolidayEmployees` (the holiday detail view)

## Test plan
- [x] Updated state machine test to verify cancel returns to `viewHolidayEmployees` instead of `policyList`
- [x] All 64 state machine tests pass
- [ ] Manual: Edit a holiday policy, press Cancel/Back, verify you return to the holiday detail view