### PR TITLE
feat: fuzzy search for sdk-app command palette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "eslint-plugin-storybook": "^10.3.6",
+        "fuse.js": "^7.3.0",
         "globals": "^17.6.0",
         "husky": "^9.1.7",
         "jest-axe": "^9.0.0",
@@ -13303,6 +13304,20 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/generator-function": {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "eslint-plugin-storybook": "^10.3.6",
+    "fuse.js": "^7.3.0",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
     "jest-axe": "^9.0.0",

--- a/sdk-app/src/CommandPalette/componentMetadata.ts
+++ b/sdk-app/src/CommandPalette/componentMetadata.ts
@@ -1,0 +1,199 @@
+/**
+ * Natural-language metadata for the command palette.
+ *
+ * Keyed by `<Category>.<ComponentName>` (matching the keys used in
+ * `sdk-app/src/generated-registry-data.ts`). Each entry attaches a
+ * human-readable description and a list of keywords/synonyms a user
+ * might actually type — e.g. "run payroll" → PayrollFlow.
+ *
+ * Coverage is intentionally partial: top-level flows and major
+ * landing/list screens. Components without a metadata entry still
+ * appear in the palette by name; they just won't have rich fuzzy
+ * matching until someone adds an entry here.
+ */
+
+export interface ComponentMetadata {
+  description: string
+  keywords: string[]
+}
+
+export const componentMetadata: Record<string, ComponentMetadata> = {
+  // ─── Company ─────────────────────────────────────────────────────────
+  'Company.OnboardingFlow': {
+    description: 'Onboard a company end-to-end (industry, signatory, taxes, bank, pay schedule).',
+    keywords: [
+      'onboard company',
+      'new company',
+      'company setup',
+      'company onboarding',
+      'start company',
+    ],
+  },
+  'Company.OnboardingOverview': {
+    description: 'Overview of remaining company onboarding steps.',
+    keywords: ['company onboarding status', 'company progress', 'company checklist'],
+  },
+
+  // ─── Contractor ──────────────────────────────────────────────────────
+  'Contractor.OnboardingFlow': {
+    description: 'Onboard a new contractor.',
+    keywords: [
+      'onboard contractor',
+      'new contractor',
+      'add contractor',
+      'create contractor',
+      'contractor signup',
+    ],
+  },
+  'Contractor.PaymentFlow': {
+    description: 'Pay contractors (single or batch).',
+    keywords: [
+      'pay contractor',
+      'pay contractors',
+      'contractor payment',
+      'send contractor payment',
+      '1099 payment',
+    ],
+  },
+  'Contractor.ContractorList': {
+    description: 'List all contractors for the company.',
+    keywords: ['contractors', 'view contractors', 'all contractors'],
+  },
+
+  // ─── Employee ────────────────────────────────────────────────────────
+  'Employee.OnboardingFlow': {
+    description: 'Admin-led onboarding for a new employee.',
+    keywords: [
+      'add employee',
+      'new hire',
+      'onboard employee',
+      'create employee',
+      'hire employee',
+      'admin onboarding',
+    ],
+  },
+  'Employee.SelfOnboardingFlow': {
+    description: 'Employee-led self-onboarding (employee fills out their own details).',
+    keywords: [
+      'self onboarding',
+      'employee signup',
+      'new hire onboarding',
+      'self serve onboarding',
+    ],
+  },
+  'Employee.DashboardFlow': {
+    description: 'Employee-facing dashboard.',
+    keywords: ['employee dashboard', 'employee home', 'employee portal'],
+  },
+  'Employee.TerminationFlow': {
+    description: 'Terminate an employee (offboarding flow).',
+    keywords: [
+      'terminate',
+      'terminate employee',
+      'fire',
+      'offboard',
+      'offboard employee',
+      'end employment',
+      'dismiss employee',
+      'let go',
+    ],
+  },
+  'Employee.EmployeeList': {
+    description: 'List all employees for the company.',
+    keywords: ['employees', 'view employees', 'all employees', 'employee roster'],
+  },
+
+  // ─── InformationRequests ─────────────────────────────────────────────
+  'InformationRequests.InformationRequestsFlow': {
+    description: 'Respond to outstanding information requests from Gusto.',
+    keywords: [
+      'information requests',
+      'info requests',
+      'requests',
+      'respond to requests',
+      'pending requests',
+    ],
+  },
+
+  // ─── Payroll ─────────────────────────────────────────────────────────
+  'Payroll.PayrollFlow': {
+    description: 'Run a regular payroll cycle end-to-end.',
+    keywords: [
+      'run payroll',
+      'process payroll',
+      'pay employees',
+      'regular payroll',
+      'submit payroll',
+      'do payroll',
+      'start payroll',
+    ],
+  },
+  'Payroll.PayrollExecutionFlow': {
+    description: 'Execute (review and submit) an in-progress payroll.',
+    keywords: [
+      'execute payroll',
+      'submit payroll',
+      'review payroll',
+      'finalize payroll',
+      'approve payroll',
+    ],
+  },
+  'Payroll.OffCycleFlow': {
+    description: 'Run an off-cycle payroll (bonus, correction, supplemental pay).',
+    keywords: [
+      'off cycle payroll',
+      'offcycle',
+      'bonus payroll',
+      'bonus',
+      'correction',
+      'one off payroll',
+      'supplemental payroll',
+    ],
+  },
+  'Payroll.TransitionFlow': {
+    description: 'Run a transition payroll when migrating from another provider mid-quarter.',
+    keywords: [
+      'transition payroll',
+      'migration payroll',
+      'switch provider',
+      'historical payroll',
+      'mid quarter migration',
+    ],
+  },
+  'Payroll.DismissalFlow': {
+    description: 'Run a dismissal/final-paycheck payroll for a terminated employee.',
+    keywords: [
+      'dismissal payroll',
+      'final paycheck',
+      'termination pay',
+      'severance payroll',
+      'last paycheck',
+    ],
+  },
+  'Payroll.PayrollHistory': {
+    description: 'View past payrolls.',
+    keywords: ['payroll history', 'past payrolls', 'previous payrolls', 'payroll log'],
+  },
+  'Payroll.PayrollList': {
+    description: 'List of payrolls (drafts and processed).',
+    keywords: ['payrolls', 'all payrolls', 'view payrolls'],
+  },
+  'Payroll.PayrollLanding': {
+    description: 'Payroll landing / home page.',
+    keywords: ['payroll home', 'payroll', 'payroll overview'],
+  },
+
+  // ─── TimeOff ─────────────────────────────────────────────────────────
+  'TimeOff.TimeOffFlow': {
+    description: 'Manage time off policies (create, edit, assign to employees).',
+    keywords: [
+      'time off',
+      'pto',
+      'time off policy',
+      'vacation policy',
+      'sick policy',
+      'paid time off',
+      'leave policy',
+    ],
+  },
+}

--- a/sdk-app/src/CommandPalette/pages.ts
+++ b/sdk-app/src/CommandPalette/pages.ts
@@ -1,5 +1,7 @@
+import Fuse from 'fuse.js'
 import { componentRegistry } from '../registry'
 import { categorizedRegistry as designRegistry } from '../design/registry'
+import { componentMetadata } from './componentMetadata'
 
 interface BaseEntry {
   id: string
@@ -34,12 +36,15 @@ function buildPages(): NavEntry[] {
   ]
 
   for (const entry of componentRegistry) {
+    const meta = componentMetadata[`${entry.category}.${entry.name}`]
     pages.push({
       kind: 'navigate',
       id: `component:${entry.category}:${entry.name}`,
       label: entry.name,
       category: entry.category,
       path: `/${entry.category.toLowerCase()}/${entry.name}`,
+      ...(meta?.description ? { description: meta.description } : {}),
+      ...(meta?.keywords ? { keywords: meta.keywords } : {}),
     })
   }
 
@@ -63,30 +68,36 @@ export const PAGES: NavEntry[] = buildPages()
 
 const MAX_RESULTS = 50
 
-export function searchEntries(entries: PaletteEntry[], query: string): PaletteEntry[] {
-  const trimmed = query.trim().toLowerCase()
+const FUSE_OPTIONS: ConstructorParameters<typeof Fuse<PaletteEntry>>[1] = {
+  keys: [
+    { name: 'label', weight: 0.5 },
+    { name: 'keywords', weight: 0.3 },
+    { name: 'description', weight: 0.15 },
+    { name: 'category', weight: 0.05 },
+  ],
+  threshold: 0.4,
+  ignoreLocation: true,
+  includeScore: true,
+  minMatchCharLength: 2,
+}
+
+const fuseCache = new WeakMap<readonly PaletteEntry[], Fuse<PaletteEntry>>()
+
+function getFuse(entries: readonly PaletteEntry[]): Fuse<PaletteEntry> {
+  let fuse = fuseCache.get(entries)
+  if (!fuse) {
+    fuse = new Fuse([...entries], FUSE_OPTIONS)
+    fuseCache.set(entries, fuse)
+  }
+  return fuse
+}
+
+export function searchEntries(entries: readonly PaletteEntry[], query: string): PaletteEntry[] {
+  const trimmed = query.trim()
   if (!trimmed) return []
 
-  const prefixMatches: PaletteEntry[] = []
-  const labelMatches: PaletteEntry[] = []
-  const otherMatches: PaletteEntry[] = []
-
-  for (const entry of entries) {
-    const label = entry.label.toLowerCase()
-    if (label.startsWith(trimmed)) {
-      prefixMatches.push(entry)
-      continue
-    }
-    if (label.includes(trimmed)) {
-      labelMatches.push(entry)
-      continue
-    }
-    const keywords = entry.keywords?.join(' ') ?? ''
-    const haystack = `${entry.category} ${entry.description ?? ''} ${keywords}`.toLowerCase()
-    if (haystack.includes(trimmed)) {
-      otherMatches.push(entry)
-    }
-  }
-
-  return [...prefixMatches, ...labelMatches, ...otherMatches].slice(0, MAX_RESULTS)
+  return getFuse(entries)
+    .search(trimmed)
+    .slice(0, MAX_RESULTS)
+    .map(result => result.item)
 }


### PR DESCRIPTION
## Summary
- Replace the substring matcher in the Cmd+K command palette ([sdk-app/src/CommandPalette/pages.ts](sdk-app/src/CommandPalette/pages.ts)) with a `fuse.js` fuzzy search. Weighted keys (label > keywords > description > category), `threshold: 0.4`, results memoized via a `WeakMap` keyed on entries identity so the per-keystroke cost is just `fuse.search()`.
- Add [sdk-app/src/CommandPalette/componentMetadata.ts](sdk-app/src/CommandPalette/componentMetadata.ts) — natural-language descriptions + keywords for every public Flow component (and major landing/list screens). Merged into the auto-built nav entries in `buildPages()`. Now `run payroll`, `process payroll`, `pay employees` etc. all surface `PayrollFlow`.
- `CommandPalette.tsx` needed no changes — same `searchEntries(entries, query)` signature.
- Public SDK surface untouched; `fuse.js` lands as a `devDependency`. Bundle impact is dev-app only.

## Screenshot
<img width="559" height="488" alt="Screenshot 2026-05-13 at 2 01 13 PM" src="https://github.com/user-attachments/assets/166a8eb4-7234-42e3-9243-7b8c1d6b9bde" />



## Test plan
- [ ] `npm run sdk-app`, open Cmd+K, confirm top-3 results for each:
  - [ ] `run payroll` → `PayrollFlow`
  - [ ] `process payroll` → `PayrollFlow`
  - [ ] `bonus` → `OffCycleFlow`
  - [ ] `add employee` → `Employee.OnboardingFlow`
  - [ ] `terminate` / `fire` → `TerminationFlow`
  - [ ] `payrol` (typo) → `PayrollFlow` (proves fuzziness)
- [ ] Existing action entries still match: `theme`, `code panel`, `sidebar`
- [ ] Tune `threshold` in `pages.ts` if results feel noisy or relevant matches are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)