### PR TITLE
chore(sdk-app): positive messaging for token expired modal

### DIFF
--- a/sdk-app/src/TokenExpiredOverlay.module.scss
+++ b/sdk-app/src/TokenExpiredOverlay.module.scss
@@ -46,12 +46,12 @@
   height: 3.5rem;
   margin: 0 auto 1.25rem;
   border-radius: 50%;
-  background: var(--color-danger-icon-bg);
+  background: #d1fae5;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 1.5rem;
-  color: var(--color-danger);
+  color: #059669;
 }
 
 .title {

--- a/sdk-app/src/TokenExpiredOverlay.tsx
+++ b/sdk-app/src/TokenExpiredOverlay.tsx
@@ -17,19 +17,17 @@ export function TokenExpiredOverlay({ onRefresh, isRefreshing, error }: TokenExp
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
-            strokeWidth="2"
+            strokeWidth="2.5"
             strokeLinecap="round"
             strokeLinejoin="round"
           >
-            <circle cx="12" cy="12" r="10" />
-            <line x1="12" y1="8" x2="12" y2="12" />
-            <line x1="12" y1="16" x2="12.01" y2="16" />
+            <polyline points="20 6 9 17 4 12" />
           </svg>
         </div>
-        <h2 className={styles.title}>Demo Token Expired</h2>
+        <h2 className={styles.title}>Time for a New Company!</h2>
         <p className={styles.description}>
-          Your demo session has expired. This will create a fresh demo environment with a new token
-          and reload the page. It typically takes 1–2 minutes.
+          Your demo token has expired — the perfect excuse for a fresh start. We&apos;ll spin up a
+          brand new demo company and reload the page. It typically takes 1–2 minutes.
         </p>
         <button
           className={styles.refreshBtn}
@@ -40,15 +38,15 @@ export function TokenExpiredOverlay({ onRefresh, isRefreshing, error }: TokenExp
           {isRefreshing ? (
             <>
               <span className={styles.spinner} />
-              Creating New Demo…
+              Building Your New Company…
             </>
           ) : (
-            'Refresh Demo'
+            'New Demo Company!'
           )}
         </button>
         {isRefreshing && (
           <p className={styles.progress}>
-            Provisioning a new demo environment. The page will reload automatically.
+            Your new demo company is being set up. The page will reload when it&apos;s ready.
           </p>
         )}
         {error && <p className={styles.error}>{error}</p>}


### PR DESCRIPTION
## Summary

Reframes the token-expired overlay in the SDK demo app with upbeat, encouraging copy and a green checkmark icon instead of a red warning icon.

## Screenshot
<img width="978" height="714" alt="Screenshot 2026-05-08 at 9 53 47 AM" src="https://github.com/user-attachments/assets/35e240cd-b926-4c6e-8c68-90eab2546e37" />


## Changes

- Title changed from "Demo Token Expired" to "Time for a New Company!"
- Description reframed as an opportunity rather than an error state
- CTA button changed from "Refresh Demo" to "New Demo Company!"
- Loading/progress copy updated to match the positive tone
- Icon swapped from a red warning circle to a green checkmark

## Testing

- Launched SDK app locally (`npm run sdk-app`)
- Forced the overlay open by short-circuiting the condition in `App.tsx`, confirmed visual appearance, then reverted