### PR TITLE
fix: use component context for dialog buttons

### DIFF
--- a/src/components/Common/UI/Dialog/Dialog.test.tsx
+++ b/src/components/Common/UI/Dialog/Dialog.test.tsx
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { Dialog } from './Dialog'
 import { DialogDefaults } from './DialogTypes'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import { ThemeProvider } from '@/contexts/ThemeProvider'
+import { ComponentsProvider } from '@/contexts/ComponentAdapter/ComponentsProvider'
+import { defaultComponents } from '@/contexts/ComponentAdapter/adapters/defaultComponentAdapter'
 
 const defaultProps = {
   primaryActionLabel: 'Confirm',
@@ -91,5 +94,27 @@ describe('Dialog', () => {
     closeButton.click()
 
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders action buttons via the Button component adapter', () => {
+    const CustomButton = vi.fn(({ children, onClick }) => (
+      <button data-testid="custom-adapter-button" onClick={onClick}>
+        {children}
+      </button>
+    ))
+
+    render(
+      <ThemeProvider>
+        <ComponentsProvider value={{ ...defaultComponents, Button: CustomButton }}>
+          <Dialog {...defaultProps} />
+        </ComponentsProvider>
+      </ThemeProvider>,
+    )
+
+    const adapterButtons = screen.getAllByTestId('custom-adapter-button')
+    expect(adapterButtons).toHaveLength(2)
+    expect(adapterButtons[0]).toHaveTextContent('Cancel')
+    expect(adapterButtons[1]).toHaveTextContent('Confirm')
+    expect(CustomButton).toHaveBeenCalled()
   })
 })

--- a/src/components/Common/UI/Dialog/Dialog.tsx
+++ b/src/components/Common/UI/Dialog/Dialog.tsx
@@ -1,5 +1,4 @@
 import { useRef } from 'react'
-import { Button } from '../Button/Button'
 import { Grid } from '../../Grid/Grid'
 import { type DialogProps, DialogDefaults } from './DialogTypes'
 import styles from './Dialog.module.scss'
@@ -52,16 +51,16 @@ export function Dialog(rawProps: DialogProps) {
 
   const dialogFooter = (
     <Grid gridTemplateColumns={gridColumns} gap={12} className={styles.actions}>
-      <Button variant="secondary" onClick={handleClose}>
+      <Components.Button variant="secondary" onClick={handleClose}>
         {closeActionLabel}
-      </Button>
-      <Button
+      </Components.Button>
+      <Components.Button
         variant={isDestructive ? 'error' : 'primary'}
         onClick={handlePrimaryAction}
         isLoading={isPrimaryActionLoading}
       >
         {primaryActionLabel}
-      </Button>
+      </Components.Button>
     </Grid>
   )
 


### PR DESCRIPTION
## Summary

Dialog was importing `Button` directly, bypassing the `ComponentsContext` adapter pattern. This meant consumer-supplied Button adapters didn't apply inside dialogs.

## Changes

- Swap direct `Button` imports in `Dialog.tsx` for `Components.Button` from `useComponentContext()`

## Testing

- Render any dialog in Storybook with a custom Button adapter and confirm the adapter's Button is used for both the close and primary actions
- `npm run test -- --run src/components/Common/UI/Dialog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)