### PR TITLE
fix(Compensation): stabilize flow state machine across getJobs refetches

### DIFF
--- a/src/components/Employee/Compensation/Compensation.tsx
+++ b/src/components/Employee/Compensation/Compensation.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { createMachine } from 'robot3'
 import { useTranslation } from 'react-i18next'
 import { useJobsAndCompensationsGetJobsSuspense } from '@gusto/embedded-api/react-query/jobsAndCompensationsGetJobs'
@@ -91,7 +91,16 @@ function CompensationFlow({
 
   const { data: jobsData } = useJobsAndCompensationsGetJobsSuspense({ employeeId })
 
-  const { initialState, currentJobId } = deriveInitialFlowConfig(jobsData.jobs ?? [])
+  // Capture the routing decision from the first jobsData snapshot only. Suspense
+  // guarantees that snapshot is fresh on first render. Subsequent refetches (e.g.
+  // the getJobs invalidation that fires between EditCompensation's awaited job +
+  // compensation mutations) must NOT re-seat the machine and reset the user's
+  // place in the flow. Callers needing to re-derive routing for a different
+  // employee should remount via `key`, matching the contract used by
+  // OnboardingFlow / PayrollExecutionFlow / DismissalFlow.
+  const [{ initialState, currentJobId }] = useState<InitialFlowConfig>(() =>
+    deriveInitialFlowConfig(jobsData.jobs ?? []),
+  )
 
   const manageCompensation = useMemo(
     () =>
@@ -107,11 +116,10 @@ function CompensationFlow({
           currentJobId,
         }),
       ),
-    // `defaultValues` is intentionally omitted: it's a partner-supplied prop that may
-    // arrive as a fresh object reference on every render. It seeds the form once at
-    // initialization, so re-creating the machine on reference churn would only serve
-    // to discard in-flight state. Genuine API state changes (different employee, a
-    // change in the only-job FLSA status) flow through the scalar deps below.
+    // `defaultValues` is intentionally omitted: a partner-supplied prop that may
+    // arrive as a fresh object reference each render and only seeds the form
+    // once. `initialState` and `currentJobId` are stable values from useState
+    // above, so they're listed here as honest deps but never trigger recompute.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [employeeId, startDate, initialState, currentJobId],
   )


### PR DESCRIPTION
## Summary

PR #1700 introduced a `robot3` state machine wrapper around `Employee.Compensation` whose `initialState` derived from a live `getJobs` query result. Each render recomputed the routing decision, so the `getJobs` invalidation that fires after every mutation re-seated the machine with a fresh snapshot — most visibly causing the JobsList view to flash on-screen between an `EditCompensation` chained job-then-compensation submit and the flow's transition to the next step.

This PR snapshots the routing decision via `useState` lazy initialization from the first suspense-resolved jobs payload (guaranteed fresh by `useSuspenseQuery`) and never recomputes. The state machine identity stays stable across all subsequent refetches, so the user's place in the flow is preserved through chained mutations.

Callers that legitimately need to re-derive the routing for a different employee should remount via `key`, which matches the existing contract used by `OnboardingFlow`, `PayrollExecutionFlow`, and `DismissalFlow`.

## Why this is safe

- `useSuspenseQuery` guarantees `jobsData` is populated before `CompensationFlow` renders, so the lazy initializer always sees real data.
- Dependent refetches that legitimately change routing semantics (e.g. switching to a different employee) cause an unmount+remount from upstream, not a re-render of the same instance.
- `initialState` and `currentJobId` remain in the `useMemo` deps array as honest signals — they're now stable identities sourced from `useState`, so they never trigger machine recreation but the eslint-disable on the deps line is preserved for clarity.

## Test plan

- [ ] Compensation tests pass locally (`npm run test -- --run src/components/Employee/Compensation`)
- [ ] Manual: trigger an onboarding-style chained job-then-compensation save; confirm the JobsList view does not flash between mutations
- [ ] Manual: confirm steady-state JobsList navigation (add/edit secondary, edit primary) still routes correctly when remounted via `key` for a different employee


Made with [Cursor](https://cursor.com)