### PR TITLE
fix: add back navigation from add-employees to correct previous step (SDK-865)

### DIFF
--- a/src/components/TimeOff/TimeOffFlow/TimeOffFlowComponents.tsx
+++ b/src/components/TimeOff/TimeOffFlow/TimeOffFlowComponents.tsx
@@ -26,11 +26,14 @@ export type TimeOffFlowAlert = {
   content?: ReactNode
 }
 
+export type AddEmployeesSource = 'policySettings' | 'policyDetailsForm' | 'viewTimeOffPolicyDetail'
+
 export interface TimeOffFlowContextInterface extends FlowContextInterface {
   companyId: string
   policyType?: TimeOffPolicyType
   policyId?: string
   alerts?: TimeOffFlowAlert[]
+  addEmployeesSource?: AddEmployeesSource
 }
 
 export function PolicyListContextual() {

--- a/src/components/TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -14,6 +14,7 @@ import {
   ViewHolidayScheduleContextual,
   type TimeOffFlowContextInterface,
   type TimeOffFlowAlert,
+  type AddEmployeesSource,
 } from './TimeOffFlowComponents'
 import type { TimeOffPolicyType } from './timeOffPolicyTypes'
 import { componentEvents } from '@/shared/constants'
@@ -46,6 +47,10 @@ function isUnlimitedPolicy(
   ev: { payload: PolicyCreatedPayload },
 ) {
   return ev.payload.accrualMethod === 'unlimited'
+}
+
+function addEmployeesSourceIs(source: AddEmployeesSource) {
+  return (ctx: TimeOffFlowContextInterface) => ctx.addEmployeesSource === source
 }
 
 const cancelToPolicyList = transition(
@@ -177,6 +182,7 @@ export const timeOffMachine = {
           component: AddEmployeesToPolicyContextual,
           policyId: ev.payload.policyId,
           alerts: undefined,
+          addEmployeesSource: 'policyDetailsForm',
         }),
       ),
     ),
@@ -221,6 +227,7 @@ export const timeOffMachine = {
           ...ctx,
           component: AddEmployeesToPolicyContextual,
           alerts: undefined,
+          addEmployeesSource: 'policySettings',
         }),
       ),
     ),
@@ -261,6 +268,60 @@ export const timeOffMachine = {
           ...ctx,
           component: TimeOffPolicyDetailContextual,
           alerts: undefined,
+          addEmployeesSource: undefined,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.TIME_OFF_ADD_EMPLOYEES_BACK,
+      'viewTimeOffPolicyDetail',
+      guard(addEmployeesSourceIs('viewTimeOffPolicyDetail')),
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: TimeOffPolicyDetailContextual,
+          alerts: undefined,
+          addEmployeesSource: undefined,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.TIME_OFF_ADD_EMPLOYEES_BACK,
+      'policyDetailsForm',
+      guard(addEmployeesSourceIs('policyDetailsForm')),
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: PolicyDetailsFormContextual,
+          alerts: undefined,
+          addEmployeesSource: undefined,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.TIME_OFF_ADD_EMPLOYEES_BACK,
+      'policySettings',
+      reduce(
+        (ctx: TimeOffFlowContextInterface): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: PolicySettingsContextual,
+          alerts: undefined,
+          addEmployeesSource: undefined,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.TIME_OFF_ADD_EMPLOYEES_ERROR,
+      'policyDetailsForm',
+      guard(addEmployeesSourceIs('policyDetailsForm')),
+      reduce(
+        (
+          ctx: TimeOffFlowContextInterface,
+          ev: { payload: ErrorPayload },
+        ): TimeOffFlowContextInterface => ({
+          ...ctx,
+          component: PolicyDetailsFormContextual,
+          alerts: ev.payload.alert ? [ev.payload.alert] : undefined,
         }),
       ),
     ),
@@ -294,6 +355,7 @@ export const timeOffMachine = {
           component: AddEmployeesToPolicyContextual,
           policyId: ev.payload.policyId,
           alerts: undefined,
+          addEmployeesSource: 'viewTimeOffPolicyDetail',
         }),
       ),
     ),

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
@@ -202,7 +202,7 @@ describe('SelectEmployeesTimeOff', () => {
     expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
   })
 
-  it('fires CANCEL when Back is clicked', async () => {
+  it('fires TIME_OFF_ADD_EMPLOYEES_BACK when Back is clicked', async () => {
     const user = userEvent.setup()
     renderComponent()
 
@@ -211,7 +211,7 @@ describe('SelectEmployeesTimeOff', () => {
     })
 
     await user.click(screen.getByRole('button', { name: 'backCta' }))
-    expect(mockOnEvent).toHaveBeenCalledWith(componentEvents.CANCEL)
+    expect(mockOnEvent).toHaveBeenCalledWith(componentEvents.TIME_OFF_ADD_EMPLOYEES_BACK)
   })
 
   describe('carry-over balance pre-fill', () => {

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
@@ -283,7 +283,7 @@ function SelectEmployeesTimeOffInner({
   }, [originalUuids, selectedUuids])
 
   const handleBack = useCallback(() => {
-    onEvent(componentEvents.CANCEL)
+    onEvent(componentEvents.TIME_OFF_ADD_EMPLOYEES_BACK)
   }, [onEvent])
 
   return (

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -238,6 +238,7 @@ export const timeOffEvents = {
   TIME_OFF_POLICY_SETTINGS_DONE: 'timeOff/policySettings/done',
   TIME_OFF_POLICY_SETTINGS_BACK: 'timeOff/policySettings/back',
   TIME_OFF_ADD_EMPLOYEES_DONE: 'timeOff/addEmployees/done',
+  TIME_OFF_ADD_EMPLOYEES_BACK: 'timeOff/addEmployees/back',
   TIME_OFF_HOLIDAY_SELECTION_DONE: 'timeOff/holidaySelection/done',
   TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE: 'timeOff/holidayAddEmployees/done',
   TIME_OFF_VIEW_POLICY_DETAILS: 'timeOff/viewPolicyDetails',


### PR DESCRIPTION
## Summary
- The Back button on the add-employees screen dispatched `CANCEL`, which navigated to the policy list and cleared all context instead of returning to the previous step.
- Added a new `TIME_OFF_ADD_EMPLOYEES_BACK` event that tracks the source of navigation (`policyDetailsForm`, `policySettings`, or `viewTimeOffPolicyDetail`) and routes back accordingly.
- Updated the state machine with guarded transitions based on `addEmployeesSource` context.

## Test plan
- [ ] Navigate to add-employees from policy details form (unlimited) → Back returns to policy details
- [ ] Navigate to add-employees from policy settings → Back returns to policy settings
- [ ] Navigate to add-employees from policy detail view → Back returns to policy detail
- [ ] Cancel still navigates to policy list