### PR TITLE
feat(sdk-app): add command palette for page navigation

### DIFF
--- a/sdk-app/src/App.tsx
+++ b/sdk-app/src/App.tsx
@@ -14,6 +14,7 @@ import { ThemeModeProvider } from './ThemeModeContext'
 import { useManualConfig, type ManualConfig } from './useManualConfig'
 import { useChromeVisibility } from './useChromeVisibility'
 import { ShortcutHelper, useShortcutHelper } from './ShortcutHelper'
+import { CommandPalette, useCommandPalette } from './CommandPalette'
 import { useGlobalShortcut } from './useGlobalShortcut'
 import { useCodePanel } from './useCodePanel'
 import { CodePanel } from './CodePanel'
@@ -61,6 +62,7 @@ export function App() {
   const themeMode = useThemeMode()
   const { chromeHidden, showChrome } = useChromeVisibility()
   const shortcutHelper = useShortcutHelper()
+  const commandPalette = useCommandPalette()
   const navigate = useNavigate()
   const codePanel = useCodePanel()
   const { chromeId, setChromeId } = useDemoChrome()
@@ -232,6 +234,7 @@ export function App() {
             onChromeIdChange={setChromeId}
           />
           <ShortcutHelper isOpen={shortcutHelper.isOpen} onClose={shortcutHelper.close} />
+          <CommandPalette isOpen={commandPalette.isOpen} onClose={commandPalette.close} />
           {!isManual && demoManager.tokenStatus === 'expired' && (
             <TokenExpiredOverlay
               onRefresh={demoManager.refreshToken}

--- a/sdk-app/src/CommandPalette/CommandPalette.module.scss
+++ b/sdk-app/src/CommandPalette/CommandPalette.module.scss
@@ -1,0 +1,109 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  justify-content: center;
+  padding-top: 15vh;
+}
+
+.backdrop {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: rgba(0, 0, 0, 0.45);
+  cursor: default;
+
+  &:focus-visible {
+    outline: none;
+  }
+}
+
+.container {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 32rem;
+  margin: 0 1rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border-radius: 0.5rem;
+  border: 0.0625rem solid var(--color-border);
+  box-shadow: 0 0.625rem 2rem rgba(0, 0, 0, 0.18);
+  overflow: hidden;
+  height: fit-content;
+}
+
+.input {
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--color-text);
+  font-size: 1rem;
+  padding: 0.875rem 1rem;
+  box-sizing: border-box;
+
+  &::placeholder {
+    color: var(--color-text-muted);
+  }
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  max-height: 24rem;
+  overflow-y: auto;
+  border-top: 0.0625rem solid var(--color-border);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: var(--color-text);
+
+  &:hover {
+    background: var(--color-hover-bg);
+  }
+}
+
+.rowActive {
+  background: var(--color-active-bg);
+
+  &:hover {
+    background: var(--color-active-bg);
+  }
+}
+
+.label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.category {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  background: var(--color-badge-bg);
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.4375rem;
+}
+
+.empty {
+  padding: 0.875rem 1rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  border-top: 0.0625rem solid var(--color-border);
+}

--- a/sdk-app/src/CommandPalette/CommandPalette.tsx
+++ b/sdk-app/src/CommandPalette/CommandPalette.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useMemo, useRef, useState, type ChangeEvent, type KeyboardEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { searchPages, type PageEntry } from './pages'
+import styles from './CommandPalette.module.scss'
+
+interface CommandPaletteProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const ROW_ID_PREFIX = 'command-palette-row-'
+
+export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
+  const [query, setQuery] = useState('')
+  const [highlightIndex, setHighlightIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const navigate = useNavigate()
+
+  const results = useMemo(() => (isOpen ? searchPages(query) : []), [isOpen, query])
+  const showResults = isOpen && query.trim().length > 0
+
+  useEffect(() => {
+    if (!isOpen) {
+      setQuery('')
+      setHighlightIndex(0)
+      return
+    }
+    inputRef.current?.focus()
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!showResults) return
+    const target = results[highlightIndex]
+    if (!target) return
+    document.getElementById(`${ROW_ID_PREFIX}${target.id}`)?.scrollIntoView({ block: 'nearest' })
+  }, [highlightIndex, showResults, results])
+
+  if (!isOpen) return null
+
+  const goTo = (page: PageEntry) => {
+    void navigate(page.path)
+    onClose()
+  }
+
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      onClose()
+      return
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      const target = results[highlightIndex] ?? results[0]
+      if (target) goTo(target)
+      return
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      if (results.length === 0) return
+      setHighlightIndex(prev => Math.min(prev + 1, results.length - 1))
+      return
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      if (results.length === 0) return
+      setHighlightIndex(prev => Math.max(prev - 1, 0))
+    }
+  }
+
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setQuery(event.target.value)
+    setHighlightIndex(0)
+  }
+
+  const activeId =
+    showResults && results[highlightIndex]
+      ? `${ROW_ID_PREFIX}${results[highlightIndex].id}`
+      : undefined
+
+  return (
+    <div className={styles.overlay}>
+      <button
+        type="button"
+        className={styles.backdrop}
+        onClick={onClose}
+        aria-label="Close page search"
+      />
+      <div className={styles.container}>
+        <input
+          ref={inputRef}
+          type="text"
+          role="combobox"
+          className={styles.input}
+          placeholder="Search pages…"
+          value={query}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          aria-label="Search pages"
+          aria-autocomplete="list"
+          aria-controls="command-palette-list"
+          aria-expanded={showResults}
+          aria-activedescendant={activeId}
+          spellCheck={false}
+          autoComplete="off"
+        />
+        {showResults &&
+          (results.length > 0 ? (
+            <ul id="command-palette-list" className={styles.list} role="listbox">
+              {results.map((page, index) => {
+                const isActive = index === highlightIndex
+                return (
+                  // eslint-disable-next-line jsx-a11y/click-events-have-key-events -- listbox keyboard nav happens on the input via aria-activedescendant
+                  <li
+                    id={`${ROW_ID_PREFIX}${page.id}`}
+                    key={page.id}
+                    role="option"
+                    aria-selected={isActive}
+                    className={`${styles.row}${isActive ? ` ${styles.rowActive}` : ''}`}
+                    onClick={() => {
+                      goTo(page)
+                    }}
+                    onMouseEnter={() => {
+                      setHighlightIndex(index)
+                    }}
+                  >
+                    <span className={styles.label}>{page.label}</span>
+                    <span className={styles.category}>{page.category}</span>
+                  </li>
+                )
+              })}
+            </ul>
+          ) : (
+            <div className={styles.empty}>No matches</div>
+          ))}
+      </div>
+    </div>
+  )
+}

--- a/sdk-app/src/CommandPalette/index.ts
+++ b/sdk-app/src/CommandPalette/index.ts
@@ -1,0 +1,2 @@
+export { CommandPalette } from './CommandPalette'
+export { useCommandPalette } from './useCommandPalette'

--- a/sdk-app/src/CommandPalette/pages.ts
+++ b/sdk-app/src/CommandPalette/pages.ts
@@ -1,0 +1,71 @@
+import { componentRegistry } from '../registry'
+import { categorizedRegistry as designRegistry } from '../design/registry'
+
+export interface PageEntry {
+  id: string
+  label: string
+  category: string
+  path: string
+  description?: string
+}
+
+function buildPages(): PageEntry[] {
+  const pages: PageEntry[] = [
+    { id: 'home', label: 'Home', category: 'Components', path: '/' },
+    { id: 'design-home', label: 'Design Home', category: 'Design', path: '/design' },
+  ]
+
+  for (const entry of componentRegistry) {
+    pages.push({
+      id: `component:${entry.category}:${entry.name}`,
+      label: entry.name,
+      category: entry.category,
+      path: `/${entry.category.toLowerCase()}/${entry.name}`,
+    })
+  }
+
+  for (const [category, entries] of Object.entries(designRegistry)) {
+    for (const entry of entries) {
+      pages.push({
+        id: `design:${category}:${entry.name}`,
+        label: entry.name,
+        category: `Design / ${category}`,
+        path: entry.path,
+        description: entry.description,
+      })
+    }
+  }
+
+  return pages
+}
+
+export const PAGES: PageEntry[] = buildPages()
+
+const MAX_RESULTS = 50
+
+export function searchPages(query: string): PageEntry[] {
+  const trimmed = query.trim().toLowerCase()
+  if (!trimmed) return []
+
+  const prefixMatches: PageEntry[] = []
+  const labelMatches: PageEntry[] = []
+  const otherMatches: PageEntry[] = []
+
+  for (const page of PAGES) {
+    const label = page.label.toLowerCase()
+    if (label.startsWith(trimmed)) {
+      prefixMatches.push(page)
+      continue
+    }
+    if (label.includes(trimmed)) {
+      labelMatches.push(page)
+      continue
+    }
+    const haystack = `${page.category} ${page.description ?? ''}`.toLowerCase()
+    if (haystack.includes(trimmed)) {
+      otherMatches.push(page)
+    }
+  }
+
+  return [...prefixMatches, ...labelMatches, ...otherMatches].slice(0, MAX_RESULTS)
+}

--- a/sdk-app/src/CommandPalette/useCommandPalette.ts
+++ b/sdk-app/src/CommandPalette/useCommandPalette.ts
@@ -1,0 +1,33 @@
+import { useCallback, useState } from 'react'
+import { useGlobalShortcut } from '../useGlobalShortcut'
+
+const TOGGLE_KEY = 'k'
+
+export interface UseCommandPaletteResult {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+}
+
+export function useCommandPalette(): UseCommandPaletteResult {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = useCallback(() => {
+    setIsOpen(true)
+  }, [])
+
+  const close = useCallback(() => {
+    setIsOpen(false)
+  }, [])
+
+  useGlobalShortcut({
+    key: TOGGLE_KEY,
+    modifier: 'mod',
+    onTrigger: event => {
+      event.preventDefault()
+      setIsOpen(prev => !prev)
+    },
+  })
+
+  return { isOpen, open, close }
+}

--- a/sdk-app/src/ShortcutHelper/ShortcutHelper.tsx
+++ b/sdk-app/src/ShortcutHelper/ShortcutHelper.tsx
@@ -11,6 +11,7 @@ const MOD = isMac ? '⌘' : 'Ctrl'
 
 const SHORTCUTS: Shortcut[] = [
   { keys: ['?'], label: 'Show keyboard shortcuts' },
+  { keys: [MOD, 'K'], label: 'Open page search' },
   { keys: ['\\'], label: 'Hide chrome' },
   { keys: ['Esc'], label: 'Restore chrome (when hidden)' },
   { keys: [MOD, ','], label: 'Open settings' },


### PR DESCRIPTION
## Summary
- Adds a Spotlight-style command palette to the SDK dev app: ⌘K opens a floating search box that filters across every navigable page (SDK component previews + design prototypes + Home / Design Home).
- Arrow keys highlight, Enter navigates, Esc / backdrop click closes. Highlighted result auto-scrolls into view.
- Pages list is built once at module load by merging the existing `componentRegistry` and design `categorizedRegistry` — no new metadata to maintain.
- Mirrors the `ShortcutHelper` folder/hook layout but uses its own bare-input visual (no modal header/title/close button). Theming reuses existing CSS variables.
- Helper modal (`?`) now lists ⌘K — Open page search.

## Demo
https://github.com/user-attachments/assets/3f77062f-2961-4f2f-a87d-7f56f311a5b0


## Test plan
- [ ] `npm run sdk-app` and press ⌘K — bare floating search box appears, input focused
- [ ] Type `onboard` — filtered list across Company / Contractor / Employee previews + Design contractor self-onboarding
- [ ] Arrow ↓ / ↑ moves the highlight without moving the input cursor; long lists auto-scroll the highlighted row into view
- [ ] Enter on a highlighted row navigates and closes the palette; query resets on next open
- [ ] Esc closes; backdrop click closes
- [ ] Open the sidebar's component-search input, focus it, then press ⌘K — palette still opens (mod shortcut bypasses typing-target check)
- [ ] Press `?` and confirm `⌘ K — Open page search` is listed in the helper modal
- [ ] `npm run tsc` and lint stay clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)