### PR TITLE
fix: clear stale policyId when starting new create flow in TimeOff wizard

### DIFF
--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
@@ -648,6 +648,61 @@ describe('timeOffStateMachine', () => {
     })
   })
 
+  describe('policyId cleanup on create/cancel/backToList', () => {
+    it('clears policyId when starting a new create flow after viewing a policy', () => {
+      const service = createService()
+
+      send(service, componentEvents.TIME_OFF_VIEW_POLICY, {
+        policyId: 'policy-existing',
+        policyType: 'vacation',
+      })
+      expect(service.context.policyId).toBe('policy-existing')
+
+      send(service, componentEvents.TIME_OFF_BACK_TO_LIST)
+      expect(service.machine.current).toBe('policyList')
+      expect(service.context.policyId).toBeUndefined()
+      expect(service.context.policyType).toBeUndefined()
+
+      send(service, componentEvents.TIME_OFF_CREATE_POLICY)
+      expect(service.machine.current).toBe('policyTypeSelector')
+      expect(service.context.policyId).toBeUndefined()
+      expect(service.context.policyType).toBeUndefined()
+    })
+
+    it('clears policyId when starting a new create flow after completing a policy creation', () => {
+      const service = createService()
+
+      send(service, componentEvents.TIME_OFF_CREATE_POLICY)
+      send(service, componentEvents.TIME_OFF_POLICY_TYPE_SELECTED, { policyType: 'vacation' })
+      send(service, componentEvents.TIME_OFF_POLICY_DETAILS_DONE, {
+        policyId: 'first-policy',
+        accrualMethod: 'unlimited',
+      })
+      send(service, componentEvents.TIME_OFF_ADD_EMPLOYEES_DONE)
+      expect(service.machine.current).toBe('viewTimeOffPolicyDetail')
+      expect(service.context.policyId).toBe('first-policy')
+
+      send(service, componentEvents.TIME_OFF_BACK_TO_LIST)
+      expect(service.context.policyId).toBeUndefined()
+
+      send(service, componentEvents.TIME_OFF_CREATE_POLICY)
+      expect(service.context.policyId).toBeUndefined()
+      expect(service.context.policyType).toBeUndefined()
+    })
+
+    it('clears policyId on cancel from policyDetailsForm', () => {
+      const service = createService()
+      toPolicyDetailsForm(service)
+      send(service, componentEvents.TIME_OFF_POLICY_DETAILS_DONE, { policyId: 'policy-123' })
+      expect(service.context.policyId).toBe('policy-123')
+
+      send(service, componentEvents.CANCEL)
+      expect(service.machine.current).toBe('policyList')
+      expect(service.context.policyId).toBeUndefined()
+      expect(service.context.policyType).toBeUndefined()
+    })
+  })
+
   describe('cancel transitions', () => {
     it('cancels from policyTypeSelector to policyList', () => {
       const service = createService()

--- a/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/UNSTABLE_TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -54,6 +54,8 @@ const cancelToPolicyList = transition(
     (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
       ...ctx,
       component: PolicyListContextual,
+      policyId: undefined,
+      policyType: undefined,
       alerts: undefined,
     }),
   ),
@@ -66,6 +68,8 @@ const backToListTransition = transition(
     (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
       ...ctx,
       component: PolicyListContextual,
+      policyId: undefined,
+      policyType: undefined,
       alerts: undefined,
     }),
   ),
@@ -80,6 +84,8 @@ export const timeOffMachine = {
         (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
           ...ctx,
           component: SelectPolicyTypeContextual,
+          policyId: undefined,
+          policyType: undefined,
           alerts: undefined,
         }),
       ),


### PR DESCRIPTION
## Summary

- Fixes a state management bug where starting a second "Create policy" flow reused the `policyId` from a previously created/viewed policy
- The stale `policyId` caused `PolicyConfigurationForm` to render in edit mode (calling the update API) instead of create mode, resulting in "Policy type is not allowed to update" errors
- Clears `policyId` and `policyType` in the `TIME_OFF_CREATE_POLICY`, `CANCEL`, and `TIME_OFF_BACK_TO_LIST` state machine transitions

## Test plan

- [x] Added unit tests verifying `policyId` is cleared after back-to-list and create-policy transitions
- [ ] Manual: create a PTO policy, navigate back to list, create a Sick Leave policy — should succeed without "Policy type is not allowed to update" error