### PR TITLE
fix: improve error message when removing employees with pending time-off requests

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
@@ -104,10 +104,12 @@ vi.mock('@tanstack/react-query', async importActual => {
   }
 })
 
+const mockBaseSubmitHandler = vi.fn(async (_: unknown, fn: () => Promise<void>) => fn())
+
 vi.mock('@/components/Base/useBase', () => ({
   useBase: () => ({
     onEvent: mockOnEvent,
-    baseSubmitHandler: vi.fn(async (_, fn: () => Promise<void>) => fn()),
+    baseSubmitHandler: mockBaseSubmitHandler,
     setError: vi.fn(),
     error: null,
     LoadingIndicator: () => null,
@@ -526,6 +528,60 @@ describe('SelectEmployeesTimeOff', () => {
       expect(mockInvalidateQueries).toHaveBeenCalledWith({
         queryKey: ['@gusto/embedded-api', 'timeOffPolicies', 'get'],
       })
+    })
+  })
+
+  describe('remove employee 422 error', () => {
+    it('re-throws a contextual SDKInternalError when remove_employees returns a 422', async () => {
+      const user = userEvent.setup()
+      mockPolicyEmployees = [{ uuid: '1', balance: '12' }]
+
+      const { UnprocessableEntityErrorObject } =
+        await import('@gusto/embedded-api/models/errors/unprocessableentityerrorobject')
+      const apiError = new UnprocessableEntityErrorObject(
+        {
+          errors: [
+            {
+              errorKey: 'base',
+              category: 'invalid_operation',
+              message:
+                'There are pending or approved time off requests from a previous policy. Please decline them before removing the employee from the policy',
+            },
+          ],
+        },
+        {
+          response: new Response(null, { status: 422 }),
+          request: new Request('https://example.com'),
+          body: '',
+        },
+      )
+      mockRemoveEmployees.mockRejectedValueOnce(apiError)
+
+      const caughtErrors: Error[] = []
+      mockBaseSubmitHandler.mockImplementation(async (_: unknown, fn: () => Promise<void>) => {
+        try {
+          await fn()
+        } catch (err) {
+          caughtErrors.push(err as Error)
+        }
+      })
+
+      renderComponent({ mode: 'standalone' })
+      await waitFor(() => {
+        expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
+      await user.click(screen.getByRole('button', { name: 'continueCta' }))
+      const confirmBtn = await screen.findByRole('button', {
+        name: 'removeConfirmDialog.confirmCta',
+      })
+      await user.click(confirmBtn)
+
+      await waitFor(() => {
+        expect(caughtErrors).toHaveLength(1)
+      })
+      expect(caughtErrors[0]!.message).toContain('errors.removeEmployeesFailed')
     })
   })
 

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef, useState } from 'react'
 import { useTimeOffPoliciesAddEmployeesMutation } from '@gusto/embedded-api/react-query/timeOffPoliciesAddEmployees'
 import { useTimeOffPoliciesRemoveEmployeesMutation } from '@gusto/embedded-api/react-query/timeOffPoliciesRemoveEmployees'
 import { useTimeOffPoliciesGetSuspense } from '@gusto/embedded-api/react-query/timeOffPoliciesGet'
+import { UnprocessableEntityErrorObject } from '@gusto/embedded-api/models/errors/unprocessableentityerrorobject'
 import { useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import type { CreatableTimeOffPolicyType } from '../../TimeOffFlow/timeOffPolicyTypes'
@@ -9,6 +10,7 @@ import { SelectEmployeesPresentation } from './SelectEmployeesPresentation'
 import { useSelectEmployeesData } from './useSelectEmployeesData'
 import type { EmployeeItem } from './SelectEmployeesPresentationTypes'
 import { useBase } from '@/components/Base/useBase'
+import { SDKInternalError } from '@/types/sdkError'
 import { componentEvents } from '@/shared/constants'
 import { useI18n } from '@/i18n'
 
@@ -193,12 +195,23 @@ function SelectEmployeesTimeOffInner({
     async (toAdd: string[], toRemove: string[]) => {
       await baseSubmitHandler({}, async () => {
         if (toRemove.length > 0) {
-          await removeEmployees({
-            request: {
-              timeOffPolicyUuid: policyId,
-              requestBody: { employees: toRemove.map(uuid => ({ uuid })) },
-            },
-          })
+          try {
+            await removeEmployees({
+              request: {
+                timeOffPolicyUuid: policyId,
+                requestBody: { employees: toRemove.map(uuid => ({ uuid })) },
+              },
+            })
+          } catch (err) {
+            if (err instanceof UnprocessableEntityErrorObject) {
+              const apiMessage = err.errors[0]?.message ?? ''
+              throw new SDKInternalError(
+                t('errors.removeEmployeesFailed', { details: apiMessage }),
+                'api_error',
+              )
+            }
+            throw err
+          }
         }
         let policyResult: unknown
         if (toAdd.length > 0) {
@@ -224,6 +237,7 @@ function SelectEmployeesTimeOffInner({
       policyId,
       queryClient,
       onEvent,
+      t,
     ],
   )
 

--- a/src/i18n/en/Company.TimeOff.SelectEmployees.json
+++ b/src/i18n/en/Company.TimeOff.SelectEmployees.json
@@ -9,6 +9,9 @@
   "startingBalanceColumn": "Starting balance (hrs)",
   "backCta": "Back",
   "continueCta": "Continue",
+  "errors": {
+    "removeEmployeesFailed": "Unable to remove employees from this policy. {{details}}"
+  },
   "removeConfirmDialog": {
     "title_one": "Remove {{count}} employee from this policy?",
     "title_other": "Remove {{count}} employees from this policy?",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -578,6 +578,9 @@ export interface CompanyTimeOffSelectEmployees{
 "startingBalanceColumn":string;
 "backCta":string;
 "continueCta":string;
+"errors":{
+"removeEmployeesFailed":string;
+};
 "removeConfirmDialog":{
 "title_one":string;
 "title_other":string;


### PR DESCRIPTION
## Summary
- Improves the error display when `remove_employees` returns a 422 due to pending/approved time-off requests on a previous policy (F-004 from TimeOff findings log)
- Catches `UnprocessableEntityErrorObject` specifically in `submitDiff` and wraps it in a contextual `SDKInternalError` with an i18n-backed message
- The error now displays "Unable to remove employees from this policy. [API details]" instead of the raw API error passthrough
- Adds i18n key `errors.removeEmployeesFailed` to `Company.TimeOff.SelectEmployees.json`

## Test plan
- [x] New test: verify contextual error thrown when remove_employees returns 422
- [x] All 23 SelectEmployeesTimeOff tests pass
- [x] Full test suite: 2573 tests pass
- [x] Pre-commit hooks pass (build, lint, format, endpoints)