### PR TITLE
fix: center-align empty search state in time off employee table (SDK-885)

### DIFF
--- a/src/components/TimeOff/shared/EmployeeTable/EmployeeTable.tsx
+++ b/src/components/TimeOff/shared/EmployeeTable/EmployeeTable.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { EmployeeTableItem, EmployeeTableProps } from './EmployeeTableTypes'
 import styles from './EmployeeTable.module.scss'
-import { DataView, useDataView } from '@/components/Common'
+import { DataView, Flex, useDataView } from '@/components/Common'
 import type { useDataViewProp } from '@/components/Common/DataView/useDataView'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n/I18n'
@@ -117,5 +117,9 @@ export function EmployeeTable<T extends EmployeeTableItem>({
 
 function DefaultEmptySearchState({ message }: { message: string }) {
   const { Text } = useComponentContext()
-  return <Text>{message}</Text>
+  return (
+    <Flex flexDirection="column" alignItems="center" gap={8}>
+      <Text size="sm">{message}</Text>
+    </Flex>
+  )
 }


### PR DESCRIPTION
## Summary

Fixes the alignment of the empty search state in the time off employee table. The empty state was previously left-aligned and used the default text size; it now renders centered with a smaller text size, matching the intended design.

## Changes

- Wrap the `DefaultEmptySearchState` message in a centered `Flex` container
- Use `size="sm"` on the empty state text

## Demo

<!-- Screenshots/recording to be added -->

## Related

- Jira ticket: [SDK-885](https://gustohq.atlassian.net/browse/SDK-885)

## Testing

- Open the time off employee table in Storybook and trigger an empty search result
- Verify the empty state message is horizontally centered and renders at the smaller text size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-885]: https://gustohq.atlassian.net/browse/SDK-885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ