### PR TITLE
fix: constrain starting balance input width in employee table (SDK-893)

### DIFF
--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.module.scss
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.module.scss
@@ -1,0 +1,7 @@
+.balanceInput {
+  width: toRem(120);
+
+  :global(.react-aria-Cell) & {
+    margin-left: auto;
+  }
+}

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
@@ -5,6 +5,7 @@ import type {
   EmployeeItem,
   SelectEmployeesPresentationProps,
 } from './SelectEmployeesPresentationTypes'
+import styles from './SelectEmployeesPresentation.module.scss'
 import { ActionsLayout, Flex } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
@@ -88,6 +89,7 @@ export function SelectEmployeesPresentation({
                           onBalanceChange(employee.uuid, value)
                         }}
                         placeholder="0"
+                        className={styles.balanceInput}
                       />
                     )
                   },


### PR DESCRIPTION
## Summary

Constrains the starting balance input in the Select Employees table to 120px so the column doesn't stretch to fill available space, and right-aligns it within the cell (when in table mode) so the input sits flush with the column's right-aligned header.

## Changes

- New `SelectEmployeesPresentation.module.scss` with a `.balanceInput` class: `width: toRem(120)` plus `margin-left: auto` scoped to `.react-aria-Cell` ancestors only.
- Applied the class via `className` on the balance `TextInput` in `SelectEmployeesPresentation.tsx`.

## Demo

<!-- Add screenshots of the table at desktop width and the responsive DataCard view -->

## Related

- Jira ticket: [SDK-893](https://gustohq.atlassian.net/browse/SDK-893)

## Testing

- Storybook: `npm run storybook` → Company / TimeOff / SelectEmployees stories
- Verify in table mode the balance input is 120px wide and right-aligned within its cell
- Verify in responsive DataCard mode the input remains left-aligned (no `margin-left: auto` because there's no `.react-aria-Cell` ancestor)

[SDK-893]: https://gustohq.atlassian.net/browse/SDK-893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ