### PR TITLE
fix: keep delete confirmation dialog open when deletion fails

### DIFF
--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.test.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.test.tsx
@@ -435,6 +435,53 @@ describe('PolicyList', () => {
       })
     })
 
+    it('keeps dialog open when delete fails with API error', async () => {
+      server.use(
+        http.put(`${API_BASE_URL}/v1/time_off_policies/:timeOffPolicyUuid/deactivate`, () => {
+          return HttpResponse.json(
+            {
+              errors: [
+                {
+                  error_key: 'base',
+                  category: 'invalid_request',
+                  message:
+                    'There are pending or approved time off requests that need to be declined before deactivating this policy',
+                },
+              ],
+            },
+            { status: 422 },
+          )
+        }),
+      )
+
+      renderWithProviders(<PolicyList {...defaultProps} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Vacation')).toBeInTheDocument()
+      })
+
+      const menuButtons = screen.getAllByRole('button', { name: 'Open menu' })
+      await user.click(menuButtons[0]!)
+
+      await waitFor(() => {
+        expect(screen.getByRole('menuitem', { name: 'Delete policy' })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('menuitem', { name: 'Delete policy' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+
+      const dialog = screen.getByRole('dialog')
+      await user.click(within(dialog).getByRole('button', { name: 'Delete policy' }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('Policy "Vacation" deleted successfully')).not.toBeInTheDocument()
+    })
+
     it('closes dialog when cancel is clicked', async () => {
       renderWithProviders(<PolicyList {...defaultProps} />)
 

--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyList.tsx
@@ -127,7 +127,8 @@ function Root({ companyId, onEvent }: PolicyListProps) {
     })
   }
 
-  const handleDeletePolicy = async (policy: PolicyListItem) => {
+  const handleDeletePolicy = async (policy: PolicyListItem): Promise<boolean> => {
+    let success = false
     setIsDeletingPolicyId(policy.uuid)
     await baseSubmitHandler({}, async () => {
       if (policy.isHoliday) {
@@ -144,8 +145,10 @@ function Root({ companyId, onEvent }: PolicyListProps) {
         setDeleteSuccessAlert(t('flash.policyDeleted', { name: policy.name }))
       }
       onEvent(componentEvents.TIME_OFF_DELETE_POLICY_DONE, { policyId: policy.uuid })
+      success = true
     })
     setIsDeletingPolicyId(null)
+    return success
   }
 
   return (

--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyListPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyListPresentation.tsx
@@ -47,8 +47,10 @@ export function PolicyListPresentation({
 
   const handleConfirmDelete = async () => {
     if (deletePolicyDialogState.policy) {
-      await onDeletePolicy(deletePolicyDialogState.policy)
-      handleCloseDeleteDialog()
+      const success = await onDeletePolicy(deletePolicyDialogState.policy)
+      if (success) {
+        handleCloseDeleteDialog()
+      }
     }
   }
 

--- a/src/components/UNSTABLE_TimeOff/PolicyList/PolicyListTypes.ts
+++ b/src/components/UNSTABLE_TimeOff/PolicyList/PolicyListTypes.ts
@@ -12,7 +12,7 @@ export interface PolicyListPresentationProps {
   onCreatePolicy: () => void
   onEditPolicy: (policy: PolicyListItem) => void
   onFinishSetup: (policy: PolicyListItem) => void
-  onDeletePolicy: (policy: PolicyListItem) => void | Promise<void>
+  onDeletePolicy: (policy: PolicyListItem) => Promise<boolean>
   deleteSuccessAlert?: string | null
   onDismissDeleteAlert?: () => void
   isDeletingPolicyId?: string | null


### PR DESCRIPTION
## Summary

- Fixes the delete confirmation dialog closing immediately on API errors (e.g., "pending time off requests need to be declined")
- The dialog now stays open when deletion fails, preserving user context
- Returns a `success` boolean from `handleDeletePolicy` so `PolicyListPresentation` can decide whether to close the dialog

## Test plan

- [x] Added unit test that mocks a 422 response from the deactivate API and asserts the dialog remains open
- [ ] Manual: attempt to delete a policy with pending time-off requests — dialog should stay open with error visible