### PR TITLE
fix: remove unused addEmployees i18n keys from CreateTimeOffPolicy

### DIFF
--- a/src/i18n/en/Company.TimeOff.CreateTimeOffPolicy.json
+++ b/src/i18n/en/Company.TimeOff.CreateTimeOffPolicy.json
@@ -59,15 +59,6 @@
     "numberOfDaysPlaceholder": "Number of days",
     "continueCta": "Save"
   },
-  "addEmployees": {
-    "title": "Add employees to your policy",
-    "employeesMovedWarning": "Any employees currently assigned to another {{policyType}} policy will be moved to this policy.",
-    "createPolicyCta": "Create policy",
-    "policyType": {
-      "vacation": "paid time off",
-      "sick": "sick leave"
-    }
-  },
   "startingBalances": {
     "title": "Starting balances",
     "description": "If your employees have an existing balance, please enter those hours here. Employees moving to this policy from another will carry over their accrued hours.",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -425,15 +425,6 @@ export interface CompanyTimeOffCreateTimeOffPolicy{
 "numberOfDaysPlaceholder":string;
 "continueCta":string;
 };
-"addEmployees":{
-"title":string;
-"employeesMovedWarning":string;
-"createPolicyCta":string;
-"policyType":{
-"vacation":string;
-"sick":string;
-};
-};
 "startingBalances":{
 "title":string;
 "description":string;


### PR DESCRIPTION
## Summary
- Removes the unused `addEmployees` block from `Company.TimeOff.CreateTimeOffPolicy.json` (F-002 from TimeOff findings log)
- The live "Add employees" screen uses `Company.TimeOff.SelectEmployees.json` instead — the `addEmployees.title`, `employeesMovedWarning`, `createPolicyCta`, and `policyType` keys were never referenced by any component
- Regenerates i18n types to keep them in sync

## Test plan
- [x] `npm run i18n:generate` succeeds
- [x] `npm run format:check` passes
- [x] `npm run lint:check` passes (0 errors)
- [x] `npx tsc --noEmit` passes
- [x] `npm run test -- --run` — all 2572 tests pass
- [x] `npm run endpoints:verify` passes