### PR TITLE
fix(SDK-878, SDK-880): responsive policy detail cards follow Tabs mode

### DIFF
--- a/src/components/Common/UI/Tabs/Tabs.tsx
+++ b/src/components/Common/UI/Tabs/Tabs.tsx
@@ -27,7 +27,11 @@ export function Tabs({ tabs, selectedId, onSelectionChange, className, ...ariaPr
   }))
 
   return (
-    <div ref={containerRef} className={classNames(styles.root, className)}>
+    <div
+      ref={containerRef}
+      className={classNames(styles.root, className)}
+      data-tabs-mode={shouldUseDropdown ? 'dropdown' : 'tabs'}
+    >
       {!shouldUseDropdown ? (
         <AriaTabs
           className={styles.tabsContainer}

--- a/src/components/Common/UI/Tabs/Tabs.tsx
+++ b/src/components/Common/UI/Tabs/Tabs.tsx
@@ -27,11 +27,7 @@ export function Tabs({ tabs, selectedId, onSelectionChange, className, ...ariaPr
   }))
 
   return (
-    <div
-      ref={containerRef}
-      className={classNames(styles.root, className)}
-      data-tabs-mode={shouldUseDropdown ? 'dropdown' : 'tabs'}
-    >
+    <div ref={containerRef} className={classNames(styles.root, className)}>
       {!shouldUseDropdown ? (
         <AriaTabs
           className={styles.tabsContainer}

--- a/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.module.scss
+++ b/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.module.scss
@@ -1,9 +1,15 @@
+.cardsContainer {
+  container-type: inline-size;
+}
+
 .cards {
   display: grid;
   gap: toRem(20);
-  grid-template-columns: minmax(0, toRem(480));
+  grid-template-columns: 1fr;
 }
 
-[data-tabs-mode='dropdown'] .cards {
-  grid-template-columns: 1fr;
+@container (min-width: 40rem) {
+  .cards {
+    grid-template-columns: minmax(0, toRem(480));
+  }
 }

--- a/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.module.scss
+++ b/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.module.scss
@@ -1,7 +1,9 @@
-.descriptionCard {
-  max-width: toRem(480);
+.cards {
+  display: grid;
+  gap: toRem(20);
+  grid-template-columns: minmax(0, toRem(480));
 }
 
-.descriptionCardUnlimited {
-  min-width: toRem(320);
+[data-tabs-mode='dropdown'] .cards {
+  grid-template-columns: 1fr;
 }

--- a/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
+++ b/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
@@ -8,7 +8,6 @@ import type {
   PolicySettingsDisplay,
 } from './TimeOffPolicyDetailTypes'
 import styles from './TimeOffPolicyDetail.module.scss'
-import { Flex } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
 
@@ -191,39 +190,31 @@ function DetailsTab({
     return items
   }, [policySettings, t, showAccrualMaxAndWaiting])
 
-  const detailsCardClassName = isUnlimited
-    ? `${styles.descriptionCard} ${styles.descriptionCardUnlimited}`
-    : styles.descriptionCard
-
   return (
-    <Flex flexDirection="column" gap={20}>
-      <div className={detailsCardClassName}>
-        <Box header={<BoxHeader title={t('details')} />} withPadding>
-          <DescriptionList items={detailItems} showSeparators={false} layout="stacked" />
-        </Box>
-      </div>
+    <div className={styles.cards}>
+      <Box header={<BoxHeader title={t('details')} />} withPadding>
+        <DescriptionList items={detailItems} showSeparators={false} layout="stacked" />
+      </Box>
 
       {!isUnlimited && policySettings && (
-        <div className={styles.descriptionCard}>
-          <Box
-            header={
-              <BoxHeader
-                title={t('policySettingsTitle')}
-                action={
-                  onChangeSettings && (
-                    <Button variant="secondary" onClick={onChangeSettings}>
-                      {t('changeSettingsCta')}
-                    </Button>
-                  )
-                }
-              />
-            }
-            withPadding
-          >
-            <DescriptionList items={settingsItems} showSeparators={false} layout="stacked" />
-          </Box>
-        </div>
+        <Box
+          header={
+            <BoxHeader
+              title={t('policySettingsTitle')}
+              action={
+                onChangeSettings && (
+                  <Button variant="secondary" onClick={onChangeSettings}>
+                    {t('changeSettingsCta')}
+                  </Button>
+                )
+              }
+            />
+          }
+          withPadding
+        >
+          <DescriptionList items={settingsItems} showSeparators={false} layout="stacked" />
+        </Box>
       )}
-    </Flex>
+    </div>
   )
 }

--- a/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
+++ b/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
@@ -193,30 +193,32 @@ function DetailsTab({
   }, [policySettings, t, showAccrualMaxAndWaiting])
 
   return (
-    <div className={styles.cards}>
-      <Box header={<BoxHeader title={t('details')} />} withPadding>
-        <DescriptionList items={detailItems} showSeparators={false} layout="stacked" />
-      </Box>
-
-      {!isUnlimited && policySettings && (
-        <Box
-          header={
-            <BoxHeader
-              title={t('policySettingsTitle')}
-              action={
-                onChangeSettings && (
-                  <Button variant="secondary" onClick={onChangeSettings}>
-                    {t('changeSettingsCta')}
-                  </Button>
-                )
-              }
-            />
-          }
-          withPadding
-        >
-          <DescriptionList items={settingsItems} showSeparators={false} layout="stacked" />
+    <div className={styles.cardsContainer}>
+      <div className={styles.cards}>
+        <Box header={<BoxHeader title={t('details')} />} withPadding>
+          <DescriptionList items={detailItems} showSeparators={false} layout="stacked" />
         </Box>
-      )}
+
+        {!isUnlimited && policySettings && (
+          <Box
+            header={
+              <BoxHeader
+                title={t('policySettingsTitle')}
+                action={
+                  onChangeSettings && (
+                    <Button variant="secondary" onClick={onChangeSettings}>
+                      {t('changeSettingsCta')}
+                    </Button>
+                  )
+                }
+              />
+            }
+            withPadding
+          >
+            <DescriptionList items={settingsItems} showSeparators={false} layout="stacked" />
+          </Box>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/TimeOff/shared/EmployeeTable/EmployeeTable.module.scss
+++ b/src/components/TimeOff/shared/EmployeeTable/EmployeeTable.module.scss
@@ -1,4 +1,5 @@
 .root {
+  container-type: inline-size;
   display: flex;
   flex-direction: column;
   gap: toRem(16);
@@ -14,7 +15,13 @@
 }
 
 .searchContainer {
-  max-width: toRem(320);
+  width: 100%;
+}
+
+@container (min-width: 40rem) {
+  .searchContainer {
+    max-width: toRem(320);
+  }
 }
 
 .balanceInput {


### PR DESCRIPTION
## Summary

Make the policy detail cards and the employees-tab search bar share the same width as the Tabs control at every viewport size.

- **Wide container** (≥ 40rem / 640px): tab strip renders as a row. Cards cap at `30rem`, search bar caps at `20rem` (unchanged from before).
- **Narrow container** (< 40rem): tab strip renders as a Select dropdown that fills the container width. Cards and search bar now also span the full container, so the Select dropdown and the content beneath it line up.

## Approach

The previous version of this PR set a `data-tabs-mode` attribute on the SDK's `Tabs` root and read it from descendant CSS. That broke the contract that `Tabs` is swappable via `ComponentsContext` — if a partner supplied their own `Tabs`, the attribute would not exist and the layout would silently fall back to fixed widths.

Replaced with **CSS container queries** declared at the consumer level:

- `TimeOffPolicyDetail.module.scss` — wraps the two `Box` cards in a `.cardsContainer` (the query container). Above the `40rem` threshold the inner `.cards` grid switches from `1fr` to `minmax(0, 30rem)`.
- `EmployeeTable.module.scss` — `.root` becomes the query container; the `.searchContainer` is `width: 100%` by default and caps at `20rem` above the same threshold.

Both wrappers subscribe to the same `40rem` breakpoint Tabs uses (`BREAKPOINTS.SMALL` in `src/shared/constants.ts`) without depending on Tabs' DOM. Any partner-provided `Tabs` adapter works unchanged.

## Changes

- `Tabs.tsx` — reverted `data-tabs-mode` attribute.
- `TimeOffPolicyDetail.module.scss` — container-query rules; removed `.descriptionCard` / `.descriptionCardUnlimited`.
- `TimeOffPolicyDetailPresentation.tsx` — `.cardsContainer` > `.cards` wrapper around both `Box` components; removed unused `Flex` import.
- `EmployeeTable.module.scss` — `container-type: inline-size` on `.root`; `.searchContainer` cap moved inside an `@container (min-width: 40rem)` rule.

## Related

- Jira: [SDK-878](https://gustohq.atlassian.net/browse/SDK-878), [SDK-880](https://gustohq.atlassian.net/browse/SDK-880)

## Testing

- `npm run sdk-app` and open the TimeOff policy detail (`TimeOffFlow` → policy detail).
- Resize the main content area through the 640px / 40rem threshold:
  - **Above the breakpoint** (Details tab): both cards share a 30rem track, left-aligned.
  - **Below the breakpoint** (Details tab): tab strip collapses to a Select; both cards span the full container, matching the Select's edges.
  - **Above the breakpoint** (Employees tab): search bar capped at 20rem.
  - **Below the breakpoint** (Employees tab): search bar spans the full container, matching the Select's edges.
- Optional partner-adapter check: render with a custom `Tabs` adapter in `sdk-app` and confirm the cards / search bar still resize correctly (they should — the queries no longer depend on Tabs' DOM).
- `npm run test -- --run src/components/TimeOff`
- `npm run test -- --run src/components/Common/UI/Tabs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-878]: https://gustohq.atlassian.net/browse/SDK-878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ