### PR TITLE
feat(sdk-app): keyboard shortcuts with on-screen helper

### DIFF
--- a/sdk-app/src/App.tsx
+++ b/sdk-app/src/App.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
-import { useState } from 'react'
-import { Outlet } from 'react-router-dom'
+import { useCallback, useState } from 'react'
+import { Outlet, useNavigate } from 'react-router-dom'
 import { TopBar } from './TopBar'
 import { Sidebar } from './Sidebar'
 import { DemoSettingsPanel } from './DemoSettingsPanel'
@@ -9,10 +9,14 @@ import { useEntities, type EntityIds } from './useEntities'
 import { useEntityCatalog } from './useEntityCatalog'
 import { useDemoManager } from './useDemoManager'
 import { useAppMode } from './useAppMode'
-import { useThemeMode } from './useThemeMode'
+import { useThemeMode, type ThemeMode } from './useThemeMode'
 import { ThemeModeProvider } from './ThemeModeContext'
 import { useManualConfig, type ManualConfig } from './useManualConfig'
 import { useChromeVisibility } from './useChromeVisibility'
+import { ShortcutHelper, useShortcutHelper } from './ShortcutHelper'
+import { useGlobalShortcut } from './useGlobalShortcut'
+
+const THEME_CYCLE: ThemeMode[] = ['system', 'light', 'dark']
 
 function entitiesFromManualConfig(config: ManualConfig): EntityIds {
   return {
@@ -38,6 +42,47 @@ export function App() {
   const appMode = useAppMode()
   const themeMode = useThemeMode()
   const { chromeHidden, showChrome } = useChromeVisibility()
+  const shortcutHelper = useShortcutHelper()
+  const navigate = useNavigate()
+
+  const openSettings = useCallback(() => {
+    setSettingsOpen(true)
+  }, [])
+
+  const toggleAppMode = useCallback(() => {
+    void navigate(appMode === 'design' ? '/' : '/design')
+  }, [navigate, appMode])
+
+  const cycleTheme = useCallback(() => {
+    const current = THEME_CYCLE.indexOf(themeMode.mode)
+    const next = THEME_CYCLE[(current + 1) % THEME_CYCLE.length]
+    if (next) themeMode.setMode(next)
+  }, [themeMode])
+
+  useGlobalShortcut({
+    key: ',',
+    modifier: 'mod',
+    onTrigger: event => {
+      event.preventDefault()
+      openSettings()
+    },
+  })
+  useGlobalShortcut({
+    key: '.',
+    modifier: 'mod',
+    onTrigger: event => {
+      event.preventDefault()
+      toggleAppMode()
+    },
+  })
+  useGlobalShortcut({
+    key: ';',
+    modifier: 'mod',
+    onTrigger: event => {
+      event.preventDefault()
+      cycleTheme()
+    },
+  })
 
   const handleCreateNewDemo = async (demoType: string) => {
     const result = await demoManager.createNewDemo(demoType)
@@ -79,9 +124,7 @@ export function App() {
           <TopBar
             companyId={activeEntities.companyId}
             tokenStatus={demoManager.tokenStatus}
-            onOpenSettings={() => {
-              setSettingsOpen(true)
-            }}
+            onOpenSettings={openSettings}
           />
         )}
         <div className="app-body">
@@ -94,6 +137,7 @@ export function App() {
               onToggle={() => {
                 setSidebarOpen(open => !open)
               }}
+              onShowShortcuts={shortcutHelper.open}
             />
           )}
           <main
@@ -136,6 +180,7 @@ export function App() {
           onSaveManualConfig={manual.saveConfig}
           onDeleteManualSave={manual.deleteSave}
         />
+        <ShortcutHelper isOpen={shortcutHelper.isOpen} onClose={shortcutHelper.close} />
         {!isManual && demoManager.tokenStatus === 'expired' && (
           <TokenExpiredOverlay
             onRefresh={demoManager.refreshToken}

--- a/sdk-app/src/App.tsx
+++ b/sdk-app/src/App.tsx
@@ -12,6 +12,7 @@ import { useAppMode } from './useAppMode'
 import { useThemeMode } from './useThemeMode'
 import { ThemeModeProvider } from './ThemeModeContext'
 import { useManualConfig, type ManualConfig } from './useManualConfig'
+import { useChromeVisibility } from './useChromeVisibility'
 
 function entitiesFromManualConfig(config: ManualConfig): EntityIds {
   return {
@@ -36,6 +37,7 @@ export function App() {
   const demoManager = useDemoManager({ pollingDisabled: isManual })
   const appMode = useAppMode()
   const themeMode = useThemeMode()
+  const { chromeHidden, showChrome } = useChromeVisibility()
 
   const handleCreateNewDemo = async (demoType: string) => {
     const result = await demoManager.createNewDemo(demoType)
@@ -68,35 +70,49 @@ export function App() {
     )
   }
 
+  const sidebarWidth = chromeHidden ? '0rem' : sidebarOpen ? '16.25rem' : '2.75rem'
+
   return (
     <ThemeModeProvider value={themeMode}>
-      <div className="app-layout">
-        <TopBar
-          companyId={activeEntities.companyId}
-          tokenStatus={demoManager.tokenStatus}
-          onOpenSettings={() => {
-            setSettingsOpen(true)
-          }}
-        />
-        <div className="app-body">
-          <Sidebar
-            mode={appMode}
-            searchQuery={searchQuery}
-            onSearchChange={setSearchQuery}
-            isOpen={sidebarOpen}
-            onToggle={() => {
-              setSidebarOpen(open => !open)
+      <div className={`app-layout${chromeHidden ? ' app-layout-chrome-hidden' : ''}`}>
+        {!chromeHidden && (
+          <TopBar
+            companyId={activeEntities.companyId}
+            tokenStatus={demoManager.tokenStatus}
+            onOpenSettings={() => {
+              setSettingsOpen(true)
             }}
           />
+        )}
+        <div className="app-body">
+          {!chromeHidden && (
+            <Sidebar
+              mode={appMode}
+              searchQuery={searchQuery}
+              onSearchChange={setSearchQuery}
+              isOpen={sidebarOpen}
+              onToggle={() => {
+                setSidebarOpen(open => !open)
+              }}
+            />
+          )}
           <main
             className="main-content"
-            style={
-              { '--sidebar-width': sidebarOpen ? '16.25rem' : '2.75rem' } as React.CSSProperties
-            }
+            style={{ '--sidebar-width': sidebarWidth } as React.CSSProperties}
           >
-            <Outlet context={{ entities: activeEntities }} />
+            <Outlet context={{ entities: activeEntities, chromeHidden }} />
           </main>
         </div>
+        {chromeHidden && (
+          <button
+            type="button"
+            className="chrome-restore-pill"
+            onClick={showChrome}
+            aria-label="Show chrome"
+          >
+            <span className="chrome-restore-pill-key">\</span> Show chrome
+          </button>
+        )}
         <DemoSettingsPanel
           isOpen={settingsOpen}
           onClose={() => {

--- a/sdk-app/src/ComponentRenderer.tsx
+++ b/sdk-app/src/ComponentRenderer.tsx
@@ -11,6 +11,7 @@ import { GustoProvider } from '@/contexts'
 
 interface ComponentRendererProps {
   entities: EntityIds
+  chromeHidden?: boolean
 }
 
 interface EventLogEntry {
@@ -119,7 +120,7 @@ class ComponentErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundary
   }
 }
 
-export function ComponentRenderer({ entities }: ComponentRendererProps) {
+export function ComponentRenderer({ entities, chromeHidden = false }: ComponentRendererProps) {
   const { category, component: componentName } = useParams<{
     category: string
     component: string
@@ -202,9 +203,11 @@ export function ComponentRenderer({ entities }: ComponentRendererProps) {
 
   return (
     <>
-      <div className={styles.contentHeader}>
-        {displayCategory} &rsaquo; <span>{entry.name}</span>
-      </div>
+      {!chromeHidden && (
+        <div className={styles.contentHeader}>
+          {displayCategory} &rsaquo; <span>{entry.name}</span>
+        </div>
+      )}
       {missingIds.length > 0 || missingAdditionalProps.length > 0 ? (
         <div className={styles.componentContainer}>
           <div className={styles.contentBody}>
@@ -270,37 +273,39 @@ export function ComponentRenderer({ entities }: ComponentRendererProps) {
           </div>
         </div>
       )}
-      <div className={styles.eventsLog}>
-        <div className={styles.eventsLogHeader}>
-          <span>Events Log ({events.length})</span>
-          <button
-            className={styles.eventsLogToggle}
-            onClick={() => {
-              setEventsOpen(o => !o)
-            }}
-            type="button"
-          >
-            {eventsOpen ? 'Collapse' : 'Expand'}
-          </button>
+      {!chromeHidden && (
+        <div className={styles.eventsLog}>
+          <div className={styles.eventsLogHeader}>
+            <span>Events Log ({events.length})</span>
+            <button
+              className={styles.eventsLogToggle}
+              onClick={() => {
+                setEventsOpen(o => !o)
+              }}
+              type="button"
+            >
+              {eventsOpen ? 'Collapse' : 'Expand'}
+            </button>
+          </div>
+          {eventsOpen &&
+            (events.length > 0 ? (
+              <div className={styles.eventsLogEntries}>
+                {events.map((entry, i) => (
+                  <div key={i} className={styles.eventsLogEntry}>
+                    <span className={styles.eventsLogTimestamp}>[{entry.timestamp}]</span>{' '}
+                    {typeof entry.event === 'object'
+                      ? JSON.stringify(entry.event, null, 2)
+                      : JSON.stringify(entry.event)}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className={styles.eventsLogEmpty}>
+                No events yet. Interact with the component above.
+              </div>
+            ))}
         </div>
-        {eventsOpen &&
-          (events.length > 0 ? (
-            <div className={styles.eventsLogEntries}>
-              {events.map((entry, i) => (
-                <div key={i} className={styles.eventsLogEntry}>
-                  <span className={styles.eventsLogTimestamp}>[{entry.timestamp}]</span>{' '}
-                  {typeof entry.event === 'object'
-                    ? JSON.stringify(entry.event, null, 2)
-                    : JSON.stringify(entry.event)}
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className={styles.eventsLogEmpty}>
-              No events yet. Interact with the component above.
-            </div>
-          ))}
-      </div>
+      )}
     </>
   )
 }

--- a/sdk-app/src/RoutedComponentRenderer.tsx
+++ b/sdk-app/src/RoutedComponentRenderer.tsx
@@ -3,6 +3,9 @@ import { ComponentRenderer } from './ComponentRenderer'
 import type { EntityIds } from './useEntities'
 
 export function RoutedComponentRenderer() {
-  const { entities } = useOutletContext<{ entities: EntityIds }>()
-  return <ComponentRenderer entities={entities} />
+  const { entities, chromeHidden } = useOutletContext<{
+    entities: EntityIds
+    chromeHidden: boolean
+  }>()
+  return <ComponentRenderer entities={entities} chromeHidden={chromeHidden} />
 }

--- a/sdk-app/src/ShortcutHelper/ShortcutHelper.module.scss
+++ b/sdk-app/src/ShortcutHelper/ShortcutHelper.module.scss
@@ -1,0 +1,112 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.backdrop {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: rgba(0, 0, 0, 0.45);
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: none;
+  }
+}
+
+.modal {
+  position: relative;
+  z-index: 1;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border-radius: 0.5rem;
+  border: 0.0625rem solid var(--color-border);
+  box-shadow: 0 0.625rem 2rem rgba(0, 0, 0, 0.18);
+  width: 100%;
+  max-width: 27.5rem;
+  padding: 1.25rem 1.25rem 1rem;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.875rem;
+}
+
+.title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.closeBtn {
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
+
+  &:hover {
+    color: var(--color-text);
+    background: var(--color-hover-bg);
+  }
+
+  &:focus-visible {
+    outline: 0.125rem solid var(--color-active);
+    outline-offset: 0.125rem;
+  }
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.8125rem;
+}
+
+.keys {
+  display: inline-flex;
+  gap: 0.25rem;
+  flex-shrink: 0;
+  min-width: 5.5rem;
+}
+
+.key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  padding: 0.0625rem 0.375rem;
+  border: 0.0625rem solid var(--color-border);
+  border-radius: 0.25rem;
+  background: var(--color-badge-bg);
+  font-family: monospace;
+  font-size: 0.6875rem;
+  color: var(--color-text);
+}
+
+.label {
+  color: var(--color-text);
+}

--- a/sdk-app/src/ShortcutHelper/ShortcutHelper.tsx
+++ b/sdk-app/src/ShortcutHelper/ShortcutHelper.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from 'react'
+import styles from './ShortcutHelper.module.scss'
+
+interface Shortcut {
+  keys: string[]
+  label: string
+}
+
+const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+const MOD = isMac ? '⌘' : 'Ctrl'
+
+const SHORTCUTS: Shortcut[] = [
+  { keys: ['?'], label: 'Show keyboard shortcuts' },
+  { keys: ['\\'], label: 'Hide chrome' },
+  { keys: ['Esc'], label: 'Restore chrome (when hidden)' },
+  { keys: [MOD, ','], label: 'Open settings' },
+  { keys: [MOD, '.'], label: 'Toggle design / development' },
+  { keys: [MOD, ';'], label: 'Cycle theme (system → light → dark)' },
+]
+
+interface ShortcutHelperProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function ShortcutHelper({ isOpen, onClose }: ShortcutHelperProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (isOpen) closeButtonRef.current?.focus()
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  return (
+    <div className={styles.overlay}>
+      <button
+        type="button"
+        className={styles.backdrop}
+        onClick={onClose}
+        aria-label="Close keyboard shortcuts"
+      />
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="shortcut-helper-title"
+      >
+        <div className={styles.header}>
+          <h2 id="shortcut-helper-title" className={styles.title}>
+            Keyboard shortcuts
+          </h2>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className={styles.closeBtn}
+            onClick={onClose}
+            aria-label="Close shortcuts"
+          >
+            ×
+          </button>
+        </div>
+        <ul className={styles.list}>
+          {SHORTCUTS.map(({ keys, label }) => (
+            <li key={label} className={styles.row}>
+              <span className={styles.keys}>
+                {keys.map(k => (
+                  <kbd key={k} className={styles.key}>
+                    {k}
+                  </kbd>
+                ))}
+              </span>
+              <span className={styles.label}>{label}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/sdk-app/src/ShortcutHelper/index.ts
+++ b/sdk-app/src/ShortcutHelper/index.ts
@@ -1,0 +1,2 @@
+export { ShortcutHelper } from './ShortcutHelper'
+export { useShortcutHelper } from './useShortcutHelper'

--- a/sdk-app/src/ShortcutHelper/useShortcutHelper.ts
+++ b/sdk-app/src/ShortcutHelper/useShortcutHelper.ts
@@ -1,0 +1,40 @@
+import { useCallback, useState } from 'react'
+import { useGlobalShortcut } from '../useGlobalShortcut'
+
+const TOGGLE_KEY = '?'
+
+export interface UseShortcutHelperResult {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+}
+
+export function useShortcutHelper(): UseShortcutHelperResult {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = useCallback(() => {
+    setIsOpen(true)
+  }, [])
+
+  const close = useCallback(() => {
+    setIsOpen(false)
+  }, [])
+
+  useGlobalShortcut({
+    key: TOGGLE_KEY,
+    onTrigger: event => {
+      event.preventDefault()
+      setIsOpen(prev => !prev)
+    },
+  })
+
+  useGlobalShortcut({
+    key: 'Escape',
+    enabled: isOpen,
+    onTrigger: () => {
+      setIsOpen(false)
+    },
+  })
+
+  return { isOpen, open, close }
+}

--- a/sdk-app/src/Sidebar.module.scss
+++ b/sdk-app/src/Sidebar.module.scss
@@ -51,6 +51,48 @@
   border-bottom: 0.0625rem solid var(--color-border);
 }
 
+.shortcutHint {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  width: 100%;
+  margin-bottom: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border: none;
+  border-radius: 0.25rem;
+  background: transparent;
+  font: inherit;
+  font-size: 0.6875rem;
+  text-align: left;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  user-select: none;
+
+  &:hover {
+    color: var(--color-text);
+    background: var(--color-hover-bg);
+  }
+
+  &:focus-visible {
+    outline: 0.125rem solid var(--color-active);
+    outline-offset: 0.125rem;
+  }
+}
+
+.shortcutHintKey {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.125rem;
+  padding: 0 0.3125rem;
+  border: 0.0625rem solid var(--color-border);
+  border-radius: 0.1875rem;
+  background: var(--color-badge-bg);
+  font-family: monospace;
+  font-size: 0.625rem;
+  color: var(--color-text);
+}
+
 .searchRow {
   display: flex;
   align-items: stretch;

--- a/sdk-app/src/Sidebar.tsx
+++ b/sdk-app/src/Sidebar.tsx
@@ -18,6 +18,7 @@ interface SidebarProps {
   onSearchChange: (query: string) => void
   isOpen: boolean
   onToggle: () => void
+  onShowShortcuts: () => void
 }
 
 function CategorySection({
@@ -83,7 +84,14 @@ function CategorySection({
   )
 }
 
-export function Sidebar({ mode, searchQuery, onSearchChange, isOpen, onToggle }: SidebarProps) {
+export function Sidebar({
+  mode,
+  searchQuery,
+  onSearchChange,
+  isOpen,
+  onToggle,
+  onShowShortcuts,
+}: SidebarProps) {
   const placeholder = mode === 'design' ? 'Search prototypes...' : 'Search components...'
 
   if (!isOpen) {
@@ -105,6 +113,14 @@ export function Sidebar({ mode, searchQuery, onSearchChange, isOpen, onToggle }:
   return (
     <aside className={styles.root}>
       <div className={styles.search}>
+        <button
+          type="button"
+          className={styles.shortcutHint}
+          onClick={onShowShortcuts}
+          aria-label="Show keyboard shortcuts"
+        >
+          Press <kbd className={styles.shortcutHintKey}>?</kbd> for shortcuts
+        </button>
         <div className={styles.searchRow}>
           <input
             type="text"

--- a/sdk-app/src/app.scss
+++ b/sdk-app/src/app.scss
@@ -103,3 +103,49 @@ body {
   flex-direction: column;
   flex: 1;
 }
+
+.chrome-restore-pill {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  z-index: 90;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.875rem;
+  border: 0.0625rem solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-bg);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.12);
+  opacity: 0.85;
+  transition:
+    opacity 0.15s,
+    background 0.15s;
+
+  &:hover {
+    opacity: 1;
+    background: var(--color-hover-bg);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-active);
+    outline-offset: 2px;
+  }
+}
+
+.chrome-restore-pill-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  padding: 0.0625rem 0.375rem;
+  border: 0.0625rem solid var(--color-border);
+  border-radius: 0.25rem;
+  background: var(--color-badge-bg);
+  font-family: monospace;
+  font-size: 0.6875rem;
+  color: var(--color-text);
+}

--- a/sdk-app/src/useChromeVisibility.ts
+++ b/sdk-app/src/useChromeVisibility.ts
@@ -1,0 +1,65 @@
+import { useCallback, useState } from 'react'
+import { useGlobalShortcut } from './useGlobalShortcut'
+
+const STORAGE_KEY = 'sdk-app-chrome-hidden'
+const TOGGLE_KEY = '\\'
+
+function readInitial(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+function persist(hidden: boolean) {
+  try {
+    localStorage.setItem(STORAGE_KEY, hidden ? 'true' : 'false')
+  } catch {
+    // Storage unavailable; continue without persistence.
+  }
+}
+
+export interface UseChromeVisibilityResult {
+  chromeHidden: boolean
+  toggleChrome: () => void
+  showChrome: () => void
+}
+
+export function useChromeVisibility(): UseChromeVisibilityResult {
+  const [chromeHidden, setChromeHidden] = useState<boolean>(readInitial)
+
+  const toggleChrome = useCallback(() => {
+    setChromeHidden(prev => {
+      const next = !prev
+      persist(next)
+      return next
+    })
+  }, [])
+
+  const showChrome = useCallback(() => {
+    setChromeHidden(prev => {
+      if (!prev) return prev
+      persist(false)
+      return false
+    })
+  }, [])
+
+  useGlobalShortcut({
+    key: TOGGLE_KEY,
+    onTrigger: event => {
+      event.preventDefault()
+      toggleChrome()
+    },
+  })
+
+  useGlobalShortcut({
+    key: 'Escape',
+    enabled: chromeHidden,
+    onTrigger: () => {
+      showChrome()
+    },
+  })
+
+  return { chromeHidden, toggleChrome, showChrome }
+}

--- a/sdk-app/src/useGlobalShortcut.ts
+++ b/sdk-app/src/useGlobalShortcut.ts
@@ -4,6 +4,8 @@ interface UseGlobalShortcutOptions {
   key: string
   onTrigger: (event: KeyboardEvent) => void
   enabled?: boolean
+  /** When 'mod', requires Cmd on Mac or Ctrl on other platforms. */
+  modifier?: 'mod'
 }
 
 function isTypingTarget(target: EventTarget | null): boolean {
@@ -16,18 +18,28 @@ function isTypingTarget(target: EventTarget | null): boolean {
   return false
 }
 
-export function useGlobalShortcut({ key, onTrigger, enabled = true }: UseGlobalShortcutOptions) {
+export function useGlobalShortcut({
+  key,
+  onTrigger,
+  enabled = true,
+  modifier,
+}: UseGlobalShortcutOptions) {
   useEffect(() => {
     if (!enabled) return
     const handler = (event: KeyboardEvent) => {
-      if (event.metaKey || event.ctrlKey || event.altKey) return
+      if (modifier === 'mod') {
+        const hasMod = event.metaKey || event.ctrlKey
+        if (!hasMod || event.altKey) return
+      } else {
+        if (event.metaKey || event.ctrlKey || event.altKey) return
+        if (isTypingTarget(event.target)) return
+      }
       if (event.key !== key) return
-      if (isTypingTarget(event.target)) return
       onTrigger(event)
     }
     document.addEventListener('keydown', handler)
     return () => {
       document.removeEventListener('keydown', handler)
     }
-  }, [key, enabled, onTrigger])
+  }, [key, enabled, modifier, onTrigger])
 }

--- a/sdk-app/src/useGlobalShortcut.ts
+++ b/sdk-app/src/useGlobalShortcut.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react'
+
+interface UseGlobalShortcutOptions {
+  key: string
+  onTrigger: (event: KeyboardEvent) => void
+  enabled?: boolean
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  const tag = target.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  if (target.isContentEditable) return true
+  const role = target.getAttribute('role')
+  if (role === 'textbox' || role === 'combobox') return true
+  return false
+}
+
+export function useGlobalShortcut({ key, onTrigger, enabled = true }: UseGlobalShortcutOptions) {
+  useEffect(() => {
+    if (!enabled) return
+    const handler = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return
+      if (event.key !== key) return
+      if (isTypingTarget(event.target)) return
+      onTrigger(event)
+    }
+    document.addEventListener('keydown', handler)
+    return () => {
+      document.removeEventListener('keydown', handler)
+    }
+  }, [key, enabled, onTrigger])
+}


### PR DESCRIPTION
## Summary
- New `?` key opens a modal listing every keyboard shortcut. The sidebar now shows a small `Press ? for shortcuts` hint above the search input that also opens the modal on click.
- Keyboard shortcuts available now:
  - `?` — Show keyboard shortcuts (toggle)
  - `\` — Hide chrome (TopBar / Sidebar / Events Log)
  - `Esc` — Restore chrome when hidden, or close the shortcut modal
  - `Cmd/Ctrl + ,` — Open settings
  - `Cmd/Ctrl + .` — Toggle design / development
  - `Cmd/Ctrl + ;` — Cycle theme (system → light → dark)
- `useGlobalShortcut` gained an optional `modifier: 'mod'` flag (Cmd on Mac, Ctrl elsewhere). Modifier shortcuts fire even when focus is in an input; un-modified shortcuts still ignore typing targets so plain `?`/`\` don't fire from the search box.
- Modifier symbol in the helper auto-adapts: `⌘` on Mac, `Ctrl` on Windows/Linux.

## Screenshots
<img width="483" height="255" alt="Screenshot 2026-05-07 at 6 38 16 PM" src="https://github.com/user-attachments/assets/7a5b4700-b9bc-4d27-95a7-4b35a602b982" />
<img width="1474" height="745" alt="Screenshot 2026-05-07 at 6 38 09 PM" src="https://github.com/user-attachments/assets/c5a81d8e-feeb-4754-9c68-2c1b5136c9be" />
<img width="1479" height="841" alt="Screenshot 2026-05-07 at 6 38 01 PM" src="https://github.com/user-attachments/assets/c7d6e04f-4ad3-417d-8d0e-93a3bfaee2d7" />



## Why
Two motivations bundled here:
1. For screen-shares and customer demos we want the SDK component to fill the viewport without sdk-app's own chrome bleeding through. `\` is the lightweight alternative to Feature 4 (selectable demo chromes).
2. The shortcut set has grown enough that nothing surfaces them. The helper modal makes them discoverable, scales as we add more, and does so without permanent UI clutter — only a small hint above the sidebar search.

The punctuation choice for the modifier shortcuts (`,` `.` `;`) was deliberate: letter combos with Cmd/Ctrl conflict with browser defaults that often can't be intercepted (e.g. `Cmd+T` is reserved by Chrome on macOS). Punctuation under Cmd/Ctrl has no OS or browser conflicts on Mac/Windows/Linux. `Cmd+,` doubles as the macOS preferences convention.

## Test plan
Chrome toggle (commit 1):
- [ ] On any `/category/Component` route, press `\` — TopBar, Sidebar, Events Log disappear; floating "Show chrome" pill appears bottom-left.
- [ ] Press `\` again, or `Esc`, or click the pill — chrome restored.
- [ ] Click into the sidebar search field, type `\` — chrome stays visible and the field receives the character.
- [ ] Hide chrome, refresh — chrome stays hidden.
- [ ] Verify `Cmd+\` / `Ctrl+\` / `Alt+\` do not trigger the toggle.

Shortcut helper (commit 2):
- [ ] "Press `?` for shortcuts" hint is visible above the sidebar search input, left-aligned.
- [ ] Click the hint — modal opens listing every shortcut.
- [ ] Press `?` outside any input — modal opens; press `?` again or `Esc` — modal closes.
- [ ] Type `?` inside the sidebar search field — modal does NOT open; field receives the character.
- [ ] Click backdrop — modal closes.
- [ ] Hide chrome with `\`, then press `?` — modal still opens. `Esc` dismisses (and restores chrome).
- [ ] Modifier symbol shows `⌘` on Mac, `Ctrl` on Windows/Linux.

Modifier shortcuts (commit 2):
- [ ] `Cmd/Ctrl + ,` opens the settings panel.
- [ ] `Cmd/Ctrl + .` toggles between Development and Design mode (URL switches between `/` and `/design`).
- [ ] `Cmd/Ctrl + ;` cycles theme: system → light → dark → system. The `data-theme` attribute on `<html>` updates accordingly.
- [ ] All three modifier shortcuts work with focus inside the sidebar search input.
- [ ] None of the modifier shortcuts conflict with browser defaults (no save dialog, no bookmark, no print).

## Branch base
This branch stacks on top of `feat/sdk-app-manual-token-mode` (#1727). Re-target to `al/create-secondary-ui-components` once that PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)