### PR TITLE
fix: rename policy list menu item from "Edit policy" to "View policy"

### DIFF
--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.test.tsx
@@ -287,7 +287,7 @@ describe('PolicyList', () => {
       expect(onEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_CREATE_POLICY)
     })
 
-    it('emits TIME_OFF_VIEW_POLICY event when edit policy is clicked from menu', async () => {
+    it('emits TIME_OFF_VIEW_POLICY event when view policy is clicked from menu', async () => {
       renderWithProviders(<PolicyList {...defaultProps} />)
 
       await waitFor(() => {
@@ -298,10 +298,10 @@ describe('PolicyList', () => {
       await user.click(menuButtons[0]!)
 
       await waitFor(() => {
-        expect(screen.getByText('Edit policy')).toBeInTheDocument()
+        expect(screen.getByText('View policy')).toBeInTheDocument()
       })
 
-      await user.click(screen.getByText('Edit policy'))
+      await user.click(screen.getByText('View policy'))
 
       expect(onEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_VIEW_POLICY, {
         policyId: 'policy-1',
@@ -541,10 +541,10 @@ describe('PolicyList', () => {
       await user.click(holidayMenuButton)
 
       await waitFor(() => {
-        expect(screen.getByText('Edit policy')).toBeInTheDocument()
+        expect(screen.getByText('View policy')).toBeInTheDocument()
       })
 
-      await user.click(screen.getByText('Edit policy'))
+      await user.click(screen.getByText('View policy'))
 
       expect(onEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_VIEW_POLICY, {
         policyId: 'company-123',

--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyListPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyListPresentation.tsx
@@ -73,7 +73,7 @@ export function PolicyListPresentation({
       const menuItems = isEditable
         ? [
             {
-              label: t('actions.editPolicy'),
+              label: t('actions.viewPolicy'),
               onClick: () => {
                 onEditPolicy(policy)
               },

--- a/src/i18n/en/Company.TimeOff.TimeOffPolicies.json
+++ b/src/i18n/en/Company.TimeOff.TimeOffPolicies.json
@@ -7,7 +7,6 @@
   },
   "tableLabel": "Time off policies",
   "actions": {
-    "editPolicy": "Edit policy",
     "viewPolicy": "View policy",
     "deletePolicy": "Delete policy"
   },

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -609,7 +609,6 @@ export interface CompanyTimeOffTimeOffPolicies{
 };
 "tableLabel":string;
 "actions":{
-"editPolicy":string;
 "viewPolicy":string;
 "deletePolicy":string;
 };


### PR DESCRIPTION
## Summary
- Fixes duplicate "Edit policy" label appearing with different semantics in the time-off flow (F-010 from TimeOff findings log)
- The PolicyList hamburger menu now uses "View policy" for all policy types, matching the `TIME_OFF_VIEW_POLICY` event it fires
- The detail screen retains "Edit policy" for its button that fires `TIME_OFF_EDIT_POLICY`
- Removes the now-unused `actions.editPolicy` i18n key
- Updates tests to assert on "View policy" text

## Test plan
- [x] PolicyList tests updated and passing (25 tests)
- [x] Full test suite: 2572 tests pass
- [x] `npm run i18n:generate` succeeds
- [x] `npx tsc --noEmit` passes
- [x] Pre-commit hooks pass (build, lint, format, endpoints)