### PR TITLE
chore: add Claude Code skills for SDK-aware PR review

### DIFF
--- a/.claude/install/README.md
+++ b/.claude/install/README.md
@@ -1,0 +1,58 @@
+# Claude Code Skills — Setup
+
+Skills in this repo work in two layers. Understanding both saves you time.
+
+## Layer 1: Repo-local skills (automatic — no setup required)
+
+When you open Claude Code inside this repo, it automatically picks up the skills in `.claude/skills/`:
+
+| Skill           | What it does                                                                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/review-pr`    | Full SDK-aware PR review — checks hook composition, `composeSubmitHandler` usage, `BaseBoundaries`, event payloads, validation messages, and more |
+| `/learn-review` | Adds a new pattern to `rules/learned.md` in this repo so the whole team benefits                                                                  |
+
+**No installation needed.** These work the moment you clone and open the repo in Claude Code.
+
+## Layer 2: Global skills (one-time install per machine)
+
+The global skills add the same repo-detection logic to your `~/.claude/skills/` so that:
+
+- When you correct a review or flag something missed, the learning is written to **this repo's** `learned.md` automatically — even if the trigger happens outside a formal `/review-pr` session.
+- When you use `/review-pr` in **other repos**, you still get the global baseline learned rules.
+
+### Install
+
+```bash
+bash .claude/install/install-skills.sh
+```
+
+The script copies `review-pr` and `learn-review` to `~/.claude/skills/`. It prompts before overwriting if you already have versions there. Safe to re-run.
+
+Restart Claude Code after installing.
+
+## How the learning loop works
+
+```
+/review-pr                → reads repo-local learned.md + global learned.md
+  │
+  └─ you correct a finding or flag something missed
+       │
+       └─ /learn-review fires automatically
+            │
+            └─ writes new rule to .claude/skills/review-pr/rules/learned.md
+                 │
+                 └─ commit & push → teammates get the rule on next pull
+```
+
+`learned.md` is version-controlled. Rules accumulate over time and apply to every future review in this repo.
+
+## Files
+
+```
+.claude/install/
+├── README.md                         this file
+├── install-skills.sh                 copies global skills to ~/.claude/skills/
+└── skills/
+    ├── review-pr/SKILL.md            global version (repo detection, standard checks)
+    └── learn-review/SKILL.md         global version (writes to repo-local learned.md when present)
+```

--- a/.claude/install/install-skills.sh
+++ b/.claude/install/install-skills.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Installs global Claude Code skills to ~/.claude/skills/.
+# Run once per machine. Safe to re-run — only overwrites if you confirm.
+#
+# These global skills complement the repo-local skills in .claude/skills/:
+#   - When you open Claude Code inside this repo, the repo-local skills
+#     take over automatically (no install needed).
+#   - These global versions add the same repo-detection logic for use
+#     in other repos and so the auto-learn flow works from any context.
+
+set -e
+
+INSTALL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GLOBAL_SKILLS_DIR="$HOME/.claude/skills"
+
+install_skill() {
+  local skill_name="$1"
+  local src="$INSTALL_DIR/skills/$skill_name"
+  local dest="$GLOBAL_SKILLS_DIR/$skill_name"
+
+  if [ -d "$dest" ]; then
+    read -r -p "  $skill_name already exists at $dest — overwrite? [y/N] " answer
+    if [[ ! "$answer" =~ ^[Yy]$ ]]; then
+      echo "  Skipped $skill_name."
+      return
+    fi
+  fi
+
+  mkdir -p "$dest"
+  cp -r "$src/." "$dest/"
+  echo "  Installed $skill_name → $dest"
+}
+
+echo "Installing Claude Code skills to $GLOBAL_SKILLS_DIR..."
+echo ""
+install_skill "review-pr"
+install_skill "learn-review"
+echo ""
+echo "Done. Restart Claude Code if it is currently open."

--- a/.claude/install/skills/learn-review/SKILL.md
+++ b/.claude/install/skills/learn-review/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: learn-review
+description: Add a new rule to the review-pr skill's learned patterns. Use when you notice something in a code review that the skill missed or should catch in the future.
+argument-hint: '<note about what to catch>'
+allowed-tools: [Read, Edit]
+---
+
+# Add a Learned Review Rule
+
+Append a new entry to the `review-pr` skill's learned patterns based on `$ARGUMENTS`.
+
+## Steps
+
+### Step 1: Locate and read the current learned rules
+
+Check whether a repo-local learned rules file exists:
+
+```bash
+test -f .claude/skills/review-pr/rules/learned.md && echo "exists"
+```
+
+- **If it exists**: use `.claude/skills/review-pr/rules/learned.md` as the target file for both reading and writing.
+- **If it does not exist**: use `~/.claude/skills/review-pr/rules/learned.md` as the target file.
+
+Read the target file and determine the next LEARNED-NNN number from the existing entries.
+
+### Step 2: Draft the new rule
+
+From `$ARGUMENTS`, extract:
+
+- A short title (5–8 words)
+- The rule itself (1–3 sentences: what to avoid and why)
+- A severity: `error` → Critical, `warning` → Important, `info` → Suggestion
+- A bad example (if the note contains enough detail to write one)
+- A good example (if the note contains enough detail)
+
+Use this format:
+
+```markdown
+---
+
+### LEARNED-NNN: <Title>
+
+- **Severity:** warning
+- **Rule:** <Clear rule statement.>
+
+#### Bad Example
+
+\`\`\`tsx
+// code showing what to avoid
+\`\`\`
+
+#### Good Example
+
+\`\`\`tsx
+// code showing the correct approach
+\`\`\`
+```
+
+If the note doesn't have enough detail to write good/bad examples, omit those sections and include just the rule statement. Do not invent examples.
+
+### Step 3: Append to the target learned.md
+
+Insert the new entry before the `## Adding New Patterns` footer section at the bottom of the target file identified in Step 1.
+
+Also update the footer line that says "The next entry should be `LEARNED-NNN`" to reflect the new next number.
+
+### Step 4: Confirm
+
+Report back:
+
+- The rule ID assigned (e.g., `LEARNED-006`)
+- The rule title
+- The severity
+- One sentence summarizing what was added

--- a/.claude/install/skills/review-pr/SKILL.md
+++ b/.claude/install/skills/review-pr/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: review-pr
+description: Review a GitHub pull request. Use when asked to review a PR or pull request.
+argument-hint: '<PR number or GitHub URL>'
+allowed-tools: [Bash, Read]
+---
+
+# PR Review
+
+Review a GitHub pull request and report findings with severity tiers and suggested fixes.
+
+## Arguments
+
+`$ARGUMENTS` — PR number, GitHub URL (`https://github.com/owner/repo/pull/123`), or empty to auto-detect the current branch's open PR.
+
+## Steps
+
+### Step 1: Fetch PR
+
+Parse `$ARGUMENTS`:
+
+- GitHub URL → extract `owner/repo` and number
+- Plain number → detect repo via `gh repo view --json nameWithOwner -q .nameWithOwner`
+- Empty → use `gh pr view --json number,title,body,author,url,baseRefName,headRefName`
+
+```bash
+gh pr view <number> [--repo <owner/repo>] --json number,title,body,author,url,baseRefName,headRefName
+gh pr diff <number> [--repo <owner/repo>]
+```
+
+### Step 2: Load Learned Rules
+
+Check whether a repo-local learned rules file exists:
+
+```bash
+test -f .claude/skills/review-pr/rules/learned.md && echo "exists"
+```
+
+- **If it exists**: read both `.claude/skills/review-pr/rules/learned.md` (repo-local) and `~/.claude/skills/review-pr/rules/learned.md` (global), and apply rules from both. Repo-local rules take precedence if there is a conflict.
+- **If it does not exist**: read `~/.claude/skills/review-pr/rules/learned.md` only.
+
+Apply every rule found. Each rule has a severity (error → Critical, warning → Important, info → Suggestion).
+
+### Step 3: Review the Diff
+
+Analyze the diff for the following, in addition to the learned rules:
+
+**Always check:**
+
+- Correctness: logic errors, off-by-ones, unhandled promise rejections, missing null checks
+- Security: user-controlled input reaching dangerous sinks, missing sanitization, exposed secrets
+- TypeScript: the learned rules cover `as` casts; also flag implicit `any` and unsafe non-null assertions
+- Tests: the learned rules cover redundancy; also flag new logic with zero test coverage
+
+**Check when relevant (skip if no UI/component files changed):**
+
+- Accessibility: interactive elements missing `aria-label` or role, focus management issues, missing keyboard handlers on clickable non-button elements
+
+**Check when relevant (skip if not an SDK component):**
+
+- Apply the partner-facing API rule from learned rules
+
+### Step 4: Output
+
+````
+# PR Review: <title>
+
+**PR:** #<number> · **Author:** <author> · **Branch:** `<head>` → `<base>`
+
+---
+
+## Critical
+<!-- Must fix before merge: bugs, security issues, broken a11y on interactive elements -->
+
+- **[rule or category]** `path/to/file.tsx:42` — <what's wrong and why it matters>
+  ```ts
+  // Fix:
+  <corrected snippet>
+````
+
+## Important
+
+<!-- Significant quality concerns: unsafe types, missing tests on non-trivial code, API design issues -->
+
+- **[rule or category]** `path/to/file.ts:88` — <description>
+  ```ts
+  // Fix:
+  <corrected snippet>
+  ```
+
+## Suggestions
+
+<!-- Nice-to-have: minor improvements that aren't blocking -->
+
+- **[rule or category]** `path/to/file.ts:12` — <description>
+
+## Strengths
+
+<!-- What's well done — always include at least one observation -->
+
+---
+
+## Assessment
+
+<One paragraph: what the PR accomplishes, main quality signal, merge recommendation.>
+
+```
+
+### Step 5: Learn from Feedback
+
+After delivering the review, stay alert for follow-up messages where the user:
+- Corrects a finding ("that's not actually a problem because…", "this is intentional")
+- Points out something the review missed ("you didn't flag…", "what about…")
+- Describes a pattern to watch for going forward
+
+When this happens, **immediately** invoke the `learn-review` skill with a concise summary of the new pattern or correction. Do not wait for the user to explicitly ask — treat any correction or missed-pattern note as a learning trigger.
+
+## Rules
+
+- Include a fix snippet for every Critical and Important finding
+- Cite `file:line` for every finding — no vague descriptions
+- If the diff is large (600+ lines), focus on Critical and Important only
+- Never omit the Strengths section
+- Tag each finding with the LEARNED-NNN rule ID when one applies (e.g., `[LEARNED-002]`)
+```

--- a/.claude/skills/learn-review/SKILL.md
+++ b/.claude/skills/learn-review/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: learn-review
+description: Add a new rule to the review-pr skill's learned patterns. Use when you notice something in a code review that the skill missed or should catch in the future.
+argument-hint: '<note about what to catch>'
+allowed-tools: [Read, Edit]
+---
+
+# Add a Learned Review Rule
+
+Append a new entry to the `review-pr` skill's learned patterns based on `$ARGUMENTS`.
+
+## Steps
+
+### Step 1: Read the current learned rules
+
+Read the file at:
+
+```
+.claude/skills/review-pr/rules/learned.md
+```
+
+Determine the next LEARNED-NNN number from the existing entries.
+
+### Step 2: Draft the new rule
+
+From `$ARGUMENTS`, extract:
+
+- A short title (5–8 words)
+- The rule itself (1–3 sentences: what to avoid and why)
+- A severity: `error` → Critical, `warning` → Important, `info` → Suggestion
+- A bad example (if the note contains enough detail to write one)
+- A good example (if the note contains enough detail)
+
+Use this format:
+
+```markdown
+---
+
+### LEARNED-NNN: <Title>
+
+- **Severity:** warning
+- **Rule:** <Clear rule statement.>
+
+#### Bad Example
+
+\`\`\`tsx
+// code showing what to avoid
+\`\`\`
+
+#### Good Example
+
+\`\`\`tsx
+// code showing the correct approach
+\`\`\`
+```
+
+If the note doesn't have enough detail to write good/bad examples, omit those sections and include just the rule statement. Do not invent examples.
+
+### Step 3: Append to learned.md
+
+Insert the new entry before the `## Adding New Patterns` footer section at the bottom of the file.
+
+Also update the footer line that says "The next entry should be `LEARNED-NNN`" to reflect the new next number.
+
+### Step 4: Confirm
+
+Report back:
+
+- The rule ID assigned (e.g., `LEARNED-006`)
+- The rule title
+- The severity
+- One sentence summarizing what was added

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: review-pr
+description: Review a GitHub pull request. Use when asked to review a PR or pull request.
+argument-hint: '<PR number or GitHub URL>'
+allowed-tools: [Bash, Read]
+---
+
+# PR Review
+
+Review a GitHub pull request and report findings with severity tiers and suggested fixes.
+
+## Arguments
+
+`$ARGUMENTS` — PR number, GitHub URL (`https://github.com/owner/repo/pull/123`), or empty to auto-detect the current branch's open PR.
+
+## Steps
+
+### Step 1: Fetch PR
+
+Parse `$ARGUMENTS`:
+
+- GitHub URL → extract `owner/repo` and number
+- Plain number → detect repo via `gh repo view --json nameWithOwner -q .nameWithOwner`
+- Empty → use `gh pr view --json number,title,body,author,url,baseRefName,headRefName`
+
+```bash
+gh pr view <number> [--repo <owner/repo>] --json number,title,body,author,url,baseRefName,headRefName
+gh pr diff <number> [--repo <owner/repo>]
+```
+
+### Step 2: Load Learned Rules
+
+Read the rules file at the path of this skill: `rules/learned.md`
+
+Apply every rule in that file to the diff. Each rule has a severity (error → Critical, warning → Important, info → Suggestion).
+
+### Step 3: Review the Diff
+
+Analyze the diff for the following, in addition to the learned rules:
+
+**Always check:**
+
+- Correctness: logic errors, off-by-ones, unhandled promise rejections, missing null checks
+- Security: user-controlled input reaching dangerous sinks, missing sanitization, exposed secrets
+- TypeScript: the learned rules cover `as` casts; also flag implicit `any` and unsafe non-null assertions
+- Tests: the learned rules cover redundancy; also flag new logic with zero test coverage
+
+**Check when relevant (skip if no UI/component files changed):**
+
+- Accessibility: interactive elements missing `aria-label` or role, focus management issues, missing keyboard handlers on clickable non-button elements
+
+**Check when relevant (skip if not an SDK component):**
+
+- Apply the partner-facing API rule from learned rules
+
+---
+
+**Check when any SDK component or hook files are in the diff:**
+
+#### Hook Architecture (component layer)
+
+- **BaseBoundaries, not BaseComponent**: Public components must wrap `BaseBoundaries` and delegate to a `Root` component. Flag any use of `BaseComponent` or `useBase()`.
+- **`onEvent` as prop**: `onEvent` must be passed as a prop through to `Root` — never read from `useBase()`.
+- **Business logic stays in the hook**: Field visibility, conditional requiredness, derived data, and loading states must come from the hook. Flag `useWatch` usage that gates field rendering or sets requiredness — this logic belongs inside the hook's schema or `Fields` selection.
+- **Conditional fields via truthiness**: Fields the hook returns as `undefined` when hidden must be rendered with a truthiness guard (`{Fields.SomeField && <Fields.SomeField ... />}`). Flag explicit `if` conditions based on form values.
+
+#### Multi-Form Composition
+
+- **`composeSubmitHandler` required**: When more than one form hook is used on a screen, errors and submit must be aggregated with `composeSubmitHandler`. Flag any manual error array spreading (e.g. `[...hookA.errorHandling.errors, ...hookB.errorHandling.errors]`).
+- **`shouldFocusError: false` on all hooks**: Every hook initialized alongside others must pass `shouldFocusError: false` so `composeSubmitHandler` controls cross-form focus. Flag any hook that omits this when siblings are present.
+- **Never memoize `activeForms` or `composeSubmitHandler` result**: Hook return values are not stable references. Flag `useMemo` wrapping either.
+- **`composeErrorHandler` for extra queries**: If the component fetches data outside the form hooks (React Query calls alongside hook usage), it must feed them through `composeErrorHandler` — not wire up a separate error display.
+
+#### Loading and Error State
+
+- **Loading gate shape**: The loading branch must use `<BaseLayout isLoading error={errorHandling.errors} />`. Flag `isLoading` rendered without passing `error`, which hides query failures behind an infinite spinner.
+- **Ready state error surface**: The ready branch must wrap content in `<BaseLayout error={errorHandling.errors}>`. Flag components that render the form without a `BaseLayout` wrapper or that pass raw error arrays instead of `errorHandling.errors`.
+
+#### SDKFormProvider Rules
+
+- **No nesting**: `SDKFormProvider` must not be nested inside another `SDKFormProvider`. Use sibling providers for fields from different hooks.
+- **No cross-hook fields**: Fields from hook B must not be rendered inside an `SDKFormProvider` wrapping hook A's result.
+- **Consistent approach per hook**: For each hook result, use either `SDKFormProvider` or the `formHookResult` prop on every field — never both for the same hook.
+
+#### Select Fields with Translated Labels
+
+- **`getOptionLabel` required for translated options**: Select fields with translated option labels must use `getOptionLabel` on the hook's field component combined with `withOptions(baseMetadata.field, options, entries)` in the hook. Flag any raw `<SelectField>` inside an `SDKFormProvider` used as a workaround for missing translated labels.
+- **Translations never in hooks**: Hooks must not call `useTranslation` or `t()`. Display labels belong in the component.
+
+#### Validation Messages
+
+- **All error codes covered**: Every rendered field must have `validationMessages` covering all error codes that can realistically fire. The field's type definition in `fields.tsx` distinguishes required vs optional keys — TypeScript enforces the required ones but won't catch missing optional ones. Flag fields rendered without `validationMessages` unless the field's error codes can never fire (e.g. boolean fields, fields with `requiredFieldsConfig: 'never'` and no format validator).
+
+#### Event Payloads (see also LEARNED-005)
+
+- **API response data in `onEvent`**: Any `onEvent` call following a mutation must include the API response as payload. This applies to all event types — not just `_DONE`. Pass the inner data value (e.g. `result.data`), not the top-level mutation result which includes `httpMeta`.
+- **Preserve existing event surface on migrations**: Migrations must not remove, rename, or change the payload shape of any event the pre-migration component emitted. Flag any `onEvent` call that was present before and is absent or altered in the diff.
+
+#### Partial Update Recovery (create mode)
+
+- **`resolvedId` state on partial failure only**: In create-mode multi-hook forms, a new entity ID must only be captured in component state if a downstream hook fails (recovery path). Flag code that stores a created ID in state on success — this triggers a re-render mid-submission that can unmount the form.
+
+---
+
+**Check when any hook implementation files are changed (`use*Form.tsx`, `*Schema.ts`, `fields.tsx`):**
+
+#### Schema
+
+- **4-part schema structure**: Every schema file must follow the `ErrorCodes → fieldValidators → requiredFieldsConfig → schema factory (buildFormSchema)` structure. Flag schemas that hardcode validation logic inline without this structure.
+- **Boolean fields excluded from `requiredFieldsConfig`**: Boolean fields (`z.boolean()`) always have a value — they must never appear in `requiredFieldsConfig`. Flag any boolean field listed there.
+- **`values` + `resetOptions` on `useForm`, not `useEffect` + `reset()`**: Form defaults must be synced via `values: resolvedDefaults` and `resetOptions: { keepDirtyValues: true }`. Flag any `useEffect` that calls `reset()`.
+- **Schema memoized**: `create*Schema(...)` call must be inside `useMemo`. Flag schema creation outside of `useMemo` at the hook top level.
+
+#### Return Shape
+
+- **Discriminated union with `errorHandling` in both branches**: The hook must return `{ isLoading: true as const, errorHandling }` in the loading branch and `{ isLoading: false as const, ..., errorHandling }` in the ready branch. Flag hooks where `errorHandling` is only available in the ready branch.
+- **`HookSubmitResult<Entity>` return type**: `onSubmit` must return `HookSubmitResult<TEntity>`. Flag submit handlers that return `void` or a raw API response.
+- **No `*SubmitCallbacks` on single-mutation hooks**: Hooks that fire exactly one mutation per submit (including create-or-update routing) must not add a callbacks parameter — partners read `result.data`. Only hooks chaining multiple sequential mutations in one submit (like `useEmployeeDetailsForm`) should accept callbacks.
+
+#### Hook Placement
+
+- **`shared/use*Form/` directory**: Hooks must live at `src/components/<Domain>/<Feature>/shared/use<Name>Form/`. Flag hooks created elsewhere in the component tree.
+- **Five-file structure**: Each hook directory must contain `use*Form.tsx`, `*Schema.ts`, `fields.tsx`, `index.ts`, and `use*Form.test.tsx`. Flag directories missing any of these files.
+- **Barrel exports**: New hooks must be exported from the feature-level barrel and, if partner-facing, from `src/index.ts`. Flag hooks added without barrel updates.
+
+---
+
+**Check when test files are in the diff:**
+
+- **`HttpResponseResolver` generic on `vi.fn`**: Any `vi.fn()` wrapping an MSW resolver must be typed as `vi.fn<HttpResponseResolver>`. Without it, `request` is inferred as `any` and `request.json()` / `request.url` are unsafe. Flag untyped resolver mocks.
+- **`mock.invocationCallOrder` for ordering assertions**: Cross-endpoint call order must be asserted via `resolver.mock.invocationCallOrder[0]`. Flag tests that try to assert ordering via timing, counters, or manual flags.
+- **`npm run test -- --run`**: Any test command in comments, README additions, or CI config must include `--run`. Flag `npm run test` without `--run` (starts watch mode, hangs in CI).
+
+---
+
+**Check when CSS/SCSS files are in the diff:**
+
+- **No `!important`**: Flag any `!important` declaration — use CSS specificity instead.
+- **No `@use` for auto-injected modules**: Do not add `@use` imports for modules globally available via Vite (e.g. `@/styles/Helpers` is auto-injected). Flag redundant imports.
+
+---
+
+**Check when any commit message or PR title convention may be violated:**
+
+- **Conventional commits**: Commits must use `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`, etc. Breaking changes use `feat!:` or `fix!:`. Flag PR titles that don't match this format.
+
+### Step 4: Output
+
+````
+# PR Review: <title>
+
+**PR:** #<number> · **Author:** <author> · **Branch:** `<head>` → `<base>`
+
+---
+
+## Critical
+<!-- Must fix before merge: bugs, security issues, broken a11y on interactive elements -->
+
+- **[rule or category]** `path/to/file.tsx:42` — <what's wrong and why it matters>
+  ```ts
+  // Fix:
+  <corrected snippet>
+````
+
+## Important
+
+<!-- Significant quality concerns: unsafe types, missing tests on non-trivial code, API design issues -->
+
+- **[rule or category]** `path/to/file.ts:88` — <description>
+  ```ts
+  // Fix:
+  <corrected snippet>
+  ```
+
+## Suggestions
+
+<!-- Nice-to-have: minor improvements that aren't blocking -->
+
+- **[rule or category]** `path/to/file.ts:12` — <description>
+
+## Strengths
+
+<!-- What's well done — always include at least one observation -->
+
+---
+
+## Assessment
+
+<One paragraph: what the PR accomplishes, main quality signal, merge recommendation.>
+
+```
+
+## Rules
+
+- Include a fix snippet for every Critical and Important finding
+- Cite `file:line` for every finding — no vague descriptions
+- If the diff is large (600+ lines), focus on Critical and Important only
+- Never omit the Strengths section
+- Tag each finding with the LEARNED-NNN rule ID when one applies (e.g., `[LEARNED-002]`)
+```

--- a/.claude/skills/review-pr/rules/learned.md
+++ b/.claude/skills/review-pr/rules/learned.md
@@ -1,0 +1,142 @@
+---
+version: 1
+last_updated: 2026-04-22
+---
+
+# Learned Review Rules
+
+Patterns from actual review feedback. Add new entries with `/learn-review <note>`.
+
+---
+
+### LEARNED-001: Avoid Unnecessary Memoization
+
+- **Severity:** warning
+- **Rule:** Do not add `useMemo`, `useCallback`, or `React.memo` unless there is a demonstrated or obvious performance problem. Memoization on deep objects with referential equality checks is especially risky — the equality check will almost always fail on re-render, making the memoization useless at best and a maintenance trap at worst.
+
+#### Bad Example
+
+```tsx
+// Object recreated every render anyway — memo check always fails
+const config = useMemo(() => ({ filters: { status, page }, sort }), [status, page, sort])
+
+// React.memo on a component with a complex object prop — not buying you anything
+export const EmployeeList = React.memo(({ filters }: { filters: FilterConfig }) => { ... })
+```
+
+#### Good Example
+
+```tsx
+// No memoization needed for simple derived values
+const config = { filters: { status, page }, sort }
+
+// Add memo only when a profiler shows a real problem
+```
+
+---
+
+### LEARNED-002: Avoid Type Casts (`as`)
+
+- **Severity:** warning
+- **Rule:** Avoid `as SomeType` unless there is clearly no alternative. Every `as` cast bypasses TypeScript's safety checks. Instead, use type guards, discriminated union narrowing, or generics. If you spot an `as` cast, suggest the specific alternative that applies to that code.
+
+#### Bad Example
+
+```tsx
+const employee = data as Employee
+const id = event.target.value as string
+```
+
+#### Good Example
+
+```tsx
+// Use a type guard
+function isEmployee(val: unknown): val is Employee {
+  return typeof val === 'object' && val !== null && 'id' in val
+}
+if (isEmployee(data)) { /* data is Employee here */ }
+
+// Use a generic to let the caller specify the type safely
+function useFormField<T>(name: string): T { ... }
+```
+
+---
+
+### LEARNED-003: Avoid Redundant Test Cases
+
+- **Severity:** info
+- **Rule:** Tests should verify meaningful, distinct behavior — not repeat the same assertion with minor variations. Prefer a small set of representative test cases that cover the real value (happy path, key error path, important edge case) over a large number of shallow tests that add noise. Flag test suites where multiple cases are asserting the same thing in slightly different ways.
+
+#### Bad Example
+
+```tsx
+it('renders with name "Alice"', () => { ... })
+it('renders with name "Bob"', () => { ... })
+it('renders with name "Charlie"', () => { ... })
+// These all verify the same behavior — one parameterized test or a single representative case is enough
+```
+
+#### Good Example
+
+```tsx
+it('renders the employee name', () => { ... })       // happy path
+it('shows a placeholder when name is empty', () => { ... })  // meaningful edge case
+```
+
+---
+
+### LEARNED-004: SDK Partner-Facing Component APIs Should Be Minimal
+
+- **Severity:** warning
+- **Rule:** Components in the SDK that are provided to partners should expose a minimal, stable API. The primary prop is typically an entity ID (e.g., `employeeId`, `companyId`). Feature flags and opt-in behaviors (e.g., `withI9`, `isSelfOnboardingEnabled`) are acceptable as named booleans. Internal implementation details — sub-component props, internal state shapes, handler signatures — should not be exposed. If a new prop doesn't clearly belong in a partner integration contract, question it.
+
+#### Bad Example
+
+```tsx
+// Exposing internal plumbing to partners
+<EmployeeOnboarding
+  employeeId={id}
+  formConfig={{ sections: ['personal', 'tax'], layout: 'stacked' }}
+  onStepChange={(step, data) => { ... }}
+  internalFlowState={flowState}
+/>
+```
+
+#### Good Example
+
+```tsx
+// Minimal partner API: entity ID + opt-in feature flags
+<EmployeeOnboarding employeeId={id} withI9={true} isSelfOnboardingEnabled={false} />
+```
+
+---
+
+---
+
+### LEARNED-005: Pass API Response Data in Component Events
+
+- **Severity:** warning
+- **Rule:** Any event emitted after an API call should include the API response data as the payload. This applies to all event types (DONE, BACK, ERROR, etc.) — not just DONE. The top-level mutation result includes transport-level fields like `httpMeta` that partners don't need — extract the inner data value (e.g. `result.data` or whichever property contains the updated resource) and pass that instead. Discarding the result leaves partners without the updated state they need to react to the operation.
+
+#### Bad Example
+
+```tsx
+await updateTimeOffPolicy({
+  request: { timeOffPolicyUuid: policyId, requestBody: buildUpdateRequestBody(data, version) },
+})
+onEvent(componentEvents.TIME_OFF_POLICY_SETTINGS_DONE)
+```
+
+#### Good Example
+
+```tsx
+const result = await updateTimeOffPolicy({
+  request: { timeOffPolicyUuid: policyId, requestBody: buildUpdateRequestBody(data, version) },
+})
+// Pass the inner data value — not the top-level result which includes httpMeta etc.
+onEvent(componentEvents.TIME_OFF_POLICY_SETTINGS_DONE, result.data)
+```
+
+## Adding New Patterns
+
+Use `/learn-review <note>` to append a new entry. The next entry should be `LEARNED-006`.


### PR DESCRIPTION
## Summary

- Adds repo-local Claude Code `/review-pr` skill with SDK-specific checks for hook composition, `composeSubmitHandler`, `BaseBoundaries`, `SDKFormProvider` rules, event payloads, validation messages, test patterns, and more
- Adds repo-local `/learn-review` skill that writes new patterns back to a version-controlled `learned.md` — corrections made during any review session accumulate as shared team knowledge
- Adds `.claude/install/` with global-installable versions of both skills and a one-line setup script for engineers who want the repo-detection logic outside this repo

## How it works

**No setup needed to get started.** Claude Code automatically picks up skills in `.claude/skills/` when opened inside this repo. `/review-pr` runs the full SDK-aware checklist; if you correct a finding or flag something missed, `/learn-review` fires automatically and writes the new rule to `.claude/skills/review-pr/rules/learned.md`.

**Optional one-time global install** (for the learning flow to work from any context, and for use in other repos):
```bash
bash .claude/install/install-skills.sh
```

## Test plan

- [x] Open Claude Code in this repo and run `/review-pr <any open PR number>` — confirm SDK-specific checks appear in the output
- [x] After the review, correct a finding or describe something missed — confirm `/learn-review` fires and appends a new entry to `.claude/skills/review-pr/rules/learned.md`
- [x] Run `bash .claude/install/install-skills.sh` on a clean machine or with a `--dry-run` inspection — confirm it copies skills to `~/.claude/skills/` without error

*Posted by Claude on behalf of Steve*

🤖 Generated with [Claude Code](https://claude.com/claude-code)