### PR TITLE
feat(sdk-app): progressive responsive collapse in TopBar

### DIFF
--- a/sdk-app/src/ModeSwitcher.module.scss
+++ b/sdk-app/src/ModeSwitcher.module.scss
@@ -51,3 +51,17 @@
     color: #fff;
   }
 }
+
+.label {
+  display: inline;
+}
+
+@media (max-width: 850px) {
+  .label {
+    display: none;
+  }
+
+  .option {
+    padding: 0.6rem 0.625rem;
+  }
+}

--- a/sdk-app/src/ModeSwitcher.tsx
+++ b/sdk-app/src/ModeSwitcher.tsx
@@ -9,13 +9,23 @@ export function ModeSwitcher() {
 
   return (
     <div className={styles.root}>
-      <Link to="/" className={`${styles.option} ${mode === 'preview' ? styles.active : ''}`}>
+      <Link
+        to="/"
+        className={`${styles.option} ${mode === 'preview' ? styles.active : ''}`}
+        title="Development"
+        aria-label="Development"
+      >
         <TerminalIcon />
-        Development
+        <span className={styles.label}>Development</span>
       </Link>
-      <Link to="/design" className={`${styles.option} ${mode === 'design' ? styles.active : ''}`}>
+      <Link
+        to="/design"
+        className={`${styles.option} ${mode === 'design' ? styles.active : ''}`}
+        title="Design"
+        aria-label="Design"
+      >
         <BrushIcon />
-        Design
+        <span className={styles.label}>Design</span>
       </Link>
     </div>
   )

--- a/sdk-app/src/TopBar.module.scss
+++ b/sdk-app/src/TopBar.module.scss
@@ -14,6 +14,7 @@
   z-index: 100;
   border-bottom: 1px solid var(--color-border);
   box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.05);
+  min-width: 0;
 }
 
 .title {
@@ -21,6 +22,7 @@
   font-size: 1.1rem;
   color: var(--color-text);
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .designTitle {
@@ -33,19 +35,73 @@
 .rightBar {
   display: flex;
   align-items: center;
-  gap: 2rem;
+  gap: 1.25rem;
+  min-width: 0;
+  flex: 1;
+  justify-content: flex-end;
+}
+
+.envInfoWrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .envInfo {
   display: flex;
   align-items: center;
   gap: 0.625rem;
+  min-width: 0;
+  flex-shrink: 1;
+  overflow: hidden;
+}
+
+.infoToggle {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+  color: var(--color-text);
+  cursor: pointer;
+  padding: 0.375rem 0.5rem 0.375rem 0.625rem;
+  font: inherit;
+  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.08);
+  transition: background 0.15s;
+
+  &:hover {
+    background: var(--color-hover-bg);
+  }
+
+  &[aria-expanded='true'] {
+    background: var(--color-active-bg);
+    color: var(--color-active);
+  }
+}
+
+.infoToggleSummary {
+  display: inline-flex;
+  align-items: center;
+}
+
+.infoToggleChevron {
+  width: 1rem;
+  height: 1rem;
+  transition: transform 0.15s;
+
+  .infoToggle[aria-expanded='true'] & {
+    transform: rotate(180deg);
+  }
 }
 
 .actions {
   display: flex;
   align-items: center;
   gap: 0.625rem;
+  flex-shrink: 0;
 }
 
 .badge {
@@ -58,6 +114,8 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.03125rem;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .badgeLabel {
@@ -98,6 +156,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
+  flex-shrink: 1;
 
   .badgeLabel {
     font-family:
@@ -106,7 +166,15 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.03125rem;
+    flex-shrink: 0;
   }
+}
+
+.companyValue {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .tokenStatus {
@@ -115,6 +183,8 @@
   gap: 0.375rem;
   font-size: 0.75rem;
   color: var(--color-text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .tokenDot {
@@ -194,5 +264,90 @@
 
   &:hover {
     background: var(--color-active-bg);
+  }
+}
+
+.panelBtnLabel {
+  display: inline;
+}
+
+@media (max-width: 1400px) {
+  .company {
+    max-width: 10rem;
+  }
+
+  .rightBar {
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 1300px) {
+  .envInfo {
+    display: none;
+  }
+
+  .infoToggle {
+    display: inline-flex;
+  }
+
+  .envInfoWrapOpen .envInfo {
+    display: flex;
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 0.875rem 1rem;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.12);
+    z-index: 101;
+    min-width: 18rem;
+    max-width: calc(100vw - 2rem);
+    overflow: visible;
+  }
+
+  .envInfoWrapOpen .company {
+    max-width: 100%;
+  }
+
+  .envInfoWrapOpen .divider {
+    display: none;
+  }
+}
+
+@media (max-width: 1050px) {
+  .panelBtnLabel {
+    display: none;
+  }
+
+  .panelBtn {
+    padding: 0.6rem 0.625rem;
+  }
+}
+
+@media (max-width: 700px) {
+  .designTitle {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .root {
+    padding: 0 0.625rem;
+    gap: 0.5rem;
+  }
+
+  .title {
+    font-size: 1rem;
+  }
+
+  .rightBar {
+    gap: 0.5rem;
+  }
+
+  .actions {
+    gap: 0.375rem;
   }
 }

--- a/sdk-app/src/TopBar.tsx
+++ b/sdk-app/src/TopBar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useId, useRef, useState } from 'react'
 import { ModeSwitcher } from './ModeSwitcher'
 import { ThemeSwitcher } from './ThemeSwitcher'
 import { useAppMode } from './useAppMode'
@@ -5,7 +6,8 @@ import { useCompanyName } from './design/useCompanyName'
 import type { TokenStatus } from './useDemoManager'
 import SettingsIcon from './assets/icons/icon-settings.svg?react'
 import CodeIcon from './assets/icons/icon-code.svg?react'
-import BrushIcon from './assets/icons/icon-brush.svg?react'
+import PaletteIcon from './assets/icons/icon-palette.svg?react'
+import ChevronDownIcon from './assets/icons/icon-chevron-down.svg?react'
 import styles from './TopBar.module.scss'
 
 type ActivePanel = 'theme' | 'settings' | 'code' | null
@@ -17,7 +19,7 @@ interface TopBarProps {
   onPanelToggle: (panel: 'theme' | 'settings' | 'code') => void
 }
 
-function TokenDot({ status }: { status: TokenStatus }) {
+function TokenDot({ status, compact = false }: { status: TokenStatus; compact?: boolean }) {
   const label =
     status === 'valid'
       ? 'Token OK'
@@ -33,6 +35,10 @@ function TokenDot({ status }: { status: TokenStatus }) {
     checking: styles.tokenDotChecking,
     unknown: styles.tokenDotUnknown,
   }[status]
+
+  if (compact) {
+    return <div className={`${styles.tokenDot} ${dotClass}`} title={label} aria-label={label} />
+  }
 
   return (
     <div className={styles.tokenStatus}>
@@ -55,6 +61,27 @@ export function TopBar({ companyId, tokenStatus, activePanel, onPanelToggle }: T
   const demoType = import.meta.env.VITE_DEMO_TYPE || ''
   const demoTypeLabel = DEMO_TYPE_LABELS[demoType] || demoType
   const companyName = useCompanyName(companyId)
+  const [infoOpen, setInfoOpen] = useState(false)
+  const infoWrapRef = useRef<HTMLDivElement>(null)
+  const infoPanelId = useId()
+
+  useEffect(() => {
+    if (!infoOpen) return
+    const handleClick = (e: MouseEvent) => {
+      if (infoWrapRef.current && !infoWrapRef.current.contains(e.target as Node)) {
+        setInfoOpen(false)
+      }
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setInfoOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [infoOpen])
 
   return (
     <header className={styles.root}>
@@ -63,43 +90,64 @@ export function TopBar({ companyId, tokenStatus, activePanel, onPanelToggle }: T
       </span>
 
       <div className={styles.rightBar}>
-        <div className={styles.envInfo}>
-          <span
-            className={`${styles.badge} ${styles.badgeEnv}`}
-            title="ZenPayroll environment (demo, staging, or local)"
+        <div
+          className={`${styles.envInfoWrap} ${infoOpen ? styles.envInfoWrapOpen : ''}`}
+          ref={infoWrapRef}
+        >
+          <button
+            type="button"
+            className={styles.infoToggle}
+            onClick={() => {
+              setInfoOpen(o => !o)
+            }}
+            aria-expanded={infoOpen}
+            aria-controls={infoPanelId}
+            aria-label={infoOpen ? 'Hide environment info' : 'Show environment info'}
+            title="Environment info"
           >
-            <span className={styles.badgeLabel}>API</span>
-            {displayEnv}
-          </span>
-          <span
-            className={`${styles.badge} ${styles.badgeBuild}`}
-            title="SDK build mode (dev = live source with HMR, prod = built dist)"
-          >
-            <span className={styles.badgeLabel}>SDK</span>
-            {build}
-          </span>
-          {demoTypeLabel && (
+            <span className={styles.infoToggleSummary}>
+              <TokenDot status={tokenStatus} compact />
+            </span>
+            <ChevronDownIcon className={styles.infoToggleChevron} />
+          </button>
+          <div id={infoPanelId} className={styles.envInfo}>
             <span
-              className={`${styles.badge} ${styles.badgeDemoType}`}
-              title={`Demo type: ${demoType}`}
+              className={`${styles.badge} ${styles.badgeEnv}`}
+              title="ZenPayroll environment (demo, staging, or local)"
             >
-              {demoTypeLabel}
+              <span className={styles.badgeLabel}>API</span>
+              {displayEnv}
             </span>
-          )}
-          <div className={styles.divider} />
-          {companyName && (
-            <span className={styles.company} title={companyId}>
-              <span className={styles.badgeLabel}>Company</span>
-              {companyName}
+            <span
+              className={`${styles.badge} ${styles.badgeBuild}`}
+              title="SDK build mode (dev = live source with HMR, prod = built dist)"
+            >
+              <span className={styles.badgeLabel}>SDK</span>
+              {build}
             </span>
-          )}
-          {companyId && !companyName && (
-            <span className={styles.company} title={companyId}>
-              <span className={styles.badgeLabel}>Company</span>
-              {companyId}
-            </span>
-          )}
-          <TokenDot status={tokenStatus} />
+            {demoTypeLabel && (
+              <span
+                className={`${styles.badge} ${styles.badgeDemoType}`}
+                title={`Demo type: ${demoType}`}
+              >
+                {demoTypeLabel}
+              </span>
+            )}
+            <div className={styles.divider} />
+            {companyName && (
+              <span className={styles.company} title={companyId}>
+                <span className={styles.badgeLabel}>Company</span>
+                <span className={styles.companyValue}>{companyName}</span>
+              </span>
+            )}
+            {companyId && !companyName && (
+              <span className={styles.company} title={companyId}>
+                <span className={styles.badgeLabel}>Company</span>
+                <span className={styles.companyValue}>{companyId}</span>
+              </span>
+            )}
+            <TokenDot status={tokenStatus} />
+          </div>
         </div>
 
         <div className={styles.actions}>
@@ -116,8 +164,8 @@ export function TopBar({ companyId, tokenStatus, activePanel, onPanelToggle }: T
               aria-label="Toggle theme panel"
               title="Toggle theme panel (⌘J)"
             >
-              <BrushIcon />
-              Theme
+              <PaletteIcon />
+              <span className={styles.panelBtnLabel}>Theme</span>
             </button>
             <button
               className={`${styles.panelBtn} ${activePanel === 'settings' ? styles.panelBtnActive : ''}`}
@@ -130,7 +178,7 @@ export function TopBar({ companyId, tokenStatus, activePanel, onPanelToggle }: T
               title="Toggle settings panel (⌘,)"
             >
               <SettingsIcon />
-              Settings
+              <span className={styles.panelBtnLabel}>Settings</span>
             </button>
             <button
               className={`${styles.panelBtn} ${activePanel === 'code' ? styles.panelBtnActive : ''}`}
@@ -143,7 +191,7 @@ export function TopBar({ companyId, tokenStatus, activePanel, onPanelToggle }: T
               title="Toggle code panel (?)"
             >
               <CodeIcon />
-              Code
+              <span className={styles.panelBtnLabel}>Code</span>
             </button>
           </div>
         </div>

--- a/sdk-app/src/assets/icons/icon-chevron-down.svg
+++ b/sdk-app/src/assets/icons/icon-chevron-down.svg
@@ -1,0 +1,3 @@
+<svg width="100%" height="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+ <path d="M6 9L12 15L18 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/sdk-app/src/assets/icons/icon-palette.svg
+++ b/sdk-app/src/assets/icons/icon-palette.svg
@@ -1,0 +1,7 @@
+<svg width="100%" height="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="13.5" cy="6.5" r="1.25" fill="currentColor"/>
+  <circle cx="17.5" cy="10.5" r="1.25" fill="currentColor"/>
+  <circle cx="8.5" cy="7.5" r="1.25" fill="currentColor"/>
+  <circle cx="6.5" cy="12.5" r="1.25" fill="currentColor"/>
+  <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary

Stagger TopBar breakpoints so elements drop off by importance as the window narrows, instead of everything collapsing at once at 1200px. Bar now fits down to ~320px.

| Width | What collapses |
|---|---|
| ≤1400px | Company name truncates (existing) |
| ≤1300px | Env info → popover (was 1200px) |
| ≤1050px | Theme/Settings/Code labels hide (was 1200px) |
| ≤850px | Development/Design labels hide (new — were never hiding) |
| ≤700px | "/ Design" subtitle hides |
| ≤480px | Title shrinks, gaps tighten |

Also swap the Theme button icon from brush → palette to disambiguate from the Design mode brush icon next to it.

## Screenshots
<img width="623" height="74" alt="Screenshot 2026-05-12 at 1 49 14 PM" src="https://github.com/user-attachments/assets/4380ac6a-eb7a-4504-9a56-4a04cc6db024" />
<img width="957" height="84" alt="Screenshot 2026-05-12 at 1 49 06 PM" src="https://github.com/user-attachments/assets/eb3ac560-23d6-4621-82bc-917149195995" />
<img width="1309" height="73" alt="Screenshot 2026-05-12 at 1 49 02 PM" src="https://github.com/user-attachments/assets/d6e0b752-2a4e-475c-ac9a-aec6358595a1" />
<img width="1512" height="88" alt="Screenshot 2026-05-12 at 1 48 59 PM" src="https://github.com/user-attachments/assets/2eae9961-0251-4cb8-aab2-6a261e796294" />


## Test plan

- [ ] Screenshots at 1440 / 1200 / 1024 / 768 / 480 / 320 widths
- [ ] Env info popover still opens/closes via click + Escape + outside-click
- [ ] Icon-only buttons retain accessible labels (title + aria-label)
- [ ] Theme button paint-palette icon renders cleanly in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)