### PR TITLE
test: align policy settings tests with "0" placeholder

### DIFF
--- a/src/components/TimeOff/PolicySettings/PolicySettings.test.tsx
+++ b/src/components/TimeOff/PolicySettings/PolicySettings.test.tsx
@@ -189,7 +189,9 @@ describe('PolicySettings container', () => {
       await user.click(balanceSwitches[0])
 
       await waitFor(() => {
-        expect(screen.getAllByPlaceholderText('Number of hours')[0]).not.toBeDisabled()
+        const balanceInput = screen.getByRole('textbox', { name: /^Balance maximum/ })
+        expect(balanceInput).toHaveAttribute('placeholder', '0')
+        expect(balanceInput).not.toBeDisabled()
       })
 
       await user.click(screen.getByRole('button', { name: 'Save' }))

--- a/src/components/TimeOff/PolicySettings/PolicySettingsPresentation.test.tsx
+++ b/src/components/TimeOff/PolicySettings/PolicySettingsPresentation.test.tsx
@@ -155,8 +155,9 @@ describe('PolicySettingsPresentation', () => {
         expect(screen.getAllByText('Balance maximum').length).toBeGreaterThan(0)
       })
 
-      const balanceInputs = screen.getAllByPlaceholderText('Number of hours')
-      expect(balanceInputs[0]).toBeDisabled()
+      const balanceInput = screen.getByRole('textbox', { name: /^Balance maximum/ })
+      expect(balanceInput).toHaveAttribute('placeholder', '0')
+      expect(balanceInput).toBeDisabled()
 
       const balanceSwitches = screen
         .getAllByRole('switch')
@@ -167,7 +168,7 @@ describe('PolicySettingsPresentation', () => {
       await user.click(balanceSwitch)
 
       await waitFor(() => {
-        expect(screen.getAllByPlaceholderText('Number of hours')[0]).not.toBeDisabled()
+        expect(screen.getByRole('textbox', { name: /^Balance maximum/ })).not.toBeDisabled()
       })
     })
   })


### PR DESCRIPTION
## Summary
- PR #1818 changed the policy settings number-input placeholder from "Number of hours" to "0" but didn't update the two tests that queried inputs by that placeholder text, which broke the `test` job on main.
- Updates the `getAllByPlaceholderText('Number of hours')` lookups in [PolicySettings.test.tsx](src/components/TimeOff/PolicySettings/PolicySettings.test.tsx) and [PolicySettingsPresentation.test.tsx](src/components/TimeOff/PolicySettings/PolicySettingsPresentation.test.tsx) to match the new `"0"` placeholder.

## Test plan
- [x] `npm run test -- --run src/components/TimeOff/PolicySettings/` — both files pass (29/29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)