### PR TITLE
fix: show reassignment warning only when selected employees have existing PTO (SDK-870)

### DIFF
--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
@@ -178,11 +178,30 @@ describe('SelectEmployeesTimeOff', () => {
     expect(screen.getByText('Design')).toBeInTheDocument()
   })
 
-  it('shows reassignment warning alert', async () => {
+  it('shows reassignment warning alert when selecting employee with existing PTO', async () => {
     renderComponent()
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    })
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    fireEvent.click(checkboxes[FIRST_EMPLOYEE_CHECKBOX]!)
+
     await waitFor(() => {
       expect(screen.getByText('reassignmentWarning')).toBeInTheDocument()
     })
+  })
+
+  it('does not show reassignment warning for employee without existing PTO', async () => {
+    renderComponent()
+    await waitFor(() => {
+      expect(screen.getByText('Carol Davis')).toBeInTheDocument()
+    })
+
+    const checkboxes = screen.getAllByRole('checkbox')
+    fireEvent.click(checkboxes[checkboxes.length - 1]!)
+
+    expect(screen.queryByText('reassignmentWarning')).not.toBeInTheDocument()
   })
 
   it('filters employees by search value', async () => {

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
@@ -282,6 +282,19 @@ function SelectEmployeesTimeOffInner({
     return count
   }, [originalUuids, selectedUuids])
 
+  const showReassignmentWarning = useMemo(() => {
+    const originalSet = originalUuids ?? new Set<string>()
+    const targetPtoName = PAID_TIME_OFF_NAME_BY_POLICY_TYPE[policyType]
+    for (const uuid of selectedUuids) {
+      if (originalSet.has(uuid)) continue
+      const employee = selectedEmployeesRef.current.get(uuid)
+      if (employee?.eligiblePaidTimeOff?.some(pto => pto.name === targetPtoName)) {
+        return true
+      }
+    }
+    return false
+  }, [selectedUuids, originalUuids, policyType])
+
   const handleBack = useCallback(() => {
     onEvent(componentEvents.CANCEL)
   }, [onEvent])
@@ -297,7 +310,7 @@ function SelectEmployeesTimeOffInner({
       onSearchClear={handleSearchClear}
       onBack={handleBack}
       onContinue={handleContinue}
-      showReassignmentWarning
+      showReassignmentWarning={showReassignmentWarning}
       policyTypeLabel={t(`policyTypeLabel_${policyType}`)}
       balances={hideBalances ? undefined : effectiveBalances}
       onBalanceChange={hideBalances ? undefined : handleBalanceChange}


### PR DESCRIPTION
## Summary
- The reassignment warning was always shown (bare `showReassignmentWarning` boolean = `true`).
- Added a `useMemo` that checks whether any newly-selected employee has existing PTO matching the current policy type via `eligiblePaidTimeOff`.
- Warning now only displays when at least one new selection would cause a reassignment.

## Test plan
- [ ] Select employees without existing PTO of the same type → no warning
- [ ] Select employees with existing PTO of the same type → warning appears
- [ ] Deselect the employee with existing PTO → warning disappears