### PR TITLE
fix: await delete handler before closing policy delete dialog

### DIFF
--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyListPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyListPresentation.tsx
@@ -45,9 +45,9 @@ export function PolicyListPresentation({
     setDeletePolicyDialogState({ isOpen: false, policy: null })
   }
 
-  const handleConfirmDelete = () => {
+  const handleConfirmDelete = async () => {
     if (deletePolicyDialogState.policy) {
-      onDeletePolicy(deletePolicyDialogState.policy)
+      await onDeletePolicy(deletePolicyDialogState.policy)
       handleCloseDeleteDialog()
     }
   }

--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyListTypes.ts
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyListTypes.ts
@@ -12,7 +12,7 @@ export interface PolicyListPresentationProps {
   onCreatePolicy: () => void
   onEditPolicy: (policy: PolicyListItem) => void
   onFinishSetup: (policy: PolicyListItem) => void
-  onDeletePolicy: (policy: PolicyListItem) => void
+  onDeletePolicy: (policy: PolicyListItem) => void | Promise<void>
   deleteSuccessAlert?: string | null
   onDismissDeleteAlert?: () => void
   isDeletingPolicyId?: string | null


### PR DESCRIPTION
## Summary
- The delete confirmation dialog in `PolicyListPresentation` closed optimistically before the async delete resolved
- If the API call failed, the user saw no dialog and the error was not clearly surfaced
- Now `handleConfirmDelete` awaits `onDeletePolicy` before dismissing the dialog, keeping the loading state visible during the API call

## Test plan
- [x] All 25 PolicyList tests pass
- [ ] Manual: Delete a policy and verify the dialog stays open with loading spinner until the delete completes