### PR TITLE
ci: auto-publish to NPM when release commit lands on main

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -50,7 +50,7 @@ Do not make any file changes or git operations in dry-run mode.
    git push -u origin chore/release-<version>
    gh pr create --title "chore: release <version>"
    ```
-6. Once the PR is merged, trigger the [Publish to NPM](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish.yaml) GitHub action
+6. Once the PR is merged, publishing happens automatically — the [Publish to NPM](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish.yaml) workflow triggers when the `chore: release` commit lands on `main` and CI passes. No manual action needed unless something goes wrong.
 
 ## Changelog curation (step 4)
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,16 @@
 name: Publish to NPM
-on: workflow_dispatch
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
 jobs:
   publish:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_commit.message, 'chore: release'))
     runs-on:
       group: gusto-ubuntu-default
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -339,4 +339,6 @@ Trigger the [Prepare Release](https://github.com/Gusto/embedded-react-sdk/action
 
 ### After the PR is merged
 
-Run the [Publish to NPM](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish.yaml) GitHub action (`Run workflow`) to publish to NPM.
+Publishing happens automatically. When a `chore: release` commit lands on `main` and all CI checks pass, the [Publish to NPM](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish.yaml) workflow runs automatically and publishes to NPM.
+
+If you need to trigger a publish manually (e.g. CI was re-run after the auto-trigger fired, or something went wrong), you can still run the workflow manually from the Actions UI (`Run workflow`).


### PR DESCRIPTION
## Summary

- Adds a `workflow_run` trigger to `publish.yaml` so it fires automatically when the `CI` workflow completes successfully on `main` with a `chore: release` commit — no manual "Run workflow" step needed after merging a release PR
- Keeps `workflow_dispatch` for manual fallback (e.g. if the auto-trigger misfired)
- Updates `CONTRIBUTING.md` and `.claude/commands/release.md` to reflect the new automated flow

## How it works

```yaml
on:
  workflow_run:
    workflows: [CI]
    types: [completed]
    branches: [main]
  workflow_dispatch:

jobs:
  publish:
    if: |
      github.event_name == 'workflow_dispatch' ||
      (github.event.workflow_run.conclusion == 'success' &&
       startsWith(github.event.workflow_run.head_commit.message, 'chore: release'))
```

The `workflow_dispatch` path has no condition so it always runs when triggered manually.

## Test plan

- [ ] Merge a release PR and confirm the publish workflow triggers automatically
- [ ] Confirm it does _not_ trigger on non-release merges to main
- [ ] Confirm manual `workflow_dispatch` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)