### PR TITLE
feat(sdk-app): add action commands to command palette

### DIFF
--- a/sdk-app/src/App.tsx
+++ b/sdk-app/src/App.tsx
@@ -14,7 +14,7 @@ import { ThemeModeProvider } from './ThemeModeContext'
 import { useManualConfig, type ManualConfig } from './useManualConfig'
 import { useChromeVisibility } from './useChromeVisibility'
 import { ShortcutHelper, useShortcutHelper } from './ShortcutHelper'
-import { CommandPalette, useCommandPalette } from './CommandPalette'
+import { CommandPalette, useCommandPalette, useCommands, PAGES } from './CommandPalette'
 import { useGlobalShortcut } from './useGlobalShortcut'
 import { useCodePanel } from './useCodePanel'
 import { CodePanel } from './CodePanel'
@@ -69,7 +69,8 @@ export function App() {
   const demoManager = useDemoManager({ pollingDisabled: isManual })
   const appMode = useAppMode()
   const themeMode = useThemeMode()
-  const { chromeHidden, showChrome } = useChromeVisibility()
+  const chromeVisibility = useChromeVisibility()
+  const { chromeHidden, showChrome } = chromeVisibility
   const shortcutHelper = useShortcutHelper()
   const commandPalette = useCommandPalette()
   const navigate = useNavigate()
@@ -174,24 +175,59 @@ export function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [themePanel.isOpen])
 
-  const handleCreateNewDemo = async (demoType: string) => {
-    const result = await demoManager.createNewDemo(demoType)
-    if (result) {
-      replaceEntities({
-        companyId: result.companyId || '',
-        employeeId: result.entities.employeeId || '',
-        contractorId: result.entities.contractorId || '',
-        payrollId: result.entities.payrollId || '',
-        requestId: '',
-      })
-      window.location.reload()
-    }
-  }
+  const handleCreateNewDemo = useCallback(
+    async (demoType: string) => {
+      const result = await demoManager.createNewDemo(demoType)
+      if (result) {
+        replaceEntities({
+          companyId: result.companyId || '',
+          employeeId: result.entities.employeeId || '',
+          contractorId: result.entities.contractorId || '',
+          payrollId: result.entities.payrollId || '',
+          requestId: '',
+        })
+        window.location.reload()
+      }
+    },
+    [demoManager, replaceEntities],
+  )
 
   const handleApplyManualConfig = async (next: ManualConfig) => {
     await manual.applyManualConfig(next)
     replaceEntities(entitiesFromManualConfig(next))
   }
+
+  const onCreateNewDemoCommand = useCallback(
+    (demoType: string) => {
+      void handleCreateNewDemo(demoType)
+    },
+    [handleCreateNewDemo],
+  )
+
+  const commands = useCommands({
+    themeMode,
+    cycleTheme,
+    appMode,
+    toggleAppMode,
+    codePanel,
+    chromeVisibility,
+    settingsOpen,
+    setSettingsOpen,
+    sidebarOpen,
+    setSidebarOpen,
+    chromeId,
+    setChromeId,
+    designSystem: designSystemState.designSystem,
+    setDesignSystem: designSystemState.setDesignSystem,
+    demoManager,
+    manualMode: manual.mode,
+    switchToAuto: manual.switchToAuto,
+    shortcutHelper,
+    onCreateNewDemo: onCreateNewDemoCommand,
+    resetEntitiesToDefaults: resetToDefaults,
+  })
+
+  const paletteEntries = useMemo(() => [...PAGES, ...commands], [commands])
 
   if (!manual.isReady) {
     return (
@@ -298,7 +334,11 @@ export function App() {
                 </button>
               )}
               <ShortcutHelper isOpen={shortcutHelper.isOpen} onClose={shortcutHelper.close} />
-              <CommandPalette isOpen={commandPalette.isOpen} onClose={commandPalette.close} />
+              <CommandPalette
+                isOpen={commandPalette.isOpen}
+                onClose={commandPalette.close}
+                entries={paletteEntries}
+              />
               {!isManual && demoManager.tokenStatus === 'expired' && (
                 <TokenExpiredOverlay
                   onRefresh={demoManager.refreshToken}

--- a/sdk-app/src/CommandPalette/CommandPalette.tsx
+++ b/sdk-app/src/CommandPalette/CommandPalette.tsx
@@ -45,7 +45,10 @@ export function CommandPalette({ isOpen, onClose, entries }: CommandPaletteProps
     if (entry.kind === 'navigate') {
       void navigate(entry.path)
     } else {
-      entry.perform()
+      Promise.resolve(entry.perform()).catch((err: unknown) => {
+        // eslint-disable-next-line no-console
+        console.error(`Command "${entry.id}" failed:`, err)
+      })
     }
     onClose()
   }

--- a/sdk-app/src/CommandPalette/CommandPalette.tsx
+++ b/sdk-app/src/CommandPalette/CommandPalette.tsx
@@ -1,22 +1,26 @@
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type KeyboardEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { searchPages, type PageEntry } from './pages'
+import { searchEntries, type PaletteEntry } from './pages'
 import styles from './CommandPalette.module.scss'
 
 interface CommandPaletteProps {
   isOpen: boolean
   onClose: () => void
+  entries: PaletteEntry[]
 }
 
 const ROW_ID_PREFIX = 'command-palette-row-'
 
-export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
+export function CommandPalette({ isOpen, onClose, entries }: CommandPaletteProps) {
   const [query, setQuery] = useState('')
   const [highlightIndex, setHighlightIndex] = useState(0)
   const inputRef = useRef<HTMLInputElement>(null)
   const navigate = useNavigate()
 
-  const results = useMemo(() => (isOpen ? searchPages(query) : []), [isOpen, query])
+  const results = useMemo(
+    () => (isOpen ? searchEntries(entries, query) : []),
+    [isOpen, query, entries],
+  )
   const showResults = isOpen && query.trim().length > 0
 
   useEffect(() => {
@@ -37,8 +41,12 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
 
   if (!isOpen) return null
 
-  const goTo = (page: PageEntry) => {
-    void navigate(page.path)
+  const execute = (entry: PaletteEntry) => {
+    if (entry.kind === 'navigate') {
+      void navigate(entry.path)
+    } else {
+      entry.perform()
+    }
     onClose()
   }
 
@@ -51,7 +59,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
     if (event.key === 'Enter') {
       event.preventDefault()
       const target = results[highlightIndex] ?? results[0]
-      if (target) goTo(target)
+      if (target) execute(target)
       return
     }
     if (event.key === 'ArrowDown') {
@@ -83,7 +91,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
         type="button"
         className={styles.backdrop}
         onClick={onClose}
-        aria-label="Close page search"
+        aria-label="Close command palette"
       />
       <div className={styles.container}>
         <input
@@ -91,11 +99,11 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
           type="text"
           role="combobox"
           className={styles.input}
-          placeholder="Search pages…"
+          placeholder="Search pages and commands…"
           value={query}
           onChange={onChange}
           onKeyDown={onKeyDown}
-          aria-label="Search pages"
+          aria-label="Search pages and commands"
           aria-autocomplete="list"
           aria-controls="command-palette-list"
           aria-expanded={showResults}
@@ -106,25 +114,25 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
         {showResults &&
           (results.length > 0 ? (
             <ul id="command-palette-list" className={styles.list} role="listbox">
-              {results.map((page, index) => {
+              {results.map((entry, index) => {
                 const isActive = index === highlightIndex
                 return (
                   // eslint-disable-next-line jsx-a11y/click-events-have-key-events -- listbox keyboard nav happens on the input via aria-activedescendant
                   <li
-                    id={`${ROW_ID_PREFIX}${page.id}`}
-                    key={page.id}
+                    id={`${ROW_ID_PREFIX}${entry.id}`}
+                    key={entry.id}
                     role="option"
                     aria-selected={isActive}
                     className={`${styles.row}${isActive ? ` ${styles.rowActive}` : ''}`}
                     onClick={() => {
-                      goTo(page)
+                      execute(entry)
                     }}
                     onMouseEnter={() => {
                       setHighlightIndex(index)
                     }}
                   >
-                    <span className={styles.label}>{page.label}</span>
-                    <span className={styles.category}>{page.category}</span>
+                    <span className={styles.label}>{entry.label}</span>
+                    <span className={styles.category}>{entry.category}</span>
                   </li>
                 )
               })}

--- a/sdk-app/src/CommandPalette/index.ts
+++ b/sdk-app/src/CommandPalette/index.ts
@@ -1,2 +1,5 @@
 export { CommandPalette } from './CommandPalette'
 export { useCommandPalette } from './useCommandPalette'
+export { useCommands } from './useCommands'
+export { PAGES } from './pages'
+export type { PaletteEntry, NavEntry, ActionEntry } from './pages'

--- a/sdk-app/src/CommandPalette/pages.ts
+++ b/sdk-app/src/CommandPalette/pages.ts
@@ -16,7 +16,7 @@ export interface NavEntry extends BaseEntry {
 
 export interface ActionEntry extends BaseEntry {
   kind: 'action'
-  perform: () => void
+  perform: () => void | Promise<void>
 }
 
 export type PaletteEntry = NavEntry | ActionEntry

--- a/sdk-app/src/CommandPalette/pages.ts
+++ b/sdk-app/src/CommandPalette/pages.ts
@@ -1,22 +1,41 @@
 import { componentRegistry } from '../registry'
 import { categorizedRegistry as designRegistry } from '../design/registry'
 
-export interface PageEntry {
+interface BaseEntry {
   id: string
   label: string
   category: string
-  path: string
   description?: string
+  keywords?: string[]
 }
 
-function buildPages(): PageEntry[] {
-  const pages: PageEntry[] = [
-    { id: 'home', label: 'Home', category: 'Components', path: '/' },
-    { id: 'design-home', label: 'Design Home', category: 'Design', path: '/design' },
+export interface NavEntry extends BaseEntry {
+  kind: 'navigate'
+  path: string
+}
+
+export interface ActionEntry extends BaseEntry {
+  kind: 'action'
+  perform: () => void
+}
+
+export type PaletteEntry = NavEntry | ActionEntry
+
+function buildPages(): NavEntry[] {
+  const pages: NavEntry[] = [
+    { kind: 'navigate', id: 'home', label: 'Home', category: 'Components', path: '/' },
+    {
+      kind: 'navigate',
+      id: 'design-home',
+      label: 'Design Home',
+      category: 'Design',
+      path: '/design',
+    },
   ]
 
   for (const entry of componentRegistry) {
     pages.push({
+      kind: 'navigate',
       id: `component:${entry.category}:${entry.name}`,
       label: entry.name,
       category: entry.category,
@@ -27,6 +46,7 @@ function buildPages(): PageEntry[] {
   for (const [category, entries] of Object.entries(designRegistry)) {
     for (const entry of entries) {
       pages.push({
+        kind: 'navigate',
         id: `design:${category}:${entry.name}`,
         label: entry.name,
         category: `Design / ${category}`,
@@ -39,31 +59,32 @@ function buildPages(): PageEntry[] {
   return pages
 }
 
-export const PAGES: PageEntry[] = buildPages()
+export const PAGES: NavEntry[] = buildPages()
 
 const MAX_RESULTS = 50
 
-export function searchPages(query: string): PageEntry[] {
+export function searchEntries(entries: PaletteEntry[], query: string): PaletteEntry[] {
   const trimmed = query.trim().toLowerCase()
   if (!trimmed) return []
 
-  const prefixMatches: PageEntry[] = []
-  const labelMatches: PageEntry[] = []
-  const otherMatches: PageEntry[] = []
+  const prefixMatches: PaletteEntry[] = []
+  const labelMatches: PaletteEntry[] = []
+  const otherMatches: PaletteEntry[] = []
 
-  for (const page of PAGES) {
-    const label = page.label.toLowerCase()
+  for (const entry of entries) {
+    const label = entry.label.toLowerCase()
     if (label.startsWith(trimmed)) {
-      prefixMatches.push(page)
+      prefixMatches.push(entry)
       continue
     }
     if (label.includes(trimmed)) {
-      labelMatches.push(page)
+      labelMatches.push(entry)
       continue
     }
-    const haystack = `${page.category} ${page.description ?? ''}`.toLowerCase()
+    const keywords = entry.keywords?.join(' ') ?? ''
+    const haystack = `${entry.category} ${entry.description ?? ''} ${keywords}`.toLowerCase()
     if (haystack.includes(trimmed)) {
-      otherMatches.push(page)
+      otherMatches.push(entry)
     }
   }
 

--- a/sdk-app/src/CommandPalette/useCommands.ts
+++ b/sdk-app/src/CommandPalette/useCommands.ts
@@ -1,0 +1,372 @@
+import { type Dispatch, type SetStateAction, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { demoChromes } from '../demoChromes/registry'
+import type { ThemeMode } from '../useThemeMode'
+import type { TokenStatus } from '../useDemoManager'
+import type { AppMode as DemoMode } from '../useManualConfig'
+import type { DesignSystem } from '../ThemePanel/DesignSystemContext'
+import { DESIGN_SYSTEM_OPTIONS } from '../ThemePanel/designSystemOptions'
+import type { ActionEntry } from './pages'
+
+export interface UseCommandsArgs {
+  themeMode: { mode: ThemeMode; setMode: (next: ThemeMode) => void }
+  cycleTheme: () => void
+  appMode: 'preview' | 'design'
+  toggleAppMode: () => void
+  codePanel: { isOpen: boolean; open: () => void; close: () => void; toggle: () => void }
+  chromeVisibility: { chromeHidden: boolean; toggleChrome: () => void; showChrome: () => void }
+  settingsOpen: boolean
+  setSettingsOpen: Dispatch<SetStateAction<boolean>>
+  sidebarOpen: boolean
+  setSidebarOpen: Dispatch<SetStateAction<boolean>>
+  chromeId: string
+  setChromeId: (next: string) => void
+  designSystem: DesignSystem
+  setDesignSystem: (next: DesignSystem) => void
+  demoManager: { tokenStatus: TokenStatus; refreshToken: () => void }
+  manualMode: DemoMode
+  switchToAuto: () => void
+  shortcutHelper: { open: () => void }
+  onCreateNewDemo: (demoType: string) => void
+  resetEntitiesToDefaults: () => void
+}
+
+export function useCommands(args: UseCommandsArgs): ActionEntry[] {
+  const navigate = useNavigate()
+  const {
+    themeMode,
+    cycleTheme,
+    appMode,
+    toggleAppMode,
+    codePanel,
+    chromeVisibility,
+    settingsOpen,
+    setSettingsOpen,
+    sidebarOpen,
+    setSidebarOpen,
+    chromeId,
+    setChromeId,
+    designSystem,
+    setDesignSystem,
+    demoManager,
+    manualMode,
+    switchToAuto,
+    shortcutHelper,
+    onCreateNewDemo,
+    resetEntitiesToDefaults,
+  } = args
+
+  return useMemo(() => {
+    const out: ActionEntry[] = []
+
+    if (themeMode.mode !== 'light') {
+      out.push({
+        kind: 'action',
+        id: 'action:theme:light',
+        label: 'Switch to Light Theme',
+        category: 'Theme',
+        keywords: ['appearance', 'color', 'mode'],
+        perform: () => {
+          themeMode.setMode('light')
+        },
+      })
+    }
+    if (themeMode.mode !== 'dark') {
+      out.push({
+        kind: 'action',
+        id: 'action:theme:dark',
+        label: 'Switch to Dark Theme',
+        category: 'Theme',
+        keywords: ['appearance', 'color', 'mode'],
+        perform: () => {
+          themeMode.setMode('dark')
+        },
+      })
+    }
+    if (themeMode.mode !== 'system') {
+      out.push({
+        kind: 'action',
+        id: 'action:theme:system',
+        label: 'Switch to System Color Mode',
+        category: 'Theme',
+        keywords: ['appearance', 'color', 'auto', 'os'],
+        perform: () => {
+          themeMode.setMode('system')
+        },
+      })
+    }
+    out.push({
+      kind: 'action',
+      id: 'action:theme:cycle',
+      label: 'Cycle Theme',
+      category: 'Theme',
+      description: 'Cycle through System → Light → Dark',
+      keywords: ['next', 'rotate', 'appearance'],
+      perform: cycleTheme,
+    })
+
+    if (appMode === 'design') {
+      out.push({
+        kind: 'action',
+        id: 'action:appmode:dev',
+        label: 'Switch to Development Mode',
+        category: 'App Mode',
+        keywords: ['preview', 'components', 'dev'],
+        perform: () => {
+          void navigate('/')
+        },
+      })
+    } else {
+      out.push({
+        kind: 'action',
+        id: 'action:appmode:design',
+        label: 'Switch to Design Mode',
+        category: 'App Mode',
+        keywords: ['design system', 'tokens'],
+        perform: () => {
+          void navigate('/design')
+        },
+      })
+    }
+    out.push({
+      kind: 'action',
+      id: 'action:appmode:toggle',
+      label: 'Toggle App Mode',
+      category: 'App Mode',
+      keywords: ['development', 'design', 'switch'],
+      perform: toggleAppMode,
+    })
+
+    if (codePanel.isOpen) {
+      out.push({
+        kind: 'action',
+        id: 'action:codepanel:close',
+        label: 'Close Code Panel',
+        category: 'Panels',
+        keywords: ['hide', 'snippet', 'source'],
+        perform: codePanel.close,
+      })
+    } else {
+      out.push({
+        kind: 'action',
+        id: 'action:codepanel:open',
+        label: 'Open Code Panel',
+        category: 'Panels',
+        keywords: ['show', 'snippet', 'source'],
+        perform: codePanel.open,
+      })
+    }
+    out.push({
+      kind: 'action',
+      id: 'action:codepanel:toggle',
+      label: 'Toggle Code Panel',
+      category: 'Panels',
+      keywords: ['snippet', 'source'],
+      perform: codePanel.toggle,
+    })
+
+    if (settingsOpen) {
+      out.push({
+        kind: 'action',
+        id: 'action:settings:close',
+        label: 'Close Demo Settings',
+        category: 'Panels',
+        keywords: ['hide', 'preferences'],
+        perform: () => {
+          setSettingsOpen(false)
+        },
+      })
+    } else {
+      out.push({
+        kind: 'action',
+        id: 'action:settings:open',
+        label: 'Open Demo Settings',
+        category: 'Panels',
+        keywords: ['show', 'preferences', 'config'],
+        perform: () => {
+          setSettingsOpen(true)
+        },
+      })
+    }
+
+    if (sidebarOpen) {
+      out.push({
+        kind: 'action',
+        id: 'action:sidebar:close',
+        label: 'Close Sidebar',
+        category: 'Layout',
+        keywords: ['hide', 'navigation', 'nav'],
+        perform: () => {
+          setSidebarOpen(false)
+        },
+      })
+    } else {
+      out.push({
+        kind: 'action',
+        id: 'action:sidebar:open',
+        label: 'Open Sidebar',
+        category: 'Layout',
+        keywords: ['show', 'navigation', 'nav'],
+        perform: () => {
+          setSidebarOpen(true)
+        },
+      })
+    }
+    out.push({
+      kind: 'action',
+      id: 'action:sidebar:toggle',
+      label: 'Toggle Sidebar',
+      category: 'Layout',
+      keywords: ['navigation', 'nav'],
+      perform: () => {
+        setSidebarOpen(prev => !prev)
+      },
+    })
+
+    if (chromeVisibility.chromeHidden) {
+      out.push({
+        kind: 'action',
+        id: 'action:chrome:show',
+        label: 'Show Chrome',
+        category: 'Layout',
+        description: 'Restore the SDK app shell',
+        keywords: ['exit focus mode', 'topbar', 'header'],
+        perform: chromeVisibility.showChrome,
+      })
+    } else {
+      out.push({
+        kind: 'action',
+        id: 'action:chrome:hide',
+        label: 'Hide Chrome (Focus Mode)',
+        category: 'Layout',
+        description: 'Hide the SDK app shell to focus on the rendered component',
+        keywords: ['focus mode', 'fullscreen', 'distraction free'],
+        perform: chromeVisibility.toggleChrome,
+      })
+    }
+
+    for (const chrome of demoChromes) {
+      if (chrome.id === chromeId) continue
+      out.push({
+        kind: 'action',
+        id: `action:demochrome:${chrome.id}`,
+        label: `Switch Demo Chrome → ${chrome.label}`,
+        category: 'Demo Chrome',
+        description: chrome.description,
+        keywords: ['partner', 'shell', 'wrapper'],
+        perform: () => {
+          setChromeId(chrome.id)
+        },
+      })
+    }
+
+    for (const option of DESIGN_SYSTEM_OPTIONS) {
+      if (!option.available) continue
+      if (option.id === designSystem) continue
+      out.push({
+        kind: 'action',
+        id: `action:adapter:${option.id}`,
+        label: `Switch Component Adapter → ${option.label}`,
+        category: 'Component Adapter',
+        keywords: ['design system', 'components', 'theme'],
+        perform: () => {
+          setDesignSystem(option.id)
+        },
+      })
+    }
+
+    out.push({
+      kind: 'action',
+      id: 'action:demo:create-onboarded',
+      label: 'Create New Demo (Onboarded Company)',
+      category: 'Demo',
+      keywords: ['fresh', 'reset', 'data'],
+      perform: () => {
+        onCreateNewDemo('onboarded-company')
+      },
+    })
+    out.push({
+      kind: 'action',
+      id: 'action:demo:create-new',
+      label: 'Create New Demo (New Company)',
+      category: 'Demo',
+      keywords: ['fresh', 'reset', 'data'],
+      perform: () => {
+        onCreateNewDemo('new-company')
+      },
+    })
+    if (demoManager.tokenStatus === 'expired') {
+      out.push({
+        kind: 'action',
+        id: 'action:demo:refresh-token',
+        label: 'Refresh Demo Token',
+        category: 'Demo',
+        keywords: ['auth', 'expired'],
+        perform: demoManager.refreshToken,
+      })
+    }
+    out.push({
+      kind: 'action',
+      id: 'action:demo:reset-entities',
+      label: 'Reset Entity IDs to Defaults',
+      category: 'Demo',
+      keywords: ['restore', 'clear'],
+      perform: resetEntitiesToDefaults,
+    })
+    if (manualMode === 'manual') {
+      out.push({
+        kind: 'action',
+        id: 'action:demo:auto-mode',
+        label: 'Switch to Auto Demo Mode',
+        category: 'Demo',
+        keywords: ['automatic'],
+        perform: switchToAuto,
+      })
+    } else {
+      out.push({
+        kind: 'action',
+        id: 'action:demo:manual-mode',
+        label: 'Switch to Manual Demo Mode',
+        category: 'Demo',
+        description: 'Open Demo Settings to configure manual IDs',
+        keywords: ['custom ids'],
+        perform: () => {
+          setSettingsOpen(true)
+        },
+      })
+    }
+
+    out.push({
+      kind: 'action',
+      id: 'action:help:shortcuts',
+      label: 'Show Keyboard Shortcuts',
+      category: 'Help',
+      keywords: ['keys', 'cheatsheet'],
+      perform: shortcutHelper.open,
+    })
+
+    return out
+  }, [
+    themeMode,
+    cycleTheme,
+    appMode,
+    toggleAppMode,
+    navigate,
+    codePanel,
+    chromeVisibility,
+    settingsOpen,
+    setSettingsOpen,
+    sidebarOpen,
+    setSidebarOpen,
+    chromeId,
+    setChromeId,
+    designSystem,
+    setDesignSystem,
+    demoManager,
+    manualMode,
+    switchToAuto,
+    shortcutHelper,
+    onCreateNewDemo,
+    resetEntitiesToDefaults,
+  ])
+}

--- a/sdk-app/src/ThemePanel/DesignSystemSwitcher.tsx
+++ b/sdk-app/src/ThemePanel/DesignSystemSwitcher.tsx
@@ -1,17 +1,6 @@
-import { useDesignSystem, type DesignSystem } from './DesignSystemContext'
+import { useDesignSystem } from './DesignSystemContext'
+import { DESIGN_SYSTEM_OPTIONS } from './designSystemOptions'
 import styles from './DesignSystemSwitcher.module.scss'
-
-interface DesignSystemOption {
-  id: DesignSystem
-  label: string
-  logo: string
-  available: boolean
-}
-
-const OPTIONS: DesignSystemOption[] = [
-  { id: 'default', label: 'Gusto Default', logo: '🎨', available: true },
-  { id: 'native', label: 'Native HTML', logo: '🌐', available: true },
-]
 
 export function DesignSystemSwitcher() {
   const { designSystem, setDesignSystem } = useDesignSystem()
@@ -19,7 +8,7 @@ export function DesignSystemSwitcher() {
   return (
     <div className={styles.root}>
       <div className={styles.options}>
-        {OPTIONS.map(option => (
+        {DESIGN_SYSTEM_OPTIONS.map(option => (
           <button
             key={option.id}
             type="button"

--- a/sdk-app/src/ThemePanel/designSystemOptions.ts
+++ b/sdk-app/src/ThemePanel/designSystemOptions.ts
@@ -1,0 +1,13 @@
+import type { DesignSystem } from './DesignSystemContext'
+
+export interface DesignSystemOption {
+  id: DesignSystem
+  label: string
+  logo: string
+  available: boolean
+}
+
+export const DESIGN_SYSTEM_OPTIONS: DesignSystemOption[] = [
+  { id: 'default', label: 'Gusto Default', logo: '🎨', available: true },
+  { id: 'native', label: 'Native HTML', logo: '🌐', available: true },
+]


### PR DESCRIPTION
## Summary

Extends the `Mod+K` command palette beyond page navigation to also expose UI actions, so the palette becomes a single keyboard entry point for both "go somewhere" and "do something" (in the spirit of VS Code / Linear / Raycast).

- Generalizes the palette entry shape to a discriminated union (`NavEntry | ActionEntry`) and adds a `keywords` field for synonym matching.
- New `useCommands()` hook builds the action catalog from live app state with conditional filtering (e.g. "Switch to Light Theme" hides when already light, "Refresh Demo Token" only appears when the token is expired).
- Demo chrome and component adapter commands iterate their respective option lists, so newly registered chromes/adapters auto-surface as commands without further wiring.

## Commands shipped (v1)

| Category | Commands |
|---|---|
| Theme | Switch to Light / Dark / System; Cycle Theme |
| App Mode | Switch to Development / Design; Toggle App Mode |
| Panels | Open / Close / Toggle Code Panel; Open / Close Demo Settings |
| Layout | Open / Close / Toggle Sidebar; Hide / Show Chrome |
| Demo Chrome | One entry per registered chrome (current selection filtered) |
| Component Adapter | One entry per available adapter (current selection filtered) |
| Demo | Create New Demo (Onboarded / New Company); Refresh Demo Token (when expired); Reset Entity IDs to Defaults; Switch Auto / Manual Demo Mode |
| Help | Show Keyboard Shortcuts |

## Test plan
- [ ] `npm run sdk-app`, press `Mod+K`
- [ ] Type `light` → "Switch to Light Theme" appears, Enter switches the theme
- [ ] Type `dark` while already in dark → not shown (conditional filter works)
- [ ] Type `code` → Open / Toggle commands appear; opening it works
- [ ] Type `acme` → demo-chrome switch command appears
- [ ] Type `native` → "Switch Component Adapter → Native HTML" appears, Enter switches adapter
- [ ] Existing page navigation (`home`, component names) still works
- [ ] Existing keyboard shortcuts (`Mod+E`, `Mod+B`, `Mod+;`, `Mod+,`, `Mod+.`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)