### PR TITLE
fix: add aria-labelledby to Time Off form landmarks

### DIFF
--- a/src/components/UNSTABLE_TimeOff/PolicySettings/PolicySettingsPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicySettings/PolicySettingsPresentation.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { FormProvider, useForm, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import type { PolicySettingsFormData, PolicySettingsPresentationProps } from './PolicySettingsTypes'
@@ -16,6 +17,7 @@ export function PolicySettingsPresentation({
   useI18n('Company.TimeOff.CreateTimeOffPolicy')
   const { t } = useTranslation('Company.TimeOff.CreateTimeOffPolicy')
   const { Heading, Button } = useComponentContext()
+  const headingId = useId()
 
   const formMethods = useForm<PolicySettingsFormData>({
     defaultValues: {
@@ -45,10 +47,12 @@ export function PolicySettingsPresentation({
 
   return (
     <FormProvider {...formMethods}>
-      <HtmlForm onSubmit={formMethods.handleSubmit(handleSubmit)}>
+      <HtmlForm aria-labelledby={headingId} onSubmit={formMethods.handleSubmit(handleSubmit)}>
         <div className={styles.policySettings}>
           <Flex flexDirection="column" gap={32}>
-            <Heading as="h2">{t('policySettings.title')}</Heading>
+            <Heading as="h2" id={headingId}>
+              {t('policySettings.title')}
+            </Heading>
 
             <Flex flexDirection="column" gap={20}>
               {showAccrualMaximum && (

--- a/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelectorPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/PolicyTypeSelector/PolicyTypeSelectorPresentation.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useId, useMemo } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import type { PolicyType, PolicyTypeSelectorPresentationProps } from './PolicyTypeSelectorTypes'
@@ -20,6 +20,7 @@ export function PolicyTypeSelectorPresentation({
   useI18n('Company.TimeOff.SelectPolicyType')
   const { t } = useTranslation('Company.TimeOff.SelectPolicyType')
   const { Heading, Text, Button } = useComponentContext()
+  const headingId = useId()
 
   const formMethods = useForm<PolicyTypeSelectorFormData>({
     defaultValues: {
@@ -57,10 +58,12 @@ export function PolicyTypeSelectorPresentation({
 
   return (
     <FormProvider {...formMethods}>
-      <HtmlForm onSubmit={formMethods.handleSubmit(handleSubmit)}>
+      <HtmlForm aria-labelledby={headingId} onSubmit={formMethods.handleSubmit(handleSubmit)}>
         <Flex flexDirection="column" gap={24}>
           <Flex flexDirection="column" gap={4}>
-            <Heading as="h2">{t('title')}</Heading>
+            <Heading as="h2" id={headingId}>
+              {t('title')}
+            </Heading>
             <Text variant="supporting">{t('policyTypeHint')}</Text>
           </Flex>
 

--- a/src/components/UNSTABLE_TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx
+++ b/src/components/UNSTABLE_TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useId, useMemo } from 'react'
 import { FormProvider, useForm, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import type {
@@ -33,6 +33,7 @@ export function PolicyConfigurationFormPresentation({
   const { t } = useTranslation('Company.TimeOff.CreateTimeOffPolicy')
   const { Heading, Text, Button } = useComponentContext()
   const { locale } = useLocale()
+  const headingId = useId()
 
   const monthOptions = useMemo(() => {
     const formatter = new Intl.DateTimeFormat(locale, { month: 'long' })
@@ -134,9 +135,11 @@ export function PolicyConfigurationFormPresentation({
 
   return (
     <FormProvider {...formMethods}>
-      <HtmlForm onSubmit={formMethods.handleSubmit(handleSubmit)}>
+      <HtmlForm aria-labelledby={headingId} onSubmit={formMethods.handleSubmit(handleSubmit)}>
         <Flex flexDirection="column" gap={32}>
-          <Heading as="h2">{t('policyDetails.title')}</Heading>
+          <Heading as="h2" id={headingId}>
+            {t('policyDetails.title')}
+          </Heading>
 
           <Flex flexDirection="column" gap={20}>
             <TextInputField


### PR DESCRIPTION
## Summary
- Adds `aria-labelledby` to the `<form>` elements in PolicyTypeSelector, PolicyConfigurationForm, and PolicySettings
- Each form heading (`<h2>`) now has an `id` that the form references, creating a named form landmark
- Screen reader users navigating by landmarks can now identify each form by its heading (WCAG 4.1.2)

## Test plan
- [ ] Verify in browser DevTools that `<form>` elements have `aria-labelledby` pointing to valid heading IDs
- [ ] Confirm screen reader announces form name when entering each form landmark
- [ ] Run existing tests for all three components