### PR TITLE
fix: use "0" as number input placeholder in policy settings (SDK-886)

### DIFF
--- a/src/i18n/en/Company.TimeOff.CreateTimeOffPolicy.json
+++ b/src/i18n/en/Company.TimeOff.CreateTimeOffPolicy.json
@@ -57,8 +57,8 @@
     "waitingPeriodHint": "The number of days employees must work before they begin accruing time off.",
     "paidOutOnTerminationLabel": "Payout on dismissal",
     "paidOutOnTerminationHint": "Choose if unused time off is paid out when an employee leaves. Some states require it by law.",
-    "numberOfHoursPlaceholder": "Number of hours",
-    "numberOfDaysPlaceholder": "Number of days",
+    "numberOfHoursPlaceholder": "0",
+    "numberOfDaysPlaceholder": "0",
     "continueCta": "Save"
   },
   "startingBalances": {


### PR DESCRIPTION
## Summary

Simplifies the placeholders on the four numeric inputs in the time off policy settings form ("Accrual maximum", "Balance maximum", "Carry over limit", "Waiting period") from the verbose "Number of hours" / "Number of days" to just `0`. The hours/days unit is already shown via the input's `adornmentEnd`, so the placeholder was redundant.

## Changes

- Update `numberOfHoursPlaceholder` and `numberOfDaysPlaceholder` in `Company.TimeOff.CreateTimeOffPolicy.json` to `"0"`.

## Demo

<!-- Add a before/after screenshot of the policy settings form -->

## Related

- Jira ticket: [SDK-886](https://gustohq.atlassian.net/browse/SDK-886)

## Testing

- `npm run storybook` → Company → TimeOff → CreateTimeOffPolicy → PolicySettings: confirm each number field shows `0` as the placeholder, with the hrs/days adornment unchanged on the right.
- `npm run test -- --run src/components/TimeOff/PolicySettings/` (29 tests, all passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-886]: https://gustohq.atlassian.net/browse/SDK-886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ