### PR TITLE
fix: use server-side search for employee selection in time-off flows

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.test.tsx
@@ -31,13 +31,20 @@ const mockEmployees = [
 ]
 
 vi.mock('@gusto/embedded-api/react-query/employeesList', () => ({
-  useEmployeesListSuspense: () => ({
-    data: {
-      showEmployees: mockEmployees,
-      httpMeta: { response: { headers: new Headers() } },
-    },
-    isFetching: false,
-  }),
+  useEmployeesListSuspense: (request: { searchTerm?: string }) => {
+    const filtered = request.searchTerm
+      ? mockEmployees.filter(e =>
+          `${e.firstName} ${e.lastName}`.toLowerCase().includes(request.searchTerm!.toLowerCase()),
+        )
+      : mockEmployees
+    return {
+      data: {
+        showEmployees: filtered,
+        httpMeta: { response: { headers: new Headers() } },
+      },
+      isFetching: false,
+    }
+  },
 }))
 
 const mockHolidayPolicyEmployees: Array<{ uuid: string }> = []

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
@@ -67,13 +67,20 @@ const mockEmployees = [
 ]
 
 vi.mock('@gusto/embedded-api/react-query/employeesList', () => ({
-  useEmployeesListSuspense: () => ({
-    data: {
-      showEmployees: mockEmployees,
-      httpMeta: { response: { headers: new Headers() } },
-    },
-    isFetching: false,
-  }),
+  useEmployeesListSuspense: (request: { searchTerm?: string }) => {
+    const filtered = request.searchTerm
+      ? mockEmployees.filter(e =>
+          `${e.firstName} ${e.lastName}`.toLowerCase().includes(request.searchTerm!.toLowerCase()),
+        )
+      : mockEmployees
+    return {
+      data: {
+        showEmployees: filtered,
+        httpMeta: { response: { headers: new Headers() } },
+      },
+      isFetching: false,
+    }
+  },
 }))
 
 vi.mock('@gusto/embedded-api/react-query/timeOffPoliciesAddEmployees', () => ({

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/useSelectEmployeesData.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/useSelectEmployeesData.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useDeferredValue, useMemo, useState } from 'react'
 import { useEmployeesListSuspense } from '@gusto/embedded-api/react-query/employeesList'
 import { Include } from '@gusto/embedded-api/models/operations/getv1companiescompanyidemployees'
 import type { PaidTimeOff } from '@gusto/embedded-api/models/components/paidtimeoff'
@@ -10,6 +10,7 @@ export function useSelectEmployeesData(companyId: string, initialSelectedUuids?:
     () => new Set(initialSelectedUuids ?? []),
   )
   const [searchValue, setSearchValue] = useState('')
+  const deferredSearchValue = useDeferredValue(searchValue)
   const { currentPage, itemsPerPage, getPaginationProps, resetPage } = usePagination()
 
   // include: all_compensations is required to populate eligiblePaidTimeOff,
@@ -21,9 +22,10 @@ export function useSelectEmployeesData(companyId: string, initialSelectedUuids?:
     page: currentPage,
     per: itemsPerPage,
     include: [Include.AllCompensations],
+    ...(deferredSearchValue ? { searchTerm: deferredSearchValue } : {}),
   })
 
-  const employees = useMemo<EmployeeItem[]>(
+  const filteredEmployees = useMemo<EmployeeItem[]>(
     () =>
       (employeesData.showEmployees ?? []).map(e => ({
         uuid: e.uuid,
@@ -35,14 +37,6 @@ export function useSelectEmployeesData(companyId: string, initialSelectedUuids?:
       })),
     [employeesData.showEmployees],
   )
-
-  const filteredEmployees = useMemo(() => {
-    if (!searchValue) return employees
-    const lower = searchValue.toLowerCase()
-    return employees.filter(e =>
-      `${e.firstName ?? ''} ${e.lastName ?? ''}`.toLowerCase().includes(lower),
-    )
-  }, [employees, searchValue])
 
   const pagination = useMemo(
     () => getPaginationProps(employeesData.httpMeta.response.headers, isFetching),


### PR DESCRIPTION
## Summary
- Employee search in the add-employees step only filtered the current page of API results, so employees on other pages were unfindable
- The employees list API already supports a `searchTerm` parameter -- this wires it up to `useEmployeesListSuspense`
- Uses `useDeferredValue` to avoid excessive re-fetches on every keystroke while keeping the input responsive
- Removes the now-unnecessary client-side filtering logic

## Test plan
- [x] All 70 SelectEmployees tests pass (TimeOff + Holiday)
- [x] Updated test mocks to simulate server-side search filtering
- [ ] Manual: Add employees to a policy with multiple pages of employees, search for one on a later page