### PR TITLE
fix(sdk-app): InterfaceLib adapter prop gaps

### DIFF
--- a/docs/component-adapter/component-inventory.md
+++ b/docs/component-adapter/component-inventory.md
@@ -18,6 +18,8 @@
 - [ComboBoxProps](#comboboxprops)
   - [ComboBoxOption](#comboboxoption)
 - [DatePickerProps](#datepickerprops)
+- [DateRangePickerProps](#daterangepickerprops)
+  - [DateRange](#daterange)
 - [DescriptionListProps](#descriptionlistprops)
   - [DescriptionListItem](#descriptionlistitem)
 - [DialogProps](#dialogprops)
@@ -28,6 +30,8 @@
 - [MenuProps](#menuprops)
   - [MenuItem](#menuitem)
 - [ModalProps](#modalprops)
+- [MultiSelectComboBoxProps](#multiselectcomboboxprops)
+  - [MultiSelectComboBoxOption](#multiselectcomboboxoption)
 - [NumberInputProps](#numberinputprops)
 - [OrderedListProps](#orderedlistprops)
 - [PaginationControlProps](#paginationcontrolprops)
@@ -301,6 +305,26 @@
 | **id**                      | `string`                        | No       | -                                                                                             |
 | **name**                    | `string`                        | No       | -                                                                                             |
 
+## DateRangePickerProps
+
+| Prop                        | Type                                               | Required | Description |
+| --------------------------- | -------------------------------------------------- | -------- | ----------- |
+| **label**                   | `string`                                           | Yes      | -           |
+| **shouldVisuallyHideLabel** | `boolean`                                          | No       | -           |
+| **value**                   | `null \| [DateRange](#daterange)`                  | Yes      | -           |
+| **onChange**                | `(range: [DateRange](#daterange) \| null) => void` | Yes      | -           |
+| **startDateLabel**          | `string`                                           | Yes      | -           |
+| **endDateLabel**            | `string`                                           | Yes      | -           |
+| **minValue**                | `Date`                                             | No       | -           |
+| **maxValue**                | `Date`                                             | No       | -           |
+
+### DateRange
+
+| Prop      | Type   | Required | Description |
+| --------- | ------ | -------- | ----------- |
+| **start** | `Date` | Yes      | -           |
+| **end**   | `Date` | Yes      | -           |
+
 ## DescriptionListProps
 
 | Prop               | Type                                          | Required | Description |
@@ -421,6 +445,35 @@
 | **children**                   | `React.ReactNode` | No       | Main content to be rendered in the modal body            |
 | **footer**                     | `React.ReactNode` | No       | Footer content to be rendered at the bottom of the modal |
 | **containerRef**               | `RefObject`       | No       | Optional ref to the backdrop container                   |
+
+## MultiSelectComboBoxProps
+
+| Prop                        | Type                                                      | Required | Description                                                            |
+| --------------------------- | --------------------------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| **inputRef**                | `Ref<HTMLInputElement \| null>`                           | No       | -                                                                      |
+| **isDisabled**              | `boolean`                                                 | No       | -                                                                      |
+| **isInvalid**               | `boolean`                                                 | No       | -                                                                      |
+| **isLoading**               | `boolean`                                                 | No       | -                                                                      |
+| **label**                   | `string`                                                  | Yes      | -                                                                      |
+| **options**                 | [MultiSelectComboBoxOption](#multiselectcomboboxoption)[] | Yes      | -                                                                      |
+| **value**                   | `string[]`                                                | No       | -                                                                      |
+| **onChange**                | `(values: string[]) => void`                              | No       | -                                                                      |
+| **onBlur**                  | `() => void`                                              | No       | -                                                                      |
+| **description**             | `React.ReactNode`                                         | No       | Optional description text for the field                                |
+| **errorMessage**            | `string`                                                  | No       | Error message to display when the field is invalid                     |
+| **isRequired**              | `boolean`                                                 | No       | Indicates if the field is required                                     |
+| **shouldVisuallyHideLabel** | `boolean`                                                 | No       | Hides the label visually while keeping it accessible to screen readers |
+| **className**               | `string`                                                  | No       | -                                                                      |
+| **id**                      | `string`                                                  | No       | -                                                                      |
+| **name**                    | `string`                                                  | No       | -                                                                      |
+| **placeholder**             | `string`                                                  | No       | -                                                                      |
+
+### MultiSelectComboBoxOption
+
+| Prop      | Type     | Required | Description |
+| --------- | -------- | -------- | ----------- |
+| **label** | `string` | Yes      | -           |
+| **value** | `string` | Yes      | -           |
 
 ## NumberInputProps
 

--- a/sdk-app/src/InterfaceLib/DatePicker/DatePicker.tsx
+++ b/sdk-app/src/InterfaceLib/DatePicker/DatePicker.tsx
@@ -63,6 +63,7 @@ export function DatePicker({
   value,
   shouldVisuallyHideLabel,
   className,
+  placeholder,
   portalContainer,
   minDate,
   maxDate,
@@ -141,7 +142,7 @@ export function DatePicker({
                 {value ? (
                   formatDisplay(value)
                 ) : (
-                  <span className={styles.placeholder}>mm/dd/yyyy</span>
+                  <span className={styles.placeholder}>{placeholder ?? 'mm/dd/yyyy'}</span>
                 )}
               </span>
             </span>

--- a/sdk-app/src/InterfaceLib/Heading/Heading.tsx
+++ b/sdk-app/src/InterfaceLib/Heading/Heading.tsx
@@ -19,7 +19,7 @@ export const Heading = ({
         className,
         styles.root,
         styles[levelStyles as string],
-        styles[`textAlign-${textAlign}`],
+        textAlign && styles[`textAlign-${textAlign}`],
       )}
     >
       {children}

--- a/sdk-app/src/InterfaceLib/Switch/Switch.tsx
+++ b/sdk-app/src/InterfaceLib/Switch/Switch.tsx
@@ -18,6 +18,7 @@ export function Switch({
   value = false,
   shouldVisuallyHideLabel,
   className,
+  'aria-controls': ariaControls,
 }: SwitchProps) {
   const reactId = useId()
   const inputId = id ?? `il-switch-${reactId}`
@@ -50,6 +51,7 @@ export function Switch({
         aria-invalid={isInvalid}
         aria-required={isRequired}
         aria-describedby={describedByIds}
+        aria-controls={ariaControls}
         onChange={handleChange}
         onBlur={onBlur}
         className={styles.input}

--- a/src/contexts/ComponentAdapter/componentAdapterTypes.ts
+++ b/src/contexts/ComponentAdapter/componentAdapterTypes.ts
@@ -10,7 +10,15 @@ export type {
   CheckboxGroupOption,
 } from '@/components/Common/UI/CheckboxGroup/CheckboxGroupTypes'
 export type { ComboBoxProps, ComboBoxOption } from '@/components/Common/UI/ComboBox/ComboBoxTypes'
+export type {
+  MultiSelectComboBoxProps,
+  MultiSelectComboBoxOption,
+} from '@/components/Common/UI/MultiSelectComboBox/MultiSelectComboBoxTypes'
 export type { DatePickerProps } from '@/components/Common/UI/DatePicker/DatePickerTypes'
+export type {
+  DateRangePickerProps,
+  DateRange,
+} from '@/components/Common/UI/DateRangePicker/DateRangePickerTypes'
 export type { LinkProps } from '@/components/Common/UI/Link/LinkTypes'
 export type { MenuProps, MenuItem } from '@/components/Common/UI/Menu/MenuTypes'
 export type { NumberInputProps } from '@/components/Common/UI/NumberInput/NumberInputTypes'


### PR DESCRIPTION
## Summary

Closes two prop-passing gaps in the existing InterfaceLib adapters and exposes two missing prop types from the SDK's public surface so they can be referenced by any external adapter.

- **DatePicker** now uses the `placeholder` prop instead of hardcoding `'mm/dd/yyyy'` ([DatePickerProps.placeholder](src/components/Common/UI/DatePicker/DatePickerTypes.ts) was previously ignored).
- **Switch** forwards `aria-controls` to the underlying input (declared on `SwitchProps`, previously ignored).
- **Heading** no longer emits a spurious `textAlign-undefined` class when `textAlign` is omitted (matches the pattern already used in `Text`).
- **SDK types**: re-exports `DateRangePickerProps`, `DateRange`, `MultiSelectComboBoxProps`, and `MultiSelectComboBoxOption` from `componentAdapterTypes`. Both slots already exist on `ComponentsContextType`, but the prop types weren't reachable via `@gusto/embedded-react-sdk`, blocking any partner from writing an adapter for them. The pre-commit hook also regenerated [docs/component-adapter/component-inventory.md](docs/component-adapter/component-inventory.md) to reflect the new exports.

## Out of scope

This PR intentionally does **not** add adapters for the `ComponentsContext` slots that InterfaceLib doesn't currently override. Those will be added on demand — when a specific demo screen is observed to be rendering with the wrong (SDK-default) look — in focused per-component PRs.

## Test plan

- [ ] `npm run build` succeeds
- [ ] `npm run lint` clean
- [ ] Render a DatePicker with a custom `placeholder` and confirm it shows instead of `'mm/dd/yyyy'`
- [ ] Render a Switch with `aria-controls="<id>"` and confirm the attribute is in the DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)