### PR TITLE
fix: show empty state CTA when policy has no employees (SDK-883)

### DIFF
--- a/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.tsx
+++ b/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.tsx
@@ -162,6 +162,7 @@ function Root({ companyId, defaultTab = 'holidays' }: HolidayPolicyDetailProps) 
       onBack={handleBack}
       backLabel={tShared('backLabel')}
       actions={actions}
+      onAddEmployee={handleAddEmployees}
       holidays={holidays}
       selectedTabId={selectedTabId}
       onTabChange={setSelectedTabId}

--- a/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetailPresentation.tsx
+++ b/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetailPresentation.tsx
@@ -18,6 +18,7 @@ export function HolidayPolicyDetailPresentation({
   selectedTabId,
   onTabChange,
   employees,
+  onAddEmployee,
   removeDialog,
   successAlert,
   onDismissAlert,
@@ -42,6 +43,7 @@ export function HolidayPolicyDetailPresentation({
       selectedTabId={selectedTabId}
       onTabChange={onTabChange}
       employees={employees}
+      onAddEmployee={onAddEmployee}
       removeDialog={removeDialog}
       successAlert={successAlert}
       onDismissAlert={onDismissAlert}

--- a/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetailTypes.ts
+++ b/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetailTypes.ts
@@ -35,6 +35,8 @@ export interface HolidayPolicyDetailPresentationProps {
     | 'emptyState'
   >
 
+  onAddEmployee?: () => void
+
   removeDialog: RemoveDialogState
   successAlert?: string
   onDismissAlert?: () => void

--- a/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.tsx
+++ b/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.tsx
@@ -224,6 +224,10 @@ function Root({ policyId }: TimeOffPolicyDetailProps) {
     [baseSubmitHandler, updateBalance, policyId, editBalanceState, invalidatePolicy, t],
   )
 
+  const handleAddEmployees = useCallback(() => {
+    onEvent(componentEvents.TIME_OFF_ADD_EMPLOYEES_TO_POLICY, { policyId })
+  }, [onEvent, policyId])
+
   const actions = useMemo(() => {
     if (!isEditable) return undefined
     return [
@@ -231,9 +235,7 @@ function Root({ policyId }: TimeOffPolicyDetailProps) {
         key="add"
         variant="secondary"
         icon={<PlusCircleIcon aria-hidden />}
-        onClick={() => {
-          onEvent(componentEvents.TIME_OFF_ADD_EMPLOYEES_TO_POLICY, { policyId })
-        }}
+        onClick={handleAddEmployees}
       >
         {t('addEmployeeCta')}
       </Button>,
@@ -248,7 +250,7 @@ function Root({ policyId }: TimeOffPolicyDetailProps) {
         {t('editPolicyCta')}
       </Button>,
     ]
-  }, [Button, onEvent, policyId, t, isEditable])
+  }, [Button, onEvent, policyId, t, isEditable, handleAddEmployees])
 
   const isUnlimited = policy.accrualMethod === 'unlimited'
 
@@ -324,6 +326,7 @@ function Root({ policyId }: TimeOffPolicyDetailProps) {
           },
           ...(isEditable ? { itemMenu } : {}),
         }}
+        onAddEmployee={isEditable ? handleAddEmployees : undefined}
         removeDialog={{
           isOpen: removeTarget !== null,
           employeeName: removeTarget?.name ?? '',

--- a/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
+++ b/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
@@ -26,6 +26,7 @@ export function TimeOffPolicyDetailPresentation({
   selectedTabId,
   onTabChange,
   employees,
+  onAddEmployee,
   removeDialog,
   successAlert,
   onDismissAlert,
@@ -79,6 +80,7 @@ export function TimeOffPolicyDetailPresentation({
         additionalColumns: balanceColumn,
         hideJobTitle: true,
       }}
+      onAddEmployee={onAddEmployee}
       removeDialog={removeDialog}
       successAlert={successAlert}
       onDismissAlert={onDismissAlert}

--- a/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailTypes.ts
+++ b/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailTypes.ts
@@ -69,6 +69,8 @@ interface TimeOffPolicyDetailPresentationBaseProps {
     | 'emptyState'
   >
 
+  onAddEmployee?: () => void
+
   removeDialog: RemoveDialogState
   successAlert?: string
   onDismissAlert?: () => void

--- a/src/components/TimeOff/shared/PolicyDetailLayout/PolicyDetailLayout.tsx
+++ b/src/components/TimeOff/shared/PolicyDetailLayout/PolicyDetailLayout.tsx
@@ -2,9 +2,10 @@ import { useTranslation } from 'react-i18next'
 import type { EmployeeTableItem } from '../EmployeeTable/EmployeeTableTypes'
 import { EmployeeTable } from '../EmployeeTable/EmployeeTable'
 import type { PolicyDetailLayoutProps } from './PolicyDetailLayoutTypes'
-import { DetailViewLayout } from '@/components/Common'
+import { DetailViewLayout, EmptyData } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
+import PlusCircleIcon from '@/assets/icons/plus-circle.svg?react'
 
 const EMPLOYEES_TAB_ID = 'employees'
 
@@ -18,13 +19,30 @@ export function PolicyDetailLayout<T extends EmployeeTableItem>({
   selectedTabId,
   onTabChange,
   employees,
+  onAddEmployee,
   removeDialog,
   successAlert,
   onDismissAlert,
 }: PolicyDetailLayoutProps<T>) {
   useI18n('Company.TimeOff.PolicyDetail')
   const { t } = useTranslation('Company.TimeOff.PolicyDetail')
-  const { Alert, Dialog } = useComponentContext()
+  const { Alert, Dialog, Button } = useComponentContext()
+
+  const emptyEmployeesState =
+    employees.emptyState ??
+    (onAddEmployee
+      ? () => (
+          <EmptyData title={t('emptyEmployees.title')}>
+            <Button
+              variant="secondary"
+              icon={<PlusCircleIcon aria-hidden />}
+              onClick={onAddEmployee}
+            >
+              {t('emptyEmployees.addEmployeeCta')}
+            </Button>
+          </EmptyData>
+        )
+      : undefined)
 
   const tabs = [
     {
@@ -45,7 +63,7 @@ export function PolicyDetailLayout<T extends EmployeeTableItem>({
           itemMenu={employees.itemMenu}
           pagination={employees.pagination}
           isFetching={employees.isFetching}
-          emptyState={employees.emptyState}
+          emptyState={emptyEmployeesState}
           additionalColumns={employees.additionalColumns}
           hideJobTitle={employees.hideJobTitle}
         />

--- a/src/components/TimeOff/shared/PolicyDetailLayout/PolicyDetailLayoutTypes.ts
+++ b/src/components/TimeOff/shared/PolicyDetailLayout/PolicyDetailLayoutTypes.ts
@@ -39,6 +39,8 @@ export interface PolicyDetailLayoutProps<T extends EmployeeTableItem> {
     | 'hideJobTitle'
   >
 
+  onAddEmployee?: () => void
+
   removeDialog: RemoveDialogState
   successAlert?: string
   onDismissAlert?: () => void

--- a/src/i18n/en/Company.TimeOff.PolicyDetail.json
+++ b/src/i18n/en/Company.TimeOff.PolicyDetail.json
@@ -4,6 +4,10 @@
   },
   "backLabel": "Back to policies",
   "employeeActions": "Actions for {{name}}",
+  "emptyEmployees": {
+    "title": "No employees have been added to this policy",
+    "addEmployeeCta": "Add employee"
+  },
   "removeEmployeeDialog": {
     "title": "Remove {{name}}",
     "description": "Are you sure you want to remove {{name}} from this policy?",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -552,6 +552,10 @@ export interface CompanyTimeOffPolicyDetail{
 };
 "backLabel":string;
 "employeeActions":string;
+"emptyEmployees":{
+"title":string;
+"addEmployeeCta":string;
+};
 "removeEmployeeDialog":{
 "title":string;
 "description":string;


### PR DESCRIPTION
## Summary

Renders an empty-state CTA in the employees tab of a policy detail page when no employees have been added, so admins have a clear path to add their first employee instead of seeing an empty table.

## Changes

- Add `onAddEmployee` to `PolicyDetailLayout`; when provided, renders an `EmptyData` with the message "No employees have been added to this policy" and a secondary "Add employee" button (plus icon) that mirrors the header CTA.
- Thread `onAddEmployee` through `HolidayPolicyDetail` and `TimeOffPolicyDetail` so both policy types pick up the empty state.
- Only show the CTA when the user can edit the policy (skipped in read-only views).
- Add `emptyEmployees.title` / `emptyEmployees.addEmployeeCta` translation keys.

## Related

- Jira ticket: [SDK-883](https://gustohq.atlassian.net/browse/SDK-883)

## Testing

- `npm run test -- --run src/components/TimeOff/HolidayPolicyDetail src/components/TimeOff/TimeOffPolicyDetail src/components/TimeOff/shared`
- In Storybook / sdk-app, open a holiday or time-off policy detail page with no employees added and verify the empty state appears with a working "Add employee" CTA. Add an employee and verify the table renders normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-883]: https://gustohq.atlassian.net/browse/SDK-883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ