### PR TITLE
fix: prevent skeleton/gap pop-in for empty TransitionPayrollAlert

### DIFF
--- a/src/components/Payroll/TransitionPayrollAlert/TransitionPayrollAlert.test.tsx
+++ b/src/components/Payroll/TransitionPayrollAlert/TransitionPayrollAlert.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { TransitionPayrollAlert } from './TransitionPayrollAlert'
+import { server } from '@/test/mocks/server'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import { API_BASE_URL } from '@/test/constants'
+import { componentEvents } from '@/shared/constants'
+
+const COMPANY_ID = 'company-123'
+const payPeriodsPath = `${API_BASE_URL}/v1/companies/:company_id/pay_periods`
+const paySchedulesPath = `${API_BASE_URL}/v1/companies/:company_id/pay_schedules`
+
+const paySchedulesResponse = [
+  {
+    uuid: 'schedule-1',
+    version: 'v1',
+    custom_name: 'Weekly Schedule',
+    active: true,
+  },
+]
+
+const transitionPayPeriod = {
+  start_date: '2025-01-01',
+  end_date: '2025-01-15',
+  pay_schedule_uuid: 'schedule-1',
+  payroll: { processed: false, payroll_type: 'transition' },
+}
+
+describe('TransitionPayrollAlert', () => {
+  it('renders nothing when there are no unprocessed transition pay periods', async () => {
+    let payPeriodsCalled = false
+    server.use(
+      http.get(payPeriodsPath, () => {
+        payPeriodsCalled = true
+        return HttpResponse.json([])
+      }),
+      http.get(paySchedulesPath, () => HttpResponse.json(paySchedulesResponse)),
+    )
+    const onEvent = vi.fn()
+
+    renderWithProviders(<TransitionPayrollAlert companyId={COMPANY_ID} onEvent={onEvent} />)
+
+    await waitFor(() => {
+      expect(payPeriodsCalled).toBe(true)
+    })
+    expect(screen.queryByText(/Transition payroll/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(onEvent).not.toHaveBeenCalledWith(componentEvents.ERROR, expect.anything())
+  })
+
+  it('renders the alert when an unprocessed transition pay period is returned', async () => {
+    server.use(
+      http.get(payPeriodsPath, () => HttpResponse.json([transitionPayPeriod])),
+      http.get(paySchedulesPath, () => HttpResponse.json(paySchedulesResponse)),
+    )
+    const onEvent = vi.fn()
+
+    renderWithProviders(<TransitionPayrollAlert companyId={COMPANY_ID} onEvent={onEvent} />)
+
+    expect(await screen.findByText(/Transition payroll -/)).toBeInTheDocument()
+  })
+
+  it('renders nothing and emits an ERROR event when a gate query fails', async () => {
+    server.use(
+      http.get(payPeriodsPath, () => new HttpResponse(null, { status: 500 })),
+      http.get(paySchedulesPath, () => HttpResponse.json(paySchedulesResponse)),
+    )
+    const onEvent = vi.fn()
+
+    renderWithProviders(<TransitionPayrollAlert companyId={COMPANY_ID} onEvent={onEvent} />)
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(componentEvents.ERROR, expect.anything())
+    })
+    expect(screen.queryByText(/Transition payroll/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/Payroll/TransitionPayrollAlert/TransitionPayrollAlert.tsx
+++ b/src/components/Payroll/TransitionPayrollAlert/TransitionPayrollAlert.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback } from 'react'
+import { Suspense, useMemo, useState, useCallback } from 'react'
 import { usePaySchedulesGetPayPeriodsSuspense } from '@gusto/embedded-api/react-query/paySchedulesGetPayPeriods'
 import { usePaySchedulesGetAllSuspense } from '@gusto/embedded-api/react-query/paySchedulesGetAll'
 import { usePayrollsSkipMutation } from '@gusto/embedded-api/react-query/payrollsSkip'
@@ -18,22 +18,28 @@ interface TransitionPayrollAlertProps {
   onEvent: OnEventType<EventType, unknown>
 }
 
+interface GroupedTransitionPayPeriods {
+  payScheduleUuid: string
+  payScheduleName: string
+  payPeriods: PayPeriod[]
+}
+
+interface RootProps {
+  companyId: string
+  groupedPayPeriods: GroupedTransitionPayPeriods[]
+}
+
 const LOOK_AHEAD_DAYS = 90
 
 export function TransitionPayrollAlert(props: TransitionPayrollAlertProps) {
   return (
-    <BaseComponent onEvent={props.onEvent}>
-      <Root {...props} />
-    </BaseComponent>
+    <Suspense fallback={null}>
+      <TransitionPayrollAlertGate {...props} />
+    </Suspense>
   )
 }
 
-function Root({ companyId }: TransitionPayrollAlertProps) {
-  const { onEvent, baseSubmitHandler } = useBase()
-
-  const [showSkipSuccessAlert, setShowSkipSuccessAlert] = useState(false)
-  const [skippingPayPeriod, setSkippingPayPeriod] = useState<PayPeriod | null>(null)
-
+function TransitionPayrollAlertGate({ companyId, onEvent }: TransitionPayrollAlertProps) {
   const lookAheadEndDate = useMemo(() => {
     const date = new Date()
     date.setDate(date.getDate() + LOOK_AHEAD_DAYS)
@@ -47,19 +53,15 @@ function Root({ companyId }: TransitionPayrollAlertProps) {
   })
 
   const { data: paySchedulesData } = usePaySchedulesGetAllSuspense({ companyId })
-  const paySchedules = paySchedulesData.payScheduleShowResponse ?? []
 
-  const { mutateAsync: skipPayroll } = usePayrollsSkipMutation()
+  const groupedPayPeriods = useMemo<GroupedTransitionPayPeriods[]>(() => {
+    const paySchedules = paySchedulesData.payScheduleShowResponse ?? []
+    const unprocessed = (payPeriodsData.payPeriods ?? []).filter(
+      (pp: PayPeriod) => !pp.payroll?.processed,
+    )
 
-  const unprocessedTransitionPeriods = useMemo(() => {
-    const periods = payPeriodsData.payPeriods ?? []
-    return periods.filter((pp: PayPeriod) => !pp.payroll?.processed)
-  }, [payPeriodsData])
-
-  const groupedPayPeriods = useMemo(() => {
     const groups = new Map<string, PayPeriod[]>()
-
-    for (const period of unprocessedTransitionPeriods) {
+    for (const period of unprocessed) {
       const uuid = period.payScheduleUuid ?? 'unknown'
       const existing = groups.get(uuid) ?? []
       existing.push(period)
@@ -69,10 +71,28 @@ function Root({ companyId }: TransitionPayrollAlertProps) {
     return Array.from(groups.entries()).map(([payScheduleUuid, payPeriods]) => {
       const schedule = paySchedules.find(s => s.uuid === payScheduleUuid)
       const payScheduleName = schedule?.customName || schedule?.name || 'Transition'
-
       return { payScheduleUuid, payScheduleName, payPeriods }
     })
-  }, [unprocessedTransitionPeriods, paySchedules])
+  }, [payPeriodsData, paySchedulesData])
+
+  if (groupedPayPeriods.length === 0) {
+    return null
+  }
+
+  return (
+    <BaseComponent onEvent={onEvent}>
+      <Root companyId={companyId} groupedPayPeriods={groupedPayPeriods} />
+    </BaseComponent>
+  )
+}
+
+function Root({ companyId, groupedPayPeriods }: RootProps) {
+  const { onEvent, baseSubmitHandler } = useBase()
+
+  const [showSkipSuccessAlert, setShowSkipSuccessAlert] = useState(false)
+  const [skippingPayPeriod, setSkippingPayPeriod] = useState<PayPeriod | null>(null)
+
+  const { mutateAsync: skipPayroll } = usePayrollsSkipMutation()
 
   const handleRunPayroll = useCallback(
     (payPeriod: PayPeriod) => {
@@ -115,10 +135,6 @@ function Root({ companyId }: TransitionPayrollAlertProps) {
   const handleDismissSkipSuccessAlert = useCallback(() => {
     setShowSkipSuccessAlert(false)
   }, [])
-
-  if (groupedPayPeriods.length === 0) {
-    return null
-  }
 
   return (
     <TransitionPayrollAlertPresentation

--- a/src/components/Payroll/TransitionPayrollAlert/TransitionPayrollAlert.tsx
+++ b/src/components/Payroll/TransitionPayrollAlert/TransitionPayrollAlert.tsx
@@ -1,9 +1,6 @@
-import { Suspense, useMemo, useState, useCallback, type ErrorInfo } from 'react'
-import type { FallbackProps } from 'react-error-boundary'
-import { ErrorBoundary } from 'react-error-boundary'
-import { QueryErrorResetBoundary } from '@tanstack/react-query'
-import { usePaySchedulesGetPayPeriodsSuspense } from '@gusto/embedded-api/react-query/paySchedulesGetPayPeriods'
-import { usePaySchedulesGetAllSuspense } from '@gusto/embedded-api/react-query/paySchedulesGetAll'
+import { useMemo, useState, useCallback, useEffect } from 'react'
+import { usePaySchedulesGetPayPeriods } from '@gusto/embedded-api/react-query/paySchedulesGetPayPeriods'
+import { usePaySchedulesGetAll } from '@gusto/embedded-api/react-query/paySchedulesGetAll'
 import { usePayrollsSkipMutation } from '@gusto/embedded-api/react-query/payrollsSkip'
 import { PayrollType } from '@gusto/embedded-api/models/operations/postcompaniespayrollskipcompanyuuid'
 import { PayrollTypes } from '@gusto/embedded-api/models/operations/getv1companiescompanyidpayperiods'
@@ -32,63 +29,40 @@ interface RootProps {
 }
 
 const LOOK_AHEAD_DAYS = 90
+const COMPONENT_NAME = 'Payroll.TransitionPayrollAlert'
 
-export function TransitionPayrollAlert(props: TransitionPayrollAlertProps) {
-  const { onEvent } = props
+export function TransitionPayrollAlert({ companyId, onEvent }: TransitionPayrollAlertProps) {
   const { observability } = useObservability()
 
-  const handleGateError = useCallback(
-    (boundaryError: unknown, errorInfo: ErrorInfo) => {
-      onEvent(componentEvents.ERROR, boundaryError)
-
-      const sdkError = normalizeToSDKError(boundaryError)
-      observability?.onError?.({
-        ...sdkError,
-        timestamp: Date.now(),
-        componentName: 'Payroll.TransitionPayrollAlert',
-        componentStack: errorInfo.componentStack ?? undefined,
-      })
-    },
-    [observability, onEvent],
-  )
-
-  return (
-    <QueryErrorResetBoundary>
-      {({ reset: resetQueries }) => (
-        <ErrorBoundary
-          FallbackComponent={NullFallback}
-          onReset={resetQueries}
-          onError={handleGateError}
-        >
-          <Suspense fallback={null}>
-            <TransitionPayrollAlertGate {...props} />
-          </Suspense>
-        </ErrorBoundary>
-      )}
-    </QueryErrorResetBoundary>
-  )
-}
-
-function NullFallback(_: FallbackProps) {
-  return null
-}
-
-function TransitionPayrollAlertGate({ companyId, onEvent }: TransitionPayrollAlertProps) {
   const lookAheadEndDate = useMemo(() => {
     const date = new Date()
     date.setDate(date.getDate() + LOOK_AHEAD_DAYS)
     return new RFCDate(date)
   }, [])
 
-  const { data: payPeriodsData } = usePaySchedulesGetPayPeriodsSuspense({
+  const { data: payPeriodsData, error: payPeriodsError } = usePaySchedulesGetPayPeriods({
     companyId,
     payrollTypes: PayrollTypes.Transition,
     endDate: lookAheadEndDate,
   })
 
-  const { data: paySchedulesData } = usePaySchedulesGetAllSuspense({ companyId })
+  const { data: paySchedulesData, error: paySchedulesError } = usePaySchedulesGetAll({ companyId })
+
+  const gateError = payPeriodsError ?? paySchedulesError
+
+  useEffect(() => {
+    if (!gateError) return
+    onEvent(componentEvents.ERROR, gateError)
+    const sdkError = normalizeToSDKError(gateError)
+    observability?.onError?.({
+      ...sdkError,
+      timestamp: Date.now(),
+      componentName: COMPONENT_NAME,
+    })
+  }, [gateError, onEvent, observability])
 
   const groupedPayPeriods = useMemo<TransitionPayPeriodGroup[]>(() => {
+    if (!payPeriodsData || !paySchedulesData) return []
     const paySchedules = paySchedulesData.payScheduleShowResponse ?? []
     const unprocessed = (payPeriodsData.payPeriods ?? []).filter(
       (pp: PayPeriod) => !pp.payroll?.processed,
@@ -109,7 +83,7 @@ function TransitionPayrollAlertGate({ companyId, onEvent }: TransitionPayrollAle
     })
   }, [payPeriodsData, paySchedulesData])
 
-  if (groupedPayPeriods.length === 0) {
+  if (!payPeriodsData || !paySchedulesData || groupedPayPeriods.length === 0) {
     return null
   }
 

--- a/src/components/Payroll/TransitionPayrollAlert/TransitionPayrollAlert.tsx
+++ b/src/components/Payroll/TransitionPayrollAlert/TransitionPayrollAlert.tsx
@@ -1,4 +1,7 @@
-import { Suspense, useMemo, useState, useCallback } from 'react'
+import { Suspense, useMemo, useState, useCallback, type ErrorInfo } from 'react'
+import type { FallbackProps } from 'react-error-boundary'
+import { ErrorBoundary } from 'react-error-boundary'
+import { QueryErrorResetBoundary } from '@tanstack/react-query'
 import { usePaySchedulesGetPayPeriodsSuspense } from '@gusto/embedded-api/react-query/paySchedulesGetPayPeriods'
 import { usePaySchedulesGetAllSuspense } from '@gusto/embedded-api/react-query/paySchedulesGetAll'
 import { usePayrollsSkipMutation } from '@gusto/embedded-api/react-query/payrollsSkip'
@@ -6,37 +9,68 @@ import { PayrollType } from '@gusto/embedded-api/models/operations/postcompanies
 import { PayrollTypes } from '@gusto/embedded-api/models/operations/getv1companiescompanyidpayperiods'
 import type { PayPeriod } from '@gusto/embedded-api/models/components/payperiod'
 import { RFCDate } from '@gusto/embedded-api/types/rfcdate'
-import { TransitionPayrollAlertPresentation } from './TransitionPayrollAlertPresentation'
+import {
+  TransitionPayrollAlertPresentation,
+  type TransitionPayPeriodGroup,
+} from './TransitionPayrollAlertPresentation'
 import { BaseComponent } from '@/components/Base/Base'
 import { useBase } from '@/components/Base/useBase'
 import type { OnEventType } from '@/components/Base/useBase'
 import type { EventType } from '@/shared/constants'
 import { componentEvents } from '@/shared/constants'
+import { useObservability } from '@/contexts/ObservabilityProvider/useObservability'
+import { normalizeToSDKError } from '@/types/sdkError'
 
 interface TransitionPayrollAlertProps {
   companyId: string
   onEvent: OnEventType<EventType, unknown>
 }
 
-interface GroupedTransitionPayPeriods {
-  payScheduleUuid: string
-  payScheduleName: string
-  payPeriods: PayPeriod[]
-}
-
 interface RootProps {
   companyId: string
-  groupedPayPeriods: GroupedTransitionPayPeriods[]
+  groupedPayPeriods: TransitionPayPeriodGroup[]
 }
 
 const LOOK_AHEAD_DAYS = 90
 
 export function TransitionPayrollAlert(props: TransitionPayrollAlertProps) {
-  return (
-    <Suspense fallback={null}>
-      <TransitionPayrollAlertGate {...props} />
-    </Suspense>
+  const { onEvent } = props
+  const { observability } = useObservability()
+
+  const handleGateError = useCallback(
+    (boundaryError: unknown, errorInfo: ErrorInfo) => {
+      onEvent(componentEvents.ERROR, boundaryError)
+
+      const sdkError = normalizeToSDKError(boundaryError)
+      observability?.onError?.({
+        ...sdkError,
+        timestamp: Date.now(),
+        componentName: 'Payroll.TransitionPayrollAlert',
+        componentStack: errorInfo.componentStack ?? undefined,
+      })
+    },
+    [observability, onEvent],
   )
+
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset: resetQueries }) => (
+        <ErrorBoundary
+          FallbackComponent={NullFallback}
+          onReset={resetQueries}
+          onError={handleGateError}
+        >
+          <Suspense fallback={null}>
+            <TransitionPayrollAlertGate {...props} />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  )
+}
+
+function NullFallback(_: FallbackProps) {
+  return null
 }
 
 function TransitionPayrollAlertGate({ companyId, onEvent }: TransitionPayrollAlertProps) {
@@ -54,7 +88,7 @@ function TransitionPayrollAlertGate({ companyId, onEvent }: TransitionPayrollAle
 
   const { data: paySchedulesData } = usePaySchedulesGetAllSuspense({ companyId })
 
-  const groupedPayPeriods = useMemo<GroupedTransitionPayPeriods[]>(() => {
+  const groupedPayPeriods = useMemo<TransitionPayPeriodGroup[]>(() => {
     const paySchedules = paySchedulesData.payScheduleShowResponse ?? []
     const unprocessed = (payPeriodsData.payPeriods ?? []).filter(
       (pp: PayPeriod) => !pp.payroll?.processed,

--- a/src/components/Payroll/TransitionPayrollAlert/TransitionPayrollAlertPresentation.tsx
+++ b/src/components/Payroll/TransitionPayrollAlert/TransitionPayrollAlertPresentation.tsx
@@ -6,7 +6,7 @@ import { Flex } from '@/components/Common/Flex/Flex'
 import { useI18n } from '@/i18n'
 import { useDateFormatter } from '@/hooks/useDateFormatter'
 
-interface TransitionPayPeriodGroup {
+export interface TransitionPayPeriodGroup {
   payScheduleUuid: string
   payScheduleName: string
   payPeriods: PayPeriod[]


### PR DESCRIPTION
## Summary

`TransitionPayrollAlert` is rendered unconditionally on `PayrollLanding`, but it has nothing to show unless the company has unprocessed transition pay periods. Today, even when it ends up returning `null`, the component still produces a visible artifact in the layout:

1. While its Suspense queries are loading, `BaseComponent` shows its default 200px skeleton fallback above the tabs.
2. After load, `BaseComponent` keeps an empty `FadeIn` `<div>` in the DOM even when `Root` returns `null`. Because the parent `Flex` uses `gap={32}`, that empty wrapper still consumes a gap slot — producing a small, visible "pop-in" as content finishes loading.

This PR hoists the Suspense queries above `BaseComponent`. A new gate component does the data fetching, computes `groupedPayPeriods`, and returns `null` *before* mounting `BaseComponent` when there's nothing to render. The outer wrapper becomes `<Suspense fallback={null}>`, so:

- Loading state → nothing in the DOM
- Resolved, no transition pay periods → nothing in the DOM
- Resolved, has transition pay periods → `BaseComponent` + `FadeIn` + alert mount as usual

No layout shift, no skeleton flash, and no behavioral change when there *is* a transition alert to show.

## Fix Video

Uploading Screen Recording 2026-05-11 at 2.41.16 PM.mov…



## Test plan

- [ ] `npm run test -- --run src/components/Payroll/TransitionPayrollAlert/` passes (10/10)
- [ ] Visit `PayrollLanding` for a company with no transition pay periods — no skeleton box and no gap above the tabs at any point during page load
- [ ] Visit `PayrollLanding` for a company with an active transition pay period — alert still renders correctly with skip / run-payroll handlers wired up
- [ ] Skip-payroll mutation still surfaces errors through the alert (no regression from removing the outer `BaseComponent` wrap around the loading state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)