### PR TITLE
chore: update CODEOWNERS to use team instead of individuals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be automatically requested for review on all PRs
-* @jeffredodd @dmortal @serikjensen @krisxcrash @hukid @mariechatfield
+* @Gusto/embedded-sdk
 


### PR DESCRIPTION
Update the codeowners in GitHub to use our team instead of listing people individually. This means when we add new team members, we only have to add them one place.