### PR TITLE
chore: release 0.44.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.44.1
+
+### Chores & Maintenance
+
+- Upgrade `@gusto/embedded-api` to `0.13.0` (adapts SDK to renamed error class `UnprocessableEntityError`, `PayScheduleShow` rename, typed mutation bodies, and renamed response payload keys; no public SDK API changes)
+- Bump various dev dependencies (`@commitlint/cli`, `@commitlint/config-conventional`, `lint-staged`, `msw`)
+- Bump `fast-uri` to `3.1.2` (transitive npm/yarn security update)
+
 ## 0.44.0
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-react-sdk",
-      "version": "0.44.0",
+      "version": "0.44.1",
       "license": "MIT",
       "dependencies": {
         "@gusto/embedded-api": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "homepage": "https://github.com/Gusto/embedded-react-sdk",
   "bugs": {
     "url": "https://github.com/Gusto/embedded-react-sdk/issues"


### PR DESCRIPTION
## Summary

Patch release covering chore and build-deps commits merged to `main` since [0.44.0](https://github.com/Gusto/embedded-react-sdk/releases/tag/v0.44.0). No public SDK API changes.

### Chores & Maintenance

- Upgrade `@gusto/embedded-api` to `0.13.0` (#1770) — adapts SDK internals to renamed error class `UnprocessableEntityError`, `PayScheduleShow` rename, typed mutation bodies, and renamed response payload keys
- Bump dev dependencies: `@commitlint/cli` 20.5.3 → 21.0.0 (#1762), `@commitlint/config-conventional` 20.5.3 → 21.0.0 (#1760), `lint-staged` 17.0.2 → 17.0.4 (#1761), `msw` 2.14.4 → 2.14.6 (#1759)
- Bump `fast-uri` 3.1.0 → 3.1.2 (#1758) — transitive npm/yarn security update

## Test plan

- [ ] CI passes (build, lint, tsc, unit tests)
- [ ] After merge: run `Publish to NPM` GitHub Action to publish `0.44.1`


Made with [Cursor](https://cursor.com)