### PR TITLE
fix: explicitly send accrualRateUnit null for non-hourly methods (SDK-859)

### DIFF
--- a/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationForm.tsx
+++ b/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationForm.tsx
@@ -140,6 +140,7 @@ function buildCreateRequestBody(
   return {
     ...base,
     accrualRate: data.accrualRate != null ? String(data.accrualRate) : undefined,
+    accrualRateUnit: null,
     policyResetDate,
     complete: false,
   }
@@ -186,6 +187,7 @@ function buildUpdateRequestBody(
   return {
     ...base,
     accrualRate: data.accrualRate != null ? String(data.accrualRate) : undefined,
+    accrualRateUnit: null,
     policyResetDate,
   }
 }

--- a/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx
+++ b/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx
@@ -74,6 +74,18 @@ export function PolicyConfigurationFormPresentation({
     }
   }, [resetMonth, getValues, setValue])
 
+  useEffect(() => {
+    if (accrualMethod !== 'per_hour_paid') {
+      setValue('accrualRateUnit', undefined)
+      setValue('includeOvertime', undefined)
+      setValue('allPaidHours', undefined)
+    }
+    if (accrualMethod !== 'per_calendar_year') {
+      setValue('accrualMethodFixed', undefined)
+      setValue('resetDateType', undefined)
+    }
+  }, [accrualMethod, setValue])
+
   const accrualMethodOptions = useMemo(
     () => [
       {

--- a/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx
+++ b/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx
@@ -82,6 +82,8 @@ export function PolicyConfigurationFormPresentation({
     }
     if (accrualMethod !== 'per_calendar_year') {
       setValue('accrualMethodFixed', undefined)
+    }
+    if (accrualMethod !== 'per_hour_paid' && accrualMethod !== 'per_calendar_year') {
       setValue('resetDateType', undefined)
     }
   }, [accrualMethod, setValue])


### PR DESCRIPTION
## Summary
- When switching accrual method from hourly to fixed, `accrualRateUnit` was omitted from the API payload instead of being explicitly set to `null`, causing the API to retain stale values.
- `buildCreateRequestBody` and `buildUpdateRequestBody` now send `accrualRateUnit: null` for non-hourly methods.
- Added a `useEffect` in `PolicyConfigurationFormPresentation` to clear stale hourly/fixed-specific form fields when the accrual method changes.

## Test plan
- [ ] Switch a policy from per-hour to per-calendar-year and verify the API payload includes `accrual_rate_unit: null`
- [ ] Verify hourly-specific fields (rate unit, overtime, all paid hours) are cleared when switching away from hourly
- [ ] Verify fixed-specific fields (accrual method fixed, reset date type) are cleared when switching away from fixed