### PR TITLE
chore(sdk-app): add Mod+E and Mod+B keyboard shortcuts

### DIFF
--- a/sdk-app/src/App.tsx
+++ b/sdk-app/src/App.tsx
@@ -106,6 +106,14 @@ export function App() {
       cycleTheme()
     },
   })
+  useGlobalShortcut({
+    key: 'b',
+    modifier: 'mod',
+    onTrigger: event => {
+      event.preventDefault()
+      setSidebarOpen(open => !open)
+    },
+  })
 
   useEffect(() => {
     if (codePanel.isOpen && settingsOpen) setSettingsOpen(false)

--- a/sdk-app/src/ShortcutHelper/ShortcutHelper.tsx
+++ b/sdk-app/src/ShortcutHelper/ShortcutHelper.tsx
@@ -13,6 +13,8 @@ const SHORTCUTS: Shortcut[] = [
   { keys: ['?'], label: 'Show keyboard shortcuts' },
   { keys: [MOD, 'K'], label: 'Open page search' },
   { keys: ['\\'], label: 'Hide chrome' },
+  { keys: [MOD, 'B'], label: 'Toggle sidebar' },
+  { keys: [MOD, 'E'], label: 'Toggle code panel' },
   { keys: ['Esc'], label: 'Restore chrome (when hidden)' },
   { keys: [MOD, ','], label: 'Open settings' },
   { keys: [MOD, '.'], label: 'Toggle design / development' },

--- a/sdk-app/src/useCodePanel.ts
+++ b/sdk-app/src/useCodePanel.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useGlobalShortcut } from './useGlobalShortcut'
 
 const STORAGE_KEY = 'sdk-app-code-panel-open'
-const TOGGLE_KEY = '?'
+const TOGGLE_KEY = 'e'
 
 function readInitial(): boolean {
   try {
@@ -48,6 +48,7 @@ export function useCodePanel(): UseCodePanelResult {
 
   useGlobalShortcut({
     key: TOGGLE_KEY,
+    modifier: 'mod',
     onTrigger: event => {
       event.preventDefault()
       toggle()


### PR DESCRIPTION
## Summary

Fixes the code panel shortcut (was incorrectly bound to `?`, conflicting with the shortcut helper) and adds a new sidebar toggle shortcut. Both are documented in the shortcut helper modal.

## Changes

- `useCodePanel`: fixes toggle key from `?` to `Mod+E` with a proper `modifier: 'mod'`
- `App`: adds `Mod+B` shortcut to toggle sidebar open/collapsed
- `ShortcutHelper`: registers both new shortcuts in the `?` modal

## Testing

- Open sdk-app (`npm run sdk-app`)
- Press `?` to confirm shortcut helper lists `Mod+B` (Toggle sidebar) and `Mod+E` (Toggle code panel)
- Press `Mod+E` — code panel opens/closes
- Press `Mod+B` — sidebar collapses/expands
- Press `?` — shortcut helper still opens (no longer conflicts with code panel)