### PR TITLE
fix: add loading and disabled button states across TimeOff flow (SDK-877)

### DIFF
--- a/src/components/TimeOff/HolidaySelectionForm/HolidaySelectionForm.tsx
+++ b/src/components/TimeOff/HolidaySelectionForm/HolidaySelectionForm.tsx
@@ -99,7 +99,7 @@ function CreateRoot({ companyId }: RootProps) {
   const allKeys = useMemo(() => new Set(FEDERAL_HOLIDAY_KEYS), [])
   const { selectedUuids, handleSelectionChange, handleSelectAll } = useHolidaySelection(allKeys)
 
-  const { mutateAsync: createPolicy } = useHolidayPayPoliciesCreateMutation()
+  const { mutateAsync: createPolicy, isPending } = useHolidayPayPoliciesCreateMutation()
 
   const handleContinue = useCallback(async () => {
     await baseSubmitHandler({}, async () => {
@@ -133,6 +133,7 @@ function CreateRoot({ companyId }: RootProps) {
       onSelectAll={handleSelectAll}
       onContinue={handleContinue}
       onBack={handleBack}
+      isPending={isPending}
     />
   )
 }
@@ -164,7 +165,7 @@ function EditRoot({ companyId }: RootProps) {
   const { selectedUuids, handleSelectionChange, handleSelectAll } =
     useHolidaySelection(initialSelected)
 
-  const { mutateAsync: updatePolicy } = useHolidayPayPoliciesUpdateMutation()
+  const { mutateAsync: updatePolicy, isPending } = useHolidayPayPoliciesUpdateMutation()
 
   const handleContinue = useCallback(async () => {
     await baseSubmitHandler({}, async () => {
@@ -203,6 +204,7 @@ function EditRoot({ companyId }: RootProps) {
       onSelectAll={handleSelectAll}
       onContinue={handleContinue}
       onBack={handleBack}
+      isPending={isPending}
     />
   )
 }

--- a/src/components/TimeOff/HolidaySelectionForm/HolidaySelectionFormPresentation.tsx
+++ b/src/components/TimeOff/HolidaySelectionForm/HolidaySelectionFormPresentation.tsx
@@ -65,10 +65,10 @@ export function HolidaySelectionFormPresentation(props: HolidaySelectionFormPres
 
       {!isViewMode && (
         <ActionsLayout>
-          <Button variant="secondary" onClick={props.onBack}>
+          <Button variant="secondary" onClick={props.onBack} isDisabled={props.isPending}>
             {t('backCta')}
           </Button>
-          <Button variant="primary" onClick={props.onContinue}>
+          <Button variant="primary" onClick={props.onContinue} isLoading={props.isPending}>
             {t('continueCta')}
           </Button>
         </ActionsLayout>

--- a/src/components/TimeOff/HolidaySelectionForm/HolidaySelectionFormTypes.ts
+++ b/src/components/TimeOff/HolidaySelectionForm/HolidaySelectionFormTypes.ts
@@ -16,6 +16,7 @@ interface HolidaySelectionFormSelectModeProps extends HolidaySelectionFormBasePr
   onSelectAll: (selected: boolean, visibleItems: HolidayItem[]) => void
   onContinue: () => void
   onBack: () => void
+  isPending?: boolean
 }
 
 interface HolidaySelectionFormViewModeProps extends HolidaySelectionFormBaseProps {

--- a/src/components/TimeOff/PolicySettings/PolicySettings.tsx
+++ b/src/components/TimeOff/PolicySettings/PolicySettings.tsx
@@ -105,7 +105,7 @@ function Root({ policyId, mode }: PolicySettingsProps) {
     timeOffPolicyUuid: policyId,
   })
 
-  const { mutateAsync: updateTimeOffPolicy } = useTimeOffPoliciesUpdateMutation()
+  const { mutateAsync: updateTimeOffPolicy, isPending } = useTimeOffPoliciesUpdateMutation()
 
   const policy = policyResponse.timeOffPolicy
   if (!policy) throw new Error('Unexpected response: missing timeOffPolicy')
@@ -141,6 +141,7 @@ function Root({ policyId, mode }: PolicySettingsProps) {
       defaultValues={deriveDefaultValues(policy)}
       mode={mode}
       editingPolicyName={mode === 'edit' ? policy.name : undefined}
+      isPending={isPending}
     />
   )
 }

--- a/src/components/TimeOff/PolicySettings/PolicySettingsPresentation.tsx
+++ b/src/components/TimeOff/PolicySettings/PolicySettingsPresentation.tsx
@@ -15,6 +15,7 @@ export function PolicySettingsPresentation({
   defaultValues,
   mode,
   editingPolicyName,
+  isPending = false,
 }: PolicySettingsPresentationProps) {
   useI18n('Company.TimeOff.CreateTimeOffPolicy')
   const { t } = useTranslation('Company.TimeOff.CreateTimeOffPolicy')
@@ -177,10 +178,10 @@ export function PolicySettingsPresentation({
               <hr className={styles.divider} />
 
               <ActionsLayout>
-                <Button variant="secondary" onClick={onBack}>
+                <Button variant="secondary" onClick={onBack} isDisabled={isPending}>
                   {t('backCta')}
                 </Button>
-                <Button variant="primary" type="submit">
+                <Button variant="primary" type="submit" isLoading={isPending}>
                   {t('policySettings.continueCta')}
                 </Button>
               </ActionsLayout>

--- a/src/components/TimeOff/PolicySettings/PolicySettingsTypes.ts
+++ b/src/components/TimeOff/PolicySettings/PolicySettingsTypes.ts
@@ -22,4 +22,5 @@ export interface PolicySettingsPresentationProps {
   defaultValues?: Partial<PolicySettingsFormData>
   mode?: 'create' | 'edit'
   editingPolicyName?: string
+  isPending?: boolean
 }

--- a/src/components/TimeOff/PolicyTypeSelector/PolicyTypeSelectorPresentation.tsx
+++ b/src/components/TimeOff/PolicyTypeSelector/PolicyTypeSelectorPresentation.tsx
@@ -1,5 +1,5 @@
 import { useId, useMemo } from 'react'
-import { FormProvider, useForm } from 'react-hook-form'
+import { FormProvider, useForm, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import type { PolicyType, PolicyTypeSelectorPresentationProps } from './PolicyTypeSelectorTypes'
 import { Flex, ActionsLayout, RadioGroupField } from '@/components/Common'
@@ -27,6 +27,8 @@ export function PolicyTypeSelectorPresentation({
       policyType: defaultPolicyType as PolicyType,
     },
   })
+
+  const selectedPolicyType = useWatch({ control: formMethods.control, name: 'policyType' })
 
   const policyTypeOptions = useMemo(() => {
     const options: Array<{ value: PolicyType; label: string; description: string }> = []
@@ -78,7 +80,7 @@ export function PolicyTypeSelectorPresentation({
             <Button variant="secondary" onClick={onCancel}>
               {t('cancelCta')}
             </Button>
-            <Button variant="primary" type="submit">
+            <Button variant="primary" type="submit" isDisabled={!selectedPolicyType}>
               {t('continueCta')}
             </Button>
           </ActionsLayout>

--- a/src/components/TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
+++ b/src/components/TimeOff/TimeOffFlow/timeOffStateMachine.test.ts
@@ -406,7 +406,7 @@ describe('timeOffStateMachine', () => {
       expect(service.context.alerts).toBeUndefined()
     })
 
-    it('transitions from editPolicyDetailsForm to editPolicySettings on POLICY_DETAILS_DONE (non-unlimited)', () => {
+    it('transitions from editPolicyDetailsForm to viewTimeOffPolicyDetail on POLICY_DETAILS_DONE', () => {
       const service = createService()
       toViewPolicyDetail(service)
       send(service, componentEvents.TIME_OFF_EDIT_POLICY, { policyId: 'policy-existing' })
@@ -414,21 +414,6 @@ describe('timeOffStateMachine', () => {
       send(service, componentEvents.TIME_OFF_POLICY_DETAILS_DONE, {
         policyId: 'policy-existing',
         accrualMethod: 'per_hour_worked',
-      })
-
-      expect(service.machine.current).toBe('editPolicySettings')
-      expect(service.context.policyId).toBe('policy-existing')
-      expect(service.context.alerts).toBeUndefined()
-    })
-
-    it('transitions from editPolicyDetailsForm to viewTimeOffPolicyDetail on POLICY_DETAILS_DONE (unlimited)', () => {
-      const service = createService()
-      toViewPolicyDetail(service)
-      send(service, componentEvents.TIME_OFF_EDIT_POLICY, { policyId: 'policy-existing' })
-
-      send(service, componentEvents.TIME_OFF_POLICY_DETAILS_DONE, {
-        policyId: 'policy-existing',
-        accrualMethod: 'unlimited',
       })
 
       expect(service.machine.current).toBe('viewTimeOffPolicyDetail')

--- a/src/components/TimeOff/TimeOffFlow/timeOffStateMachine.ts
+++ b/src/components/TimeOff/TimeOffFlow/timeOffStateMachine.ts
@@ -330,14 +330,13 @@ export const timeOffMachine = {
     backToListTransition,
   ),
 
-  // Distinct from `policyDetailsForm` (the create-flow step) so that
-  // DONE/CANCEL return to the policy detail view and settings route through
-  // `editPolicySettings` instead of the create flow's steps.
+  // Distinct from `policyDetailsForm` (the create-flow step) so that DONE
+  // returns to the policy detail view rather than continuing into the
+  // create flow's settings step.
   editPolicyDetailsForm: state<MachineTransition>(
     transition(
       componentEvents.TIME_OFF_POLICY_DETAILS_DONE,
       'viewTimeOffPolicyDetail',
-      guard(isUnlimitedPolicy),
       reduce(
         (
           ctx: TimeOffFlowContextInterface,
@@ -345,21 +344,6 @@ export const timeOffMachine = {
         ): TimeOffFlowContextInterface => ({
           ...ctx,
           component: TimeOffPolicyDetailContextual,
-          policyId: ev.payload.policyId,
-          alerts: undefined,
-        }),
-      ),
-    ),
-    transition(
-      componentEvents.TIME_OFF_POLICY_DETAILS_DONE,
-      'editPolicySettings',
-      reduce(
-        (
-          ctx: TimeOffFlowContextInterface,
-          ev: { payload: PolicyCreatedPayload },
-        ): TimeOffFlowContextInterface => ({
-          ...ctx,
-          component: EditPolicySettingsContextual,
           policyId: ev.payload.policyId,
           alerts: undefined,
         }),

--- a/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationForm.tsx
+++ b/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationForm.tsx
@@ -213,7 +213,7 @@ interface CreateRootProps {
 function CreateRoot({ companyId, policyType, defaultValues }: CreateRootProps) {
   const { onEvent, baseSubmitHandler } = useBase()
 
-  const { mutateAsync: createTimeOffPolicy } = useTimeOffPoliciesCreateMutation()
+  const { mutateAsync: createTimeOffPolicy, isPending } = useTimeOffPoliciesCreateMutation()
 
   const handleContinue = useCallback(
     async (data: PolicyConfigurationFormData) => {
@@ -245,6 +245,7 @@ function CreateRoot({ companyId, policyType, defaultValues }: CreateRootProps) {
       onContinue={handleContinue}
       onCancel={handleCancel}
       defaultValues={defaultValues}
+      isPending={isPending}
     />
   )
 }
@@ -264,7 +265,7 @@ function EditRoot({ companyId, policyType, policyId, defaultValues }: EditRootPr
     timeOffPolicyUuid: policyId,
   })
 
-  const { mutateAsync: updateTimeOffPolicy } = useTimeOffPoliciesUpdateMutation()
+  const { mutateAsync: updateTimeOffPolicy, isPending } = useTimeOffPoliciesUpdateMutation()
 
   const policy = policyResponse.timeOffPolicy
   if (!policy) throw new Error('Unexpected response: missing timeOffPolicy')
@@ -308,6 +309,7 @@ function EditRoot({ companyId, policyType, policyId, defaultValues }: EditRootPr
       onCancel={handleCancel}
       defaultValues={mergedDefaults}
       editingPolicyName={policy.name}
+      isPending={isPending}
     />
   )
 }

--- a/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx
+++ b/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx
@@ -29,6 +29,7 @@ export function PolicyConfigurationFormPresentation({
   onCancel,
   defaultValues,
   editingPolicyName,
+  isPending = false,
 }: PolicyConfigurationFormPresentationProps) {
   useI18n('Company.TimeOff.CreateTimeOffPolicy')
   const { t } = useTranslation('Company.TimeOff.CreateTimeOffPolicy')
@@ -54,9 +55,11 @@ export function PolicyConfigurationFormPresentation({
   })
 
   const { control, setValue, getValues } = formMethods
+  const name = useWatch({ control, name: 'name' })
   const accrualMethod = useWatch({ control, name: 'accrualMethod' })
   const resetDateType = useWatch({ control, name: 'resetDateType' })
   const resetMonth = useWatch({ control, name: 'resetMonth' })
+  const isContinueDisabled = !name.trim() || !accrualMethod
 
   const dayOptions = useMemo(() => {
     const days = getDaysInMonth(resetMonth ?? 1)
@@ -255,10 +258,15 @@ export function PolicyConfigurationFormPresentation({
             )}
 
             <ActionsLayout>
-              <Button variant="secondary" onClick={onCancel}>
+              <Button variant="secondary" onClick={onCancel} isDisabled={isPending}>
                 {t('cancelCta')}
               </Button>
-              <Button variant="primary" type="submit">
+              <Button
+                variant="primary"
+                type="submit"
+                isLoading={isPending}
+                isDisabled={isContinueDisabled}
+              >
                 {t('continueCta')}
               </Button>
             </ActionsLayout>

--- a/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormTypes.ts
+++ b/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormTypes.ts
@@ -20,4 +20,5 @@ export interface PolicyConfigurationFormPresentationProps {
   onCancel: () => void
   defaultValues?: Partial<PolicyConfigurationFormData>
   editingPolicyName?: string
+  isPending?: boolean
 }

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.tsx
@@ -76,9 +76,11 @@ function SelectEmployeesHolidayInner({
     handleSearchClear,
   } = useSelectEmployeesData(companyId, originalUuids)
 
-  const { mutateAsync: addEmployees } = useHolidayPayPoliciesAddEmployeesMutation()
+  const { mutateAsync: addEmployees, isPending: isAddPending } =
+    useHolidayPayPoliciesAddEmployeesMutation()
   const { mutateAsync: removeEmployees, isPending: isRemovePending } =
     useHolidayPayPoliciesRemoveEmployeesMutation()
+  const isSubmitPending = isAddPending || isRemovePending
 
   const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false)
 
@@ -192,6 +194,7 @@ function SelectEmployeesHolidayInner({
       showReassignmentWarning={false}
       pagination={pagination}
       isFetching={isFetching}
+      isPending={isSubmitPending}
       originallyOnPolicyUuids={originalUuids}
       removeConfirmDialog={
         mode === 'standalone'

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
@@ -28,6 +28,7 @@ export function SelectEmployeesPresentation({
   originallyOnPolicyUuids,
   originalBalances,
   removeConfirmDialog,
+  isPending = false,
 }: SelectEmployeesPresentationProps) {
   useI18n('Company.TimeOff.SelectEmployees')
   const { t } = useTranslation('Company.TimeOff.SelectEmployees')
@@ -94,10 +95,10 @@ export function SelectEmployeesPresentation({
       />
 
       <ActionsLayout>
-        <Button variant="secondary" onClick={onBack}>
+        <Button variant="secondary" onClick={onBack} isDisabled={isPending}>
           {t('backCta')}
         </Button>
-        <Button variant="primary" onClick={onContinue}>
+        <Button variant="primary" onClick={onContinue} isLoading={isPending}>
           {t('continueCta')}
         </Button>
       </ActionsLayout>

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentationTypes.ts
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentationTypes.ts
@@ -41,4 +41,6 @@ export interface SelectEmployeesPresentationProps {
   originalBalances?: Record<string, string>
   /** Optional confirm dialog shown before submitting when the user is about to remove employees from the policy. */
   removeConfirmDialog?: RemoveConfirmDialogState
+  /** Disables the back button and shows a spinner on the continue button while a submit is in flight. */
+  isPending?: boolean
 }

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
@@ -169,9 +169,11 @@ function SelectEmployeesTimeOffInner({
     [carryOverBalances, balances],
   )
 
-  const { mutateAsync: addEmployees } = useTimeOffPoliciesAddEmployeesMutation()
+  const { mutateAsync: addEmployees, isPending: isAddPending } =
+    useTimeOffPoliciesAddEmployeesMutation()
   const { mutateAsync: removeEmployees, isPending: isRemovePending } =
     useTimeOffPoliciesRemoveEmployeesMutation()
+  const isSubmitPending = isAddPending || isRemovePending
 
   const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false)
 
@@ -303,6 +305,7 @@ function SelectEmployeesTimeOffInner({
       onBalanceChange={hideBalances ? undefined : handleBalanceChange}
       pagination={pagination}
       isFetching={isFetching}
+      isPending={isSubmitPending}
       originallyOnPolicyUuids={originalUuids}
       originalBalances={originalBalances}
       removeConfirmDialog={


### PR DESCRIPTION
## Summary

Adds loading and disabled button states to TimeOff flow forms so partners get clear feedback during submission and cannot double-submit while a mutation is in flight.

## Changes

- Thread `isPending` from mutation hooks into each form's presentation component (HolidaySelectionForm, PolicySettings, PolicyConfigurationForm, SelectEmployees).
- Apply `isLoading` on primary submit buttons and `isDisabled` on secondary back/cancel buttons while the request is pending.
- Disable the PolicyTypeSelector continue button until a policy type is selected.
- Disable the PolicyConfigurationForm continue button until name and accrual method are populated.
- Simplify `editPolicyDetailsForm` transition so `POLICY_DETAILS_DONE` always returns to the policy detail view (removes the unlimited-policy guard branch through `editPolicySettings`).

## Related

- Jira ticket: [SDK-877](https://gustohq.atlassian.net/browse/SDK-877)

## Testing

- `npm run test -- --run src/components/TimeOff`
- In Storybook / sdk-app, walk through each TimeOff form and verify primary buttons show loading and secondary buttons disable while a submit is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-877]: https://gustohq.atlassian.net/browse/SDK-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ