### PR TITLE
feat(sdk-app): complete InterfaceLib component adapter coverage

### DIFF
--- a/docs/component-adapter/component-inventory.md
+++ b/docs/component-adapter/component-inventory.md
@@ -18,6 +18,8 @@
 - [ComboBoxProps](#comboboxprops)
   - [ComboBoxOption](#comboboxoption)
 - [DatePickerProps](#datepickerprops)
+- [DateRangePickerProps](#daterangepickerprops)
+  - [DateRange](#daterange)
 - [DescriptionListProps](#descriptionlistprops)
   - [DescriptionListItem](#descriptionlistitem)
 - [DialogProps](#dialogprops)
@@ -28,6 +30,8 @@
 - [MenuProps](#menuprops)
   - [MenuItem](#menuitem)
 - [ModalProps](#modalprops)
+- [MultiSelectComboBoxProps](#multiselectcomboboxprops)
+  - [MultiSelectComboBoxOption](#multiselectcomboboxoption)
 - [NumberInputProps](#numberinputprops)
 - [OrderedListProps](#orderedlistprops)
 - [PaginationControlProps](#paginationcontrolprops)
@@ -301,6 +305,26 @@
 | **id**                      | `string`                        | No       | -                                                                                             |
 | **name**                    | `string`                        | No       | -                                                                                             |
 
+## DateRangePickerProps
+
+| Prop                        | Type                                               | Required | Description |
+| --------------------------- | -------------------------------------------------- | -------- | ----------- |
+| **label**                   | `string`                                           | Yes      | -           |
+| **shouldVisuallyHideLabel** | `boolean`                                          | No       | -           |
+| **value**                   | `null \| [DateRange](#daterange)`                  | Yes      | -           |
+| **onChange**                | `(range: [DateRange](#daterange) \| null) => void` | Yes      | -           |
+| **startDateLabel**          | `string`                                           | Yes      | -           |
+| **endDateLabel**            | `string`                                           | Yes      | -           |
+| **minValue**                | `Date`                                             | No       | -           |
+| **maxValue**                | `Date`                                             | No       | -           |
+
+### DateRange
+
+| Prop      | Type   | Required | Description |
+| --------- | ------ | -------- | ----------- |
+| **start** | `Date` | Yes      | -           |
+| **end**   | `Date` | Yes      | -           |
+
 ## DescriptionListProps
 
 | Prop               | Type                                          | Required | Description |
@@ -421,6 +445,35 @@
 | **children**                   | `React.ReactNode` | No       | Main content to be rendered in the modal body            |
 | **footer**                     | `React.ReactNode` | No       | Footer content to be rendered at the bottom of the modal |
 | **containerRef**               | `RefObject`       | No       | Optional ref to the backdrop container                   |
+
+## MultiSelectComboBoxProps
+
+| Prop                        | Type                                                      | Required | Description                                                            |
+| --------------------------- | --------------------------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| **inputRef**                | `Ref<HTMLInputElement \| null>`                           | No       | -                                                                      |
+| **isDisabled**              | `boolean`                                                 | No       | -                                                                      |
+| **isInvalid**               | `boolean`                                                 | No       | -                                                                      |
+| **isLoading**               | `boolean`                                                 | No       | -                                                                      |
+| **label**                   | `string`                                                  | Yes      | -                                                                      |
+| **options**                 | [MultiSelectComboBoxOption](#multiselectcomboboxoption)[] | Yes      | -                                                                      |
+| **value**                   | `string[]`                                                | No       | -                                                                      |
+| **onChange**                | `(values: string[]) => void`                              | No       | -                                                                      |
+| **onBlur**                  | `() => void`                                              | No       | -                                                                      |
+| **description**             | `React.ReactNode`                                         | No       | Optional description text for the field                                |
+| **errorMessage**            | `string`                                                  | No       | Error message to display when the field is invalid                     |
+| **isRequired**              | `boolean`                                                 | No       | Indicates if the field is required                                     |
+| **shouldVisuallyHideLabel** | `boolean`                                                 | No       | Hides the label visually while keeping it accessible to screen readers |
+| **className**               | `string`                                                  | No       | -                                                                      |
+| **id**                      | `string`                                                  | No       | -                                                                      |
+| **name**                    | `string`                                                  | No       | -                                                                      |
+| **placeholder**             | `string`                                                  | No       | -                                                                      |
+
+### MultiSelectComboBoxOption
+
+| Prop      | Type     | Required | Description |
+| --------- | -------- | -------- | ----------- |
+| **label** | `string` | Yes      | -           |
+| **value** | `string` | Yes      | -           |
 
 ## NumberInputProps
 

--- a/sdk-app/src/InterfaceLib/Banner/Banner.module.scss
+++ b/sdk-app/src/InterfaceLib/Banner/Banner.module.scss
@@ -1,0 +1,32 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  border-radius: 12px;
+  overflow: hidden;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+  box-shadow: inset 0 0 0 1px #dadada;
+}
+
+.header {
+  padding: 12px 20px;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 22px;
+  color: #ffffff;
+}
+
+.root[data-status='warning'] .header {
+  background-color: #d97706;
+}
+
+.root[data-status='error'] .header {
+  background-color: #cc0023;
+}
+
+.body {
+  padding: 16px 20px;
+  background-color: #ffffff;
+  font-size: 14px;
+  line-height: 20px;
+}

--- a/sdk-app/src/InterfaceLib/Banner/Banner.tsx
+++ b/sdk-app/src/InterfaceLib/Banner/Banner.tsx
@@ -1,0 +1,25 @@
+import classNames from 'classnames'
+import type { BannerProps } from '@gusto/embedded-react-sdk'
+import styles from './Banner.module.scss'
+
+export function Banner({
+  title,
+  children,
+  status = 'warning',
+  className,
+  id,
+  'aria-label': ariaLabel,
+}: BannerProps) {
+  return (
+    <div
+      id={id}
+      role="region"
+      aria-label={ariaLabel}
+      data-status={status}
+      className={classNames(styles.root, className)}
+    >
+      <div className={styles.header}>{title}</div>
+      <div className={styles.body}>{children}</div>
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/Banner/index.ts
+++ b/sdk-app/src/InterfaceLib/Banner/index.ts
@@ -1,0 +1,1 @@
+export { Banner } from './Banner'

--- a/sdk-app/src/InterfaceLib/Box/Box.module.scss
+++ b/sdk-app/src/InterfaceLib/Box/Box.module.scss
@@ -1,0 +1,30 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  border-radius: 12px;
+  background-color: #ffffff;
+  box-shadow: inset 0 0 0 1px #dadada;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+  overflow: hidden;
+}
+
+.header {
+  padding: 16px 20px;
+  border-bottom: 1px solid #dadada;
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+}
+
+.bodyPadded {
+  padding: 20px;
+}
+
+.footer {
+  padding: 16px 20px;
+  border-top: 1px solid #dadada;
+  background-color: #fafafa;
+}

--- a/sdk-app/src/InterfaceLib/Box/Box.tsx
+++ b/sdk-app/src/InterfaceLib/Box/Box.tsx
@@ -1,0 +1,19 @@
+import classNames from 'classnames'
+import type { BoxProps } from '@gusto/embedded-react-sdk'
+import styles from './Box.module.scss'
+
+export function Box({ children, header, footer, withPadding = true, className }: BoxProps) {
+  return (
+    <div className={classNames(styles.root, className)}>
+      {header && <div className={styles.header}>{header}</div>}
+      <div
+        className={classNames(styles.body, {
+          [styles.bodyPadded as string]: withPadding,
+        })}
+      >
+        {children}
+      </div>
+      {footer && <div className={styles.footer}>{footer}</div>}
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/Box/index.ts
+++ b/sdk-app/src/InterfaceLib/Box/index.ts
@@ -1,0 +1,1 @@
+export { Box } from './Box'

--- a/sdk-app/src/InterfaceLib/BoxHeader/BoxHeader.module.scss
+++ b/sdk-app/src/InterfaceLib/BoxHeader/BoxHeader.module.scss
@@ -1,0 +1,33 @@
+.root {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.titleBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 24px;
+}
+
+.description {
+  margin: 0;
+  font-size: 14px;
+  line-height: 20px;
+  color: #666666;
+}
+
+.action {
+  flex-shrink: 0;
+}

--- a/sdk-app/src/InterfaceLib/BoxHeader/BoxHeader.tsx
+++ b/sdk-app/src/InterfaceLib/BoxHeader/BoxHeader.tsx
@@ -1,0 +1,15 @@
+import type { BoxHeaderProps } from '@gusto/embedded-react-sdk'
+import styles from './BoxHeader.module.scss'
+
+export function BoxHeader({ title, description, action, headingLevel = 'h3' }: BoxHeaderProps) {
+  const Heading = headingLevel
+  return (
+    <div className={styles.root}>
+      <div className={styles.titleBlock}>
+        <Heading className={styles.title}>{title}</Heading>
+        {description && <p className={styles.description}>{description}</p>}
+      </div>
+      {action && <div className={styles.action}>{action}</div>}
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/BoxHeader/index.ts
+++ b/sdk-app/src/InterfaceLib/BoxHeader/index.ts
@@ -1,0 +1,1 @@
+export { BoxHeader } from './BoxHeader'

--- a/sdk-app/src/InterfaceLib/Breadcrumbs/Breadcrumbs.module.scss
+++ b/sdk-app/src/InterfaceLib/Breadcrumbs/Breadcrumbs.module.scss
@@ -1,0 +1,47 @@
+.root {
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+  color: #666666;
+}
+
+.list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.separator {
+  color: #b3b3b3;
+}
+
+.link {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #101010;
+  font: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: none;
+  }
+}
+
+.current {
+  color: #101010;
+  font-weight: 500;
+}

--- a/sdk-app/src/InterfaceLib/Breadcrumbs/Breadcrumbs.tsx
+++ b/sdk-app/src/InterfaceLib/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,48 @@
+import classNames from 'classnames'
+import type { BreadcrumbsProps } from '@gusto/embedded-react-sdk'
+import styles from './Breadcrumbs.module.scss'
+
+export function Breadcrumbs({
+  breadcrumbs,
+  currentBreadcrumbId,
+  'aria-label': ariaLabel = 'Breadcrumbs',
+  className,
+  onClick,
+  isSmallContainer = false,
+}: BreadcrumbsProps) {
+  const items = isSmallContainer
+    ? breadcrumbs.filter(b => b.id === currentBreadcrumbId).slice(-1)
+    : breadcrumbs
+
+  return (
+    <nav aria-label={ariaLabel} className={classNames(styles.root, className)}>
+      <ol className={styles.list}>
+        {items.map((breadcrumb, index) => {
+          const isCurrent = breadcrumb.id === currentBreadcrumbId
+          const isClickable = breadcrumb.isClickable !== false && !!onClick
+          const handleClick = () => {
+            if (isClickable) onClick!(breadcrumb.id)
+          }
+          return (
+            <li key={breadcrumb.id} className={styles.item}>
+              {index > 0 && (
+                <span aria-hidden="true" className={styles.separator}>
+                  /
+                </span>
+              )}
+              {isClickable && !isCurrent ? (
+                <button type="button" onClick={handleClick} className={styles.link}>
+                  {breadcrumb.label}
+                </button>
+              ) : (
+                <span className={styles.current} aria-current={isCurrent ? 'page' : undefined}>
+                  {breadcrumb.label}
+                </span>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/sdk-app/src/InterfaceLib/Breadcrumbs/index.ts
+++ b/sdk-app/src/InterfaceLib/Breadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export { Breadcrumbs } from './Breadcrumbs'

--- a/sdk-app/src/InterfaceLib/CalendarPreview/CalendarPreview.module.scss
+++ b/sdk-app/src/InterfaceLib/CalendarPreview/CalendarPreview.module.scss
@@ -1,0 +1,66 @@
+.root {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.month {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 8px;
+  background-color: #ffffff;
+  box-shadow: inset 0 0 0 1px #dadada;
+}
+
+.monthHeader {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.weekdays,
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+}
+
+.weekday {
+  text-align: center;
+  font-size: 11px;
+  font-weight: 500;
+  color: #666666;
+}
+
+.day,
+.empty {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  font-size: 12px;
+  border-radius: 6px;
+  color: #b3b3b3;
+}
+
+.day.inRange {
+  color: #101010;
+  background-color: #f5f5f5;
+}
+
+.day.primaryHighlight {
+  background-color: rgb(16, 16, 16);
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.day.secondaryHighlight {
+  background-color: #d97706;
+  color: #ffffff;
+  font-weight: 600;
+}

--- a/sdk-app/src/InterfaceLib/CalendarPreview/CalendarPreview.tsx
+++ b/sdk-app/src/InterfaceLib/CalendarPreview/CalendarPreview.tsx
@@ -1,0 +1,101 @@
+import { useMemo } from 'react'
+import classNames from 'classnames'
+import type { CalendarPreviewProps } from '@gusto/embedded-react-sdk'
+import styles from './CalendarPreview.module.scss'
+
+function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1)
+}
+
+function addMonths(date: Date, months: number): Date {
+  return new Date(date.getFullYear(), date.getMonth() + months, 1)
+}
+
+function daysInMonth(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate()
+}
+
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  )
+}
+
+function isWithin(date: Date, start: Date, end: Date): boolean {
+  const t = date.getTime()
+  return t >= start.getTime() && t <= end.getTime()
+}
+
+const monthFormatter = new Intl.DateTimeFormat(undefined, {
+  month: 'long',
+  year: 'numeric',
+})
+
+export function CalendarPreview({ highlightDates = [], dateRange }: CalendarPreviewProps) {
+  const months = useMemo(() => {
+    const result: Date[] = []
+    let cursor = startOfMonth(dateRange.start)
+    const endMonth = startOfMonth(dateRange.end)
+    while (cursor.getTime() <= endMonth.getTime()) {
+      result.push(cursor)
+      cursor = addMonths(cursor, 1)
+    }
+    return result.length > 0 ? result : [startOfMonth(dateRange.start)]
+  }, [dateRange])
+
+  return (
+    <div className={styles.root} aria-label={dateRange.label}>
+      {months.map(monthStart => {
+        const total = daysInMonth(monthStart)
+        const offset = monthStart.getDay()
+        const cells: Array<{ date: Date | null; key: string }> = []
+        for (let i = 0; i < offset; i += 1) {
+          cells.push({ date: null, key: `pad-${monthStart.getMonth()}-${i}` })
+        }
+        for (let d = 1; d <= total; d += 1) {
+          cells.push({
+            date: new Date(monthStart.getFullYear(), monthStart.getMonth(), d),
+            key: `${monthStart.getMonth()}-${d}`,
+          })
+        }
+        return (
+          <div key={monthStart.toISOString()} className={styles.month}>
+            <div className={styles.monthHeader}>{monthFormatter.format(monthStart)}</div>
+            <div className={styles.weekdays}>
+              {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, idx) => (
+                <span key={idx} className={styles.weekday}>
+                  {day}
+                </span>
+              ))}
+            </div>
+            <div className={styles.grid}>
+              {cells.map(cell => {
+                if (!cell.date) {
+                  return <span key={cell.key} className={styles.empty} />
+                }
+                const highlight = highlightDates.find(h => isSameDay(h.date, cell.date as Date))
+                const inRange = isWithin(cell.date, dateRange.start, dateRange.end)
+                return (
+                  <span
+                    key={cell.key}
+                    title={highlight?.label}
+                    className={classNames(styles.day, {
+                      [styles.inRange as string]: inRange,
+                      [styles.primaryHighlight as string]: highlight?.highlightColor === 'primary',
+                      [styles.secondaryHighlight as string]:
+                        highlight?.highlightColor === 'secondary',
+                    })}
+                  >
+                    {cell.date.getDate()}
+                  </span>
+                )
+              })}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/CalendarPreview/index.ts
+++ b/sdk-app/src/InterfaceLib/CalendarPreview/index.ts
@@ -1,0 +1,1 @@
+export { CalendarPreview } from './CalendarPreview'

--- a/sdk-app/src/InterfaceLib/Card/Card.module.scss
+++ b/sdk-app/src/InterfaceLib/Card/Card.module.scss
@@ -1,0 +1,24 @@
+.root {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 12px;
+  background-color: #ffffff;
+  box-shadow: inset 0 0 0 1px #dadada;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.action {
+  flex-shrink: 0;
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+}
+
+.menu {
+  flex-shrink: 0;
+}

--- a/sdk-app/src/InterfaceLib/Card/Card.tsx
+++ b/sdk-app/src/InterfaceLib/Card/Card.tsx
@@ -1,0 +1,13 @@
+import classNames from 'classnames'
+import type { CardProps } from '@gusto/embedded-react-sdk'
+import styles from './Card.module.scss'
+
+export function Card({ children, menu, className, action }: CardProps) {
+  return (
+    <div className={classNames(styles.root, className)}>
+      {action && <div className={styles.action}>{action}</div>}
+      <div className={styles.body}>{children}</div>
+      {menu && <div className={styles.menu}>{menu}</div>}
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/Card/index.ts
+++ b/sdk-app/src/InterfaceLib/Card/index.ts
@@ -1,0 +1,1 @@
+export { Card } from './Card'

--- a/sdk-app/src/InterfaceLib/Checkbox/Checkbox.module.scss
+++ b/sdk-app/src/InterfaceLib/Checkbox/Checkbox.module.scss
@@ -1,0 +1,122 @@
+.root {
+  display: inline-flex;
+  align-items: start;
+  gap: 12px;
+  padding: 8px;
+  margin: 0;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+  cursor: pointer;
+}
+
+.root[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.box {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border: 2px solid #b3b3b3;
+  border-radius: 4px;
+  background-color: #ffffff;
+  color: #ffffff;
+  transition:
+    background-color 0.125s linear,
+    border-color 0.125s linear;
+}
+
+.check {
+  opacity: 0;
+  transition: opacity 0.125s linear;
+}
+
+.root:hover:not([data-disabled]) .box {
+  border-color: rgb(16, 16, 16);
+}
+
+.input:checked ~ .box {
+  background-color: rgb(16, 16, 16);
+  border-color: rgb(16, 16, 16);
+}
+
+.input:checked ~ .box .check {
+  opacity: 1;
+}
+
+.input:focus-visible ~ .box {
+  outline: 2px solid #101010;
+  outline-offset: 2px;
+}
+
+.root[data-invalid] .box {
+  border-color: #cc0023;
+}
+
+.root[data-invalid] .input:checked ~ .box {
+  background-color: #cc0023;
+  border-color: #cc0023;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.bodyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.label {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  color: inherit;
+}
+
+.optional {
+  color: #666666;
+  font-weight: 400;
+}
+
+.description {
+  display: block;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  color: #666666;
+}
+
+.error {
+  display: block;
+  font-size: 14px;
+  line-height: 20px;
+  color: #cc0023;
+}

--- a/sdk-app/src/InterfaceLib/Checkbox/Checkbox.tsx
+++ b/sdk-app/src/InterfaceLib/Checkbox/Checkbox.tsx
@@ -1,0 +1,90 @@
+import { useId, type ChangeEvent } from 'react'
+import classNames from 'classnames'
+import type { CheckboxProps } from '@gusto/embedded-react-sdk'
+import styles from './Checkbox.module.scss'
+
+export function Checkbox({
+  id,
+  name,
+  label,
+  description,
+  errorMessage,
+  isRequired,
+  isDisabled = false,
+  isInvalid = false,
+  inputRef,
+  onChange,
+  onBlur,
+  value = false,
+  shouldVisuallyHideLabel,
+  className,
+}: CheckboxProps) {
+  const reactId = useId()
+  const inputId = id ?? `il-checkbox-${reactId}`
+  const descriptionId = `${inputId}-description`
+  const errorId = `${inputId}-error`
+
+  const describedByIds =
+    [description ? descriptionId : null, errorMessage ? errorId : null].filter(Boolean).join(' ') ||
+    undefined
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange?.(event.target.checked)
+  }
+
+  return (
+    <label
+      htmlFor={inputId}
+      className={classNames(styles.root, className)}
+      data-disabled={isDisabled || undefined}
+      data-invalid={isInvalid || undefined}
+    >
+      <input
+        id={inputId}
+        ref={inputRef}
+        name={name}
+        type="checkbox"
+        checked={value}
+        disabled={isDisabled}
+        aria-invalid={isInvalid}
+        aria-required={isRequired}
+        aria-describedby={describedByIds}
+        onChange={handleChange}
+        onBlur={onBlur}
+        className={styles.input}
+      />
+      <span className={styles.box} aria-hidden="true">
+        <svg className={styles.check} width="14" height="14" viewBox="0 0 14 14">
+          <path
+            d="M2 7l3.5 3.5L12 4"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+          />
+        </svg>
+      </span>
+      <span
+        className={classNames(styles.body, {
+          [styles.bodyHidden as string]: shouldVisuallyHideLabel,
+        })}
+      >
+        <span className={styles.label}>
+          {label}
+          {!isRequired && <span className={styles.optional}> (optional)</span>}
+        </span>
+        {description && (
+          <span id={descriptionId} className={styles.description}>
+            {description}
+          </span>
+        )}
+        {errorMessage && (
+          <span id={errorId} className={styles.error} role="alert">
+            {errorMessage}
+          </span>
+        )}
+      </span>
+    </label>
+  )
+}

--- a/sdk-app/src/InterfaceLib/Checkbox/index.ts
+++ b/sdk-app/src/InterfaceLib/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export { Checkbox } from './Checkbox'

--- a/sdk-app/src/InterfaceLib/CheckboxGroup/CheckboxGroup.module.scss
+++ b/sdk-app/src/InterfaceLib/CheckboxGroup/CheckboxGroup.module.scss
@@ -1,0 +1,151 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.legend {
+  padding: 0;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 22px;
+}
+
+.legendHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.optional {
+  color: #666666;
+  font-weight: 400;
+}
+
+.description {
+  font-size: 14px;
+  line-height: 20px;
+  color: #666666;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.option {
+  display: inline-flex;
+  align-items: start;
+  gap: 12px;
+  padding: 8px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.125s linear;
+}
+
+.option:hover:not([data-disabled]) {
+  background-color: #f5f5f5;
+}
+
+.option[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.box {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  margin-top: 2px;
+  border: 2px solid #b3b3b3;
+  border-radius: 4px;
+  background-color: #ffffff;
+  color: #ffffff;
+  transition:
+    background-color 0.125s linear,
+    border-color 0.125s linear;
+}
+
+.check {
+  opacity: 0;
+  transition: opacity 0.125s linear;
+}
+
+.option:hover:not([data-disabled]) .box {
+  border-color: rgb(16, 16, 16);
+}
+
+.input:checked ~ .box {
+  background-color: rgb(16, 16, 16);
+  border-color: rgb(16, 16, 16);
+}
+
+.input:checked ~ .box .check {
+  opacity: 1;
+}
+
+.input:focus-visible ~ .box {
+  outline: 2px solid #101010;
+  outline-offset: 2px;
+}
+
+.root[data-invalid] .box {
+  border-color: #cc0023;
+}
+
+.root[data-invalid] .input:checked ~ .box {
+  background-color: #cc0023;
+  border-color: #cc0023;
+}
+
+.optionBody {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.optionLabel {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+.optionDescription {
+  font-size: 14px;
+  line-height: 20px;
+  color: #666666;
+}
+
+.error {
+  font-size: 14px;
+  line-height: 20px;
+  color: #cc0023;
+}

--- a/sdk-app/src/InterfaceLib/CheckboxGroup/CheckboxGroup.tsx
+++ b/sdk-app/src/InterfaceLib/CheckboxGroup/CheckboxGroup.tsx
@@ -1,0 +1,113 @@
+import { useId, type ChangeEvent } from 'react'
+import classNames from 'classnames'
+import type { CheckboxGroupProps } from '@gusto/embedded-react-sdk'
+import styles from './CheckboxGroup.module.scss'
+
+export function CheckboxGroup({
+  label,
+  description,
+  errorMessage,
+  isRequired,
+  isInvalid = false,
+  isDisabled = false,
+  options,
+  value = [],
+  onChange,
+  inputRef,
+  shouldVisuallyHideLabel,
+  className,
+}: CheckboxGroupProps) {
+  const reactId = useId()
+  const groupId = `il-checkboxgroup-${reactId}`
+  const descriptionId = `${groupId}-description`
+  const errorId = `${groupId}-error`
+
+  const describedByIds =
+    [description ? descriptionId : null, errorMessage ? errorId : null].filter(Boolean).join(' ') ||
+    undefined
+
+  const handleToggle = (optionValue: string, checked: boolean) => {
+    const next = checked ? [...value, optionValue] : value.filter(v => v !== optionValue)
+    onChange?.(next)
+  }
+
+  return (
+    <fieldset
+      className={classNames(styles.root, className)}
+      data-invalid={isInvalid || undefined}
+      data-disabled={isDisabled || undefined}
+      disabled={isDisabled}
+      aria-describedby={describedByIds}
+    >
+      <legend
+        className={classNames(styles.legend, {
+          [styles.legendHidden as string]: shouldVisuallyHideLabel,
+        })}
+      >
+        {label}
+        {!isRequired && <span className={styles.optional}> (optional)</span>}
+      </legend>
+      {description && (
+        <span id={descriptionId} className={styles.description}>
+          {description}
+        </span>
+      )}
+      <div className={styles.options}>
+        {options.map((option, index) => {
+          const optionId = `${groupId}-${option.value}`
+          const optionDescriptionId = option.description ? `${optionId}-description` : undefined
+          const checked = value.includes(option.value)
+          const optionDisabled = isDisabled || option.isDisabled
+          const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+            handleToggle(option.value, event.target.checked)
+          }
+          return (
+            <label
+              key={option.value}
+              htmlFor={optionId}
+              className={styles.option}
+              data-disabled={optionDisabled || undefined}
+            >
+              <input
+                id={optionId}
+                ref={index === 0 ? inputRef : undefined}
+                type="checkbox"
+                checked={checked}
+                disabled={optionDisabled}
+                aria-invalid={isInvalid}
+                aria-describedby={optionDescriptionId}
+                onChange={handleChange}
+                className={styles.input}
+              />
+              <span className={styles.box} aria-hidden="true">
+                <svg width="14" height="14" viewBox="0 0 14 14" className={styles.check}>
+                  <path
+                    d="M2 7l3.5 3.5L12 4"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    fill="none"
+                  />
+                </svg>
+              </span>
+              <span className={styles.optionBody}>
+                <span className={styles.optionLabel}>{option.label}</span>
+                {option.description && (
+                  <span id={optionDescriptionId} className={styles.optionDescription}>
+                    {option.description}
+                  </span>
+                )}
+              </span>
+            </label>
+          )
+        })}
+      </div>
+      {errorMessage && (
+        <div id={errorId} className={styles.error} role="alert">
+          {errorMessage}
+        </div>
+      )}
+    </fieldset>
+  )
+}

--- a/sdk-app/src/InterfaceLib/CheckboxGroup/index.ts
+++ b/sdk-app/src/InterfaceLib/CheckboxGroup/index.ts
@@ -1,0 +1,1 @@
+export { CheckboxGroup } from './CheckboxGroup'

--- a/sdk-app/src/InterfaceLib/DatePicker/DatePicker.tsx
+++ b/sdk-app/src/InterfaceLib/DatePicker/DatePicker.tsx
@@ -63,6 +63,7 @@ export function DatePicker({
   value,
   shouldVisuallyHideLabel,
   className,
+  placeholder,
   portalContainer,
   minDate,
   maxDate,
@@ -141,7 +142,7 @@ export function DatePicker({
                 {value ? (
                   formatDisplay(value)
                 ) : (
-                  <span className={styles.placeholder}>mm/dd/yyyy</span>
+                  <span className={styles.placeholder}>{placeholder ?? 'mm/dd/yyyy'}</span>
                 )}
               </span>
             </span>

--- a/sdk-app/src/InterfaceLib/DateRangePicker/DateRangePicker.module.scss
+++ b/sdk-app/src/InterfaceLib/DateRangePicker/DateRangePicker.module.scss
@@ -1,0 +1,72 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.groupLabel {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+.groupLabelHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.fields {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.field {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background-color: #ffffff;
+  box-shadow: inset 0 0 0 1px #dadada;
+  transition: box-shadow 0.24s;
+
+  &:focus-within {
+    box-shadow: inset 0 0 0 2px #101010;
+  }
+}
+
+.fieldLabel {
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  color: #666666;
+}
+
+.input {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-family: inherit;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 22px;
+  outline: none;
+}
+
+.separator {
+  display: flex;
+  align-items: center;
+  font-size: 16px;
+  color: #666666;
+}

--- a/sdk-app/src/InterfaceLib/DateRangePicker/DateRangePicker.tsx
+++ b/sdk-app/src/InterfaceLib/DateRangePicker/DateRangePicker.tsx
@@ -1,0 +1,96 @@
+import { useId } from 'react'
+import classNames from 'classnames'
+import type { DateRangePickerProps } from '@gusto/embedded-react-sdk'
+import styles from './DateRangePicker.module.scss'
+
+function toInputValue(date: Date | undefined): string {
+  if (!date) return ''
+  const yyyy = date.getFullYear()
+  const mm = String(date.getMonth() + 1).padStart(2, '0')
+  const dd = String(date.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+function fromInputValue(value: string): Date | null {
+  if (!value) return null
+  const [yyyy, mm, dd] = value.split('-').map(Number)
+  if (!yyyy || !mm || !dd) return null
+  return new Date(yyyy, mm - 1, dd)
+}
+
+export function DateRangePicker({
+  label,
+  shouldVisuallyHideLabel,
+  value,
+  onChange,
+  startDateLabel,
+  endDateLabel,
+  minValue,
+  maxValue,
+}: DateRangePickerProps) {
+  const reactId = useId()
+  const startId = `il-daterange-start-${reactId}`
+  const endId = `il-daterange-end-${reactId}`
+
+  const min = toInputValue(minValue) || undefined
+  const max = toInputValue(maxValue) || undefined
+
+  const handleChange = (next: { start: Date | null; end: Date | null }) => {
+    if (next.start && next.end) {
+      onChange({ start: next.start, end: next.end })
+    } else {
+      onChange(null)
+    }
+  }
+
+  const handleStartChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const start = fromInputValue(event.target.value)
+    handleChange({ start, end: value?.end ?? null })
+  }
+
+  const handleEndChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const end = fromInputValue(event.target.value)
+    handleChange({ start: value?.start ?? null, end })
+  }
+
+  return (
+    <div className={styles.root}>
+      <span
+        className={classNames(styles.groupLabel, {
+          [styles.groupLabelHidden as string]: shouldVisuallyHideLabel,
+        })}
+      >
+        {label}
+      </span>
+      <div className={styles.fields}>
+        <label htmlFor={startId} className={styles.field}>
+          <span className={styles.fieldLabel}>{startDateLabel}</span>
+          <input
+            id={startId}
+            type="date"
+            value={toInputValue(value?.start)}
+            min={min}
+            max={max}
+            onChange={handleStartChange}
+            className={styles.input}
+          />
+        </label>
+        <span className={styles.separator} aria-hidden="true">
+          →
+        </span>
+        <label htmlFor={endId} className={styles.field}>
+          <span className={styles.fieldLabel}>{endDateLabel}</span>
+          <input
+            id={endId}
+            type="date"
+            value={toInputValue(value?.end)}
+            min={min}
+            max={max}
+            onChange={handleEndChange}
+            className={styles.input}
+          />
+        </label>
+      </div>
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/DateRangePicker/index.ts
+++ b/sdk-app/src/InterfaceLib/DateRangePicker/index.ts
@@ -1,0 +1,1 @@
+export { DateRangePicker } from './DateRangePicker'

--- a/sdk-app/src/InterfaceLib/DescriptionList/DescriptionList.module.scss
+++ b/sdk-app/src/InterfaceLib/DescriptionList/DescriptionList.module.scss
@@ -1,0 +1,51 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 0;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 0;
+}
+
+.root[data-layout='horizontal'] .item {
+  flex-direction: row;
+  align-items: baseline;
+  gap: 16px;
+}
+
+.root[data-separators] .item + .item {
+  border-top: 1px solid #ebebeb;
+}
+
+.term {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 18px;
+  color: #666666;
+  margin: 0;
+}
+
+.description {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  color: #101010;
+  margin: 0;
+}
+
+.root[data-layout='horizontal'] .term {
+  flex: 0 0 30%;
+  min-width: 120px;
+}
+
+.root[data-layout='horizontal'] .description {
+  flex: 1;
+  min-width: 0;
+}

--- a/sdk-app/src/InterfaceLib/DescriptionList/DescriptionList.tsx
+++ b/sdk-app/src/InterfaceLib/DescriptionList/DescriptionList.tsx
@@ -1,0 +1,25 @@
+import classNames from 'classnames'
+import type { DescriptionListProps } from '@gusto/embedded-react-sdk'
+import styles from './DescriptionList.module.scss'
+
+export function DescriptionList({
+  items,
+  layout = 'stacked',
+  showSeparators = true,
+  className,
+}: DescriptionListProps) {
+  return (
+    <dl
+      className={classNames(styles.root, className)}
+      data-layout={layout}
+      data-separators={showSeparators || undefined}
+    >
+      {items.map((item, index) => (
+        <div key={index} className={styles.item}>
+          <dt className={styles.term}>{item.term}</dt>
+          <dd className={styles.description}>{item.description}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/sdk-app/src/InterfaceLib/DescriptionList/index.ts
+++ b/sdk-app/src/InterfaceLib/DescriptionList/index.ts
@@ -1,0 +1,1 @@
+export { DescriptionList } from './DescriptionList'

--- a/sdk-app/src/InterfaceLib/Dialog/Dialog.module.scss
+++ b/sdk-app/src/InterfaceLib/Dialog/Dialog.module.scss
@@ -1,0 +1,88 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background-color: rgba(16, 16, 16, 0.6);
+  z-index: 100;
+}
+
+.dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 460px;
+  width: 100%;
+  padding: 24px;
+  border-radius: 12px;
+  background-color: #ffffff;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.24);
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 26px;
+}
+
+.body {
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.secondaryButton,
+.primaryButton {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  cursor: pointer;
+  border: 0;
+}
+
+.secondaryButton {
+  background-color: transparent;
+  color: #101010;
+  box-shadow: inset 0 0 0 1px #dadada;
+
+  &:hover {
+    background-color: #f5f5f5;
+  }
+}
+
+.primaryButton {
+  background-color: rgb(16, 16, 16);
+  color: #ffffff;
+
+  &:hover:not(:disabled) {
+    background-color: rgb(51, 51, 51);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+}
+
+.primaryButtonDestructive {
+  background-color: #cc0023;
+
+  &:hover:not(:disabled) {
+    background-color: #a3001c;
+  }
+}

--- a/sdk-app/src/InterfaceLib/Dialog/Dialog.tsx
+++ b/sdk-app/src/InterfaceLib/Dialog/Dialog.tsx
@@ -1,0 +1,61 @@
+import { useEffect, type MouseEvent } from 'react'
+import classNames from 'classnames'
+import type { DialogProps } from '@gusto/embedded-react-sdk'
+import styles from './Dialog.module.scss'
+
+export function Dialog({
+  isOpen = false,
+  onClose,
+  onPrimaryActionClick,
+  isDestructive = false,
+  isPrimaryActionLoading = false,
+  primaryActionLabel,
+  closeActionLabel,
+  title,
+  children,
+  shouldCloseOnBackdropClick = false,
+}: DialogProps) {
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose?.()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget && shouldCloseOnBackdropClick) {
+      onClose?.()
+    }
+  }
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <div className={styles.backdrop} onClick={handleBackdropClick}>
+      <div role="alertdialog" aria-modal="true" className={styles.dialog}>
+        {title && <h2 className={styles.title}>{title}</h2>}
+        {children && <div className={styles.body}>{children}</div>}
+        <div className={styles.actions}>
+          <button type="button" onClick={onClose} className={styles.secondaryButton}>
+            {closeActionLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onPrimaryActionClick}
+            disabled={isPrimaryActionLoading}
+            className={classNames(styles.primaryButton, {
+              [styles.primaryButtonDestructive as string]: isDestructive,
+            })}
+          >
+            {isPrimaryActionLoading ? '…' : primaryActionLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/Dialog/index.ts
+++ b/sdk-app/src/InterfaceLib/Dialog/index.ts
@@ -1,0 +1,1 @@
+export { Dialog } from './Dialog'

--- a/sdk-app/src/InterfaceLib/FileInput/FileInput.module.scss
+++ b/sdk-app/src/InterfaceLib/FileInput/FileInput.module.scss
@@ -1,0 +1,122 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.label {
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 22px;
+}
+
+.optional {
+  color: #666666;
+  font-weight: 400;
+}
+
+.description {
+  font-size: 14px;
+  line-height: 20px;
+  color: #666666;
+}
+
+.field {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px;
+  border: 1px dashed #b3b3b3;
+  border-radius: 8px;
+  background-color: #fafafa;
+}
+
+.root[data-invalid] .field {
+  border-color: #cc0023;
+}
+
+.root[data-disabled] .field {
+  opacity: 0.5;
+}
+
+.input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 16px;
+  border-radius: 6px;
+  background-color: rgb(16, 16, 16);
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  cursor: pointer;
+  transition: background-color 0.125s linear;
+
+  &:hover {
+    background-color: rgb(51, 51, 51);
+  }
+}
+
+.input:focus-visible ~ .button {
+  outline: 2px solid #101010;
+  outline-offset: 2px;
+}
+
+.root[data-disabled] .button {
+  cursor: not-allowed;
+  background-color: #959595;
+}
+
+.fileName {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  line-height: 20px;
+  color: #666666;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.clearButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background-color: transparent;
+  color: #101010;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #ebebeb;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}
+
+.error {
+  font-size: 14px;
+  line-height: 20px;
+  color: #cc0023;
+}

--- a/sdk-app/src/InterfaceLib/FileInput/FileInput.tsx
+++ b/sdk-app/src/InterfaceLib/FileInput/FileInput.tsx
@@ -1,0 +1,101 @@
+import { useId, useRef, type ChangeEvent } from 'react'
+import classNames from 'classnames'
+import type { FileInputProps } from '@gusto/embedded-react-sdk'
+import styles from './FileInput.module.scss'
+
+export function FileInput({
+  id,
+  label,
+  description,
+  errorMessage,
+  isRequired,
+  value,
+  onChange,
+  onBlur,
+  accept,
+  isInvalid = false,
+  isDisabled = false,
+  className,
+  'aria-describedby': ariaDescribedByFromProps,
+}: FileInputProps) {
+  const reactId = useId()
+  const inputId = id ?? `il-fileinput-${reactId}`
+  const descriptionId = `${inputId}-description`
+  const errorId = `${inputId}-error`
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  const describedByIds =
+    [ariaDescribedByFromProps, description ? descriptionId : null, errorMessage ? errorId : null]
+      .filter(Boolean)
+      .join(' ') || undefined
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null
+    onChange(file)
+  }
+
+  const handleClear = () => {
+    if (fileRef.current) fileRef.current.value = ''
+    onChange(null)
+  }
+
+  return (
+    <div
+      className={classNames(styles.root, className)}
+      data-invalid={isInvalid || undefined}
+      data-disabled={isDisabled || undefined}
+    >
+      <label htmlFor={inputId} className={styles.label}>
+        {label}
+        {!isRequired && <span className={styles.optional}> (optional)</span>}
+      </label>
+      {description && (
+        <span id={descriptionId} className={styles.description}>
+          {description}
+        </span>
+      )}
+      <div className={styles.field}>
+        <input
+          id={inputId}
+          ref={fileRef}
+          type="file"
+          accept={accept?.join(',')}
+          disabled={isDisabled}
+          aria-invalid={isInvalid}
+          aria-required={isRequired}
+          aria-describedby={describedByIds}
+          onChange={handleChange}
+          onBlur={onBlur}
+          className={styles.input}
+        />
+        <label htmlFor={inputId} className={styles.button}>
+          {value ? 'Replace file' : 'Choose file'}
+        </label>
+        <span className={styles.fileName}>{value?.name ?? 'No file selected'}</span>
+        {value && (
+          <button
+            type="button"
+            onClick={handleClear}
+            disabled={isDisabled}
+            className={styles.clearButton}
+            aria-label="Clear file"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+              <path
+                d="M2 2l10 10M12 2L2 12"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+      {errorMessage && (
+        <div id={errorId} className={styles.error} role="alert">
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/FileInput/index.ts
+++ b/sdk-app/src/InterfaceLib/FileInput/index.ts
@@ -1,0 +1,1 @@
+export { FileInput } from './FileInput'

--- a/sdk-app/src/InterfaceLib/Heading/Heading.tsx
+++ b/sdk-app/src/InterfaceLib/Heading/Heading.tsx
@@ -19,7 +19,7 @@ export const Heading = ({
         className,
         styles.root,
         styles[levelStyles as string],
-        styles[`textAlign-${textAlign}`],
+        textAlign && styles[`textAlign-${textAlign}`],
       )}
     >
       {children}

--- a/sdk-app/src/InterfaceLib/Link/Link.module.scss
+++ b/sdk-app/src/InterfaceLib/Link/Link.module.scss
@@ -1,0 +1,20 @@
+.root {
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: rgb(16, 16, 16);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+  cursor: pointer;
+  transition: color 0.125s linear;
+
+  &:hover {
+    color: rgb(51, 51, 51);
+    text-decoration-thickness: 2px;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #101010;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+}

--- a/sdk-app/src/InterfaceLib/Link/Link.tsx
+++ b/sdk-app/src/InterfaceLib/Link/Link.tsx
@@ -1,0 +1,38 @@
+import classNames from 'classnames'
+import type { LinkProps } from '@gusto/embedded-react-sdk'
+import styles from './Link.module.scss'
+
+export function Link({
+  href,
+  target,
+  rel,
+  download,
+  className,
+  id,
+  onKeyDown,
+  onKeyUp,
+  title,
+  children,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  'aria-describedby': ariaDescribedBy,
+}: LinkProps) {
+  return (
+    <a
+      id={id}
+      href={href}
+      target={target}
+      rel={rel}
+      download={download}
+      title={title}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
+      className={classNames(styles.root, className)}
+    >
+      {children}
+    </a>
+  )
+}

--- a/sdk-app/src/InterfaceLib/Link/index.ts
+++ b/sdk-app/src/InterfaceLib/Link/index.ts
@@ -1,0 +1,1 @@
+export { Link } from './Link'

--- a/sdk-app/src/InterfaceLib/List/List.module.scss
+++ b/sdk-app/src/InterfaceLib/List/List.module.scss
@@ -1,0 +1,24 @@
+.root {
+  margin: 0;
+  padding-left: 24px;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+  font-size: 14px;
+  line-height: 22px;
+}
+
+.ordered {
+  list-style: decimal;
+}
+
+.unordered {
+  list-style: square;
+}
+
+.item {
+  margin-bottom: 4px;
+}
+
+.item::marker {
+  color: rgb(16, 16, 16);
+}

--- a/sdk-app/src/InterfaceLib/List/OrderedList.tsx
+++ b/sdk-app/src/InterfaceLib/List/OrderedList.tsx
@@ -1,0 +1,26 @@
+import classNames from 'classnames'
+import type { OrderedListProps } from '@gusto/embedded-react-sdk'
+import styles from './List.module.scss'
+
+export function OrderedList({
+  items,
+  className,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  'aria-describedby': ariaDescribedBy,
+}: OrderedListProps) {
+  return (
+    <ol
+      className={classNames(styles.root, styles.ordered, className)}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
+    >
+      {items.map((item, index) => (
+        <li key={index} className={styles.item}>
+          {item}
+        </li>
+      ))}
+    </ol>
+  )
+}

--- a/sdk-app/src/InterfaceLib/List/UnorderedList.tsx
+++ b/sdk-app/src/InterfaceLib/List/UnorderedList.tsx
@@ -1,0 +1,26 @@
+import classNames from 'classnames'
+import type { UnorderedListProps } from '@gusto/embedded-react-sdk'
+import styles from './List.module.scss'
+
+export function UnorderedList({
+  items,
+  className,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  'aria-describedby': ariaDescribedBy,
+}: UnorderedListProps) {
+  return (
+    <ul
+      className={classNames(styles.root, styles.unordered, className)}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
+    >
+      {items.map((item, index) => (
+        <li key={index} className={styles.item}>
+          {item}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/sdk-app/src/InterfaceLib/List/index.ts
+++ b/sdk-app/src/InterfaceLib/List/index.ts
@@ -1,0 +1,2 @@
+export { OrderedList } from './OrderedList'
+export { UnorderedList } from './UnorderedList'

--- a/sdk-app/src/InterfaceLib/LoadingSpinner/LoadingSpinner.module.scss
+++ b/sdk-app/src/InterfaceLib/LoadingSpinner/LoadingSpinner.module.scss
@@ -1,0 +1,33 @@
+.root {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.root[data-style='block'] {
+  display: flex;
+  width: 100%;
+  padding: 16px 0;
+}
+
+.spinner {
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  border: 3px solid #ebebeb;
+  border-top-color: rgb(16, 16, 16);
+  animation: spin 0.8s linear infinite;
+}
+
+.root[data-size='sm'] .spinner {
+  width: 18px;
+  height: 18px;
+  border-width: 2px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/sdk-app/src/InterfaceLib/LoadingSpinner/LoadingSpinner.tsx
+++ b/sdk-app/src/InterfaceLib/LoadingSpinner/LoadingSpinner.tsx
@@ -1,0 +1,24 @@
+import classNames from 'classnames'
+import type { LoadingSpinnerProps } from '@gusto/embedded-react-sdk'
+import styles from './LoadingSpinner.module.scss'
+
+export function LoadingSpinner({
+  size = 'lg',
+  style = 'block',
+  className,
+  id,
+  'aria-label': ariaLabel = 'Loading',
+}: LoadingSpinnerProps) {
+  return (
+    <div
+      id={id}
+      role="status"
+      aria-label={ariaLabel}
+      data-size={size}
+      data-style={style}
+      className={classNames(styles.root, className)}
+    >
+      <span className={styles.spinner} aria-hidden="true" />
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/LoadingSpinner/index.ts
+++ b/sdk-app/src/InterfaceLib/LoadingSpinner/index.ts
@@ -1,0 +1,1 @@
+export { LoadingSpinner } from './LoadingSpinner'

--- a/sdk-app/src/InterfaceLib/Menu/Menu.module.scss
+++ b/sdk-app/src/InterfaceLib/Menu/Menu.module.scss
@@ -1,0 +1,58 @@
+.popover {
+  outline: none;
+}
+
+.menu {
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+  padding: 4px;
+  border-radius: 8px;
+  background-color: #ffffff;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  margin: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: left;
+  text-decoration: none;
+  border-radius: 6px;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background-color: #f5f5f5;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #101010;
+    outline-offset: -2px;
+  }
+}
+
+.itemDisabled {
+  cursor: not-allowed;
+  color: #959595;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.label {
+  flex: 1;
+  min-width: 0;
+}

--- a/sdk-app/src/InterfaceLib/Menu/Menu.tsx
+++ b/sdk-app/src/InterfaceLib/Menu/Menu.tsx
@@ -1,0 +1,48 @@
+// eslint-disable-next-line no-restricted-imports
+import { Menu as AriaMenu, MenuItem as AriaMenuItem, Popover } from 'react-aria-components'
+import type { MenuProps } from '@gusto/embedded-react-sdk'
+import styles from './Menu.module.scss'
+
+export function Menu({
+  triggerRef,
+  items = [],
+  isOpen = false,
+  onClose,
+  'aria-label': ariaLabel,
+  portalContainer,
+  placement = 'bottom start',
+  ...otherProps
+}: MenuProps) {
+  const handleOpenChange = (open: boolean) => {
+    if (!open) onClose?.()
+  }
+
+  return (
+    <Popover
+      isOpen={isOpen}
+      onOpenChange={handleOpenChange}
+      triggerRef={triggerRef}
+      placement={placement}
+      UNSTABLE_portalContainer={portalContainer}
+      offset={8}
+      shouldUpdatePosition
+      className={styles.popover}
+    >
+      <AriaMenu onClose={onClose} aria-label={ariaLabel} className={styles.menu} {...otherProps}>
+        {items.map(({ onClick, isDisabled, href, icon, label, ...itemProps }, index) => (
+          <AriaMenuItem
+            key={index}
+            onAction={onClick}
+            isDisabled={isDisabled}
+            href={href}
+            className={styles.item}
+            {...itemProps}
+          >
+            {icon && <span className={styles.icon}>{icon}</span>}
+            <span className={styles.label}>{label}</span>
+          </AriaMenuItem>
+        ))}
+      </AriaMenu>
+    </Popover>
+  )
+}

--- a/sdk-app/src/InterfaceLib/Menu/index.ts
+++ b/sdk-app/src/InterfaceLib/Menu/index.ts
@@ -1,0 +1,1 @@
+export { Menu } from './Menu'

--- a/sdk-app/src/InterfaceLib/Modal/Modal.module.scss
+++ b/sdk-app/src/InterfaceLib/Modal/Modal.module.scss
@@ -1,0 +1,52 @@
+.dialog {
+  padding: 0;
+  border: 0;
+  margin: auto;
+  max-width: none;
+  max-height: none;
+  background: transparent;
+  color: inherit;
+
+  &::backdrop {
+    background-color: rgba(16, 16, 16, 0.6);
+  }
+
+  &:not([open]) {
+    display: none;
+  }
+}
+
+.backdrop {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.modal {
+  display: flex;
+  flex-direction: column;
+  max-width: 560px;
+  max-height: calc(100vh - 48px);
+  width: 100%;
+  border-radius: 12px;
+  background-color: #ffffff;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.24);
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+  overflow: hidden;
+}
+
+.body {
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px 24px;
+  border-top: 1px solid #dadada;
+  background-color: #fafafa;
+}

--- a/sdk-app/src/InterfaceLib/Modal/Modal.tsx
+++ b/sdk-app/src/InterfaceLib/Modal/Modal.tsx
@@ -1,0 +1,51 @@
+import { useLayoutEffect, useRef, type KeyboardEvent, type MouseEvent } from 'react'
+import type { ModalProps } from '@gusto/embedded-react-sdk'
+import styles from './Modal.module.scss'
+
+export function Modal({
+  isOpen = false,
+  onClose,
+  shouldCloseOnBackdropClick = false,
+  children,
+  footer,
+  containerRef,
+}: ModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useLayoutEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    if (isOpen && !dialog.open) {
+      dialog.showModal()
+    } else if (!isOpen && dialog.open) {
+      dialog.close()
+    }
+  }, [isOpen])
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget && shouldCloseOnBackdropClick) {
+      onClose?.()
+    }
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') onClose?.()
+  }
+
+  return (
+    <dialog ref={dialogRef} className={styles.dialog} onClose={onClose}>
+      <div
+        ref={containerRef}
+        role="presentation"
+        className={styles.backdrop}
+        onClick={handleBackdropClick}
+        onKeyDown={handleKeyDown}
+      >
+        <div className={styles.modal}>
+          {children && <div className={styles.body}>{children}</div>}
+          {footer && <div className={styles.footer}>{footer}</div>}
+        </div>
+      </div>
+    </dialog>
+  )
+}

--- a/sdk-app/src/InterfaceLib/Modal/index.ts
+++ b/sdk-app/src/InterfaceLib/Modal/index.ts
@@ -1,0 +1,1 @@
+export { Modal } from './Modal'

--- a/sdk-app/src/InterfaceLib/MultiSelectComboBox/MultiSelectComboBox.module.scss
+++ b/sdk-app/src/InterfaceLib/MultiSelectComboBox/MultiSelectComboBox.module.scss
@@ -1,0 +1,202 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.fieldWrapper {
+  position: relative;
+}
+
+.field {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 64px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  background-color: #ffffff;
+  color: #101010;
+  transition: background-color 0.24s;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 8px;
+    box-shadow: inset 0 0 0 1px #dadada;
+    pointer-events: none;
+    transition: box-shadow 0.24s;
+  }
+
+  &:hover:not([data-disabled]):not(:focus-within)::after {
+    box-shadow: inset 0 0 0 1px #101010;
+  }
+
+  &:focus-within::after {
+    box-shadow: inset 0 0 0 2px #101010;
+  }
+}
+
+.root[data-invalid] .field::after {
+  box-shadow: inset 0 0 0 1px #cc0023;
+}
+
+.root[data-disabled] .field {
+  background-color: #f0f0f0;
+  color: #959595;
+}
+
+.label {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  color: #666666;
+}
+
+.labelHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.optional {
+  font-weight: 400;
+}
+
+.chipsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background-color: rgb(16, 16, 16);
+  color: #ffffff;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.chipRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background-color: transparent;
+  color: inherit;
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}
+
+.input {
+  flex: 1;
+  min-width: 80px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-family: inherit;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 22px;
+  outline: none;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+}
+
+.tooltipFloat {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.listbox {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  max-height: 220px;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  border-radius: 8px;
+  background-color: #ffffff;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.option {
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 14px;
+  line-height: 20px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f5f5f5;
+  }
+}
+
+.optionSelected {
+  background-color: rgb(16, 16, 16);
+  color: #ffffff;
+
+  &:hover {
+    background-color: rgb(51, 51, 51);
+  }
+}
+
+.loading,
+.empty {
+  padding: 8px 12px;
+  font-size: 14px;
+  color: #666666;
+}
+
+.error {
+  font-size: 14px;
+  line-height: 20px;
+  color: #cc0023;
+}

--- a/sdk-app/src/InterfaceLib/MultiSelectComboBox/MultiSelectComboBox.tsx
+++ b/sdk-app/src/InterfaceLib/MultiSelectComboBox/MultiSelectComboBox.tsx
@@ -1,0 +1,183 @@
+import { useId, useMemo, useState, type ChangeEvent } from 'react'
+import classNames from 'classnames'
+import type { MultiSelectComboBoxProps } from '@gusto/embedded-react-sdk'
+import { InfoTooltip } from '../InfoTooltip'
+import styles from './MultiSelectComboBox.module.scss'
+
+export function MultiSelectComboBox({
+  className,
+  description,
+  errorMessage,
+  id,
+  isDisabled = false,
+  isInvalid = false,
+  isLoading = false,
+  isRequired,
+  label,
+  name,
+  onChange,
+  onBlur,
+  options,
+  placeholder,
+  shouldVisuallyHideLabel,
+  value = [],
+  inputRef,
+}: MultiSelectComboBoxProps) {
+  const reactId = useId()
+  const inputId = id ?? `il-multicombobox-${reactId}`
+  const descriptionId = `${inputId}-description`
+  const errorId = `${inputId}-error`
+  const [filter, setFilter] = useState('')
+  const [open, setOpen] = useState(false)
+
+  const describedByIds =
+    [description ? descriptionId : null, errorMessage ? errorId : null].filter(Boolean).join(' ') ||
+    undefined
+
+  const filteredOptions = useMemo(
+    () =>
+      options.filter(option => option.label.toLowerCase().includes(filter.trim().toLowerCase())),
+    [options, filter],
+  )
+
+  const selectedSet = useMemo(() => new Set(value), [value])
+
+  const toggle = (optionValue: string) => {
+    const next = selectedSet.has(optionValue)
+      ? value.filter(v => v !== optionValue)
+      : [...value, optionValue]
+    onChange?.(next)
+  }
+
+  const removeChip = (optionValue: string) => {
+    onChange?.(value.filter(v => v !== optionValue))
+  }
+
+  const selectedOptions = useMemo(
+    () => value.map(v => options.find(o => o.value === v)).filter(Boolean),
+    [value, options],
+  )
+
+  return (
+    <div
+      className={classNames(styles.root, className)}
+      data-invalid={isInvalid || undefined}
+      data-disabled={isDisabled || undefined}
+    >
+      {description && (
+        <span id={descriptionId} className={styles.visuallyHidden}>
+          {description}
+        </span>
+      )}
+
+      <div className={styles.fieldWrapper}>
+        <div className={styles.field}>
+          <label
+            htmlFor={inputId}
+            className={classNames(styles.label, {
+              [styles.labelHidden as string]: shouldVisuallyHideLabel,
+            })}
+          >
+            {label}
+            {!isRequired && <span className={styles.optional}> (optional)</span>}
+          </label>
+
+          <div className={styles.chipsRow}>
+            {selectedOptions.map(option => (
+              <span key={option!.value} className={styles.chip}>
+                {option!.label}
+                <button
+                  type="button"
+                  onClick={() => {
+                    removeChip(option!.value)
+                  }}
+                  disabled={isDisabled}
+                  className={styles.chipRemove}
+                  aria-label={`Remove ${option!.label}`}
+                >
+                  <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+                    <path
+                      d="M1 1l8 8M9 1l-8 8"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                </button>
+              </span>
+            ))}
+            <input
+              id={inputId}
+              ref={inputRef}
+              name={name}
+              value={filter}
+              placeholder={selectedOptions.length === 0 ? (placeholder ?? '') : ''}
+              disabled={isDisabled}
+              aria-invalid={isInvalid}
+              aria-required={isRequired}
+              aria-describedby={describedByIds}
+              aria-expanded={open}
+              aria-controls={`${inputId}-list`}
+              role="combobox"
+              autoComplete="off"
+              onFocus={() => {
+                setOpen(true)
+              }}
+              onBlur={() => {
+                window.setTimeout(() => {
+                  setOpen(false)
+                }, 100)
+                onBlur?.()
+              }}
+              onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                setFilter(event.target.value)
+                setOpen(true)
+              }}
+              className={styles.input}
+            />
+          </div>
+        </div>
+        {description && (
+          <span className={styles.tooltipFloat}>
+            <InfoTooltip>{description}</InfoTooltip>
+          </span>
+        )}
+
+        {open && (
+          <ul id={`${inputId}-list`} role="listbox" className={styles.listbox}>
+            {isLoading && <li className={styles.loading}>Loading…</li>}
+            {!isLoading && filteredOptions.length === 0 && (
+              <li className={styles.empty}>No options</li>
+            )}
+            {!isLoading &&
+              filteredOptions.map(option => {
+                const checked = selectedSet.has(option.value)
+                return (
+                  <li
+                    key={option.value}
+                    role="option"
+                    aria-selected={checked}
+                    onMouseDown={event => {
+                      event.preventDefault()
+                      toggle(option.value)
+                    }}
+                    className={classNames(styles.option, {
+                      [styles.optionSelected as string]: checked,
+                    })}
+                  >
+                    {option.label}
+                  </li>
+                )
+              })}
+          </ul>
+        )}
+      </div>
+
+      {errorMessage && (
+        <div id={errorId} className={styles.error} role="alert">
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/MultiSelectComboBox/index.ts
+++ b/sdk-app/src/InterfaceLib/MultiSelectComboBox/index.ts
@@ -1,0 +1,1 @@
+export { MultiSelectComboBox } from './MultiSelectComboBox'

--- a/sdk-app/src/InterfaceLib/PaginationControl/PaginationControl.module.scss
+++ b/sdk-app/src/InterfaceLib/PaginationControl/PaginationControl.module.scss
@@ -1,0 +1,77 @@
+.root {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  background-color: #fafafa;
+  box-shadow: inset 0 0 0 1px #ebebeb;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.info {
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pageSize {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #666666;
+}
+
+.pageSizeLabel {
+  white-space: nowrap;
+}
+
+.pageSizeSelect {
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid #dadada;
+  background-color: #ffffff;
+  color: #101010;
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.navButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background-color: #ffffff;
+  color: #101010;
+  font-size: 14px;
+  line-height: 1;
+  box-shadow: inset 0 0 0 1px #dadada;
+  cursor: pointer;
+  transition:
+    background-color 0.125s linear,
+    color 0.125s linear;
+
+  &:hover:not(:disabled) {
+    background-color: rgb(16, 16, 16);
+    color: #ffffff;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    color: #b3b3b3;
+  }
+}

--- a/sdk-app/src/InterfaceLib/PaginationControl/PaginationControl.tsx
+++ b/sdk-app/src/InterfaceLib/PaginationControl/PaginationControl.tsx
@@ -1,0 +1,83 @@
+import type { PaginationControlProps, PaginationItemsPerPage } from '@gusto/embedded-react-sdk'
+import styles from './PaginationControl.module.scss'
+
+const PAGE_SIZES: PaginationItemsPerPage[] = [5, 10, 50]
+
+export function PaginationControl({
+  handleFirstPage,
+  handlePreviousPage,
+  handleNextPage,
+  handleLastPage,
+  handleItemsPerPageChange,
+  currentPage,
+  totalPages,
+  totalCount,
+  itemsPerPage,
+  isFetching = false,
+}: PaginationControlProps) {
+  const isFirst = currentPage <= 1
+  const isLast = currentPage >= totalPages
+
+  return (
+    <div className={styles.root} aria-busy={isFetching}>
+      <div className={styles.info}>
+        Page {currentPage} of {totalPages}
+        {typeof totalCount === 'number' && <> · {totalCount} total</>}
+      </div>
+      <div className={styles.controls}>
+        <label className={styles.pageSize}>
+          <span className={styles.pageSizeLabel}>Per page</span>
+          <select
+            value={itemsPerPage ?? 10}
+            onChange={event => {
+              handleItemsPerPageChange(Number(event.target.value) as PaginationItemsPerPage)
+            }}
+            className={styles.pageSizeSelect}
+          >
+            {PAGE_SIZES.map(size => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          onClick={handleFirstPage}
+          disabled={isFirst}
+          aria-label="First page"
+          className={styles.navButton}
+        >
+          «
+        </button>
+        <button
+          type="button"
+          onClick={handlePreviousPage}
+          disabled={isFirst}
+          aria-label="Previous page"
+          className={styles.navButton}
+        >
+          ‹
+        </button>
+        <button
+          type="button"
+          onClick={handleNextPage}
+          disabled={isLast}
+          aria-label="Next page"
+          className={styles.navButton}
+        >
+          ›
+        </button>
+        <button
+          type="button"
+          onClick={handleLastPage}
+          disabled={isLast}
+          aria-label="Last page"
+          className={styles.navButton}
+        >
+          »
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/PaginationControl/index.ts
+++ b/sdk-app/src/InterfaceLib/PaginationControl/index.ts
@@ -1,0 +1,1 @@
+export { PaginationControl } from './PaginationControl'

--- a/sdk-app/src/InterfaceLib/PayrollLoading/PayrollLoading.module.scss
+++ b/sdk-app/src/InterfaceLib/PayrollLoading/PayrollLoading.module.scss
@@ -1,0 +1,49 @@
+.root {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 24px;
+  border-radius: 12px;
+  background-color: #ffffff;
+  box-shadow: inset 0 0 0 1px #dadada;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.spinner {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  border: 3px solid #ebebeb;
+  border-top-color: rgb(16, 16, 16);
+  animation: spin 0.8s linear infinite;
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 22px;
+}
+
+.description {
+  margin: 0;
+  font-size: 14px;
+  line-height: 20px;
+  color: #666666;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/sdk-app/src/InterfaceLib/PayrollLoading/PayrollLoading.tsx
+++ b/sdk-app/src/InterfaceLib/PayrollLoading/PayrollLoading.tsx
@@ -1,0 +1,14 @@
+import type { PayrollLoadingProps } from '@gusto/embedded-react-sdk'
+import styles from './PayrollLoading.module.scss'
+
+export function PayrollLoading({ title, description }: PayrollLoadingProps) {
+  return (
+    <div role="status" aria-live="polite" className={styles.root}>
+      <span className={styles.spinner} aria-hidden="true" />
+      <div className={styles.text}>
+        <p className={styles.title}>{title}</p>
+        {description && <p className={styles.description}>{description}</p>}
+      </div>
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/PayrollLoading/index.ts
+++ b/sdk-app/src/InterfaceLib/PayrollLoading/index.ts
@@ -1,0 +1,1 @@
+export { PayrollLoading } from './PayrollLoading'

--- a/sdk-app/src/InterfaceLib/ProgressBar/ProgressBar.module.scss
+++ b/sdk-app/src/InterfaceLib/ProgressBar/ProgressBar.module.scss
@@ -1,0 +1,43 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.label {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+.steps {
+  font-size: 13px;
+  line-height: 18px;
+  color: #666666;
+}
+
+.track {
+  height: 6px;
+  border-radius: 999px;
+  background-color: #ebebeb;
+  overflow: hidden;
+}
+
+.fill {
+  height: 100%;
+  background-color: rgb(16, 16, 16);
+  transition: width 0.24s ease-in-out;
+}
+
+.cta {
+  margin-top: 4px;
+}

--- a/sdk-app/src/InterfaceLib/ProgressBar/ProgressBar.tsx
+++ b/sdk-app/src/InterfaceLib/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,41 @@
+import classNames from 'classnames'
+import type { ProgressBarProps } from '@gusto/embedded-react-sdk'
+import styles from './ProgressBar.module.scss'
+
+export function ProgressBar({
+  totalSteps,
+  currentStep,
+  className,
+  label,
+  cta: Cta,
+}: ProgressBarProps) {
+  const safeTotal = Math.max(totalSteps, 1)
+  const safeCurrent = Math.min(Math.max(currentStep, 0), safeTotal)
+  const percent = (safeCurrent / safeTotal) * 100
+
+  return (
+    <div
+      className={classNames(styles.root, className)}
+      role="progressbar"
+      aria-label={label}
+      aria-valuemin={0}
+      aria-valuemax={safeTotal}
+      aria-valuenow={safeCurrent}
+    >
+      <div className={styles.header}>
+        <span className={styles.label}>{label}</span>
+        <span className={styles.steps}>
+          {safeCurrent} / {safeTotal}
+        </span>
+      </div>
+      <div className={styles.track}>
+        <div className={styles.fill} style={{ width: `${percent}%` }} />
+      </div>
+      {Cta && (
+        <div className={styles.cta}>
+          <Cta />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/ProgressBar/index.ts
+++ b/sdk-app/src/InterfaceLib/ProgressBar/index.ts
@@ -1,0 +1,1 @@
+export { ProgressBar } from './ProgressBar'

--- a/sdk-app/src/InterfaceLib/Radio/Radio.module.scss
+++ b/sdk-app/src/InterfaceLib/Radio/Radio.module.scss
@@ -1,0 +1,123 @@
+.root {
+  display: inline-flex;
+  align-items: start;
+  gap: 12px;
+  padding: 8px;
+  margin: 0;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+  cursor: pointer;
+}
+
+.root[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.dot {
+  position: relative;
+  display: inline-block;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border: 2px solid #b3b3b3;
+  border-radius: 999px;
+  background-color: #ffffff;
+  transition: border-color 0.125s linear;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background-color: rgb(16, 16, 16);
+    transform: translate(-50%, -50%) scale(0);
+    transition: transform 0.125s ease-in-out;
+  }
+}
+
+.root:hover:not([data-disabled]) .dot {
+  border-color: rgb(16, 16, 16);
+}
+
+.input:checked ~ .dot {
+  border-color: rgb(16, 16, 16);
+}
+
+.input:checked ~ .dot::after {
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.input:focus-visible ~ .dot {
+  outline: 2px solid #101010;
+  outline-offset: 2px;
+}
+
+.root[data-invalid] .dot {
+  border-color: #cc0023;
+}
+
+.root[data-invalid] .input:checked ~ .dot::after {
+  background-color: #cc0023;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.bodyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.label {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  color: inherit;
+}
+
+.optional {
+  color: #666666;
+  font-weight: 400;
+}
+
+.description {
+  display: block;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  color: #666666;
+}
+
+.error {
+  display: block;
+  font-size: 14px;
+  line-height: 20px;
+  color: #cc0023;
+}

--- a/sdk-app/src/InterfaceLib/Radio/Radio.tsx
+++ b/sdk-app/src/InterfaceLib/Radio/Radio.tsx
@@ -1,0 +1,77 @@
+import { useId, type ChangeEvent } from 'react'
+import classNames from 'classnames'
+import type { RadioProps } from '@gusto/embedded-react-sdk'
+import styles from './Radio.module.scss'
+
+export function Radio({
+  id,
+  name,
+  label,
+  description,
+  errorMessage,
+  isRequired,
+  isDisabled = false,
+  isInvalid = false,
+  inputRef,
+  onChange,
+  onBlur,
+  value = false,
+  shouldVisuallyHideLabel,
+  className,
+}: RadioProps) {
+  const reactId = useId()
+  const inputId = id ?? `il-radio-${reactId}`
+  const descriptionId = `${inputId}-description`
+  const errorId = `${inputId}-error`
+
+  const describedByIds =
+    [description ? descriptionId : null, errorMessage ? errorId : null].filter(Boolean).join(' ') ||
+    undefined
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange?.(event.target.checked)
+  }
+
+  return (
+    <label
+      htmlFor={inputId}
+      className={classNames(styles.root, className)}
+      data-disabled={isDisabled || undefined}
+      data-invalid={isInvalid || undefined}
+    >
+      <input
+        id={inputId}
+        ref={inputRef}
+        name={name}
+        type="radio"
+        checked={value}
+        disabled={isDisabled}
+        aria-describedby={describedByIds}
+        onChange={handleChange}
+        onBlur={onBlur}
+        className={styles.input}
+      />
+      <span className={styles.dot} aria-hidden="true" />
+      <span
+        className={classNames(styles.body, {
+          [styles.bodyHidden as string]: shouldVisuallyHideLabel,
+        })}
+      >
+        <span className={styles.label}>
+          {label}
+          {!isRequired && <span className={styles.optional}> (optional)</span>}
+        </span>
+        {description && (
+          <span id={descriptionId} className={styles.description}>
+            {description}
+          </span>
+        )}
+        {errorMessage && (
+          <span id={errorId} className={styles.error} role="alert">
+            {errorMessage}
+          </span>
+        )}
+      </span>
+    </label>
+  )
+}

--- a/sdk-app/src/InterfaceLib/Radio/index.ts
+++ b/sdk-app/src/InterfaceLib/Radio/index.ts
@@ -1,0 +1,1 @@
+export { Radio } from './Radio'

--- a/sdk-app/src/InterfaceLib/RadioGroup/RadioGroup.module.scss
+++ b/sdk-app/src/InterfaceLib/RadioGroup/RadioGroup.module.scss
@@ -1,0 +1,152 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+  color: #101010;
+}
+
+.legend {
+  padding: 0;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 22px;
+}
+
+.legendHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.optional {
+  color: #666666;
+  font-weight: 400;
+}
+
+.description {
+  font-size: 14px;
+  line-height: 20px;
+  color: #666666;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.option {
+  display: inline-flex;
+  align-items: start;
+  gap: 12px;
+  padding: 8px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.125s linear;
+}
+
+.option:hover:not([data-disabled]) {
+  background-color: #f5f5f5;
+}
+
+.option[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.dot {
+  position: relative;
+  display: inline-block;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  margin-top: 2px;
+  border: 2px solid #b3b3b3;
+  border-radius: 999px;
+  background-color: #ffffff;
+  transition: border-color 0.125s linear;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background-color: rgb(16, 16, 16);
+    transform: translate(-50%, -50%) scale(0);
+    transition: transform 0.125s ease-in-out;
+  }
+}
+
+.option:hover:not([data-disabled]) .dot {
+  border-color: rgb(16, 16, 16);
+}
+
+.input:checked ~ .dot {
+  border-color: rgb(16, 16, 16);
+}
+
+.input:checked ~ .dot::after {
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.input:focus-visible ~ .dot {
+  outline: 2px solid #101010;
+  outline-offset: 2px;
+}
+
+.root[data-invalid] .dot {
+  border-color: #cc0023;
+}
+
+.root[data-invalid] .input:checked ~ .dot::after {
+  background-color: #cc0023;
+}
+
+.optionBody {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.optionLabel {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+.optionDescription {
+  font-size: 14px;
+  line-height: 20px;
+  color: #666666;
+}
+
+.error {
+  font-size: 14px;
+  line-height: 20px;
+  color: #cc0023;
+}

--- a/sdk-app/src/InterfaceLib/RadioGroup/RadioGroup.tsx
+++ b/sdk-app/src/InterfaceLib/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,101 @@
+import { useId, type ChangeEvent } from 'react'
+import classNames from 'classnames'
+import type { RadioGroupProps } from '@gusto/embedded-react-sdk'
+import styles from './RadioGroup.module.scss'
+
+export function RadioGroup({
+  label,
+  description,
+  errorMessage,
+  isRequired,
+  isInvalid = false,
+  isDisabled = false,
+  options,
+  value,
+  defaultValue,
+  onChange,
+  inputRef,
+  shouldVisuallyHideLabel,
+  className,
+}: RadioGroupProps) {
+  const reactId = useId()
+  const groupId = `il-radiogroup-${reactId}`
+  const groupName = `${groupId}-name`
+  const descriptionId = `${groupId}-description`
+  const errorId = `${groupId}-error`
+
+  const describedByIds =
+    [description ? descriptionId : null, errorMessage ? errorId : null].filter(Boolean).join(' ') ||
+    undefined
+
+  const selectedValue = value ?? defaultValue ?? null
+
+  return (
+    <fieldset
+      className={classNames(styles.root, className)}
+      data-invalid={isInvalid || undefined}
+      data-disabled={isDisabled || undefined}
+      disabled={isDisabled}
+      aria-describedby={describedByIds}
+    >
+      <legend
+        className={classNames(styles.legend, {
+          [styles.legendHidden as string]: shouldVisuallyHideLabel,
+        })}
+      >
+        {label}
+        {!isRequired && <span className={styles.optional}> (optional)</span>}
+      </legend>
+      {description && (
+        <span id={descriptionId} className={styles.description}>
+          {description}
+        </span>
+      )}
+      <div className={styles.options}>
+        {options.map((option, index) => {
+          const optionId = `${groupId}-${option.value}`
+          const optionDescriptionId = option.description ? `${optionId}-description` : undefined
+          const optionDisabled = isDisabled || option.isDisabled
+          const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+            if (event.target.checked) onChange?.(option.value)
+          }
+          return (
+            <label
+              key={option.value}
+              htmlFor={optionId}
+              className={styles.option}
+              data-disabled={optionDisabled || undefined}
+            >
+              <input
+                id={optionId}
+                ref={index === 0 ? inputRef : undefined}
+                type="radio"
+                name={groupName}
+                value={option.value}
+                checked={selectedValue === option.value}
+                disabled={optionDisabled}
+                aria-describedby={optionDescriptionId}
+                onChange={handleChange}
+                className={styles.input}
+              />
+              <span className={styles.dot} aria-hidden="true" />
+              <span className={styles.optionBody}>
+                <span className={styles.optionLabel}>{option.label}</span>
+                {option.description && (
+                  <span id={optionDescriptionId} className={styles.optionDescription}>
+                    {option.description}
+                  </span>
+                )}
+              </span>
+            </label>
+          )
+        })}
+      </div>
+      {errorMessage && (
+        <div id={errorId} className={styles.error} role="alert">
+          {errorMessage}
+        </div>
+      )}
+    </fieldset>
+  )
+}

--- a/sdk-app/src/InterfaceLib/RadioGroup/index.ts
+++ b/sdk-app/src/InterfaceLib/RadioGroup/index.ts
@@ -1,0 +1,1 @@
+export { RadioGroup } from './RadioGroup'

--- a/sdk-app/src/InterfaceLib/Switch/Switch.tsx
+++ b/sdk-app/src/InterfaceLib/Switch/Switch.tsx
@@ -18,6 +18,7 @@ export function Switch({
   value = false,
   shouldVisuallyHideLabel,
   className,
+  'aria-controls': ariaControls,
 }: SwitchProps) {
   const reactId = useId()
   const inputId = id ?? `il-switch-${reactId}`
@@ -50,6 +51,7 @@ export function Switch({
         aria-invalid={isInvalid}
         aria-required={isRequired}
         aria-describedby={describedByIds}
+        aria-controls={ariaControls}
         onChange={handleChange}
         onBlur={onBlur}
         className={styles.input}

--- a/sdk-app/src/InterfaceLib/TextArea/TextArea.module.scss
+++ b/sdk-app/src/InterfaceLib/TextArea/TextArea.module.scss
@@ -1,0 +1,162 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  font-family: 'InterfaceLib Sans', Helvetica, Arial, sans-serif;
+}
+
+.tooltipSlot {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.field {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  border-radius: 8px;
+  background-color: #ffffff;
+  color: #101010;
+  transition:
+    background-color 0.24s,
+    color 0.24s;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 8px;
+    box-shadow: inset 0 0 0 1px #dadada;
+    pointer-events: none;
+    transition: box-shadow 0.24s;
+  }
+
+  &:hover:not([data-disabled]):not(:focus-within)::after {
+    box-shadow: inset 0 0 0 1px #101010;
+  }
+
+  &:focus-within::after {
+    box-shadow: inset 0 0 0 2px #101010;
+  }
+}
+
+.root[data-invalid] .field::after {
+  box-shadow: inset 0 0 0 1px #cc0023;
+}
+
+.root[data-invalid] .field:focus-within::after {
+  box-shadow: inset 0 0 0 2px #101010;
+}
+
+.root[data-disabled] .field {
+  background-color: #f0f0f0;
+  color: #959595;
+
+  &::after {
+    box-shadow: inset 0 0 0 1px #f0f0f0;
+  }
+}
+
+.labelInputContainer {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  padding: 12px 16px;
+  cursor: text;
+}
+
+.optional {
+  color: #666666;
+  font-weight: 400;
+}
+
+.label {
+  position: absolute;
+  top: 12px;
+  left: 16px;
+  font-family: inherit;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 22px;
+  color: #101010;
+  pointer-events: none;
+  transform-origin: 0 0;
+  transform: scale(0.875);
+  transition:
+    transform 0.24s,
+    color 0.24s,
+    font-weight 0.24s;
+}
+
+.input:placeholder-shown:not(:focus) ~ .label {
+  transform: translateY(10px) scale(1);
+  font-weight: 400;
+  color: #666666;
+}
+
+.root[data-invalid] .input:placeholder-shown:not(:focus) ~ .label {
+  color: #cc0023;
+}
+
+.root[data-disabled] .label,
+.root[data-disabled] .input:placeholder-shown:not(:focus) ~ .label {
+  color: #959595;
+}
+
+.labelHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.input {
+  flex-grow: 1;
+  width: 100%;
+  margin-top: 14px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-family: inherit;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 22px;
+  outline: none;
+  resize: vertical;
+  appearance: none;
+
+  &::placeholder {
+    color: transparent;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+}
+
+.error {
+  font-size: 14px;
+  line-height: 20px;
+  color: #cc0023;
+}

--- a/sdk-app/src/InterfaceLib/TextArea/TextArea.tsx
+++ b/sdk-app/src/InterfaceLib/TextArea/TextArea.tsx
@@ -1,0 +1,95 @@
+import { useId, type ChangeEvent } from 'react'
+import classNames from 'classnames'
+import type { TextAreaProps } from '@gusto/embedded-react-sdk'
+import { InfoTooltip } from '../InfoTooltip'
+import styles from './TextArea.module.scss'
+
+export function TextArea({
+  name,
+  label,
+  description,
+  errorMessage,
+  isRequired,
+  inputRef,
+  isInvalid = false,
+  isDisabled = false,
+  id,
+  value,
+  placeholder,
+  onChange,
+  onBlur,
+  className,
+  shouldVisuallyHideLabel,
+  rows = 4,
+  cols,
+  'aria-describedby': ariaDescribedByFromProps,
+}: TextAreaProps) {
+  const reactId = useId()
+  const inputId = id ?? `il-textarea-${reactId}`
+  const descriptionId = `${inputId}-description`
+  const errorId = `${inputId}-error`
+
+  const describedByIds =
+    [ariaDescribedByFromProps, description ? descriptionId : null, errorMessage ? errorId : null]
+      .filter(Boolean)
+      .join(' ') || undefined
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    onChange?.(event.target.value)
+  }
+
+  return (
+    <div
+      className={classNames(styles.root, className)}
+      data-invalid={isInvalid || undefined}
+      data-disabled={isDisabled || undefined}
+    >
+      {description && (
+        <span id={descriptionId} className={styles.visuallyHidden}>
+          {description}
+        </span>
+      )}
+
+      <div className={styles.field}>
+        <label htmlFor={inputId} className={styles.labelInputContainer}>
+          <textarea
+            id={inputId}
+            ref={inputRef}
+            name={name}
+            value={value ?? ''}
+            placeholder={placeholder ?? ' '}
+            onChange={handleChange}
+            onBlur={onBlur}
+            disabled={isDisabled}
+            rows={rows}
+            cols={cols}
+            aria-invalid={isInvalid}
+            aria-required={isRequired}
+            aria-describedby={describedByIds}
+            className={styles.input}
+          />
+          <span
+            className={classNames(styles.label, {
+              [styles.labelHidden as string]: shouldVisuallyHideLabel,
+            })}
+          >
+            {label}
+            {!isRequired && <span className={styles.optional}> (optional)</span>}
+          </span>
+        </label>
+
+        {description && (
+          <span className={styles.tooltipSlot}>
+            <InfoTooltip>{description}</InfoTooltip>
+          </span>
+        )}
+      </div>
+
+      {errorMessage && (
+        <div id={errorId} className={styles.error} role="alert">
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/sdk-app/src/InterfaceLib/TextArea/index.ts
+++ b/sdk-app/src/InterfaceLib/TextArea/index.ts
@@ -1,0 +1,1 @@
+export { TextArea } from './TextArea'

--- a/sdk-app/src/InterfaceLib/index.ts
+++ b/sdk-app/src/InterfaceLib/index.ts
@@ -1,48 +1,122 @@
 import './global.css'
+import { Alert } from './Alert'
+import { Badge } from './Badge'
+import { Banner } from './Banner'
+import { Box } from './Box'
+import { BoxHeader } from './BoxHeader'
+import { Breadcrumbs } from './Breadcrumbs'
 import { Button, ButtonIcon } from './Button'
+import { CalendarPreview } from './CalendarPreview'
+import { Card } from './Card'
+import { Checkbox } from './Checkbox'
+import { CheckboxGroup } from './CheckboxGroup'
+import { ComboBox } from './ComboBox'
+import { DatePicker } from './DatePicker'
+import { DateRangePicker } from './DateRangePicker'
+import { DescriptionList } from './DescriptionList'
+import { Dialog } from './Dialog'
+import { FileInput } from './FileInput'
 import { Heading } from './Heading'
-import { Text } from './Text'
-import { TextInput } from './TextInput'
+import { Link } from './Link'
+import { OrderedList, UnorderedList } from './List'
+import { LoadingSpinner } from './LoadingSpinner'
+import { Menu } from './Menu'
+import { Modal } from './Modal'
+import { MultiSelectComboBox } from './MultiSelectComboBox'
 import { NumberInput } from './NumberInput'
+import { PaginationControl } from './PaginationControl'
+import { PayrollLoading } from './PayrollLoading'
+import { ProgressBar } from './ProgressBar'
+import { Radio } from './Radio'
+import { RadioGroup } from './RadioGroup'
 import { Select } from './Select'
+import { Switch } from './Switch'
 import { Table } from './Table'
 import { Tabs } from './Tabs'
-import { Badge } from './Badge'
-import { Alert } from './Alert'
-import { DatePicker } from './DatePicker'
-import { Switch } from './Switch'
-import { ComboBox } from './ComboBox'
+import { Text } from './Text'
+import { TextArea } from './TextArea'
+import { TextInput } from './TextInput'
 
 export {
+  Alert,
+  Badge,
+  Banner,
+  Box,
+  BoxHeader,
+  Breadcrumbs,
   Button,
   ButtonIcon,
+  CalendarPreview,
+  Card,
+  Checkbox,
+  CheckboxGroup,
+  ComboBox,
+  DatePicker,
+  DateRangePicker,
+  DescriptionList,
+  Dialog,
+  FileInput,
   Heading,
-  Text,
-  TextInput,
+  Link,
+  LoadingSpinner,
+  Menu,
+  Modal,
+  MultiSelectComboBox,
   NumberInput,
+  OrderedList,
+  PaginationControl,
+  PayrollLoading,
+  ProgressBar,
+  Radio,
+  RadioGroup,
   Select,
+  Switch,
   Table,
   Tabs,
-  Badge,
-  Alert,
-  DatePicker,
-  Switch,
-  ComboBox,
+  Text,
+  TextArea,
+  TextInput,
+  UnorderedList,
 }
 
 export const interfaceLibComponents = {
+  Alert,
+  Badge,
+  Banner,
+  Box,
+  BoxHeader,
+  Breadcrumbs,
   Button,
   ButtonIcon,
+  CalendarPreview,
+  Card,
+  Checkbox,
+  CheckboxGroup,
+  ComboBox,
+  DatePicker,
+  DateRangePicker,
+  DescriptionList,
+  Dialog,
+  FileInput,
   Heading,
-  Text,
-  TextInput,
+  Link,
+  LoadingSpinner,
+  Menu,
+  Modal,
+  MultiSelectComboBox,
   NumberInput,
+  OrderedList,
+  PaginationControl,
+  PayrollLoading,
+  ProgressBar,
+  Radio,
+  RadioGroup,
   Select,
+  Switch,
   Table,
   Tabs,
-  Badge,
-  Alert,
-  DatePicker,
-  Switch,
-  ComboBox,
+  Text,
+  TextArea,
+  TextInput,
+  UnorderedList,
 }

--- a/src/contexts/ComponentAdapter/componentAdapterTypes.ts
+++ b/src/contexts/ComponentAdapter/componentAdapterTypes.ts
@@ -10,7 +10,15 @@ export type {
   CheckboxGroupOption,
 } from '@/components/Common/UI/CheckboxGroup/CheckboxGroupTypes'
 export type { ComboBoxProps, ComboBoxOption } from '@/components/Common/UI/ComboBox/ComboBoxTypes'
+export type {
+  MultiSelectComboBoxProps,
+  MultiSelectComboBoxOption,
+} from '@/components/Common/UI/MultiSelectComboBox/MultiSelectComboBoxTypes'
 export type { DatePickerProps } from '@/components/Common/UI/DatePicker/DatePickerTypes'
+export type {
+  DateRangePickerProps,
+  DateRange,
+} from '@/components/Common/UI/DateRangePicker/DateRangePickerTypes'
 export type { LinkProps } from '@/components/Common/UI/Link/LinkTypes'
 export type { MenuProps, MenuItem } from '@/components/Common/UI/Menu/MenuTypes'
 export type { NumberInputProps } from '@/components/Common/UI/NumberInput/NumberInputTypes'


### PR DESCRIPTION
## Summary

Closes two prop-passing gaps in the existing InterfaceLib adapters and backfills the 25 missing `ComponentsContext` slots so every UI primitive the SDK renders flows through the partner-themed override path. Previously only 14 of 39 slots were overridden; the rest fell back to the SDK default look, breaking visual cohesion on screens that rendered unmapped primitives.

Built incrementally as three commits for review:

1. **`chore(sdk):`** — Re-exports `DateRangePickerProps`, `DateRange`, `MultiSelectComboBoxProps`, `MultiSelectComboBoxOption` from `componentAdapterTypes`. The slots already existed on `ComponentsContextType` but the prop types weren't reachable via `@gusto/embedded-react-sdk`, which blocked anyone from writing an external adapter for them.
2. **`fix(sdk-app):`** — Existing adapter gaps:
   - `DatePicker` now uses the `placeholder` prop instead of hardcoding `'mm/dd/yyyy'`
   - `Switch` forwards `aria-controls` to the underlying input (declared on `SwitchProps`, previously ignored)
   - `Heading` no longer emits a spurious `textAlign-undefined` class when `textAlign` is omitted
3. **`feat(sdk-app):`** — 25 new adapter stubs:
   - **Form primitives:** Checkbox, CheckboxGroup, Radio, RadioGroup, TextArea, FileInput, MultiSelectComboBox, DateRangePicker
   - **Containers:** Card, Box, BoxHeader, Banner, OrderedList, UnorderedList, DescriptionList, Breadcrumbs
   - **Interactive:** Link, Menu, Dialog, Modal
   - **Feedback/specialty:** ProgressBar, LoadingSpinner, CalendarPreview, PaginationControl, PayrollLoading

Each new adapter destructures every prop from its SDK type, matches the existing InterfaceLib visual language (InterfaceLib Sans font, dark accent, rounded corners), and uses the `InfoTooltip` helper where the SDK exposes a `description` prop. `Menu` wraps `react-aria-components`' `Menu`/`MenuItem` for proper keyboard navigation; `Modal` uses the native `<dialog>` element for a free focus trap + escape handling.

## Test plan

- [ ] `npm run build` succeeds (type-checks the registry against `ComponentsContextType`)
- [ ] `npm run lint` clean across `sdk-app/src/InterfaceLib/`
- [ ] Run `npm run sdk-app`, switch the design system selector to `overrides`, and click through screens that render the newly-mapped primitives — confirm InterfaceLib styling, not SDK default styling, on:
  - [ ] A form with checkboxes, radios, and a textarea
  - [ ] A list view with breadcrumbs and a pagination footer
  - [ ] A flow that opens a confirmation `Dialog` or full `Modal`
  - [ ] A screen that uses `OrderedList` / `UnorderedList` / `DescriptionList`
  - [ ] A `Card` with `action` and `menu` slots populated
- [ ] Targeted prop checks for the existing-adapter fixes:
  - [ ] Render a DatePicker with a custom `placeholder` — confirm it shows
  - [ ] Render a Switch with `aria-controls` pointing to a disclosure region — confirm the attribute is in the DOM

## Notes

- No new stories or unit tests for these adapters — the SDK has its own coverage, and InterfaceLib has been visually-verified-only so far. Happy to add coverage if you'd like.
- `ComponentsContextType` itself is unchanged.
- This is intended to merge into `al/create-secondary-ui-components`, not directly into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)