### PR TITLE
fix: show policy name in heading when editing time off policy (SDK-888)

### DIFF
--- a/src/components/TimeOff/PolicySettings/PolicySettings.stories.tsx
+++ b/src/components/TimeOff/PolicySettings/PolicySettings.stories.tsx
@@ -50,6 +50,8 @@ export const EditMode = () => (
     accrualMethod="hours_worked"
     onContinue={onContinue}
     onBack={onBack}
+    mode="edit"
+    editingPolicyName="Paid Time Off Policy"
     defaultValues={{
       accrualMaximumEnabled: true,
       accrualMaximum: 100,

--- a/src/components/TimeOff/PolicySettings/PolicySettings.tsx
+++ b/src/components/TimeOff/PolicySettings/PolicySettings.tsx
@@ -11,6 +11,7 @@ import { componentEvents } from '@/shared/constants'
 
 export interface PolicySettingsProps extends BaseComponentInterface {
   policyId: string
+  mode?: 'create' | 'edit'
 }
 
 export function PolicySettings(props: PolicySettingsProps) {
@@ -96,7 +97,7 @@ function buildUpdateRequestBody(
   }
 }
 
-function Root({ policyId }: PolicySettingsProps) {
+function Root({ policyId, mode }: PolicySettingsProps) {
   const { onEvent, baseSubmitHandler } = useBase()
   const queryClient = useQueryClient()
 
@@ -138,6 +139,8 @@ function Root({ policyId }: PolicySettingsProps) {
       onContinue={handleContinue}
       onBack={handleBack}
       defaultValues={deriveDefaultValues(policy)}
+      mode={mode}
+      editingPolicyName={mode === 'edit' ? policy.name : undefined}
     />
   )
 }

--- a/src/components/TimeOff/PolicySettings/PolicySettingsPresentation.test.tsx
+++ b/src/components/TimeOff/PolicySettings/PolicySettingsPresentation.test.tsx
@@ -38,11 +38,19 @@ describe('PolicySettingsPresentation', () => {
   })
 
   describe('rendering - hours worked variant', () => {
-    it('renders the heading', async () => {
+    it('renders the create heading by default', async () => {
       renderHoursWorked()
 
       await waitFor(() => {
         expect(screen.getByText('Policy settings')).toBeInTheDocument()
+      })
+    })
+
+    it('renders the edit heading with the policy name in edit mode', async () => {
+      renderHoursWorked({ mode: 'edit', editingPolicyName: 'Paid Time Off Policy' })
+
+      await waitFor(() => {
+        expect(screen.getByText('Paid Time Off Policy settings')).toBeInTheDocument()
       })
     })
 

--- a/src/components/TimeOff/PolicySettings/PolicySettingsPresentation.tsx
+++ b/src/components/TimeOff/PolicySettings/PolicySettingsPresentation.tsx
@@ -13,6 +13,8 @@ export function PolicySettingsPresentation({
   onContinue,
   onBack,
   defaultValues,
+  mode,
+  editingPolicyName,
 }: PolicySettingsPresentationProps) {
   useI18n('Company.TimeOff.CreateTimeOffPolicy')
   const { t } = useTranslation('Company.TimeOff.CreateTimeOffPolicy')
@@ -56,7 +58,9 @@ export function PolicySettingsPresentation({
         <div className={styles.policySettings}>
           <Flex flexDirection="column" gap={32}>
             <Heading as="h2" id={headingId}>
-              {t('policySettings.title')}
+              {mode === 'edit' && editingPolicyName
+                ? t('policySettings.editTitle', { name: editingPolicyName })
+                : t('policySettings.createTitle')}
             </Heading>
 
             <Flex flexDirection="column" gap={20}>

--- a/src/components/TimeOff/PolicySettings/PolicySettingsTypes.ts
+++ b/src/components/TimeOff/PolicySettings/PolicySettingsTypes.ts
@@ -20,4 +20,6 @@ export interface PolicySettingsPresentationProps {
   onContinue: (data: PolicySettingsFormData) => void
   onBack: () => void
   defaultValues?: Partial<PolicySettingsFormData>
+  mode?: 'create' | 'edit'
+  editingPolicyName?: string
 }

--- a/src/components/TimeOff/TimeOffFlow/TimeOffFlowComponents.tsx
+++ b/src/components/TimeOff/TimeOffFlow/TimeOffFlowComponents.tsx
@@ -109,7 +109,23 @@ export function PolicySettingsContextual() {
           {alert.content}
         </Alert>
       ))}
-      <PolicySettings onEvent={onEvent} policyId={ensureRequired(policyId)} />
+      <PolicySettings onEvent={onEvent} policyId={ensureRequired(policyId)} mode="create" />
+    </Flex>
+  )
+}
+
+export function EditPolicySettingsContextual() {
+  const { onEvent, policyId, alerts } = useFlow<TimeOffFlowContextInterface>()
+  const { Alert } = useComponentContext()
+
+  return (
+    <Flex flexDirection="column" gap={8}>
+      {alerts?.map((alert, index) => (
+        <Alert key={index} status={alert.type} label={alert.title}>
+          {alert.content}
+        </Alert>
+      ))}
+      <PolicySettings onEvent={onEvent} policyId={ensureRequired(policyId)} mode="edit" />
     </Flex>
   )
 }

--- a/src/components/TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -4,6 +4,7 @@ import {
   SelectPolicyTypeContextual,
   PolicyDetailsFormContextual,
   PolicySettingsContextual,
+  EditPolicySettingsContextual,
   AddEmployeesToPolicyContextual,
   TimeOffPolicyDetailContextual,
   HolidaySelectionFormContextual,
@@ -320,7 +321,7 @@ export const timeOffMachine = {
           ev: { payload: PolicyIdPayload },
         ): TimeOffFlowContextInterface => ({
           ...ctx,
-          component: PolicySettingsContextual,
+          component: EditPolicySettingsContextual,
           policyId: ev.payload.policyId,
           alerts: undefined,
         }),
@@ -358,7 +359,7 @@ export const timeOffMachine = {
           ev: { payload: PolicyCreatedPayload },
         ): TimeOffFlowContextInterface => ({
           ...ctx,
-          component: PolicySettingsContextual,
+          component: EditPolicySettingsContextual,
           policyId: ev.payload.policyId,
           alerts: undefined,
         }),

--- a/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationForm.test.tsx
+++ b/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationForm.test.tsx
@@ -42,12 +42,26 @@ describe('PolicyConfigurationFormPresentation', () => {
   })
 
   describe('rendering', () => {
-    it('renders the heading', async () => {
+    it('renders the create heading by default', async () => {
       renderWithProviders(<PolicyConfigurationFormPresentation {...defaultProps} />)
 
       await waitFor(() => {
         expect(screen.getByText('Policy details')).toBeInTheDocument()
       })
+    })
+
+    it('renders the edit heading with the policy name when editingPolicyName is provided', async () => {
+      renderWithProviders(
+        <PolicyConfigurationFormPresentation
+          {...defaultProps}
+          editingPolicyName="Paid Time Off Policy"
+        />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Edit Paid Time Off Policy')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('Policy details')).not.toBeInTheDocument()
     })
 
     it('renders the policy name field', async () => {

--- a/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationForm.tsx
+++ b/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationForm.tsx
@@ -307,6 +307,7 @@ function EditRoot({ companyId, policyType, policyId, defaultValues }: EditRootPr
       onContinue={handleContinue}
       onCancel={handleCancel}
       defaultValues={mergedDefaults}
+      editingPolicyName={policy.name}
     />
   )
 }

--- a/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx
+++ b/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx
@@ -28,6 +28,7 @@ export function PolicyConfigurationFormPresentation({
   onContinue,
   onCancel,
   defaultValues,
+  editingPolicyName,
 }: PolicyConfigurationFormPresentationProps) {
   useI18n('Company.TimeOff.CreateTimeOffPolicy')
   const { t } = useTranslation('Company.TimeOff.CreateTimeOffPolicy')
@@ -138,7 +139,9 @@ export function PolicyConfigurationFormPresentation({
       <HtmlForm aria-labelledby={headingId} onSubmit={formMethods.handleSubmit(handleSubmit)}>
         <Flex flexDirection="column" gap={32}>
           <Heading as="h2" id={headingId}>
-            {t('policyDetails.title')}
+            {editingPolicyName
+              ? t('policyDetails.editTitle', { name: editingPolicyName })
+              : t('policyDetails.createTitle')}
           </Heading>
 
           <Flex flexDirection="column" gap={20}>

--- a/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormTypes.ts
+++ b/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormTypes.ts
@@ -19,4 +19,5 @@ export interface PolicyConfigurationFormPresentationProps {
   onContinue: (data: PolicyConfigurationFormData) => void
   onCancel: () => void
   defaultValues?: Partial<PolicyConfigurationFormData>
+  editingPolicyName?: string
 }

--- a/src/i18n/en/Company.TimeOff.CreateTimeOffPolicy.json
+++ b/src/i18n/en/Company.TimeOff.CreateTimeOffPolicy.json
@@ -1,6 +1,7 @@
 {
   "policyDetails": {
-    "title": "Policy details",
+    "createTitle": "Policy details",
+    "editTitle": "Edit {{name}}",
     "policyNameLabel": "Policy name",
     "accrualMethodLabel": "Accrual method",
     "accrualMethodHint": "The rate at which employees will accrue time paid time off.",
@@ -42,7 +43,8 @@
     }
   },
   "policySettings": {
-    "title": "Policy settings",
+    "createTitle": "Policy settings",
+    "editTitle": "{{name}} settings",
     "hoursUnit": "hours",
     "daysUnit": "days",
     "accrualMaximumLabel": "Accrual maximum",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -365,7 +365,8 @@ export interface CompanyStateTaxes{
 };
 export interface CompanyTimeOffCreateTimeOffPolicy{
 "policyDetails":{
-"title":string;
+"createTitle":string;
+"editTitle":string;
 "policyNameLabel":string;
 "accrualMethodLabel":string;
 "accrualMethodHint":string;
@@ -407,7 +408,8 @@ export interface CompanyTimeOffCreateTimeOffPolicy{
 };
 };
 "policySettings":{
-"title":string;
+"createTitle":string;
+"editTitle":string;
 "hoursUnit":string;
 "daysUnit":string;
 "accrualMaximumLabel":string;


### PR DESCRIPTION
## Summary

Time Off policy edit screens now show the saved policy name in the heading so users can confirm which policy they're editing. Create-flow headings are unchanged.

## Changes

- `PolicyConfigurationForm` (details step): heading reads `Edit {policy name}` when editing, `Policy details` when creating
- `PolicySettings` (settings step): heading reads `{policy name} settings` when editing, `Policy settings` when creating
- Split `PolicySettingsContextual` into create/edit variants in the flow (mirrors existing `HolidaySelectionForm` pattern); state machine routes edit-flow transitions to the new `EditPolicySettingsContextual`
- Aligned i18n keys with the SDK convention used by `HolidaySelectionForm` / Compensation: paired `createTitle` / `editTitle`, with name interpolation on the edit variant

## Demo

<!-- Add before/after screenshots of the policy details and policy settings headings in edit mode -->

## Related

- Jira ticket: [SDK-888](https://gustohq.atlassian.net/browse/SDK-888)

## Testing

- `npm run test -- --run src/components/TimeOff`
- Storybook: `Domain/TimeOff/PolicySettings` — verify `EditMode` story heading reads `Paid Time Off Policy settings`
- Manual:
  - From the policy list, click **Edit policy** → details heading shows `Edit {policy name}`
  - Continue to settings → heading shows `{policy name} settings`
  - From the policy list, create a new policy → details heading shows `Policy details`, settings heading shows `Policy settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-888]: https://gustohq.atlassian.net/browse/SDK-888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ