### PR TITLE
feat(sdk-app): theme panel resolved values, shared resizable panels, color swatch polish

### DIFF
--- a/sdk-app/src/App.tsx
+++ b/sdk-app/src/App.tsx
@@ -21,6 +21,15 @@ import { CodePanel } from './CodePanel'
 import { CurrentComponentProvider } from './CurrentComponentContext'
 import { useDemoChrome } from './useDemoChrome'
 import { findDemoChrome, SDK_NATIVE_CHROME_ID } from './demoChromes/registry'
+import {
+  ThemePanel,
+  useThemePanel,
+  ThemeEditorContext,
+  useThemeEditorState,
+  DesignSystemContext,
+  useDesignSystemState,
+} from './ThemePanel'
+import { RightPanelShell } from './RightPanelShell'
 
 const THEME_CYCLE: ThemeMode[] = ['system', 'light', 'dark']
 
@@ -65,12 +74,44 @@ export function App() {
   const commandPalette = useCommandPalette()
   const navigate = useNavigate()
   const codePanel = useCodePanel()
+  const themePanel = useThemePanel()
+  const themeEditorState = useThemeEditorState()
+  const designSystemState = useDesignSystemState()
   const { chromeId, setChromeId } = useDemoChrome()
   const customChrome = chromeId !== SDK_NATIVE_CHROME_ID ? findDemoChrome(chromeId) : undefined
 
+  const activePanel: 'theme' | 'settings' | 'code' | null = codePanel.isOpen
+    ? 'code'
+    : themePanel.isOpen
+      ? 'theme'
+      : settingsOpen
+        ? 'settings'
+        : null
+
+  const togglePanel = useCallback(
+    (panel: 'theme' | 'settings' | 'code') => {
+      if (panel === 'code') {
+        themePanel.close()
+        setSettingsOpen(false)
+        codePanel.toggle()
+      } else if (panel === 'theme') {
+        codePanel.close()
+        setSettingsOpen(false)
+        themePanel.toggle()
+      } else {
+        codePanel.close()
+        themePanel.close()
+        setSettingsOpen(prev => !prev)
+      }
+    },
+    [codePanel, themePanel],
+  )
+
   const openSettings = useCallback(() => {
+    codePanel.close()
+    themePanel.close()
     setSettingsOpen(true)
-  }, [])
+  }, [codePanel, themePanel])
 
   const toggleAppMode = useCallback(() => {
     void navigate(appMode === 'design' ? '/' : '/design')
@@ -87,7 +128,7 @@ export function App() {
     modifier: 'mod',
     onTrigger: event => {
       event.preventDefault()
-      openSettings()
+      togglePanel('settings')
     },
   })
   useGlobalShortcut({
@@ -117,13 +158,21 @@ export function App() {
 
   useEffect(() => {
     if (codePanel.isOpen && settingsOpen) setSettingsOpen(false)
+    if (codePanel.isOpen && themePanel.isOpen) themePanel.close()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [codePanel.isOpen])
 
   useEffect(() => {
     if (settingsOpen && codePanel.isOpen) codePanel.close()
+    if (settingsOpen && themePanel.isOpen) themePanel.close()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settingsOpen])
+
+  useEffect(() => {
+    if (themePanel.isOpen && codePanel.isOpen) codePanel.close()
+    if (themePanel.isOpen && settingsOpen) setSettingsOpen(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [themePanel.isOpen])
 
   const handleCreateNewDemo = async (demoType: string) => {
     const result = await demoManager.createNewDemo(demoType)
@@ -180,9 +229,8 @@ export function App() {
       <TopBar
         companyId={activeEntities.companyId}
         tokenStatus={demoManager.tokenStatus}
-        onOpenSettings={openSettings}
-        onToggleCode={codePanel.toggle}
-        codeOpen={codePanel.isOpen}
+        activePanel={activePanel}
+        onPanelToggle={togglePanel}
       />
       <div className="app-body">
         <Sidebar
@@ -196,62 +244,72 @@ export function App() {
           onShowShortcuts={shortcutHelper.open}
         />
         {mainEl}
-        {codePanel.isOpen && <CodePanel onClose={codePanel.close} />}
+        {(codePanel.isOpen || themePanel.isOpen || settingsOpen) && (
+          <RightPanelShell>
+            {codePanel.isOpen && <CodePanel onClose={codePanel.close} />}
+            {themePanel.isOpen && <ThemePanel onClose={themePanel.close} />}
+            {settingsOpen && (
+              <DemoSettingsPanel
+                onClose={() => {
+                  setSettingsOpen(false)
+                }}
+                entities={activeEntities}
+                onUpdateEntity={updateEntity}
+                onResetToDefaults={resetToDefaults}
+                tokenStatus={demoManager.tokenStatus}
+                isCreatingDemo={demoManager.isCreatingDemo}
+                demoError={demoManager.demoError}
+                proxyMode={demoManager.proxyMode}
+                onCreateNewDemo={handleCreateNewDemo}
+                onRefreshToken={demoManager.refreshToken}
+                entityCatalog={entityCatalog}
+                mode={manual.mode}
+                manualConfig={manual.config}
+                manualSaves={manual.saves}
+                onSwitchToAuto={manual.switchToAuto}
+                onApplyManualConfig={handleApplyManualConfig}
+                onSaveManualConfig={manual.saveConfig}
+                onDeleteManualSave={manual.deleteSave}
+                chromeId={chromeId}
+                onChromeIdChange={setChromeId}
+              />
+            )}
+          </RightPanelShell>
+        )}
       </div>
     </>
   )
 
   return (
     <ThemeModeProvider value={themeMode}>
-      <CurrentComponentProvider>
-        <div className={`app-layout${chromeHidden ? ' app-layout-chrome-hidden' : ''}`}>
-          {bodyEl}
-          {chromeHidden && (
-            <button
-              type="button"
-              className="chrome-restore-pill"
-              onClick={showChrome}
-              aria-label="Show chrome"
-            >
-              <span className="chrome-restore-pill-key">\</span> Show chrome
-            </button>
-          )}
-          <DemoSettingsPanel
-            isOpen={settingsOpen}
-            onClose={() => {
-              setSettingsOpen(false)
-            }}
-            entities={activeEntities}
-            onUpdateEntity={updateEntity}
-            onResetToDefaults={resetToDefaults}
-            tokenStatus={demoManager.tokenStatus}
-            isCreatingDemo={demoManager.isCreatingDemo}
-            demoError={demoManager.demoError}
-            proxyMode={demoManager.proxyMode}
-            onCreateNewDemo={handleCreateNewDemo}
-            onRefreshToken={demoManager.refreshToken}
-            entityCatalog={entityCatalog}
-            mode={manual.mode}
-            manualConfig={manual.config}
-            manualSaves={manual.saves}
-            onSwitchToAuto={manual.switchToAuto}
-            onApplyManualConfig={handleApplyManualConfig}
-            onSaveManualConfig={manual.saveConfig}
-            onDeleteManualSave={manual.deleteSave}
-            chromeId={chromeId}
-            onChromeIdChange={setChromeId}
-          />
-          <ShortcutHelper isOpen={shortcutHelper.isOpen} onClose={shortcutHelper.close} />
-          <CommandPalette isOpen={commandPalette.isOpen} onClose={commandPalette.close} />
-          {!isManual && demoManager.tokenStatus === 'expired' && (
-            <TokenExpiredOverlay
-              onRefresh={demoManager.refreshToken}
-              isRefreshing={demoManager.isCreatingDemo}
-              error={demoManager.demoError}
-            />
-          )}
-        </div>
-      </CurrentComponentProvider>
+      <ThemeEditorContext.Provider value={themeEditorState}>
+        <DesignSystemContext.Provider value={designSystemState}>
+          <CurrentComponentProvider>
+            <div className={`app-layout${chromeHidden ? ' app-layout-chrome-hidden' : ''}`}>
+              {bodyEl}
+              {chromeHidden && (
+                <button
+                  type="button"
+                  className="chrome-restore-pill"
+                  onClick={showChrome}
+                  aria-label="Show chrome"
+                >
+                  <span className="chrome-restore-pill-key">\</span> Show chrome
+                </button>
+              )}
+              <ShortcutHelper isOpen={shortcutHelper.isOpen} onClose={shortcutHelper.close} />
+              <CommandPalette isOpen={commandPalette.isOpen} onClose={commandPalette.close} />
+              {!isManual && demoManager.tokenStatus === 'expired' && (
+                <TokenExpiredOverlay
+                  onRefresh={demoManager.refreshToken}
+                  isRefreshing={demoManager.isCreatingDemo}
+                  error={demoManager.demoError}
+                />
+              )}
+            </div>
+          </CurrentComponentProvider>
+        </DesignSystemContext.Provider>
+      </ThemeEditorContext.Provider>
     </ThemeModeProvider>
   )
 }

--- a/sdk-app/src/CodePanel.module.scss
+++ b/sdk-app/src/CodePanel.module.scss
@@ -1,42 +1,9 @@
 .panel {
-  position: sticky;
-  top: var(--topbar-height);
-  align-self: flex-start;
-  height: calc(100vh - var(--topbar-height));
-  flex-shrink: 0;
-  background: var(--color-bg);
-  border-left: 0.0625rem solid var(--color-border);
+  flex: 1;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-}
-
-.resizeHandle {
-  position: absolute;
-  top: 0;
-  left: -0.25rem;
-  bottom: 0;
-  width: 0.5rem;
-  cursor: col-resize;
-  z-index: 1;
-  touch-action: none;
-
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 0.125rem;
-    height: 100%;
-    background: transparent;
-    transition: background 0.15s;
-  }
-
-  &:hover::after,
-  &:active::after {
-    background: var(--color-active);
-  }
+  min-width: 0;
 }
 
 .header {

--- a/sdk-app/src/CodePanel.tsx
+++ b/sdk-app/src/CodePanel.tsx
@@ -1,11 +1,4 @@
-import {
-  type PointerEvent as ReactPointerEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Highlight, themes } from 'prism-react-renderer'
 import { useCurrentComponent } from './useCurrentComponent'
 import { useResolvedTheme } from './useThemeModeContext'
@@ -16,27 +9,10 @@ interface CodePanelProps {
   onClose: () => void
 }
 
-const WIDTH_STORAGE_KEY = 'sdk-app-code-panel-width'
-const DEFAULT_WIDTH = 512
-const MIN_WIDTH = 320
-
-function readStoredWidth(): number {
-  try {
-    const raw = localStorage.getItem(WIDTH_STORAGE_KEY)
-    if (!raw) return DEFAULT_WIDTH
-    const parsed = parseInt(raw, 10)
-    return Number.isFinite(parsed) && parsed >= MIN_WIDTH ? parsed : DEFAULT_WIDTH
-  } catch {
-    return DEFAULT_WIDTH
-  }
-}
-
 export function CodePanel({ onClose }: CodePanelProps) {
   const current = useCurrentComponent()
   const resolvedTheme = useResolvedTheme()
   const [copyState, setCopyState] = useState<'idle' | 'copied'>('idle')
-  const [width, setWidth] = useState<number>(readStoredWidth)
-  const isResizingRef = useRef(false)
 
   const snippet = useMemo(() => {
     if (!current) return ''
@@ -62,61 +38,8 @@ export function CodePanel({ onClose }: CodePanelProps) {
 
   const prismTheme = resolvedTheme === 'dark' ? themes.vsDark : themes.github
 
-  const handleResizePointerDown = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    isResizingRef.current = true
-    ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
-    document.body.style.cursor = 'col-resize'
-    document.body.style.userSelect = 'none'
-  }, [])
-
-  const handleResizePointerMove = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
-    if (!isResizingRef.current) return
-    const next = Math.round(window.innerWidth - e.clientX)
-    const max = Math.round(window.innerWidth * 0.85)
-    const clamped = Math.min(Math.max(next, MIN_WIDTH), max)
-    setWidth(clamped)
-  }, [])
-
-  const handleResizePointerUp = useCallback(
-    (e: ReactPointerEvent<HTMLDivElement>) => {
-      if (!isResizingRef.current) return
-      isResizingRef.current = false
-      ;(e.target as HTMLElement).releasePointerCapture(e.pointerId)
-      document.body.style.cursor = ''
-      document.body.style.userSelect = ''
-      try {
-        localStorage.setItem(WIDTH_STORAGE_KEY, String(width))
-      } catch {
-        // Storage unavailable
-      }
-    },
-    [width],
-  )
-
-  const handleResizeDoubleClick = useCallback(() => {
-    setWidth(DEFAULT_WIDTH)
-    try {
-      localStorage.setItem(WIDTH_STORAGE_KEY, String(DEFAULT_WIDTH))
-    } catch {
-      // Storage unavailable
-    }
-  }, [])
-
   return (
-    <aside className={styles.panel} aria-label="Component code" style={{ width: `${width}px` }}>
-      <div
-        className={styles.resizeHandle}
-        role="separator"
-        aria-orientation="vertical"
-        aria-label="Resize code panel"
-        onPointerDown={handleResizePointerDown}
-        onPointerMove={handleResizePointerMove}
-        onPointerUp={handleResizePointerUp}
-        onPointerCancel={handleResizePointerUp}
-        onDoubleClick={handleResizeDoubleClick}
-        title="Drag to resize. Double-click to reset."
-      />
+    <div className={styles.panel} aria-label="Component code">
       <div className={styles.header}>
         <h2>Code</h2>
         <button className={styles.close} onClick={onClose} type="button" aria-label="Close">
@@ -156,6 +79,6 @@ export function CodePanel({ onClose }: CodePanelProps) {
           </Highlight>
         </>
       )}
-    </aside>
+    </div>
   )
 }

--- a/sdk-app/src/ComponentRenderer.tsx
+++ b/sdk-app/src/ComponentRenderer.tsx
@@ -1,9 +1,20 @@
-import { Suspense, useState, useCallback, useEffect, Component, type ReactNode } from 'react'
+import {
+  Suspense,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  Component,
+  type ReactNode,
+} from 'react'
 import { useParams } from 'react-router-dom'
 import { findComponent, CATEGORIES } from './registry'
 import { resolveDefaults } from './component-defaults'
 import { useResolvedTheme } from './useThemeModeContext'
 import { darkTheme } from './darkTheme'
+import { useThemeEditor } from './ThemePanel/ThemeEditorContext'
+import { useDesignSystem } from './ThemePanel/DesignSystemContext'
+import { nativeComponents } from './ThemePanel/adapters/nativeAdapter'
 import type { EntityIds } from './useEntities'
 import styles from './ComponentRenderer.module.scss'
 import { useCurrentComponentRegistry } from './useCurrentComponent'
@@ -126,6 +137,15 @@ export function ComponentRenderer({ entities, chromeHidden = false }: ComponentR
     component: string
   }>()
   const resolvedTheme = useResolvedTheme()
+  const { themeOverrides } = useThemeEditor()
+  const { designSystem } = useDesignSystem()
+  const resolvedComponents = designSystem === 'native' ? nativeComponents : undefined
+  const resolvedSDKTheme = useMemo(() => {
+    const base = resolvedTheme === 'dark' ? darkTheme : undefined
+    const hasOverrides = Object.keys(themeOverrides).length > 0
+    if (!base && !hasOverrides) return undefined
+    return { ...base, ...themeOverrides }
+  }, [resolvedTheme, themeOverrides])
   const { register, unregister } = useCurrentComponentRegistry()
   const [events, setEvents] = useState<EventLogEntry[]>([])
   const [eventsOpen, setEventsOpen] = useState(false)
@@ -273,7 +293,8 @@ export function ComponentRenderer({ entities, chromeHidden = false }: ComponentR
             >
               <GustoProvider
                 config={{ baseUrl: `${window.location.origin}/api/` }}
-                theme={resolvedTheme === 'dark' ? darkTheme : undefined}
+                theme={resolvedSDKTheme}
+                components={resolvedComponents}
                 key={providerKey}
               >
                 <Suspense fallback={<div className={styles.contentLoading}>Loading...</div>}>

--- a/sdk-app/src/DemoSettingsPanel.module.scss
+++ b/sdk-app/src/DemoSettingsPanel.module.scss
@@ -1,25 +1,9 @@
-.overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
-  z-index: 100;
-}
-
 .panel {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 23.75rem;
-  background: var(--color-bg);
-  box-shadow: -0.25rem 0 1.5rem rgba(0, 0, 0, 0.15);
-  z-index: 101;
+  flex: 1;
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
+  overflow: hidden;
+  min-width: 0;
 }
 
 .header {
@@ -28,11 +12,17 @@
   justify-content: space-between;
   padding: 1rem 1.25rem;
   border-bottom: 0.0625rem solid var(--color-border);
+  flex-shrink: 0;
 
   h2 {
     font-size: 1rem;
     font-weight: 600;
   }
+}
+
+.body {
+  flex: 1;
+  overflow-y: auto;
 }
 
 .close {

--- a/sdk-app/src/DemoSettingsPanel.tsx
+++ b/sdk-app/src/DemoSettingsPanel.tsx
@@ -16,7 +16,6 @@ import { demoChromes } from './demoChromes/registry'
 import styles from './DemoSettingsPanel.module.scss'
 
 interface DemoSettingsPanelProps {
-  isOpen: boolean
   onClose: () => void
   entities: EntityIds
   onUpdateEntity: (key: keyof EntityIds, value: string) => void
@@ -357,7 +356,6 @@ function EntityCombobox({
 }
 
 export function DemoSettingsPanel({
-  isOpen,
   onClose,
   entities,
   onUpdateEntity,
@@ -401,17 +399,6 @@ export function DemoSettingsPanel({
     setTabMode(mode)
   }, [mode])
 
-  useEffect(() => {
-    if (!isOpen) {
-      confirmedSnapshot.current = entities
-      setManualError(null)
-      setManualBanner(null)
-      setTabMode(mode)
-      setSaveDialogOpen(false)
-      setSaveDialogName('')
-    }
-  }, [isOpen, entities, mode])
-
   const env = typeof __SDK_APP_ENV__ !== 'undefined' ? __SDK_APP_ENV__ : 'demo'
   const build = typeof __SDK_APP_BUILD__ !== 'undefined' ? __SDK_APP_BUILD__ : 'dev'
   const buildProxyMode =
@@ -428,30 +415,17 @@ export function DemoSettingsPanel({
     entities.payrollId !== confirmedSnapshot.current.payrollId ||
     TEXT_FIELDS.some(({ key }) => entities[key] !== confirmedSnapshot.current[key])
 
-  if (!isOpen) return null
-
   const displayEnv = env === 'localzp' ? 'local' : env
 
   return (
-    <>
-      <div
-        className={styles.overlay}
-        onClick={onClose}
-        onKeyDown={e => {
-          if (e.key === 'Escape') onClose()
-        }}
-        role="button"
-        tabIndex={-1}
-        aria-label="Close settings"
-      />
-      <div className={styles.panel}>
-        <div className={styles.header}>
-          <h2>Demo Settings</h2>
-          <button className={styles.close} onClick={onClose} type="button">
-            &times;
-          </button>
-        </div>
-
+    <div className={styles.panel}>
+      <div className={styles.header}>
+        <h2>Demo Settings</h2>
+        <button className={styles.close} onClick={onClose} type="button">
+          &times;
+        </button>
+      </div>
+      <div className={styles.body}>
         <div className={styles.section}>
           <h3>Mode</h3>
           <div className={styles.modeToggle} role="tablist" aria-label="App mode">
@@ -860,6 +834,6 @@ export function DemoSettingsPanel({
           </div>
         </div>
       </div>
-    </>
+    </div>
   )
 }

--- a/sdk-app/src/RightPanelShell.module.scss
+++ b/sdk-app/src/RightPanelShell.module.scss
@@ -1,0 +1,42 @@
+.shell {
+  position: sticky;
+  top: var(--topbar-height);
+  align-self: flex-start;
+  height: calc(100vh - var(--topbar-height));
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: row;
+  background: var(--color-bg);
+  border-left: 0.0625rem solid var(--color-border);
+  overflow: hidden;
+  min-width: 0;
+}
+
+.handle {
+  width: 0.25rem;
+  flex-shrink: 0;
+  cursor: col-resize;
+  touch-action: none;
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: transparent;
+    transition: background 0.15s;
+  }
+
+  &:hover::after,
+  &:active::after {
+    background: var(--color-active);
+  }
+}
+
+.content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}

--- a/sdk-app/src/RightPanelShell.tsx
+++ b/sdk-app/src/RightPanelShell.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import styles from './RightPanelShell.module.scss'
+
+const STORAGE_KEY = 'sdk-app-right-panel-width'
+const DEFAULT_WIDTH = 380
+const MIN_WIDTH = 280
+
+function readWidth(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      const n = parseInt(raw, 10)
+      if (Number.isFinite(n) && n >= MIN_WIDTH) return n
+    }
+  } catch {
+    // ignore
+  }
+  return DEFAULT_WIDTH
+}
+
+function saveWidth(w: number) {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(w))
+  } catch {
+    // ignore
+  }
+}
+
+interface RightPanelShellProps {
+  children: ReactNode
+}
+
+export function RightPanelShell({ children }: RightPanelShellProps) {
+  const [width, setWidth] = useState<number>(readWidth)
+  const isResizingRef = useRef(false)
+
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    isResizingRef.current = true
+    ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+  }, [])
+
+  const handlePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isResizingRef.current) return
+    const next = Math.round(window.innerWidth - e.clientX)
+    const max = Math.round(window.innerWidth * 0.85)
+    setWidth(Math.min(Math.max(next, MIN_WIDTH), max))
+  }, [])
+
+  const finishResize = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isResizingRef.current) return
+    isResizingRef.current = false
+    ;(e.target as HTMLElement).releasePointerCapture(e.pointerId)
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+    setWidth(w => {
+      saveWidth(w)
+      return w
+    })
+  }, [])
+
+  const handleDoubleClick = useCallback(() => {
+    setWidth(DEFAULT_WIDTH)
+    saveWidth(DEFAULT_WIDTH)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (isResizingRef.current) {
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+      }
+    }
+  }, [])
+
+  return (
+    <aside className={styles.shell} style={{ width: `${width}px` }}>
+      <div
+        className={styles.handle}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize panel"
+        title="Drag to resize · Double-click to reset"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={finishResize}
+        onPointerCancel={finishResize}
+        onDoubleClick={handleDoubleClick}
+      />
+      <div className={styles.content}>{children}</div>
+    </aside>
+  )
+}

--- a/sdk-app/src/ShortcutHelper/ShortcutHelper.tsx
+++ b/sdk-app/src/ShortcutHelper/ShortcutHelper.tsx
@@ -19,6 +19,7 @@ const SHORTCUTS: Shortcut[] = [
   { keys: [MOD, ','], label: 'Open settings' },
   { keys: [MOD, '.'], label: 'Toggle design / development' },
   { keys: [MOD, ';'], label: 'Cycle theme (system → light → dark)' },
+  { keys: [MOD, 'J'], label: 'Open theme panel' },
 ]
 
 interface ShortcutHelperProps {

--- a/sdk-app/src/ThemePanel/DesignSystemContext.ts
+++ b/sdk-app/src/ThemePanel/DesignSystemContext.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext, useState } from 'react'
+
+export type DesignSystem = 'default' | 'native'
+
+export interface DesignSystemContextValue {
+  designSystem: DesignSystem
+  setDesignSystem: (system: DesignSystem) => void
+}
+
+export const DesignSystemContext = createContext<DesignSystemContextValue>({
+  designSystem: 'default',
+  setDesignSystem: () => {},
+})
+
+export const useDesignSystem = () => useContext(DesignSystemContext)
+
+export function useDesignSystemState(): DesignSystemContextValue {
+  const [designSystem, setDesignSystem] = useState<DesignSystem>('default')
+  return { designSystem, setDesignSystem }
+}

--- a/sdk-app/src/ThemePanel/DesignSystemSwitcher.module.scss
+++ b/sdk-app/src/ThemePanel/DesignSystemSwitcher.module.scss
@@ -1,0 +1,55 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 0.75rem;
+  border: 0.0625rem solid var(--color-border);
+  border-radius: 0.375rem;
+  background: transparent;
+  color: var(--color-text);
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.8125rem;
+  transition: background 0.15s, border-color 0.15s;
+
+  &:hover:not(:disabled) {
+    background: var(--color-hover-bg);
+    border-color: var(--color-active);
+  }
+
+  &.active {
+    background: var(--color-hover-bg);
+    border-color: var(--color-active);
+    font-weight: 600;
+  }
+
+  &.unavailable,
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+}
+
+.optionLogo {
+  font-size: 1rem;
+  line-height: 1;
+  width: 1.25rem;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.optionLabel {
+  flex: 1;
+}

--- a/sdk-app/src/ThemePanel/DesignSystemSwitcher.module.scss
+++ b/sdk-app/src/ThemePanel/DesignSystemSwitcher.module.scss
@@ -22,7 +22,9 @@
   cursor: pointer;
   text-align: left;
   font-size: 0.8125rem;
-  transition: background 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
 
   &:hover:not(:disabled) {
     background: var(--color-hover-bg);

--- a/sdk-app/src/ThemePanel/DesignSystemSwitcher.tsx
+++ b/sdk-app/src/ThemePanel/DesignSystemSwitcher.tsx
@@ -1,0 +1,40 @@
+import { useDesignSystem, type DesignSystem } from './DesignSystemContext'
+import styles from './DesignSystemSwitcher.module.scss'
+
+interface DesignSystemOption {
+  id: DesignSystem
+  label: string
+  logo: string
+  available: boolean
+}
+
+const OPTIONS: DesignSystemOption[] = [
+  { id: 'default', label: 'Gusto Default', logo: '🎨', available: true },
+  { id: 'native', label: 'Native HTML', logo: '🌐', available: true },
+]
+
+export function DesignSystemSwitcher() {
+  const { designSystem, setDesignSystem } = useDesignSystem()
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.options}>
+        {OPTIONS.map(option => (
+          <button
+            key={option.id}
+            type="button"
+            className={`${styles.option} ${designSystem === option.id ? styles.active : ''} ${!option.available ? styles.unavailable : ''}`}
+            onClick={() => {
+              if (option.available) setDesignSystem(option.id)
+            }}
+            title={option.available ? option.label : `${option.label} (coming soon)`}
+            disabled={!option.available}
+          >
+            <span className={styles.optionLogo}>{option.logo}</span>
+            <span className={styles.optionLabel}>{option.label}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/sdk-app/src/ThemePanel/ThemeEditor.module.scss
+++ b/sdk-app/src/ThemePanel/ThemeEditor.module.scss
@@ -50,7 +50,9 @@
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
-  transition: color 0.15s, border-color 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 
   &:hover {
     color: #ef4444;
@@ -153,7 +155,9 @@
   height: 1rem;
   border-radius: 0.1875rem;
   flex-shrink: 0;
-  box-shadow: inset 0 0 0 0.0625rem rgba(0, 0, 0, 0.2), inset 0 0 0 0.125rem rgba(255, 255, 255, 0.15);
+  box-shadow:
+    inset 0 0 0 0.0625rem rgba(0, 0, 0, 0.2),
+    inset 0 0 0 0.125rem rgba(255, 255, 255, 0.15);
 }
 
 .colorPickerInput {

--- a/sdk-app/src/ThemePanel/ThemeEditor.module.scss
+++ b/sdk-app/src/ThemePanel/ThemeEditor.module.scss
@@ -1,0 +1,203 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  flex: 1;
+  min-height: 0;
+}
+
+.searchRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border-bottom: 0.0625rem solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.searchInput {
+  flex: 1;
+  font-size: 0.8125rem;
+  padding: 0.3125rem 0.625rem;
+  border: 0.0625rem solid var(--color-border);
+  border-radius: 0.375rem;
+  background: transparent;
+  color: inherit;
+  min-width: 0;
+
+  &::placeholder {
+    color: var(--color-text-muted);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-active);
+  }
+
+  // Remove native search input clear button
+  &::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+  }
+}
+
+.clearBtn {
+  font-size: 0.6875rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  border: 0.0625rem solid currentColor;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: color 0.15s, border-color 0.15s;
+
+  &:hover {
+    color: #ef4444;
+    border-color: #ef4444;
+  }
+}
+
+.groups {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.group {
+  border-bottom: 0.0625rem solid var(--color-border);
+}
+
+.groupHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 1.25rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  text-align: left;
+
+  &:hover {
+    background: var(--color-hover-bg);
+  }
+}
+
+.groupLabel {
+  flex: 1;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.groupCount {
+  font-size: 0.625rem;
+  color: var(--color-text-muted);
+  background: var(--color-hover-bg);
+  border-radius: 0.75rem;
+  padding: 0.0625rem 0.375rem;
+  line-height: 1.4;
+}
+
+.groupChevron {
+  font-size: 0.625rem;
+  color: var(--color-text-muted);
+  transition: transform 0.15s;
+  display: inline-block;
+}
+
+.groupChevronOpen {
+  transform: rotate(90deg);
+}
+
+.groupBody {
+  padding: 0.25rem 0 0.5rem;
+}
+
+// Token rows
+
+.token {
+  display: grid;
+  grid-template-columns: 1.25rem 1fr;
+  grid-template-rows: auto auto;
+  gap: 0.125rem 0.5rem;
+  align-items: center;
+  padding: 0.3125rem 1.25rem;
+}
+
+.tokenPreview {
+  grid-row: 1 / 3;
+  grid-column: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tokenPreviewPlaceholder {
+  grid-row: 1 / 3;
+  grid-column: 1;
+  width: 1rem;
+}
+
+.colorPickerLabel {
+  display: flex;
+  position: relative;
+  cursor: pointer;
+}
+
+.colorSwatch {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0.1875rem;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 0.0625rem rgba(0, 0, 0, 0.2), inset 0 0 0 0.125rem rgba(255, 255, 255, 0.15);
+}
+
+.colorPickerInput {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+  padding: 0;
+  border: none;
+}
+
+.tokenLabel {
+  grid-column: 2;
+  grid-row: 1;
+  font-size: 0.6875rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.colorInput {
+  grid-column: 2;
+  grid-row: 2;
+  font-size: 0.75rem;
+  padding: 0.1875rem 0.4375rem;
+  border: 0.0625rem solid var(--color-border);
+  border-radius: 0.25rem;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  font-family: monospace;
+  transition: border-color 0.15s;
+
+  &::placeholder {
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-active);
+  }
+}

--- a/sdk-app/src/ThemePanel/ThemeEditor.tsx
+++ b/sdk-app/src/ThemePanel/ThemeEditor.tsx
@@ -1,0 +1,325 @@
+import { useState } from 'react'
+import { useThemeEditor } from './ThemeEditorContext'
+import styles from './ThemeEditor.module.scss'
+import type { GustoSDKTheme } from '@/contexts/ThemeProvider/theme'
+
+interface TokenDef {
+  key: keyof GustoSDKTheme
+  isColor?: boolean
+}
+
+interface TokenGroup {
+  label: string
+  tokens: TokenDef[]
+  defaultOpen?: boolean
+}
+
+const TOKEN_GROUPS: TokenGroup[] = [
+  {
+    label: 'Body',
+    defaultOpen: true,
+    tokens: [
+      { key: 'colorBody', isColor: true },
+      { key: 'colorBodyAccent', isColor: true },
+      { key: 'colorBodyContent', isColor: true },
+      { key: 'colorBodySubContent', isColor: true },
+    ],
+  },
+  {
+    label: 'Primary',
+    defaultOpen: true,
+    tokens: [
+      { key: 'colorPrimary', isColor: true },
+      { key: 'colorPrimaryAccent', isColor: true },
+      { key: 'colorPrimaryContent', isColor: true },
+    ],
+  },
+  {
+    label: 'Secondary',
+    defaultOpen: true,
+    tokens: [
+      { key: 'colorSecondary', isColor: true },
+      { key: 'colorSecondaryAccent', isColor: true },
+      { key: 'colorSecondaryContent', isColor: true },
+    ],
+  },
+  {
+    label: 'Status',
+    defaultOpen: false,
+    tokens: [
+      { key: 'colorInfo', isColor: true },
+      { key: 'colorInfoAccent', isColor: true },
+      { key: 'colorInfoContent', isColor: true },
+      { key: 'colorWarning', isColor: true },
+      { key: 'colorWarningAccent', isColor: true },
+      { key: 'colorWarningContent', isColor: true },
+      { key: 'colorError', isColor: true },
+      { key: 'colorErrorAccent', isColor: true },
+      { key: 'colorErrorContent', isColor: true },
+      { key: 'colorSuccess', isColor: true },
+      { key: 'colorSuccessAccent', isColor: true },
+      { key: 'colorSuccessContent', isColor: true },
+    ],
+  },
+  {
+    label: 'Borders & Icons',
+    defaultOpen: false,
+    tokens: [
+      { key: 'colorBorderPrimary', isColor: true },
+      { key: 'colorBorderSecondary', isColor: true },
+      { key: 'colorButtonIcon', isColor: true },
+    ],
+  },
+  {
+    label: 'Input Colors',
+    defaultOpen: false,
+    tokens: [
+      { key: 'inputBackgroundColor', isColor: true },
+      { key: 'inputBorderColor', isColor: true },
+      { key: 'inputContentColor', isColor: true },
+      { key: 'inputPlaceholderColor', isColor: true },
+      { key: 'inputAdornmentColor', isColor: true },
+      { key: 'inputDisabledBackgroundColor', isColor: true },
+      { key: 'inputLabelColor', isColor: true },
+      { key: 'inputDescriptionColor', isColor: true },
+      { key: 'inputErrorColor', isColor: true },
+    ],
+  },
+  {
+    label: 'Input Dimensions',
+    defaultOpen: false,
+    tokens: [
+      { key: 'inputBorderWidth' },
+      { key: 'inputRadius' },
+      { key: 'inputLabelFontSize' },
+      { key: 'inputLabelFontWeight' },
+    ],
+  },
+  {
+    label: 'Radius',
+    defaultOpen: false,
+    tokens: [
+      { key: 'buttonRadius' },
+      { key: 'cardRadius' },
+      { key: 'badgeRadius' },
+      { key: 'bannerRadius' },
+      { key: 'boxRadius' },
+    ],
+  },
+  {
+    label: 'Typography',
+    defaultOpen: false,
+    tokens: [
+      { key: 'fontFamily' },
+      { key: 'fontSizeRoot' },
+      { key: 'fontSizeExtraSmall' },
+      { key: 'fontSizeSmall' },
+      { key: 'fontSizeRegular' },
+      { key: 'fontSizeLarge' },
+      { key: 'fontSizeHeading1' },
+      { key: 'fontSizeHeading2' },
+      { key: 'fontSizeHeading3' },
+      { key: 'fontSizeHeading4' },
+      { key: 'fontSizeHeading5' },
+      { key: 'fontSizeHeading6' },
+      { key: 'fontWeightRegular' },
+      { key: 'fontWeightMedium' },
+      { key: 'fontWeightSemibold' },
+      { key: 'fontWeightBold' },
+    ],
+  },
+  {
+    label: 'Line Heights',
+    defaultOpen: false,
+    tokens: [
+      { key: 'fontLineHeightLarge' },
+      { key: 'fontLineHeightRegular' },
+      { key: 'fontLineHeightSmall' },
+      { key: 'fontLineHeightExtraSmall' },
+    ],
+  },
+  {
+    label: 'Focus',
+    defaultOpen: false,
+    tokens: [{ key: 'focusRingColor', isColor: true }, { key: 'focusRingWidth' }],
+  },
+  {
+    label: 'Shadows',
+    defaultOpen: false,
+    tokens: [{ key: 'shadowResting' }, { key: 'shadowTopmost' }],
+  },
+  {
+    label: 'Transitions',
+    defaultOpen: false,
+    tokens: [{ key: 'transitionDuration' }],
+  },
+]
+
+function tokenLabel(token: keyof GustoSDKTheme): string {
+  return (token as string)
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, s => s.toUpperCase())
+    .trim()
+}
+
+function matchesSearch(token: TokenDef, query: string): boolean {
+  if (!query) return true
+  const q = query.toLowerCase()
+  return (
+    (token.key as string).toLowerCase().includes(q) ||
+    tokenLabel(token.key).toLowerCase().includes(q)
+  )
+}
+
+interface TokenRowProps {
+  def: TokenDef
+}
+
+function TokenRow({ def }: TokenRowProps) {
+  const { themeOverrides, resolvedTheme, setThemeOverride } = useThemeEditor()
+  const override = (themeOverrides[def.key] as string | undefined) ?? ''
+  const resolved = (resolvedTheme[def.key] as string | undefined) ?? ''
+  const swatchColor = override || resolved
+
+  return (
+    <div className={styles.token}>
+      {def.isColor ? (
+        <div className={styles.tokenPreview}>
+          <label
+            className={styles.colorPickerLabel}
+            htmlFor={`theme-picker-${def.key}`}
+            aria-label="Open color picker"
+          >
+            <div
+              className={styles.colorSwatch}
+              style={{ backgroundColor: swatchColor || 'transparent' }}
+            />
+            <input
+              id={`theme-picker-${def.key}`}
+              className={styles.colorPickerInput}
+              type="color"
+              value={
+                swatchColor.startsWith('#') && swatchColor.length >= 4 ? swatchColor : '#000000'
+              }
+              onChange={e => {
+                setThemeOverride(def.key, e.target.value)
+              }}
+              tabIndex={-1}
+            />
+          </label>
+        </div>
+      ) : (
+        <div className={styles.tokenPreviewPlaceholder} />
+      )}
+      <label className={styles.tokenLabel} htmlFor={`theme-${def.key}`}>
+        {tokenLabel(def.key)}
+      </label>
+      <input
+        id={`theme-${def.key}`}
+        className={styles.colorInput}
+        type="text"
+        value={override}
+        placeholder={resolved}
+        onChange={e => {
+          setThemeOverride(def.key, e.target.value)
+        }}
+        spellCheck={false}
+      />
+    </div>
+  )
+}
+
+interface AccordionGroupProps {
+  group: TokenGroup
+  query: string
+  isOpen: boolean
+  onToggle: () => void
+}
+
+function AccordionGroup({ group, query, isOpen, onToggle }: AccordionGroupProps) {
+  const visibleTokens = group.tokens.filter(t => matchesSearch(t, query))
+  if (visibleTokens.length === 0) return null
+
+  return (
+    <div className={styles.group}>
+      <button
+        type="button"
+        className={styles.groupHeader}
+        onClick={onToggle}
+        aria-expanded={isOpen}
+      >
+        <span className={styles.groupLabel}>{group.label}</span>
+        <span className={styles.groupCount}>{visibleTokens.length}</span>
+        <span className={`${styles.groupChevron} ${isOpen ? styles.groupChevronOpen : ''}`}>▸</span>
+      </button>
+      {isOpen && (
+        <div className={styles.groupBody}>
+          {visibleTokens.map(def => (
+            <TokenRow key={def.key} def={def} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function ThemeEditor() {
+  const { clearThemeOverrides, themeOverrides } = useThemeEditor()
+  const hasOverrides = Object.values(themeOverrides).some(Boolean)
+  const [query, setQuery] = useState('')
+
+  const initialOpen = () => {
+    const state: Record<string, boolean> = {}
+    for (const group of TOKEN_GROUPS) {
+      state[group.label] = group.defaultOpen ?? false
+    }
+    return state
+  }
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(initialOpen)
+
+  const isSearching = query.trim().length > 0
+
+  const toggleGroup = (label: string) => {
+    setOpenGroups(prev => ({ ...prev, [label]: !prev[label] }))
+  }
+
+  const isGroupOpen = (group: TokenGroup) => {
+    if (isSearching) return group.tokens.some(t => matchesSearch(t, query))
+    return openGroups[group.label] ?? false
+  }
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.searchRow}>
+        <input
+          className={styles.searchInput}
+          type="search"
+          placeholder="Search tokens…"
+          value={query}
+          onChange={e => {
+            setQuery(e.target.value)
+          }}
+          aria-label="Search theme tokens"
+        />
+        {hasOverrides && (
+          <button className={styles.clearBtn} onClick={clearThemeOverrides} type="button">
+            Reset
+          </button>
+        )}
+      </div>
+      <div className={styles.groups}>
+        {TOKEN_GROUPS.map(group => (
+          <AccordionGroup
+            key={group.label}
+            group={group}
+            query={query}
+            isOpen={isGroupOpen(group)}
+            onToggle={() => {
+              toggleGroup(group.label)
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/sdk-app/src/ThemePanel/ThemeEditorContext.ts
+++ b/sdk-app/src/ThemePanel/ThemeEditorContext.ts
@@ -1,0 +1,44 @@
+import { createContext, useContext, useMemo, useState } from 'react'
+import { useResolvedTheme } from '../useThemeModeContext'
+import { darkTheme } from '../darkTheme'
+import type { GustoSDKTheme } from '@/contexts/ThemeProvider/theme'
+import { mergePartnerTheme } from '@/contexts/ThemeProvider/theme'
+
+export interface ThemeEditorContextValue {
+  themeOverrides: Partial<GustoSDKTheme>
+  resolvedTheme: GustoSDKTheme
+  setThemeOverride: (key: keyof GustoSDKTheme, value: string) => void
+  clearThemeOverrides: () => void
+}
+
+export const ThemeEditorContext = createContext<ThemeEditorContextValue>({
+  themeOverrides: {},
+  resolvedTheme: {},
+  setThemeOverride: () => {},
+  clearThemeOverrides: () => {},
+})
+
+export const useThemeEditor = () => useContext(ThemeEditorContext)
+
+export function useThemeEditorState(): ThemeEditorContextValue {
+  const [themeOverrides, setThemeOverrides] = useState<Partial<GustoSDKTheme>>({})
+  const colorMode = useResolvedTheme()
+
+  const resolvedTheme = useMemo(() => {
+    const base = colorMode === 'dark' ? darkTheme : undefined
+    return mergePartnerTheme({ ...base, ...themeOverrides })
+  }, [colorMode, themeOverrides])
+
+  const setThemeOverride = (key: keyof GustoSDKTheme, value: string) => {
+    setThemeOverrides(prev => ({
+      ...prev,
+      [key]: value || undefined,
+    }))
+  }
+
+  const clearThemeOverrides = () => {
+    setThemeOverrides({})
+  }
+
+  return { themeOverrides, resolvedTheme, setThemeOverride, clearThemeOverrides }
+}

--- a/sdk-app/src/ThemePanel/ThemeEditorContext.ts
+++ b/sdk-app/src/ThemePanel/ThemeEditorContext.ts
@@ -30,10 +30,14 @@ export function useThemeEditorState(): ThemeEditorContextValue {
   }, [colorMode, themeOverrides])
 
   const setThemeOverride = (key: keyof GustoSDKTheme, value: string) => {
-    setThemeOverrides(prev => ({
-      ...prev,
-      [key]: value || undefined,
-    }))
+    setThemeOverrides(prev => {
+      if (!value) {
+        if (!(key in prev)) return prev
+        const { [key]: _removed, ...rest } = prev
+        return rest
+      }
+      return { ...prev, [key]: value }
+    })
   }
 
   const clearThemeOverrides = () => {

--- a/sdk-app/src/ThemePanel/ThemePanel.module.scss
+++ b/sdk-app/src/ThemePanel/ThemePanel.module.scss
@@ -1,0 +1,61 @@
+.panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 0.0625rem solid var(--color-border);
+  flex-shrink: 0;
+
+  h2 {
+    font-size: 1rem;
+    font-weight: 600;
+  }
+}
+
+.close {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  padding: 0.25rem;
+  line-height: 1;
+
+  &:hover {
+    color: var(--color-text);
+  }
+}
+
+.body {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.section {
+  padding: 1rem 1.25rem;
+  border-bottom: 0.0625rem solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.sectionTitle {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.75rem;
+}
+
+.tokenSection {
+  flex-shrink: 0;
+}

--- a/sdk-app/src/ThemePanel/ThemePanel.tsx
+++ b/sdk-app/src/ThemePanel/ThemePanel.tsx
@@ -1,0 +1,34 @@
+import { ThemeEditor } from './ThemeEditor'
+import { DesignSystemSwitcher } from './DesignSystemSwitcher'
+import styles from './ThemePanel.module.scss'
+
+interface ThemePanelProps {
+  onClose: () => void
+}
+
+export function ThemePanel({ onClose }: ThemePanelProps) {
+  return (
+    <div className={styles.panel}>
+      <div className={styles.header}>
+        <h2>Theme &amp; Appearance</h2>
+        <button
+          className={styles.close}
+          onClick={onClose}
+          type="button"
+          aria-label="Close theme panel"
+        >
+          &times;
+        </button>
+      </div>
+      <div className={styles.body}>
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>Component Adapter</h3>
+          <DesignSystemSwitcher />
+        </section>
+        <section className={styles.tokenSection}>
+          <ThemeEditor />
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/sdk-app/src/ThemePanel/adapters/nativeAdapter.tsx
+++ b/sdk-app/src/ThemePanel/adapters/nativeAdapter.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import { useState, useRef } from 'react'
+import type React from 'react'
 import type { ComponentsContextType } from '@/contexts/ComponentAdapter/useComponentContext'
 import type { AlertProps } from '@/components/Common/UI/Alert/AlertTypes'
 import type { BadgeProps } from '@/components/Common/UI/Badge/BadgeTypes'

--- a/sdk-app/src/ThemePanel/adapters/nativeAdapter.tsx
+++ b/sdk-app/src/ThemePanel/adapters/nativeAdapter.tsx
@@ -1,0 +1,1423 @@
+/* eslint-disable react-refresh/only-export-components */
+import { useState, useRef } from 'react'
+import type { ComponentsContextType } from '@/contexts/ComponentAdapter/useComponentContext'
+import type { AlertProps } from '@/components/Common/UI/Alert/AlertTypes'
+import type { BadgeProps } from '@/components/Common/UI/Badge/BadgeTypes'
+import type { BannerProps } from '@/components/Common/UI/Banner/BannerTypes'
+import type { ButtonProps, ButtonIconProps } from '@/components/Common/UI/Button/ButtonTypes'
+import type { CardProps } from '@/components/Common/UI/Card/CardTypes'
+import type { BoxProps } from '@/components/Common/UI/Box/BoxTypes'
+import type { BoxHeaderProps } from '@/components/Common/UI/BoxHeader/BoxHeaderTypes'
+import type { CheckboxProps } from '@/components/Common/UI/Checkbox/CheckboxTypes'
+import type { CheckboxGroupProps } from '@/components/Common/UI/CheckboxGroup/CheckboxGroupTypes'
+import type { ComboBoxProps } from '@/components/Common/UI/ComboBox/ComboBoxTypes'
+import type { MultiSelectComboBoxProps } from '@/components/Common/UI/MultiSelectComboBox/MultiSelectComboBoxTypes'
+import type { DatePickerProps } from '@/components/Common/UI/DatePicker/DatePickerTypes'
+import type { DateRangePickerProps } from '@/components/Common/UI/DateRangePicker/DateRangePickerTypes'
+import type { OrderedListProps, UnorderedListProps } from '@/components/Common/UI/List/ListTypes'
+import type { NumberInputProps } from '@/components/Common/UI/NumberInput/NumberInputTypes'
+import type { RadioProps } from '@/components/Common/UI/Radio/RadioTypes'
+import type { RadioGroupProps } from '@/components/Common/UI/RadioGroup/RadioGroupTypes'
+import type { SelectProps } from '@/components/Common/UI/Select/SelectTypes'
+import type { SwitchProps } from '@/components/Common/UI/Switch/SwitchTypes'
+import type { TextInputProps } from '@/components/Common/UI/TextInput/TextInputTypes'
+import type { TextAreaProps } from '@/components/Common/UI/TextArea/TextAreaTypes'
+import type { LinkProps } from '@/components/Common/UI/Link/LinkTypes'
+import type { TableProps } from '@/components/Common/UI/Table/TableTypes'
+import type { HeadingProps } from '@/components/Common/UI/Heading/HeadingTypes'
+import type { TextProps } from '@/components/Common/UI/Text/TextTypes'
+import type { CalendarPreviewProps } from '@/components/Common/UI/CalendarPreview/CalendarPreviewTypes'
+import type { ProgressBarProps } from '@/components/Common/UI/ProgressBar/ProgressBarTypes'
+import type { BreadcrumbsProps } from '@/components/Common/UI/Breadcrumbs/BreadcrumbsTypes'
+import type { TabsProps } from '@/components/Common/UI/Tabs/TabsTypes'
+import type { DialogProps } from '@/components/Common/UI/Dialog/DialogTypes'
+import type { ModalProps } from '@/components/Common/UI/Modal/ModalTypes'
+import type { LoadingSpinnerProps } from '@/components/Common/UI/LoadingSpinner/LoadingSpinnerTypes'
+import type { DescriptionListProps } from '@/components/Common/UI/DescriptionList/DescriptionListTypes'
+import type { FileInputProps } from '@/components/Common/UI/FileInput/FileInputTypes'
+import type { MenuProps } from '@/components/Common/UI/Menu/MenuTypes'
+
+const inputStyle: React.CSSProperties = {
+  border: '1px solid #d1d5db',
+  borderRadius: '0.375rem',
+  padding: '0.375rem 0.625rem',
+  fontSize: '0.875rem',
+  width: '100%',
+  boxSizing: 'border-box',
+  background: '#fff',
+  color: '#111827',
+}
+
+function FieldWrapper({
+  label,
+  errorMessage,
+  description,
+  isRequired,
+  children,
+  id,
+}: {
+  label: React.ReactNode
+  errorMessage?: string
+  description?: React.ReactNode
+  isRequired?: boolean
+  children: React.ReactNode
+  id?: string
+}) {
+  return (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', marginBottom: '0.5rem' }}
+    >
+      <label htmlFor={id} style={{ fontSize: '0.875rem', fontWeight: 500 }}>
+        {label}
+        {isRequired && <span style={{ color: '#dc2626', marginLeft: '0.125rem' }}>*</span>}
+      </label>
+      {description && <div style={{ fontSize: '0.75rem', color: '#6b7280' }}>{description}</div>}
+      {children}
+      {errorMessage && <div style={{ fontSize: '0.75rem', color: '#dc2626' }}>{errorMessage}</div>}
+    </div>
+  )
+}
+
+function NativeAlert({ label, children, status }: AlertProps) {
+  const alertColors = {
+    info: { bg: '#eff6ff', border: '#3b82f6' },
+    success: { bg: '#f0fdf4', border: '#22c55e' },
+    warning: { bg: '#fffbeb', border: '#f59e0b' },
+    error: { bg: '#fef2f2', border: '#ef4444' },
+  } satisfies Record<NonNullable<typeof status>, { bg: string; border: string }>
+  const s = alertColors[status ?? 'info']
+  return (
+    <div
+      style={{
+        background: s.bg,
+        borderLeft: `4px solid ${s.border}`,
+        padding: '0.75rem 1rem',
+        borderRadius: '0.375rem',
+        marginBottom: '0.5rem',
+      }}
+    >
+      <strong style={{ fontSize: '0.875rem' }}>{label}</strong>
+      {children && <div style={{ fontSize: '0.875rem', marginTop: '0.25rem' }}>{children}</div>}
+    </div>
+  )
+}
+
+function NativeBadge({ children, status }: BadgeProps) {
+  const badgeColors = {
+    info: { bg: '#eff6ff', color: '#1d4ed8' },
+    success: { bg: '#f0fdf4', color: '#15803d' },
+    warning: { bg: '#fffbeb', color: '#92400e' },
+    error: { bg: '#fef2f2', color: '#b91c1c' },
+  } satisfies Record<NonNullable<typeof status>, { bg: string; color: string }>
+  const s = badgeColors[status ?? 'info']
+  return (
+    <span
+      style={{
+        background: s.bg,
+        color: s.color,
+        borderRadius: '9999px',
+        padding: '0.125rem 0.5rem',
+        fontSize: '0.75rem',
+        fontWeight: 500,
+      }}
+    >
+      {children}
+    </span>
+  )
+}
+
+function NativeBanner({ title, children, status }: BannerProps) {
+  const headerBg = status === 'error' ? '#ef4444' : '#f59e0b'
+  const bg = status === 'error' ? '#fef2f2' : '#fffbeb'
+  return (
+    <div
+      style={{
+        border: '1px solid #d1d5db',
+        borderRadius: '0.5rem',
+        overflow: 'hidden',
+        marginBottom: '0.5rem',
+      }}
+    >
+      <div
+        style={{
+          background: headerBg,
+          color: '#fff',
+          padding: '0.5rem 1rem',
+          fontWeight: 600,
+          fontSize: '0.875rem',
+        }}
+      >
+        {title}
+      </div>
+      <div style={{ background: bg, padding: '0.75rem 1rem', fontSize: '0.875rem' }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function NativeButton({ children, onClick, isDisabled, isLoading, variant, type }: ButtonProps) {
+  const styles: Record<string, React.CSSProperties> = {
+    primary: { background: '#2563eb', color: '#fff', border: 'none' },
+    secondary: { background: '#fff', color: '#2563eb', border: '1px solid #2563eb' },
+    tertiary: { background: 'transparent', color: '#2563eb', border: 'none' },
+    error: { background: '#dc2626', color: '#fff', border: 'none' },
+  }
+  const s = styles[variant ?? 'primary']
+  return (
+    <button
+      type={type ?? 'button'}
+      onClick={onClick}
+      disabled={isDisabled || isLoading}
+      style={{
+        ...s,
+        padding: '0.5rem 1rem',
+        borderRadius: '0.375rem',
+        fontSize: '0.875rem',
+        fontWeight: 500,
+        cursor: isDisabled || isLoading ? 'not-allowed' : 'pointer',
+        opacity: isDisabled ? 0.5 : 1,
+      }}
+    >
+      {isLoading ? '…' : children}
+    </button>
+  )
+}
+
+function NativeButtonIcon({
+  children,
+  onClick,
+  isDisabled,
+  'aria-label': ariaLabel,
+}: ButtonIconProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isDisabled}
+      aria-label={ariaLabel}
+      style={{
+        background: 'transparent',
+        border: '1px solid #d1d5db',
+        borderRadius: '0.375rem',
+        padding: '0.375rem',
+        cursor: isDisabled ? 'not-allowed' : 'pointer',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+function NativeCard({ children, menu, action }: CardProps) {
+  return (
+    <div
+      style={{
+        border: '1px solid #e5e7eb',
+        borderRadius: '0.5rem',
+        padding: '1rem',
+        marginBottom: '0.5rem',
+        display: 'flex',
+        gap: '0.75rem',
+        alignItems: 'flex-start',
+      }}
+    >
+      {action && <div>{action}</div>}
+      <div style={{ flex: 1 }}>{children}</div>
+      {menu && <div>{menu}</div>}
+    </div>
+  )
+}
+
+function NativeBox({ children, header, footer, withPadding }: BoxProps) {
+  return (
+    <div
+      style={{
+        border: '1px solid #e5e7eb',
+        borderRadius: '0.5rem',
+        overflow: 'hidden',
+        marginBottom: '0.5rem',
+      }}
+    >
+      {header && (
+        <div
+          style={{ borderBottom: '1px solid #e5e7eb', padding: '0.75rem 1rem', fontWeight: 600 }}
+        >
+          {header}
+        </div>
+      )}
+      <div style={{ padding: withPadding !== false ? '1rem' : 0 }}>{children}</div>
+      {footer && (
+        <div
+          style={{ borderTop: '1px solid #e5e7eb', padding: '0.75rem 1rem', background: '#f9fafb' }}
+        >
+          {footer}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function NativeBoxHeader({ title, description, action, headingLevel = 'h3' }: BoxHeaderProps) {
+  const Tag = headingLevel
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', marginBottom: '0.5rem' }}
+    >
+      <div style={{ flex: 1 }}>
+        <Tag style={{ margin: 0, fontSize: '1rem', fontWeight: 600 }}>{title}</Tag>
+        {description && (
+          <div style={{ fontSize: '0.875rem', color: '#6b7280', marginTop: '0.25rem' }}>
+            {description}
+          </div>
+        )}
+      </div>
+      {action && <div>{action}</div>}
+    </div>
+  )
+}
+
+function NativeCheckbox({
+  label,
+  value,
+  onChange,
+  isDisabled,
+  isInvalid,
+  id,
+  name,
+}: CheckboxProps) {
+  return (
+    <label
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        cursor: isDisabled ? 'not-allowed' : 'pointer',
+        opacity: isDisabled ? 0.5 : 1,
+        fontSize: '0.875rem',
+      }}
+    >
+      <input
+        type="checkbox"
+        id={id}
+        name={name}
+        checked={value ?? false}
+        onChange={e => onChange?.(e.target.checked)}
+        disabled={isDisabled}
+        style={{ accentColor: isInvalid ? '#dc2626' : '#2563eb', width: '1rem', height: '1rem' }}
+      />
+      {label}
+    </label>
+  )
+}
+
+function NativeCheckboxGroup({
+  label,
+  options,
+  onChange,
+  isDisabled,
+  isInvalid,
+  errorMessage,
+  description,
+  isRequired,
+}: CheckboxGroupProps) {
+  const [selected, setSelected] = useState<string[]>([])
+  const toggle = (val: string) => {
+    const next = selected.includes(val) ? selected.filter(v => v !== val) : [...selected, val]
+    setSelected(next)
+    onChange?.(next)
+  }
+  return (
+    <FieldWrapper
+      label={label}
+      errorMessage={errorMessage}
+      description={description}
+      isRequired={isRequired}
+    >
+      <fieldset
+        style={{
+          border: isInvalid ? '1px solid #dc2626' : '1px solid #d1d5db',
+          borderRadius: '0.375rem',
+          padding: '0.5rem 0.75rem',
+          margin: 0,
+        }}
+      >
+        <legend style={{ fontSize: '0.875rem', fontWeight: 500, padding: '0 0.25rem' }}>
+          {label}
+        </legend>
+        {options.map(opt => (
+          <label
+            key={opt.value}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              marginBottom: '0.25rem',
+              fontSize: '0.875rem',
+              cursor: isDisabled || opt.isDisabled ? 'not-allowed' : 'pointer',
+              opacity: isDisabled || opt.isDisabled ? 0.5 : 1,
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={selected.includes(opt.value)}
+              onChange={() => {
+                toggle(opt.value)
+              }}
+              disabled={isDisabled || opt.isDisabled}
+              style={{ accentColor: '#2563eb' }}
+            />
+            {opt.label}
+          </label>
+        ))}
+      </fieldset>
+    </FieldWrapper>
+  )
+}
+
+function NativeComboBox({
+  label,
+  options,
+  value,
+  onChange,
+  isDisabled,
+  isInvalid,
+  errorMessage,
+  description,
+  isRequired,
+  id,
+  placeholder,
+}: ComboBoxProps) {
+  return (
+    <FieldWrapper
+      label={label}
+      errorMessage={errorMessage}
+      description={description}
+      isRequired={isRequired}
+      id={id}
+    >
+      <select
+        id={id}
+        value={value ?? ''}
+        onChange={e => onChange?.(e.target.value)}
+        disabled={isDisabled}
+        style={{ ...inputStyle, borderColor: isInvalid ? '#dc2626' : '#d1d5db' }}
+      >
+        {placeholder && <option value="">{placeholder}</option>}
+        {options.map(opt => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </FieldWrapper>
+  )
+}
+
+function NativeMultiSelectComboBox({
+  label,
+  options,
+  value,
+  onChange,
+  isDisabled,
+  isInvalid,
+  errorMessage,
+  description,
+  isRequired,
+  id,
+}: MultiSelectComboBoxProps) {
+  const selected = value ?? []
+  const toggle = (val: string) => {
+    const next = selected.includes(val) ? selected.filter(v => v !== val) : [...selected, val]
+    onChange?.(next)
+  }
+  return (
+    <FieldWrapper
+      label={label}
+      errorMessage={errorMessage}
+      description={description}
+      isRequired={isRequired}
+      id={id}
+    >
+      <div
+        style={{
+          border: isInvalid ? '1px solid #dc2626' : '1px solid #d1d5db',
+          borderRadius: '0.375rem',
+          padding: '0.5rem',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '0.25rem',
+        }}
+      >
+        {options.map(opt => (
+          <label
+            key={opt.value}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.25rem',
+              fontSize: '0.75rem',
+              background: selected.includes(opt.value) ? '#dbeafe' : '#f3f4f6',
+              borderRadius: '9999px',
+              padding: '0.125rem 0.5rem',
+              cursor: isDisabled ? 'not-allowed' : 'pointer',
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={selected.includes(opt.value)}
+              onChange={() => {
+                toggle(opt.value)
+              }}
+              disabled={isDisabled}
+              style={{ display: 'none' }}
+            />
+            {opt.label}
+          </label>
+        ))}
+      </div>
+    </FieldWrapper>
+  )
+}
+
+function NativeDatePicker({
+  label,
+  value,
+  onChange,
+  isDisabled,
+  isInvalid,
+  errorMessage,
+  description,
+  isRequired,
+  id,
+}: DatePickerProps) {
+  const dateStr = value ? value.toISOString().slice(0, 10) : ''
+  return (
+    <FieldWrapper
+      label={label}
+      errorMessage={errorMessage}
+      description={description}
+      isRequired={isRequired}
+      id={id}
+    >
+      <input
+        id={id}
+        type="date"
+        value={dateStr}
+        onChange={e => onChange?.(e.target.value ? new Date(e.target.value) : null)}
+        disabled={isDisabled}
+        style={{ ...inputStyle, borderColor: isInvalid ? '#dc2626' : '#d1d5db' }}
+      />
+    </FieldWrapper>
+  )
+}
+
+function NativeDateRangePicker({
+  label,
+  value,
+  onChange,
+  startDateLabel,
+  endDateLabel,
+}: DateRangePickerProps) {
+  const toDateStr = (d: Date | undefined) => d?.toISOString().slice(0, 10) ?? ''
+  return (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', marginBottom: '0.5rem' }}
+    >
+      <span style={{ fontSize: '0.875rem', fontWeight: 500 }}>{label}</span>
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.125rem', flex: 1 }}>
+          <label style={{ fontSize: '0.75rem', color: '#6b7280' }}>{startDateLabel}</label>
+          <input
+            type="date"
+            value={toDateStr(value?.start)}
+            onChange={e => {
+              const start = e.target.value ? new Date(e.target.value) : null
+              if (start && value?.end) onChange({ start, end: value.end })
+              else if (!start) onChange(null)
+            }}
+            style={{ ...inputStyle }}
+          />
+        </div>
+        <span style={{ color: '#9ca3af', marginTop: '1.25rem' }}>–</span>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.125rem', flex: 1 }}>
+          <label style={{ fontSize: '0.75rem', color: '#6b7280' }}>{endDateLabel}</label>
+          <input
+            type="date"
+            value={toDateStr(value?.end)}
+            onChange={e => {
+              const end = e.target.value ? new Date(e.target.value) : null
+              if (end && value?.start) onChange({ start: value.start, end })
+              else if (!end) onChange(null)
+            }}
+            style={{ ...inputStyle }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function NativeOrderedList({ items }: OrderedListProps) {
+  return (
+    <ol style={{ paddingLeft: '1.5rem', margin: '0.5rem 0' }}>
+      {items.map((item, i) => (
+        <li key={i} style={{ marginBottom: '0.25rem', fontSize: '0.875rem' }}>
+          {item}
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+function NativeUnorderedList({ items }: UnorderedListProps) {
+  return (
+    <ul style={{ paddingLeft: '1.5rem', margin: '0.5rem 0' }}>
+      {items.map((item, i) => (
+        <li key={i} style={{ marginBottom: '0.25rem', fontSize: '0.875rem' }}>
+          {item}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function NativeNumberInput({
+  label,
+  value,
+  onChange,
+  isDisabled,
+  isInvalid,
+  errorMessage,
+  description,
+  isRequired,
+  id,
+  placeholder,
+  min,
+  max,
+}: NumberInputProps) {
+  return (
+    <FieldWrapper
+      label={label}
+      errorMessage={errorMessage}
+      description={description}
+      isRequired={isRequired}
+      id={id}
+    >
+      <input
+        id={id}
+        type="number"
+        value={value ?? ''}
+        onChange={e => onChange?.(e.target.valueAsNumber)}
+        disabled={isDisabled}
+        placeholder={placeholder}
+        min={min}
+        max={max}
+        style={{ ...inputStyle, borderColor: isInvalid ? '#dc2626' : '#d1d5db' }}
+      />
+    </FieldWrapper>
+  )
+}
+
+function NativeRadio({ label, value, onChange, isDisabled, isInvalid, id, name }: RadioProps) {
+  return (
+    <label
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        cursor: isDisabled ? 'not-allowed' : 'pointer',
+        opacity: isDisabled ? 0.5 : 1,
+        fontSize: '0.875rem',
+      }}
+    >
+      <input
+        type="radio"
+        id={id}
+        name={name}
+        checked={value ?? false}
+        onChange={e => onChange?.(e.target.checked)}
+        disabled={isDisabled}
+        style={{ accentColor: isInvalid ? '#dc2626' : '#2563eb', width: '1rem', height: '1rem' }}
+      />
+      {label}
+    </label>
+  )
+}
+
+function NativeRadioGroup({
+  label,
+  options,
+  value,
+  onChange,
+  isDisabled,
+  isInvalid,
+  errorMessage,
+  description,
+  isRequired,
+}: RadioGroupProps) {
+  return (
+    <FieldWrapper
+      label={label}
+      errorMessage={errorMessage}
+      description={description}
+      isRequired={isRequired}
+    >
+      <fieldset
+        style={{
+          border: isInvalid ? '1px solid #dc2626' : '1px solid #d1d5db',
+          borderRadius: '0.375rem',
+          padding: '0.5rem 0.75rem',
+          margin: 0,
+        }}
+      >
+        <legend style={{ fontSize: '0.875rem', fontWeight: 500, padding: '0 0.25rem' }}>
+          {label}
+        </legend>
+        {options.map(opt => (
+          <label
+            key={opt.value}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              marginBottom: '0.25rem',
+              fontSize: '0.875rem',
+              cursor: isDisabled || opt.isDisabled ? 'not-allowed' : 'pointer',
+              opacity: isDisabled || opt.isDisabled ? 0.5 : 1,
+            }}
+          >
+            <input
+              type="radio"
+              value={opt.value}
+              checked={value === opt.value}
+              onChange={() => onChange?.(opt.value)}
+              disabled={isDisabled || opt.isDisabled}
+              style={{ accentColor: '#2563eb' }}
+            />
+            {opt.label}
+          </label>
+        ))}
+      </fieldset>
+    </FieldWrapper>
+  )
+}
+
+function NativeSelect({
+  label,
+  options,
+  value,
+  onChange,
+  isDisabled,
+  isInvalid,
+  errorMessage,
+  description,
+  isRequired,
+  id,
+  placeholder,
+}: SelectProps) {
+  return (
+    <FieldWrapper
+      label={label}
+      errorMessage={errorMessage}
+      description={description}
+      isRequired={isRequired}
+      id={id}
+    >
+      <select
+        id={id}
+        value={value ?? ''}
+        onChange={e => onChange?.(e.target.value)}
+        disabled={isDisabled}
+        style={{ ...inputStyle, borderColor: isInvalid ? '#dc2626' : '#d1d5db' }}
+      >
+        {placeholder && <option value="">{placeholder}</option>}
+        {options.map(opt => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </FieldWrapper>
+  )
+}
+
+function NativeSwitch({ label, value, onChange, isDisabled, isInvalid, id }: SwitchProps) {
+  return (
+    <label
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        cursor: isDisabled ? 'not-allowed' : 'pointer',
+        fontSize: '0.875rem',
+      }}
+    >
+      <input
+        id={id}
+        type="checkbox"
+        role="switch"
+        checked={value ?? false}
+        onChange={e => onChange?.(e.target.checked)}
+        disabled={isDisabled}
+        style={{ accentColor: isInvalid ? '#dc2626' : '#2563eb' }}
+      />
+      {label}
+    </label>
+  )
+}
+
+function NativeTextInput({
+  label,
+  value,
+  onChange,
+  isDisabled,
+  isInvalid,
+  errorMessage,
+  description,
+  isRequired,
+  id,
+  placeholder,
+  type,
+}: TextInputProps) {
+  return (
+    <FieldWrapper
+      label={label}
+      errorMessage={errorMessage}
+      description={description}
+      isRequired={isRequired}
+      id={id}
+    >
+      <input
+        id={id}
+        type={type ?? 'text'}
+        value={value ?? ''}
+        onChange={e => onChange?.(e.target.value)}
+        disabled={isDisabled}
+        placeholder={placeholder}
+        style={{ ...inputStyle, borderColor: isInvalid ? '#dc2626' : '#d1d5db' }}
+      />
+    </FieldWrapper>
+  )
+}
+
+function NativeTextArea({
+  label,
+  value,
+  onChange,
+  isDisabled,
+  isInvalid,
+  errorMessage,
+  description,
+  isRequired,
+  id,
+  placeholder,
+  rows,
+}: TextAreaProps) {
+  return (
+    <FieldWrapper
+      label={label}
+      errorMessage={errorMessage}
+      description={description}
+      isRequired={isRequired}
+      id={id}
+    >
+      <textarea
+        id={id}
+        value={value ?? ''}
+        onChange={e => onChange?.(e.target.value)}
+        disabled={isDisabled}
+        placeholder={placeholder}
+        rows={rows ?? 3}
+        style={{
+          ...inputStyle,
+          borderColor: isInvalid ? '#dc2626' : '#d1d5db',
+          resize: 'vertical',
+        }}
+      />
+    </FieldWrapper>
+  )
+}
+
+function NativeLink({ children, href, target, rel, className }: LinkProps) {
+  return (
+    <a
+      href={href}
+      target={target}
+      rel={rel}
+      className={className}
+      style={{ color: '#2563eb', textDecoration: 'underline', fontSize: '0.875rem' }}
+    >
+      {children}
+    </a>
+  )
+}
+
+function NativeMenu({ items, isOpen, onClose, 'aria-label': ariaLabel }: MenuProps) {
+  if (!isOpen || !items?.length) return null
+  return (
+    <div
+      role="menu"
+      aria-label={ariaLabel}
+      style={{
+        background: '#fff',
+        border: '1px solid #d1d5db',
+        borderRadius: '0.375rem',
+        boxShadow: '0 4px 6px -1px rgba(0,0,0,0.1)',
+        minWidth: '10rem',
+        overflow: 'hidden',
+      }}
+    >
+      {items.map((item, i) => (
+        <button
+          key={i}
+          type="button"
+          role="menuitem"
+          disabled={item.isDisabled}
+          onClick={() => {
+            item.onClick()
+            onClose?.()
+          }}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            width: '100%',
+            textAlign: 'left',
+            padding: '0.5rem 0.75rem',
+            fontSize: '0.875rem',
+            background: 'none',
+            border: 'none',
+            cursor: item.isDisabled ? 'not-allowed' : 'pointer',
+            opacity: item.isDisabled ? 0.5 : 1,
+          }}
+        >
+          {item.icon && <span>{item.icon}</span>}
+          {item.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function NativeTable({ headers, rows, footer, ...rest }: TableProps) {
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }} {...rest}>
+      <thead>
+        <tr>
+          {headers.map(h => (
+            <th
+              key={h.key}
+              style={{
+                textAlign: 'left',
+                padding: '0.5rem 0.75rem',
+                borderBottom: '2px solid #e5e7eb',
+                fontWeight: 600,
+                color: '#374151',
+              }}
+            >
+              {h.content}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(row => (
+          <tr key={row.key} style={{ borderBottom: '1px solid #f3f4f6' }}>
+            {row.data.map(cell => (
+              <td key={cell.key} style={{ padding: '0.5rem 0.75rem' }}>
+                {cell.content}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+      {footer && (
+        <tfoot>
+          <tr>
+            {footer.map(f => (
+              <td
+                key={f.key}
+                style={{
+                  padding: '0.5rem 0.75rem',
+                  fontWeight: 600,
+                  borderTop: '2px solid #e5e7eb',
+                }}
+              >
+                {f.content}
+              </td>
+            ))}
+          </tr>
+        </tfoot>
+      )}
+    </table>
+  )
+}
+
+function NativeHeading({ as: Tag, children, className, id }: HeadingProps) {
+  const sizes: Record<string, string> = {
+    h1: '2rem',
+    h2: '1.5rem',
+    h3: '1.25rem',
+    h4: '1.125rem',
+    h5: '1rem',
+    h6: '0.875rem',
+  }
+  return (
+    <Tag
+      className={className}
+      id={id}
+      style={{ margin: '0 0 0.5rem', fontWeight: 700, fontSize: sizes[Tag] }}
+    >
+      {children}
+    </Tag>
+  )
+}
+
+function NativeText({ as: Tag = 'p', children, size, weight, className, id }: TextProps) {
+  const sizes: Record<string, string> = {
+    xs: '0.75rem',
+    sm: '0.875rem',
+    md: '1rem',
+    lg: '1.125rem',
+  }
+  const weights: Record<string, number> = { regular: 400, medium: 500, semibold: 600, bold: 700 }
+  return (
+    <Tag
+      className={className}
+      id={id}
+      style={{ margin: 0, fontSize: sizes[size ?? 'md'], fontWeight: weights[weight ?? 'regular'] }}
+    >
+      {children}
+    </Tag>
+  )
+}
+
+function NativeCalendarPreview(_props: CalendarPreviewProps) {
+  return (
+    <div
+      style={{
+        background: '#f3f4f6',
+        border: '1px solid #e5e7eb',
+        borderRadius: '0.5rem',
+        padding: '1rem',
+        fontSize: '0.75rem',
+        color: '#6b7280',
+        textAlign: 'center',
+      }}
+    >
+      Calendar preview
+    </div>
+  )
+}
+
+function NativeProgressBar({ totalSteps, currentStep, label }: ProgressBarProps) {
+  const pct = totalSteps > 0 ? Math.min(100, (currentStep / totalSteps) * 100) : 0
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          fontSize: '0.75rem',
+          color: '#6b7280',
+          marginBottom: '0.25rem',
+        }}
+      >
+        <span>{label}</span>
+        <span>
+          {currentStep}/{totalSteps}
+        </span>
+      </div>
+      <div
+        style={{
+          background: '#e5e7eb',
+          borderRadius: '9999px',
+          height: '0.5rem',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            background: '#2563eb',
+            width: `${pct}%`,
+            height: '100%',
+            borderRadius: '9999px',
+            transition: 'width 0.2s',
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function NativeBreadcrumbs({ breadcrumbs, currentBreadcrumbId, onClick }: BreadcrumbsProps) {
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol
+        style={{
+          display: 'flex',
+          gap: '0.25rem',
+          listStyle: 'none',
+          padding: 0,
+          margin: 0,
+          fontSize: '0.875rem',
+        }}
+      >
+        {breadcrumbs.map((crumb, i) => {
+          const isCurrent = crumb.id === currentBreadcrumbId
+          const isClickable = crumb.isClickable !== false && !isCurrent && !!onClick
+          return (
+            <li key={crumb.id} style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+              {i > 0 && <span style={{ color: '#9ca3af' }}>›</span>}
+              {isClickable ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    onClick!(crumb.id)
+                  }}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    color: '#2563eb',
+                    cursor: 'pointer',
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  {crumb.label}
+                </button>
+              ) : (
+                <span
+                  style={{
+                    color: isCurrent ? '#111827' : '#6b7280',
+                    fontWeight: isCurrent ? 600 : 400,
+                  }}
+                >
+                  {crumb.label}
+                </span>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}
+
+function NativeTabs({ tabs, selectedId, onSelectionChange }: TabsProps) {
+  const [active, setActive] = useState(selectedId ?? tabs[0]?.id)
+  const current = selectedId ?? active ?? tabs[0]?.id
+  const select = (id: string) => {
+    setActive(id)
+    onSelectionChange(id)
+  }
+  const activeTab = tabs.find(t => t.id === current)
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 0, borderBottom: '2px solid #e5e7eb' }}>
+        {tabs.map(tab => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => {
+              if (!tab.isDisabled) select(tab.id)
+            }}
+            disabled={tab.isDisabled}
+            style={{
+              padding: '0.5rem 1rem',
+              fontSize: '0.875rem',
+              fontWeight: 500,
+              background: 'none',
+              border: 'none',
+              borderBottom: current === tab.id ? '2px solid #2563eb' : '2px solid transparent',
+              color: current === tab.id ? '#2563eb' : '#6b7280',
+              cursor: tab.isDisabled ? 'not-allowed' : 'pointer',
+              marginBottom: '-2px',
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div style={{ padding: '1rem 0' }}>{activeTab?.content}</div>
+    </div>
+  )
+}
+
+function NativeDialog({
+  isOpen,
+  title,
+  children,
+  onClose,
+  onPrimaryActionClick,
+  primaryActionLabel,
+  closeActionLabel,
+  isDestructive,
+  isPrimaryActionLoading,
+}: DialogProps) {
+  if (!isOpen) return null
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.4)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <div
+        style={{
+          background: '#fff',
+          borderRadius: '0.5rem',
+          padding: '1.5rem',
+          maxWidth: '32rem',
+          width: '100%',
+          boxShadow: '0 20px 25px -5px rgba(0,0,0,0.1)',
+        }}
+      >
+        {title && (
+          <div style={{ fontWeight: 600, fontSize: '1.125rem', marginBottom: '1rem' }}>{title}</div>
+        )}
+        <div style={{ marginBottom: '1.5rem' }}>{children}</div>
+        <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              padding: '0.5rem 1rem',
+              borderRadius: '0.375rem',
+              border: '1px solid #d1d5db',
+              background: '#fff',
+              fontSize: '0.875rem',
+              cursor: 'pointer',
+            }}
+          >
+            {closeActionLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onPrimaryActionClick}
+            disabled={isPrimaryActionLoading}
+            style={{
+              padding: '0.5rem 1rem',
+              borderRadius: '0.375rem',
+              border: 'none',
+              background: isDestructive ? '#dc2626' : '#2563eb',
+              color: '#fff',
+              fontSize: '0.875rem',
+              fontWeight: 500,
+              cursor: isPrimaryActionLoading ? 'not-allowed' : 'pointer',
+            }}
+          >
+            {isPrimaryActionLoading ? '…' : primaryActionLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function NativeModal({ isOpen, onClose, children, footer }: ModalProps) {
+  if (!isOpen) return null
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.4)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <div
+        style={{
+          background: '#fff',
+          borderRadius: '0.5rem',
+          maxWidth: '32rem',
+          width: '100%',
+          boxShadow: '0 20px 25px -5px rgba(0,0,0,0.1)',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            padding: '1.5rem',
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+          }}
+        >
+          <div style={{ flex: 1 }}>{children}</div>
+          {onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                background: 'none',
+                border: 'none',
+                fontSize: '1.25rem',
+                cursor: 'pointer',
+                color: '#6b7280',
+                marginLeft: '0.5rem',
+              }}
+            >
+              ×
+            </button>
+          )}
+        </div>
+        {footer && (
+          <div
+            style={{
+              borderTop: '1px solid #e5e7eb',
+              padding: '1rem 1.5rem',
+              display: 'flex',
+              justifyContent: 'flex-end',
+              gap: '0.5rem',
+            }}
+          >
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function NativeLoadingSpinner({
+  'aria-label': ariaLabel,
+  size,
+  style: displayStyle,
+}: LoadingSpinnerProps) {
+  const sz = size === 'sm' ? '1rem' : '2rem'
+  const spinner = (
+    <div
+      role="status"
+      aria-label={ariaLabel ?? 'Loading'}
+      style={{
+        width: sz,
+        height: sz,
+        border: '2px solid #e5e7eb',
+        borderTop: '2px solid #2563eb',
+        borderRadius: '50%',
+        animation: 'spin 0.7s linear infinite',
+      }}
+    />
+  )
+  if (displayStyle === 'inline') return spinner
+  return <div style={{ display: 'flex', justifyContent: 'center', padding: '1rem' }}>{spinner}</div>
+}
+
+function NativeDescriptionList({ items, layout = 'stacked' }: DescriptionListProps) {
+  return (
+    <dl style={{ margin: 0 }}>
+      {items.map((item, i) => (
+        <div
+          key={i}
+          style={{
+            display: layout === 'horizontal' ? 'flex' : 'block',
+            gap: '0.5rem',
+            marginBottom: '0.75rem',
+          }}
+        >
+          <dt
+            style={{
+              fontWeight: 600,
+              fontSize: '0.875rem',
+              color: '#374151',
+              minWidth: layout === 'horizontal' ? '8rem' : undefined,
+            }}
+          >
+            {item.term}
+          </dt>
+          <dd style={{ margin: 0, fontSize: '0.875rem', color: '#6b7280' }}>{item.description}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}
+
+function NativeFileInput({
+  label,
+  onChange,
+  isDisabled,
+  isInvalid,
+  errorMessage,
+  description,
+  isRequired,
+  id,
+  accept,
+}: FileInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  return (
+    <FieldWrapper
+      label={label}
+      errorMessage={errorMessage}
+      description={description}
+      isRequired={isRequired}
+      id={id}
+    >
+      <input
+        ref={inputRef}
+        id={id}
+        type="file"
+        disabled={isDisabled}
+        accept={accept?.join(',')}
+        onChange={e => {
+          onChange(e.target.files?.[0] ?? null)
+        }}
+        style={{ fontSize: '0.875rem', borderColor: isInvalid ? '#dc2626' : undefined }}
+      />
+    </FieldWrapper>
+  )
+}
+
+export const nativeComponents: ComponentsContextType = {
+  Alert: (props: AlertProps) => <NativeAlert {...props} />,
+  Badge: (props: BadgeProps) => <NativeBadge {...props} />,
+  Banner: (props: BannerProps) => <NativeBanner {...props} />,
+  Button: (props: ButtonProps) => <NativeButton {...props} />,
+  ButtonIcon: (props: ButtonIconProps) => <NativeButtonIcon {...props} />,
+  Card: (props: CardProps) => <NativeCard {...props} />,
+  Box: (props: BoxProps) => <NativeBox {...props} />,
+  BoxHeader: (props: BoxHeaderProps) => <NativeBoxHeader {...props} />,
+  Checkbox: (props: CheckboxProps) => <NativeCheckbox {...props} />,
+  CheckboxGroup: (props: CheckboxGroupProps) => <NativeCheckboxGroup {...props} />,
+  ComboBox: (props: ComboBoxProps) => <NativeComboBox {...props} />,
+  MultiSelectComboBox: (props: MultiSelectComboBoxProps) => (
+    <NativeMultiSelectComboBox {...props} />
+  ),
+  DatePicker: (props: DatePickerProps) => <NativeDatePicker {...props} />,
+  DateRangePicker: (props: DateRangePickerProps) => <NativeDateRangePicker {...props} />,
+  OrderedList: (props: OrderedListProps) => <NativeOrderedList {...props} />,
+  UnorderedList: (props: UnorderedListProps) => <NativeUnorderedList {...props} />,
+  NumberInput: (props: NumberInputProps) => <NativeNumberInput {...props} />,
+  Radio: (props: RadioProps) => <NativeRadio {...props} />,
+  RadioGroup: (props: RadioGroupProps) => <NativeRadioGroup {...props} />,
+  Select: (props: SelectProps) => <NativeSelect {...props} />,
+  Switch: (props: SwitchProps) => <NativeSwitch {...props} />,
+  TextInput: (props: TextInputProps) => <NativeTextInput {...props} />,
+  TextArea: (props: TextAreaProps) => <NativeTextArea {...props} />,
+  Link: (props: LinkProps) => <NativeLink {...props} />,
+  Menu: (props: MenuProps) => <NativeMenu {...props} />,
+  Table: (props: TableProps) => <NativeTable {...props} />,
+  Heading: (props: HeadingProps) => <NativeHeading {...props} />,
+  Text: (props: TextProps) => <NativeText {...props} />,
+  CalendarPreview: (props: CalendarPreviewProps) => <NativeCalendarPreview {...props} />,
+  ProgressBar: (props: ProgressBarProps) => <NativeProgressBar {...props} />,
+  Breadcrumbs: (props: BreadcrumbsProps) => <NativeBreadcrumbs {...props} />,
+  Tabs: (props: TabsProps) => <NativeTabs {...props} />,
+  Dialog: (props: DialogProps) => <NativeDialog {...props} />,
+  Modal: (props: ModalProps) => <NativeModal {...props} />,
+  LoadingSpinner: (props: LoadingSpinnerProps) => <NativeLoadingSpinner {...props} />,
+  DescriptionList: (props: DescriptionListProps) => <NativeDescriptionList {...props} />,
+  FileInput: (props: FileInputProps) => <NativeFileInput {...props} />,
+}

--- a/sdk-app/src/ThemePanel/index.ts
+++ b/sdk-app/src/ThemePanel/index.ts
@@ -1,0 +1,4 @@
+export { ThemePanel } from './ThemePanel'
+export { useThemePanel } from './useThemePanel'
+export { ThemeEditorContext, useThemeEditor, useThemeEditorState } from './ThemeEditorContext'
+export { DesignSystemContext, useDesignSystem, useDesignSystemState } from './DesignSystemContext'

--- a/sdk-app/src/ThemePanel/useThemePanel.ts
+++ b/sdk-app/src/ThemePanel/useThemePanel.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from 'react'
+import { useGlobalShortcut } from '../useGlobalShortcut'
+
+export interface UseThemePanelResult {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+  toggle: () => void
+}
+
+export function useThemePanel(): UseThemePanelResult {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = useCallback(() => {
+    setIsOpen(true)
+  }, [])
+
+  const close = useCallback(() => {
+    setIsOpen(false)
+  }, [])
+
+  const toggle = useCallback(() => {
+    setIsOpen(prev => !prev)
+  }, [])
+
+  useGlobalShortcut({
+    key: 'j',
+    modifier: 'mod',
+    onTrigger: event => {
+      event.preventDefault()
+      toggle()
+    },
+  })
+
+  return { isOpen, open, close, toggle }
+}

--- a/sdk-app/src/TopBar.module.scss
+++ b/sdk-app/src/TopBar.module.scss
@@ -150,22 +150,33 @@
   }
 }
 
-.settingsBtn {
+.panelBtnGroup {
+  display: flex;
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+  overflow: hidden;
+  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.08);
+}
+
+.panelBtn {
   font-family: inherit;
   background: var(--color-bg);
-  border: 1px solid var(--color-border);
+  border: none;
+  border-left: 1px solid var(--color-border);
   color: var(--color-text);
   cursor: pointer;
   padding: 0.6rem 0.75rem;
   max-height: 2.3rem;
-  border-radius: 0.375rem;
   font-size: 0.875rem;
   font-weight: 600;
   display: flex;
   align-items: center;
-  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.08);
   gap: 0.375rem;
   transition: background 0.15s;
+
+  &:first-child {
+    border-left: none;
+  }
 
   svg {
     width: 1.2rem;
@@ -177,10 +188,9 @@
   }
 }
 
-.settingsBtnActive {
+.panelBtnActive {
   background: var(--color-active-bg);
   color: var(--color-active);
-  border-color: var(--color-active);
 
   &:hover {
     background: var(--color-active-bg);

--- a/sdk-app/src/TopBar.tsx
+++ b/sdk-app/src/TopBar.tsx
@@ -5,14 +5,16 @@ import { useCompanyName } from './design/useCompanyName'
 import type { TokenStatus } from './useDemoManager'
 import SettingsIcon from './assets/icons/icon-settings.svg?react'
 import CodeIcon from './assets/icons/icon-code.svg?react'
+import BrushIcon from './assets/icons/icon-brush.svg?react'
 import styles from './TopBar.module.scss'
+
+type ActivePanel = 'theme' | 'settings' | 'code' | null
 
 interface TopBarProps {
   companyId: string
   tokenStatus: TokenStatus
-  onOpenSettings: () => void
-  onToggleCode: () => void
-  codeOpen: boolean
+  activePanel: ActivePanel
+  onPanelToggle: (panel: 'theme' | 'settings' | 'code') => void
 }
 
 function TokenDot({ status }: { status: TokenStatus }) {
@@ -45,13 +47,7 @@ const DEMO_TYPE_LABELS: Record<string, string> = {
   react_sdk_demo: 'New Company',
 }
 
-export function TopBar({
-  companyId,
-  tokenStatus,
-  onOpenSettings,
-  onToggleCode,
-  codeOpen,
-}: TopBarProps) {
+export function TopBar({ companyId, tokenStatus, activePanel, onPanelToggle }: TopBarProps) {
   const mode = useAppMode()
   const rawEnv = typeof __SDK_APP_ENV__ !== 'undefined' ? __SDK_APP_ENV__ : 'demo'
   const displayEnv = rawEnv === 'localzp' ? 'local' : rawEnv
@@ -109,21 +105,47 @@ export function TopBar({
         <div className={styles.actions}>
           <ThemeSwitcher />
           <ModeSwitcher />
-          <button className={styles.settingsBtn} onClick={onOpenSettings} type="button">
-            <SettingsIcon />
-            Settings
-          </button>
-          <button
-            className={`${styles.settingsBtn} ${codeOpen ? styles.settingsBtnActive : ''}`}
-            onClick={onToggleCode}
-            type="button"
-            aria-pressed={codeOpen}
-            aria-label="Toggle code panel"
-            title="Toggle code panel"
-          >
-            <CodeIcon />
-            Code
-          </button>
+          <div className={styles.panelBtnGroup}>
+            <button
+              className={`${styles.panelBtn} ${activePanel === 'theme' ? styles.panelBtnActive : ''}`}
+              onClick={() => {
+                onPanelToggle('theme')
+              }}
+              type="button"
+              aria-pressed={activePanel === 'theme'}
+              aria-label="Toggle theme panel"
+              title="Toggle theme panel (⌘J)"
+            >
+              <BrushIcon />
+              Theme
+            </button>
+            <button
+              className={`${styles.panelBtn} ${activePanel === 'settings' ? styles.panelBtnActive : ''}`}
+              onClick={() => {
+                onPanelToggle('settings')
+              }}
+              type="button"
+              aria-pressed={activePanel === 'settings'}
+              aria-label="Toggle settings panel"
+              title="Toggle settings panel (⌘,)"
+            >
+              <SettingsIcon />
+              Settings
+            </button>
+            <button
+              className={`${styles.panelBtn} ${activePanel === 'code' ? styles.panelBtnActive : ''}`}
+              onClick={() => {
+                onPanelToggle('code')
+              }}
+              type="button"
+              aria-pressed={activePanel === 'code'}
+              aria-label="Toggle code panel"
+              title="Toggle code panel (?)"
+            >
+              <CodeIcon />
+              Code
+            </button>
+          </div>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary

- **Theme panel resolved values**: The theme editor now shows the resolved (default) theme token values as placeholder text in inputs and as actual colors in swatches — so you can see what each token is set to before making any overrides, in both light and dark mode
- **Color swatch contrast ring**: Color swatches now have a layered inset box-shadow ring so they're visible even when set to white or a very light color
- **Shared resizable panels**: Code, Theme, and Settings panels now all share a single `RightPanelShell` wrapper with a drag handle for resizing — switching between panels preserves the panel width (persisted to localStorage)
- **Cursor bleed fix**: The col-resize cursor was bleeding over the entire app due to absolute-positioned handle inside a sticky container; fixed by switching to a flex-row layout in `RightPanelShell` where the handle is a natural sibling with no absolute positioning
- **Theme shortcut**: Changed theme panel shortcut from `Cmd+T` (conflicts with browser new tab) to `Cmd+J`

## Test plan

- [ ] Open the theme panel — all token rows show the resolved color/value as placeholder text and color swatches show the current theme color
- [ ] Switch to dark mode — swatches and placeholders update to dark theme values
- [ ] Override a color token — swatch and input show the override; "Reset" button appears; clearing resets to resolved value
- [ ] White/light color swatches have a visible ring border for contrast
- [ ] Drag the panel resize handle to resize — width persists when switching between Theme, Settings, and Code panels
- [ ] Hover over the app content area (not the handle) — no col-resize cursor
- [ ] `Cmd+J` opens/closes the theme panel; `Cmd+T` opens a new browser tab as expected
- [ ] Shortcut helper shows updated `⌘J` binding for theme panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)