### PR TITLE
fix: change DetailViewLayout back button variant to secondary (SDK-882)

### DIFF
--- a/src/components/Common/DetailViewLayout/DetailViewLayout.tsx
+++ b/src/components/Common/DetailViewLayout/DetailViewLayout.tsx
@@ -24,7 +24,7 @@ export function DetailViewLayout({
     <section className={classNames(styles.root, className)} aria-labelledby={headingId}>
       {onBack && (
         <Button
-          variant="tertiary"
+          variant="secondary"
           className={styles.backButton}
           icon={<CaretLeftIcon aria-hidden="true" />}
           onClick={onBack}


### PR DESCRIPTION
## Summary

Updates the back button in `DetailViewLayout` from the `tertiary` variant to the `secondary` variant for improved visual prominence and consistency.

## Changes

- `Common/DetailViewLayout/DetailViewLayout.tsx`: switch back button `variant` from `tertiary` to `secondary`.

## Demo

<!-- Visual change to the back button styling in any screen using DetailViewLayout. -->

## Related

- Jira ticket: [SDK-882](https://gustohq.atlassian.net/browse/SDK-882)

## Testing

- Storybook: verify any story that uses `DetailViewLayout` renders the back button with the secondary variant.

[SDK-882]: https://gustohq.atlassian.net/browse/SDK-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ