### PR TITLE
fix(employee): apply full-width style to EmployeeStateTaxesView container

### DIFF
--- a/src/components/Employee/StateTaxes/shared/EmployeeStateTaxesView.module.scss
+++ b/src/components/Employee/StateTaxes/shared/EmployeeStateTaxesView.module.scss
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/src/components/Employee/StateTaxes/shared/EmployeeStateTaxesView.tsx
+++ b/src/components/Employee/StateTaxes/shared/EmployeeStateTaxesView.tsx
@@ -1,6 +1,8 @@
 import { Fragment, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
+import classNames from 'classnames'
 import { type useEmployeeStateTaxesForm } from './useEmployeeStateTaxesForm'
+import styles from './EmployeeStateTaxesView.module.scss'
 import { BaseLayout } from '@/components/Base'
 import { Form } from '@/components/Common/Form'
 import { SDKFormProvider } from '@/partner-hook-utils/form/SDKFormProvider'
@@ -32,7 +34,7 @@ export function EmployeeStateTaxesView({
   const groups = stateTaxes.form.Fields
 
   return (
-    <section className={className}>
+    <section className={classNames(styles.container, className)}>
       <BaseLayout error={stateTaxes.errorHandling.errors}>
         <SDKFormProvider formHookResult={stateTaxes}>
           <Form onSubmit={onSubmit}>


### PR DESCRIPTION
## Summary

`EmployeeStateTaxesView` rendered its `<section>` wrapper with only the consumer-supplied `className`, so the form didn't stretch to fill its layout container by default. Add a co-located `EmployeeStateTaxesView.module.scss` with a `.container` class (`width: 100%`) and merge it with the incoming `className` via `classNames`, matching the existing pattern in `Employee/Profile/management/Profile.tsx` + `Profile.module.scss`.

## Changes

- Add `src/components/Employee/StateTaxes/shared/EmployeeStateTaxesView.module.scss` with `.container { width: 100%; }`
- Update `EmployeeStateTaxesView.tsx` to import the module and apply `classNames(styles.container, className)` to the `<section>`

## Test plan

- [x] CI green (build, lint, tsc, unit tests)
- [x] Storybook: verify `Employee.StateTaxes` (both onboarding + management variants) still render and now fill the available width


Made with [Cursor](https://cursor.com)