### PR TITLE
fix: remove redundant Text wrappers from TimeOff DataView columns (SDK-881)

### DIFF
--- a/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetailPresentation.tsx
+++ b/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetailPresentation.tsx
@@ -53,27 +53,27 @@ export function HolidayPolicyDetailPresentation({
 function HolidaysTab({ holidays }: { holidays: HolidayItem[] }) {
   useI18n('Company.TimeOff.HolidayPolicy')
   const { t } = useTranslation('Company.TimeOff.HolidayPolicy')
-  const { Text, Box, BoxHeader } = useComponentContext()
+  const { Box, BoxHeader } = useComponentContext()
 
   const columns = useMemo(
     () => [
       {
         key: 'name' as keyof HolidayItem,
         title: t('tableHeaders.holidayName'),
-        render: (item: HolidayItem) => <Text weight="medium">{item.name}</Text>,
+        render: (item: HolidayItem) => item.name,
       },
       {
         key: 'observedDate' as keyof HolidayItem,
         title: t('tableHeaders.observedDate'),
-        render: (item: HolidayItem) => <Text variant="supporting">{item.observedDate}</Text>,
+        render: (item: HolidayItem) => item.observedDate,
       },
       {
         key: 'nextObservation' as keyof HolidayItem,
         title: t('tableHeaders.nextObservation'),
-        render: (item: HolidayItem) => <Text variant="supporting">{item.nextObservation}</Text>,
+        render: (item: HolidayItem) => item.nextObservation,
       },
     ],
-    [t, Text],
+    [t],
   )
 
   const dataViewProps = useDataView<HolidayItem>({

--- a/src/components/TimeOff/HolidaySelectionForm/HolidaySelectionFormPresentation.tsx
+++ b/src/components/TimeOff/HolidaySelectionForm/HolidaySelectionFormPresentation.tsx
@@ -21,20 +21,20 @@ export function HolidaySelectionFormPresentation(props: HolidaySelectionFormPres
       {
         key: 'name' as keyof HolidayItem,
         title: t('tableHeaders.holidayName'),
-        render: (item: HolidayItem) => <Text weight="medium">{item.name}</Text>,
+        render: (item: HolidayItem) => item.name,
       },
       {
         key: 'observedDate' as keyof HolidayItem,
         title: t('tableHeaders.observedDate'),
-        render: (item: HolidayItem) => <Text variant="supporting">{item.observedDate}</Text>,
+        render: (item: HolidayItem) => item.observedDate,
       },
       {
         key: 'nextObservation' as keyof HolidayItem,
         title: t('tableHeaders.nextObservation'),
-        render: (item: HolidayItem) => <Text variant="supporting">{item.nextObservation}</Text>,
+        render: (item: HolidayItem) => item.nextObservation,
       },
     ],
-    [t, Text],
+    [t],
   )
 
   const selectionProps = !isViewMode

--- a/src/components/TimeOff/PolicyList/PolicyListPresentation.tsx
+++ b/src/components/TimeOff/PolicyList/PolicyListPresentation.tsx
@@ -25,7 +25,7 @@ export function PolicyListPresentation({
   isDeletingPolicyId,
   isPending,
 }: PolicyListPresentationProps) {
-  const { Button, Heading, Text, Alert, Dialog } = useComponentContext()
+  const { Button, Heading, Alert, Dialog } = useComponentContext()
   useI18n('Company.TimeOff.TimeOffPolicies')
   const { t } = useTranslation('Company.TimeOff.TimeOffPolicies')
 
@@ -59,13 +59,11 @@ export function PolicyListPresentation({
     columns: [
       {
         title: t('tableHeaders.name'),
-        render: (policy: PolicyListItem) => <Text weight="medium">{policy.name}</Text>,
+        render: (policy: PolicyListItem) => policy.name,
       },
       {
         title: t('tableHeaders.enrolled'),
-        render: (policy: PolicyListItem) => (
-          <Text variant="supporting">{policy.enrolledDisplay}</Text>
-        ),
+        render: (policy: PolicyListItem) => policy.enrolledDisplay,
       },
     ],
     itemMenu: (policy: PolicyListItem) => {

--- a/src/components/TimeOff/shared/EmployeeTable/EmployeeTable.tsx
+++ b/src/components/TimeOff/shared/EmployeeTable/EmployeeTable.tsx
@@ -62,11 +62,14 @@ export function EmployeeTable<T extends EmployeeTableItem>({
       {
         key: 'name',
         title: t('name'),
-        render: (item: T) =>
-          firstLastName({
-            first_name: item.firstName,
-            last_name: item.lastName,
-          }),
+        render: (item: T) => (
+          <span id={`employee-name-${item.uuid}`}>
+            {firstLastName({
+              first_name: item.firstName,
+              last_name: item.lastName,
+            })}
+          </span>
+        ),
       },
       ...(hideJobTitle
         ? []

--- a/src/components/TimeOff/shared/EmployeeTable/EmployeeTable.tsx
+++ b/src/components/TimeOff/shared/EmployeeTable/EmployeeTable.tsx
@@ -62,14 +62,11 @@ export function EmployeeTable<T extends EmployeeTableItem>({
       {
         key: 'name',
         title: t('name'),
-        render: (item: T) => (
-          <Components.Text as="span" id={`employee-name-${item.uuid}`}>
-            {firstLastName({
-              first_name: item.firstName,
-              last_name: item.lastName,
-            })}
-          </Components.Text>
-        ),
+        render: (item: T) =>
+          firstLastName({
+            first_name: item.firstName,
+            last_name: item.lastName,
+          }),
       },
       ...(hideJobTitle
         ? []
@@ -77,14 +74,12 @@ export function EmployeeTable<T extends EmployeeTableItem>({
             {
               key: 'jobTitle' as keyof T,
               title: t('jobTitle'),
-              render: (item: T) => (
-                <Components.Text as="span">{item.jobTitle ?? ''}</Components.Text>
-              ),
+              render: (item: T) => item.jobTitle ?? '',
             },
           ]),
       ...additionalColumns,
     ],
-    [t, additionalColumns, hideJobTitle, Components],
+    [t, additionalColumns, hideJobTitle],
   )
 
   const dataViewProps = useDataView<T>({


### PR DESCRIPTION
## Summary

DataView already renders cell content through `Components.Text`, so wrapping column `render` output in `Components.Text` duplicated styling and bypassed the SDK's shared text application. This PR removes those redundant wrappers from the TimeOff DataView column configurations.

## Changes

- Removed `Components.Text` / `Text` wrappers from column `render` configs in:
  - `TimeOff/shared/EmployeeTable/EmployeeTable.tsx`
  - `TimeOff/PolicyList/PolicyListPresentation.tsx`
  - `TimeOff/HolidaySelectionForm/HolidaySelectionFormPresentation.tsx`
  - `TimeOff/HolidayPolicyDetail/HolidayPolicyDetailPresentation.tsx`
- Cleaned up unused `Text` destructure from `useComponentContext()` where it was no longer needed.

## Demo

N/A — visual output is unchanged for default text styling. DataView continues to render consistent text via its own `Components.Text` integration.

## Related

- Jira ticket: [SDK-881](https://gustohq.atlassian.net/browse/SDK-881)

## Testing

- `npm run test -- --run src/components/TimeOff`
- Storybook: verify Time Off DataViews (Policy list, Holiday selection, Holiday policy detail, Employee table) still render correctly.

[SDK-881]: https://gustohq.atlassian.net/browse/SDK-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ