### PR TITLE
fix: remove redundant Box wrappers around tables in policy detail (SDK-879)

### DIFF
--- a/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetailPresentation.tsx
+++ b/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetailPresentation.tsx
@@ -53,7 +53,7 @@ export function HolidayPolicyDetailPresentation({
 function HolidaysTab({ holidays }: { holidays: HolidayItem[] }) {
   useI18n('Company.TimeOff.HolidayPolicy')
   const { t } = useTranslation('Company.TimeOff.HolidayPolicy')
-  const { Text, Box, BoxHeader } = useComponentContext()
+  const { Text } = useComponentContext()
 
   const columns = useMemo(
     () => [
@@ -81,9 +81,5 @@ function HolidaysTab({ holidays }: { holidays: HolidayItem[] }) {
     columns,
   })
 
-  return (
-    <Box header={<BoxHeader title={t('show.holidaySchedule')} />} withPadding={false}>
-      <DataView label={t('tableLabel')} {...dataViewProps} />
-    </Box>
-  )
+  return <DataView label={t('tableLabel')} {...dataViewProps} />
 }

--- a/src/components/TimeOff/shared/PolicyDetailLayout/PolicyDetailLayout.tsx
+++ b/src/components/TimeOff/shared/PolicyDetailLayout/PolicyDetailLayout.tsx
@@ -24,7 +24,7 @@ export function PolicyDetailLayout<T extends EmployeeTableItem>({
 }: PolicyDetailLayoutProps<T>) {
   useI18n('Company.TimeOff.PolicyDetail')
   const { t } = useTranslation('Company.TimeOff.PolicyDetail')
-  const { Alert, Dialog, Box } = useComponentContext()
+  const { Alert, Dialog } = useComponentContext()
 
   const tabs = [
     {
@@ -36,21 +36,19 @@ export function PolicyDetailLayout<T extends EmployeeTableItem>({
       id: EMPLOYEES_TAB_ID,
       label: t('tabs.employees'),
       content: (
-        <Box withPadding={false}>
-          <EmployeeTable<T>
-            data={employees.data}
-            searchValue={employees.searchValue}
-            onSearchChange={employees.onSearchChange}
-            onSearchClear={employees.onSearchClear}
-            searchPlaceholder={employees.searchPlaceholder}
-            itemMenu={employees.itemMenu}
-            pagination={employees.pagination}
-            isFetching={employees.isFetching}
-            emptyState={employees.emptyState}
-            additionalColumns={employees.additionalColumns}
-            hideJobTitle={employees.hideJobTitle}
-          />
-        </Box>
+        <EmployeeTable<T>
+          data={employees.data}
+          searchValue={employees.searchValue}
+          onSearchChange={employees.onSearchChange}
+          onSearchClear={employees.onSearchClear}
+          searchPlaceholder={employees.searchPlaceholder}
+          itemMenu={employees.itemMenu}
+          pagination={employees.pagination}
+          isFetching={employees.isFetching}
+          emptyState={employees.emptyState}
+          additionalColumns={employees.additionalColumns}
+          hideJobTitle={employees.hideJobTitle}
+        />
       ),
     },
   ]

--- a/src/i18n/en/Company.TimeOff.HolidayPolicy.json
+++ b/src/i18n/en/Company.TimeOff.HolidayPolicy.json
@@ -14,7 +14,6 @@
   },
   "show": {
     "title": "Holiday pay policy",
-    "holidaySchedule": "Holiday schedule",
     "addEmployeesCta": "Add employees",
     "editPolicyCta": "Edit policy"
   },

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -479,7 +479,6 @@ export interface CompanyTimeOffHolidayPolicy{
 };
 "show":{
 "title":string;
-"holidaySchedule":string;
 "addEmployeesCta":string;
 "editPolicyCta":string;
 };


### PR DESCRIPTION
## Summary

Removes redundant `Box` wrappers around DataView/EmployeeTable in the Time Off policy detail views. DataView/EmployeeTable already provide their own container styling, so the outer `Box` added unnecessary nesting and a duplicate section title.

## Changes

- `TimeOff/HolidayPolicyDetail/HolidayPolicyDetailPresentation.tsx`: drop `Box` + `BoxHeader` wrapper around the holidays `DataView`.
- `TimeOff/shared/PolicyDetailLayout/PolicyDetailLayout.tsx`: drop `Box` wrapper around the `EmployeeTable` in the Employees tab.
- `i18n/en/Company.TimeOff.HolidayPolicy.json`: remove the now-unused `show.holidaySchedule` string.

## Demo

<!-- Visual change: tighter layout for the Time Off policy detail Holidays and Employees tabs. -->

## Related

- Jira ticket: [SDK-879](https://gustohq.atlassian.net/browse/SDK-879)

## Testing

- Storybook: verify `HolidayPolicyDetail` Holidays tab and `PolicyDetailLayout` Employees tab render correctly without the surrounding Box.
- `npm run test -- --run src/components/TimeOff`

[SDK-879]: https://gustohq.atlassian.net/browse/SDK-879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ