### PR TITLE
docs(claude): refresh hook skill, create-hook command, and review-pr rules

### DIFF
--- a/.claude/commands/create-hook.md
+++ b/.claude/commands/create-hook.md
@@ -7,42 +7,63 @@ Scaffold a new form hook in the correct feature module location.
 The user provides:
 
 - **Domain**: Employee, Company, Contractor, or Payroll
-- **Feature**: The feature name (e.g. Compensation, PaySchedule, DocumentSigner)
-- **Hook name**: The hook name without the `use` prefix (e.g. CompensationForm, PayScheduleForm)
+- **Feature**: The feature name (e.g. Compensation, PaySchedule, DocumentSigner, Profile)
+- **Hook name**: The hook name without the `use` prefix (e.g. `EmployeeDetailsForm`, `HomeAddressForm`, `JobForm`)
+
+For the rest of this doc, `{Domain}` is the entity name (e.g. `EmployeeDetails`, `HomeAddress`, `Job`) and `{name}Form` is the directory/file basename (e.g. `useEmployeeDetailsForm`).
 
 ## Steps
 
 ### Step 1: Determine the target location
 
-Hooks live in their domain's feature module under `shared/`:
+Hooks live in their feature module's `shared/` directory, one directory per hook:
 
 ```
-src/components/{Domain}/{Feature}/shared/use{Name}/
+src/components/{Domain}/{Feature}/shared/use{Name}Form/
+├── use{Name}Form.tsx        # Main hook
+├── {camelDomain}Schema.ts   # Zod schema, error codes, form data/output types
+├── fields.tsx               # Domain field components + exported field prop types
+├── index.ts                 # Barrel re-exports
+└── use{Name}Form.test.tsx   # Hook unit tests
 ```
 
 Examples:
 
+- `src/components/Employee/Profile/shared/useEmployeeDetailsForm/`
+- `src/components/Employee/Profile/shared/useHomeAddressForm/`
+- `src/components/Employee/Profile/shared/useWorkAddressForm/`
 - `src/components/Employee/Compensation/shared/useCompensationForm/`
+- `src/components/Employee/Compensation/shared/useJobForm/`
 - `src/components/Company/PaySchedule/shared/usePayScheduleForm/`
 
 ### Step 2: Read reference implementations
 
-Read these files for the canonical patterns:
+Pick the closest existing hook to the one you're building and read it end-to-end before scaffolding. The four files in any reference directory plus `.claude/hooks-implementation.md` are the canonical patterns:
 
-- `src/components/Employee/Compensation/shared/useCompensationForm/compensationSchema.ts`
-- `src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.tsx`
-- `src/components/Employee/Compensation/shared/useCompensationForm/fields.tsx`
-- `src/components/Employee/Compensation/shared/useCompensationForm/index.ts`
-- `src/partner-hook-utils/form/buildFormSchema.ts`
-- `.claude/hooks-implementation.md`
+| Closest reference                                                  | Use when…                                                                                              |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `src/components/Employee/Profile/shared/useEmployeeDetailsForm/`   | Hook does multiple sequential mutations per submit (chained API calls) — needs `*SubmitCallbacks`      |
+| `src/components/Employee/Profile/shared/useHomeAddressForm/`       | Single-mutation create-or-update hook with optional entity id resolved at submit time                  |
+| `src/components/Employee/Profile/shared/useWorkAddressForm/`       | Single-mutation hook that also exposes a list query (e.g. company locations) feeding a select field    |
+| `src/components/Employee/Compensation/shared/useJobForm/`          | Hook with predicate-based requiredness (`stateWcCovered → stateWcClassCode required`) + radio coercion |
+| `src/components/Employee/Compensation/shared/useCompensationForm/` | Cross-field `superRefine` validation, conditional fields, status flags surfaced to partners            |
+| `src/components/Company/PaySchedule/shared/usePayScheduleForm/`    | Company-domain hook with admin-only fields                                                             |
+
+Always read:
+
+- The schema file — error codes, field validators, required-fields config, schema factory
+- The fields file — domain field components and the validation-type aliases each one declares
+- The hook file — data fetching, form setup, return shape, submit handler
+- The barrel `index.ts` — what is re-exported and under which names
+- `.claude/hooks-implementation.md` — schema, fields, hook internals, error handling, exports in detail
+- `src/partner-hook-utils/form/buildFormSchema.ts` — the schema builder's full surface (`requiredFieldsConfig`, `excludeFields`, `fieldsWithRedactedValues`, `superRefine`, `OptionalFieldsToRequire`)
+- `src/partner-hook-utils/types.ts` — `BaseFormHookReady`, `HookLoadingResult`, `HookSubmitResult`, `HookErrorHandling`, `FieldsMetadata`, `HookFieldProps`
 
 ### Step 3: Create the directory and files
 
-Create the hook directory and generate these files:
+#### `{camelDomain}Schema.ts`
 
-#### `{domain}Schema.ts`
-
-Follow the 4-part structure: error codes → field validators → required fields config → schema factory.
+Follow the 4-part structure: **error codes → field validators → required fields config → schema factory**. Use the section comment style from the reference hooks.
 
 ```typescript
 import { z } from 'zod'
@@ -52,97 +73,374 @@ import {
   type OptionalFieldsToRequire,
 } from '@/partner-hook-utils/form/buildFormSchema'
 
-export const {Name}ErrorCodes = {
+// ── Error codes ────────────────────────────────────────────────────────
+
+export const {Domain}ErrorCodes = {
   REQUIRED: 'REQUIRED',
+  // Add format/cross-field codes here as needed
 } as const
-export type {Name}ErrorCode = (typeof {Name}ErrorCodes)[keyof typeof {Name}ErrorCodes]
+
+export type {Domain}ErrorCode = (typeof {Domain}ErrorCodes)[keyof typeof {Domain}ErrorCodes]
+
+// ── Field validators ───────────────────────────────────────────────────
 
 const fieldValidators = {
-  // Define field validators here
+  // Plain shape constraints; do NOT add `.optional()` — buildFormSchema does
+  // that based on `requiredFieldsConfig`. Escape hatch: an enum field that
+  // needs to render an empty placeholder before the user picks must be
+  // `.optional()` so the resolver tolerates `undefined` while editing.
+  // Requiredness is still enforced on submit via `requiredFieldsConfig`.
+  // See `flsaStatus` in `compensationSchema.ts` for the canonical example.
+  //
+  // Use z.preprocess for fields that need runtime coercion (NaN → 0, 'true'/'false' → boolean,
+  // various date inputs → ISO date). Import preprocessors from
+  // '@/partner-hook-utils/form/preprocessors'.
 }
 
-export type {Name}FormFields = keyof typeof fieldValidators
-export type {Name}FormData = { [K in keyof typeof fieldValidators]: z.infer<(typeof fieldValidators)[K]> }
-export type {Name}FormOutputs = {Name}FormData
+export type {Domain}Field = keyof typeof fieldValidators
+
+export type {Domain}FormData = {
+  [K in keyof typeof fieldValidators]: z.infer<(typeof fieldValidators)[K]>
+}
+export type {Domain}FormOutputs = {Domain}FormData
+
+// ── Required fields config ─────────────────────────────────────────────
 
 const requiredFieldsConfig = {
-  // Define requiredness rules here
+  // 'always' (default when omitted) | 'create' | 'update' | 'never'
+  // | (data, mode) => boolean — predicate. Auto-detected as a metadata
+  // dependency via a recording Proxy in buildFormSchema.
+  //
+  // Boolean fields (z.boolean()) are inherently always present — do NOT
+  // list them here, do NOT add them to optionalFieldsToRequire.
 } satisfies RequiredFieldConfig<typeof fieldValidators>
 
-export type {Name}OptionalFieldsToRequire = OptionalFieldsToRequire<typeof requiredFieldsConfig>
-export type {Name}FieldsMetadata = // derive from fieldValidators
+// ── Schema factory ─────────────────────────────────────────────────────
 
-interface {Name}SchemaOptions {
+export type {Domain}OptionalFieldsToRequire = OptionalFieldsToRequire<typeof requiredFieldsConfig>
+
+interface {Domain}SchemaOptions {
   mode?: 'create' | 'update'
-  optionalFieldsToRequire?: {Name}OptionalFieldsToRequire
+  optionalFieldsToRequire?: {Domain}OptionalFieldsToRequire
+  // Add hook-specific flags as needed:
+  // withFooField?: boolean       // → excludeFields when false
+  // hasRedactedFoo?: boolean     // → fieldsWithRedactedValues when true
+  // hireDate?: string | null     // → cross-field bound used inside superRefine
 }
 
-export function create{Name}Schema(options: {Name}SchemaOptions = {}) {
+export function create{Domain}Schema(options: {Domain}SchemaOptions = {}) {
   const { mode = 'create', optionalFieldsToRequire } = options
 
   return buildFormSchema(fieldValidators, {
     requiredFieldsConfig,
-    requiredErrorCode: {Name}ErrorCodes.REQUIRED,
+    requiredErrorCode: {Domain}ErrorCodes.REQUIRED,
     mode,
     optionalFieldsToRequire,
+    // excludeFields: withFooField ? [] : ['foo'],
+    // fieldsWithRedactedValues: hasRedactedFoo ? ['foo'] : [],
+    // superRefine: (data, ctx) => { /* cross-field rules */ },
   })
 }
 ```
 
 #### `fields.tsx`
 
-Define domain field components wrapping generic HookField components:
+Each field is a thin wrapper around a generic `*HookField` component that binds `name`. Validation-type aliases are derived from the schema's error-codes constant — never hardcode string unions.
 
-```typescript
-import { TextInputHookField, type TextInputHookFieldProps } from '@/partner-hook-utils/form/fields/TextInputHookField'
+Pick the `*HookField` that matches the Zod validator. All seven are exported from `@/partner-hook-utils/form/fields`:
+
+| `*HookField`           | Use for                                                | Typical Zod validator                         |
+| ---------------------- | ------------------------------------------------------ | --------------------------------------------- |
+| `TextInputHookField`   | Plain string input (name, address line, SSN, email)    | `z.string()`                                  |
+| `NumberInputHookField` | Numeric input (rate, amount, hours)                    | `z.preprocess(coerceNaN(0), z.number())`      |
+| `SelectHookField`      | Typeahead/dropdown over a list (state, location, enum) | `z.enum([...])` or `z.string()` for ids       |
+| `RadioGroupHookField`  | Small enum picked from visible radios                  | `z.enum([...])`, often with radio coercion    |
+| `CheckboxHookField`    | Single boolean (acknowledgements, opt-ins)             | `z.boolean()`                                 |
+| `SwitchHookField`      | Single boolean rendered as a toggle                    | `z.boolean()`                                 |
+| `DatePickerHookField`  | Date input                                             | `z.preprocess(coerceToISODate, z.iso.date())` |
+
+For canonical examples of each: `TextInput`, `DatePicker`, and `Switch` (`selfOnboarding`) in `useEmployeeDetailsForm/fields.tsx`; `Select` with a typed entity `TEntry` (`Location`) in `useWorkAddressForm/fields.tsx`; `Select`, `NumberInput` (currency `rate`), and `Checkbox` (`adjustForMinimumWage`) in `useCompensationForm/fields.tsx`; `RadioGroup` (`stateWcCovered`) in `useJobForm/fields.tsx`.
+
+```tsx
+import type { {Domain}ErrorCodes } from './{camelDomain}Schema'
+import type { TextInputHookFieldProps } from '@/partner-hook-utils/form/fields/TextInputHookField'
+// import the other *HookFieldProps you need (Select, NumberInput, Checkbox, Switch, RadioGroup, DatePicker)
+import { TextInputHookField } from '@/partner-hook-utils/form/fields'
 import type { HookFieldProps } from '@/partner-hook-utils/types'
 
-export type {Field}FieldProps = HookFieldProps<TextInputHookFieldProps<{Validation}>>
+// Default required-only validation type. When a field has additional codes,
+// derive a tuple type — e.g.:
+//   export type NameValidation = (typeof {Domain}ErrorCodes)['REQUIRED' | 'INVALID_NAME']
+// Re-export this from index.ts under `{Domain}RequiredValidation` so partners
+// can type their own validationMessages.
+export type RequiredValidation = typeof {Domain}ErrorCodes.REQUIRED
+
+export type {Field}FieldProps = HookFieldProps<TextInputHookFieldProps<RequiredValidation>>
 
 export function {Field}Field(props: {Field}FieldProps) {
   return <TextInputHookField {...props} name="{fieldName}" />
 }
+
+// Boolean (Checkbox/Switch) fields don't need a validation generic — REQUIRED
+// can never fire. Just `HookFieldProps<CheckboxHookFieldProps>`.
+
+// Select fields that produce a typed entity (Location, MinimumWage, etc.) carry
+// the entity through a TEntry generic so partners can type `getOptionLabel`:
+//   export type LocationFieldProps = HookFieldProps<SelectHookFieldProps<RequiredValidation, Location>>
+
+// Fields with a TEntry of a primitive (e.g. state abbreviation strings) still
+// pass it through so getOptionLabel is typed at the call site:
+//   export type StateFieldProps = HookFieldProps<SelectHookFieldProps<RequiredValidation, string>>
 ```
 
-#### `use{Name}.tsx`
+#### `use{Name}Form.tsx`
 
-Follow the main hook pattern: data fetching → form setup → return discriminated union.
+The hook orchestrates data fetching → form setup → submit handler → discriminated-union return. Key pieces:
 
-Key imports:
+```tsx
+import { useMemo } from 'react'
+import { useForm } from 'react-hook-form'
+import type { UseFormProps } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import type { {Entity} } from '@gusto/embedded-api/models/components/{entity}'
+// React-query hooks for the GET / mutations this hook drives
+import {
+  create{Domain}Schema,
+  type {Domain}OptionalFieldsToRequire,
+  type {Domain}FormData,
+  type {Domain}FormOutputs,
+} from './{camelDomain}Schema'
+import { /* per-field components */ } from './fields'
+import { useDeriveFieldsMetadata } from '@/partner-hook-utils/form/useDeriveFieldsMetadata'
+import { useHookFormInternals } from '@/partner-hook-utils/form/useHookFormInternals'
+import { createGetFormSubmissionValues } from '@/partner-hook-utils/form/getFormSubmissionValues'
+import { withOptions } from '@/partner-hook-utils/form/withOptions'
+import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
+import type {
+  BaseFormHookReady,
+  FieldsMetadata,
+  HookLoadingResult,
+  HookSubmitResult,
+} from '@/partner-hook-utils/types'
+import { useBaseSubmit } from '@/components/Base/useBaseSubmit'
+import { SDKInternalError } from '@/types/sdkError'
 
-- `import { useDeriveFieldsMetadata } from '@/partner-hook-utils/form/useDeriveFieldsMetadata'`
-- `import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'`
-- `import type { BaseFormHookReady, FieldsMetadata, HookLoadingResult, HookSubmitResult } from '@/partner-hook-utils/types'`
-- `import { createGetFormSubmissionValues } from '@/partner-hook-utils/form/getFormSubmissionValues'`
-- `import { composeSubmitHandler } from '@/partner-hook-utils/form/composeSubmitHandler'`
+export type { {Domain}OptionalFieldsToRequire } from './{camelDomain}Schema'
 
-**Typing:** Declare a ready-state interface that extends `BaseFormHookReady<FieldsMetadata, {Name}FormData>`, narrow `data`, `status`, and `actions` as needed, and annotate the hook with `HookLoadingResult | Use{Name}Ready`. Export `Use{Name}Result` as `HookLoadingResult | Use{Name}Ready`. Document-sign hooks always set `status.mode` to `'create'` on the ready branch (see JSDoc on `BaseFormHookReady` in `src/partner-hook-utils/types.ts`). Non-form hooks use `BaseHookReady<TData, TStatus>` instead of `Omit<BaseHookReady, …>`.
+// Only define this when the hook chains multiple sequential API calls per
+// submit (e.g. useEmployeeDetailsForm runs updateEmployee + updateOnboardingStatus).
+// Single-mutation hooks (useHomeAddressForm, useJobForm, useCompensationForm,
+// etc.) drop callbacks entirely — partners read result.data and branch on
+// result.mode from the awaited return value.
+// export interface {Domain}SubmitCallbacks { ... }
 
-**Partner composition:** Each hook returns its own `errorHandling`. For multi-form screens, partners call `composeSubmitHandler(forms, onAllValid)` which returns `{ handleSubmit, errorHandling }` aggregated across the passed forms. The result is a valid `composeErrorHandler` input, so screens that need extra `@gusto/embedded-api` queries or screen-level submit state feed it into `composeErrorHandler([submitResult, ...extras], submitState)`.
+export interface {Domain}SubmitOptions {
+  // Submit-time overrides. Most hooks accept an optional entity id here so a
+  // downstream hook can target a just-created parent without re-fetching.
+  // employeeId?: string
+}
+
+export interface Use{Domain}FormProps {
+  // Make ids optional when they double as fetch keys AND create-mutation
+  // arguments (see "Optional Entity IDs and Submit-Time Resolution" in
+  // hooks-implementation.md). Pass through:
+  // - optionalFieldsToRequire (partner promotion of optional fields)
+  // - defaultValues (partner pre-fill, server data wins on update)
+  // - validationMode (react-hook-form's `mode`)
+  // - shouldFocusError (composeSubmitHandler sets this to false externally)
+  // - any with*Field flags that gate fields out of the schema
+}
+
+export interface {Domain}FormFields {
+  // typeof {Field}Field for always-rendered fields, or
+  // typeof {Field}Field | undefined for conditionally rendered fields.
+}
+
+export interface Use{Domain}FormReady extends BaseFormHookReady<
+  FieldsMetadata,
+  {Domain}FormData,
+  {Domain}FormFields
+> {
+  data: {
+    // Domain entities the partner needs in the ready state. Use `null` (not
+    // `undefined`) for entities that may legitimately be absent — keeps the
+    // discriminated union narrow.
+  }
+  status: { isPending: boolean; mode: 'create' | 'update' }
+  actions: {
+    onSubmit: (
+      // callbacks?: {Domain}SubmitCallbacks,  // only for chained-submit hooks
+      options?: {Domain}SubmitOptions,
+    ) => Promise<HookSubmitResult<{Entity}> | undefined>
+  }
+}
+
+export function use{Domain}Form(props: Use{Domain}FormProps): HookLoadingResult | Use{Domain}FormReady {
+  // 1. Data fetching — `enabled: !!dependency` for queries that depend on
+  //    optional ids; conditionally include them in the queries-for-errors
+  //    array so loading/error states behave correctly when the id is absent.
+
+  // 2. Schema — useMemo so the tuple is stable across renders that don't
+  //    change `mode`, `optionalFieldsToRequire`, or hook-specific flags.
+  const [schema, metadataConfig] = useMemo(
+    () => create{Domain}Schema({ mode, optionalFieldsToRequire /* ... */ }),
+    [mode, optionalFieldsToRequire /* ... */],
+  )
+
+  // 3. Defaults — server data > partner defaults > hardcoded.
+
+  // 4. useForm — `values` + `resetOptions: { keepDirtyValues: true }` lets
+  //    react-hook-form deep-compare and sync when server data resolves while
+  //    preserving user edits.
+  const formMethods = useForm<{Domain}FormData, unknown, {Domain}FormOutputs>({
+    resolver: zodResolver(schema),
+    mode: validationMode,
+    shouldFocusError,
+    defaultValues: resolvedDefaults,
+    values: resolvedDefaults,
+    resetOptions: { keepDirtyValues: true },
+  })
+
+  // 5. Mutations + isPending across all of them.
+
+  // 6. Submit state + composed error handling. Pass nested SDK hook results in
+  //    the array as `{ errorHandling }` objects when wrapping another hook.
+  const {
+    baseSubmitHandler,
+    error: submitError,
+    setError: setSubmitError,
+  } = useBaseSubmit('{Domain}Form')
+  const errorHandling = composeErrorHandler(queriesForErrors, { submitError, setSubmitError })
+
+  // 7. Fields metadata — derive then enrich. `withOptions` adds `options` and
+  //    `entries` to select/radio metadata; `entries` lets the UI translate
+  //    labels via `getOptionLabel` without hooks owning translations.
+  const baseMetadata = useDeriveFieldsMetadata(metadataConfig, formMethods.control)
+  const fieldsMetadata = {
+    // ...baseMetadata fields, with isDisabled / withOptions wrappers as needed.
+  }
+
+  // 8. onSubmit — handleSubmit wrapped in a Promise so partners can await it.
+  //    Delegate to baseSubmitHandler so APIError/SDKValidationError/etc. flow
+  //    into errorHandling. Return HookSubmitResult<TEntity>.
+
+  // 9. hookFormInternals — Rules of Hooks: useHookFormInternals must be called
+  //    unconditionally BEFORE the loading-gate return, never inside the
+  //    ready-return object. createGetFormSubmissionValues is a plain factory
+  //    (not a hook) and can be called either way.
+  const hookFormInternals = useHookFormInternals(formMethods)
+
+  // 10. Loading gate — return errorHandling even on the loading branch so
+  //     partners can show error UI + retry instead of an infinite spinner.
+  if (isDataLoading || /* required entity not yet available */) {
+    return { isLoading: true as const, errorHandling }
+  }
+
+  // 11. Ready return.
+  return {
+    isLoading: false as const,
+    data: { /* entities */ },
+    status: { isPending, mode },
+    actions: { onSubmit },
+    errorHandling,
+    form: {
+      Fields: { /* per-field components, some possibly undefined */ },
+      fieldsMetadata,
+      hookFormInternals,
+      getFormSubmissionValues: createGetFormSubmissionValues(formMethods, schema),
+    },
+  }
+}
+
+export type Use{Domain}FormResult = HookLoadingResult | Use{Domain}FormReady
+export type {Domain}FieldsMetadata = Use{Domain}FormReady['form']['fieldsMetadata']
+// {Domain}FormFields is the same as the interface declared above; no alias
+// needed unless you named the interface differently (e.g. EmployeeDetailsFields
+// + an EmployeeDetailsFormFields alias — see useEmployeeDetailsForm.tsx).
+```
 
 #### `index.ts`
 
-Barrel file re-exporting everything from the hook, schema, and fields.
+Re-export the hook, the schema factory + error codes, and every field-prop type. Rename `RequiredValidation` to `{Domain}RequiredValidation` so it doesn't collide when partners import multiple hooks.
+
+```typescript
+export { use{Domain}Form } from './use{Domain}Form'
+export type {
+  // {Domain}SubmitCallbacks,  // only for chained-submit hooks
+  {Domain}SubmitOptions,
+  {Domain}OptionalFieldsToRequire,
+  Use{Domain}FormProps,
+  Use{Domain}FormResult,
+  Use{Domain}FormReady,
+  {Domain}FieldsMetadata,
+  {Domain}FormFields,
+} from './use{Domain}Form'
+export {
+  create{Domain}Schema,
+  {Domain}ErrorCodes,
+  type {Domain}ErrorCode,
+  type {Domain}FormData,
+  type {Domain}FormOutputs,
+  type {Domain}Field,
+} from './{camelDomain}Schema'
+export type {
+  RequiredValidation as {Domain}RequiredValidation,
+  // Other validation-type aliases unique to this hook
+  // Per-field prop types ({Field}FieldProps)
+} from './fields'
+```
+
+#### `use{Name}Form.test.tsx`
+
+Cover at minimum: default render, successful create, successful update, validation errors (including 422 fieldErrors mapped to inline errors), conditional field visibility, loading state, query-error state with retry. Use `vi.fn<HttpResponseResolver>()` resolvers, pull MSW handler factories from `src/test/mocks/apis/<resource>.ts` (e.g. `handleGetCompanyFederalTaxes`), entity builders from `src/test/factories/` (e.g. `buildEmployeeWithJobs`), and shared helpers from `src/test/` (`server`, `setupApiTestMocks`, `GustoTestProvider`, `fieldsMetadataEntry`, `getFixture`). See `useEmployeeDetailsForm.test.tsx` and `useJobForm.test.tsx` for the canonical shape, and `CLAUDE.md → Asserting on HTTP requests` for the verb/path/body assertion pattern.
 
 ### Step 4: Wire up exports
 
-Add the new hook's exports to `src/index.ts`:
+Add the new hook to barrels in this order:
 
-```typescript
-export {
-  use{Name},
-  {Name}ErrorCodes,
-  create{Name}Schema,
-} from '@/components/{Domain}/{Feature}/shared/use{Name}'
-export type {
-  // All exported types
-} from '@/components/{Domain}/{Feature}/shared/use{Name}'
-```
+1. **Hook directory** — `src/components/{Domain}/{Feature}/shared/use{Name}Form/index.ts` re-exports everything from the three implementation files (see template above).
+2. **Feature-level barrel** (when a feature has one) — `src/components/{Domain}/{Feature}/index.ts` re-exports from the hook directory if the feature already barrels its hooks.
+3. **SDK root barrel** — `src/index.ts` re-exports the public surface partners need:
+
+   ```typescript
+   export {
+     use{Domain}Form,
+     {Domain}ErrorCodes,
+     create{Domain}Schema,
+   } from '@/components/{Domain}/{Feature}/shared/use{Name}Form'
+   export type {
+     {Domain}SubmitOptions,
+     {Domain}OptionalFieldsToRequire,
+     Use{Domain}FormReady,
+     {Domain}FieldsMetadata,
+     {Domain}FormFields,
+     {Domain}ErrorCode,
+     {Domain}FormData,
+     {Domain}RequiredValidation,
+     // ...field-prop types and any extra validation-type aliases
+   } from '@/components/{Domain}/{Feature}/shared/use{Name}Form'
+   ```
+
+   Public surface checklist: hook function, error-codes constant, schema factory, ready/result/fields-metadata types, optional-fields-to-require type, every per-field props type, validation-type aliases, and submit-options/callbacks types if defined. Keep `buildFormSchema`, `useDeriveFieldsMetadata`, `withOptions`, `composeErrorHandler`, and other SDK-internal utilities **off** the public barrel — see `.claude/hooks-implementation.md → Exports Checklist`.
 
 ### Step 5: Verify
 
 ```bash
-npx tsc --noEmit
-npm run test -- --run
-npm run build
+npx tsc --noEmit                                           # type-check
+npm run test -- --run src/components/.../use{Name}Form.test.tsx  # focused tests
+npm run test -- --run                                      # full suite
+npm run build                                              # regenerates .d.ts — surfaces errors tsc misses
 ```
+
+The `npm run build` step is critical: TypeScript errors in hook implementations (e.g. missing `validationMessages` keys, mis-typed field generics) often only surface during build, not during unit tests or `tsc --noEmit`.
+
+Hooks must not own translations: do **not** call `useTranslation` or `t()` inside the hook, do not add i18n keys for hook-rendered labels, and do not run `npm run i18n:generate` as part of hook scaffolding. Display labels and option labels are the consuming view's responsibility — partners pass them via `validationMessages` on each field and via `getOptionLabel` on select/radio fields (paired with `withOptions(baseMetadata.field, options, entries)` in the hook so the typed `entries` flow through). Run `npm run i18n:generate` only if you also touched translation keys in a component or an existing `*.json` translation file as part of the same change.
+
+### Step 6: Document the hook
+
+Two doc updates are required for every public partner hook (skip when the hook is intentionally internal-only):
+
+1. Add a row to the inventory table in `docs/hooks/hooks.md`.
+2. Create `docs/hooks/use{Name}Form.md` following the structure of `docs/hooks/useEmployeeDetailsForm.md` and `docs/hooks/useCompensationForm.md` — frontmatter, props table, return type blocks, fields reference, and both `SDKFormProvider` and `formHookResult`-prop usage examples.
+
+See `.claude/skills/migrate-sdk-component-to-hooks/SKILL.md → 11. Documentation` for the required sections and styling conventions.

--- a/.claude/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.claude/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -10,9 +10,19 @@ description: >-
 
 # Migrating SDK Components to Hook-Based Architecture
 
-Reference implementation: `PayScheduleForm` — PR #1545 or branch `sdk-774-pay-schedule-hook`. For hook composition, error aggregation, and `composeSubmitHandler` patterns, `AdminProfile` / `EmployeeProfile` on PR #1570 / branch `sdk-777-profile-hook-migration` are also useful.
+In-tree reference implementations (in order of increasing complexity — start at the top):
+
+- `src/components/Company/PaySchedule/PayScheduleForm.tsx` — **canonical single-hook migration** (`usePayScheduleForm`) using `BaseBoundaries` + `BaseLayout` + `SDKFormProvider`. Start here when migrating a one-hook screen.
+- `src/components/Employee/Profile/onboarding/EmployeeProfile.tsx` — **canonical two-hook composition** (`useEmployeeDetailsForm` + `useCurrentHomeAddressForm`) with `composeSubmitHandler` ordering and partial-update recovery. Start here when migrating a multi-hook screen.
+- `src/components/Employee/Compensation/EditCompensation/EditCompensation.tsx` — two-hook composition (`useJobForm` + `useCompensationForm`) demonstrating submit-time threading of a freshly-created parent's `currentCompensationUuid`/version into the next submit, plus `withHireDateField: false` / `withEffectiveDateField: false` to derive dates from external context.
+
+**Advanced / exceptional reference — read for orientation, do _not_ copy the exception:**
+
+- `src/components/Employee/Profile/onboarding/AdminProfile.tsx` — three-hook composition (`useEmployeeDetailsForm` + `useCurrentHomeAddressForm` + `useCurrentWorkAddressForm`) with `composeSubmitHandler` ordering, partial-update recovery, and `SDKFormProvider` + `formHookResult` props mixed on the same screen. This screen also stands up a raw `useForm` for `startDate` — a documented, non-canonical workaround for a date field that none of the existing hooks could own without introducing side effects on shared dates. **Do not use this as a template for new work.** When tempted to reach for raw `useForm` (or `useWatch`, `setValue`, or `hookFormInternals.formMethods.*`) in a component, push the field into an existing hook or scaffold a new one (`.claude/commands/create-hook.md`) — partners shouldn't have to know about react-hook-form internals to consume the SDK. If you genuinely believe you have another exception, stop and surface it to the reviewer with a written justification before merging.
 
 Hooks reference: `.claude/hooks-implementation.md` — covers schema, fields, hook internals, error handling, and exports in detail. Read it before starting a migration.
+
+Scaffolding a new hook from scratch: `.claude/commands/create-hook.md` walks through the file layout, schema/field/hook templates, barrel wiring, and verification steps.
 
 ## Core Principle: The Hook Owns the Business Logic
 
@@ -21,11 +31,15 @@ Before writing any logic in the component, read the hook. Hooks encapsulate fiel
 Common anti-patterns to avoid:
 
 - Reaching for `useWatch` to gate field visibility when the hook already returns the field as `undefined` when it shouldn't be shown
+- Standing up a raw `useForm` in the component for fields that conceptually belong to one of the form hooks on the same screen (or for a brand-new field that no hook owns yet — scaffold a hook for it instead, see `.claude/commands/create-hook.md`)
+- Pulling values via `hookResult.form.hookFormInternals.formMethods.*` to drive cross-field validation, requiredness, or submit ordering — that logic belongs inside the hook's schema/`requiredFieldsConfig`/`onSubmit`
 - Duplicating the hook's requiredness logic via component-level conditionals
 - Querying an entity in the component when the hook is already fetching and exposing it via `data` or `status`
 - Computing derived values (e.g. "is this schedule in create vs edit mode") in the component when the hook surfaces them
 
 **Rule of thumb**: if you're writing business logic in the component that every partner using the hook would also need, that logic belongs in the hook. Stop, move it into the hook, and re-export it via the hook's return shape. The SDK component and partner code should look identical in terms of which fields are shown and when.
+
+**Hooks are partner-facing; react-hook-form is not.** Partners should be able to consume the hook's documented surface (`data`, `status`, `actions`, `errorHandling`, `form.Fields`, `form.fieldsMetadata`, `form.getFormSubmissionValues`) without ever importing from `react-hook-form` or touching `form.hookFormInternals`. If you find yourself reaching for `useWatch`, raw `useForm`, `setValue`, `watch`, or any other RHF internal in the component, that is a signal the hook is missing functionality — either there is already a hook return value for the case (use it) or the hook needs to be updated to cover it. `form.hookFormInternals` exists as an escape hatch for narrowly presentational, non-business-logic cases (see Section 6 → "Watching Form Values"); treat each new use site as a candidate for moving the logic into the hook.
 
 ## 0. Pre-Migration Test Coverage
 
@@ -548,18 +562,21 @@ All form hooks live inside a `shared/` directory scoped to the domain feature, o
 ```
 src/components/<Domain>/<Feature>/shared/
 └── use<Name>Form/
-    ├── use<Name>Form.tsx        # hook implementation
-    ├── use<Name>FormSchema.ts   # Zod schema + error codes constant
-    ├── fields.tsx               # Fields.* components wired to the hook
-    ├── index.ts                 # public re-exports
-    └── use<Name>Form.test.tsx   # hook unit tests
+    ├── use<Name>Form.tsx       # hook implementation
+    ├── <camelDomain>Schema.ts  # Zod schema + error codes constant (e.g. employeeDetailsSchema.ts, homeAddressSchema.ts, compensationSchema.ts, jobSchema.ts)
+    ├── fields.tsx              # Fields.* components wired to the hook
+    ├── index.ts                # public re-exports
+    └── use<Name>Form.test.tsx  # hook unit tests
 ```
 
-Reference examples:
+Reference examples (read the closest match before scaffolding):
 
-- `src/components/Employee/Profile/shared/useEmployeeDetailsForm/`
-- `src/components/Employee/Compensation/shared/useCompensationForm/`
-- `src/components/Company/PaySchedule/shared/usePayScheduleForm/`
+- `src/components/Employee/Profile/shared/useEmployeeDetailsForm/` — chained mutations per submit (`updateEmployee` + `updateOnboardingStatus`); single hook that needs `*SubmitCallbacks`
+- `src/components/Employee/Profile/shared/useHomeAddressForm/` — single-mutation create-or-update; optional `homeAddressUuid` switches modes; `withEffectiveDateField` flag
+- `src/components/Employee/Profile/shared/useWorkAddressForm/` — list-query (company locations) feeding a Select via `withOptions`; create-or-update with effective-date handling
+- `src/components/Employee/Compensation/shared/useJobForm/` — predicate-based requiredness (`stateWcCovered → stateWcClassCode required`), radio coercion via `coerceStringBoolean`
+- `src/components/Employee/Compensation/shared/useCompensationForm/` — cross-field `superRefine`, conditional fields, reactive `status.willDeleteSecondaryJobs` flag exposed to partners
+- `src/components/Company/PaySchedule/shared/usePayScheduleForm/` — company-domain hook with admin-only fields and a calendar preview side query
 
 ### Steps
 
@@ -577,8 +594,10 @@ Two documentation updates are required for every new hook. Complete both before 
 
 Read these files in full — structure, section order, table columns, frontmatter, and code snippet style must all match:
 
-- `docs/hooks/useEmployeeDetailsForm.md`
-- `docs/hooks/useCompensationForm.md`
+- `docs/hooks/useEmployeeDetailsForm.md` — chained-submit hook with `*SubmitCallbacks`
+- `docs/hooks/useWorkAddressForm.md` — single-mutation hook with optional submit-time entity ids
+- `docs/hooks/useJobForm.md` and `docs/hooks/useCompensationForm.md` — Compensation-domain hooks (predicate-based requiredness, cross-field `superRefine`, status flags)
+- `docs/hooks/usePayScheduleForm.md` — company-domain hook with admin-only fields and a side query
 - `docs/hooks/hooks.md` (for the inventory table format)
 
 Do not rely on the description below as a substitute for reading the source material.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -57,11 +57,19 @@ Analyze the diff for the following, in addition to the learned rules:
 
 **Check when any SDK component or hook files are in the diff:**
 
+> **Reference Standards.** When the diff introduces a new partner-facing hook (`use*Form`) or migrates an SDK component to consume one, treat these two docs as the source of truth and validate the diff against them — the rules below are derived from them, but the docs cover details that aren't enumerated as individual rules:
+>
+> - `.claude/commands/create-hook.md` — canonical scaffolding for new hooks: directory layout, schema/fields/hook/index/test file structure, barrel wiring, and verification steps.
+> - `.claude/skills/migrate-sdk-component-to-hooks/SKILL.md` — migration playbook: pre-migration tests, hook-owns-business-logic rule, multi-form composition with `composeSubmitHandler`, `BaseBoundaries`/`BaseLayout` wiring, and the four canonical reference components.
+>
+> If a partner-facing hook in the diff materially diverges from these specs — different file layout, ad-hoc schema structure, business logic in the component instead of the hook, missing barrel exports, missing partner-facing doc in `docs/hooks/` — flag it as `[LEARNED-006]` and cite the relevant section of the canonical doc in the fix. Do not let "different but works" slide; partners depend on the consistency of these patterns.
+
 #### Hook Architecture (component layer)
 
 - **BaseBoundaries, not BaseComponent**: Public components must wrap `BaseBoundaries` and delegate to a `Root` component. Flag any use of `BaseComponent` or `useBase()`.
 - **`onEvent` as prop**: `onEvent` must be passed as a prop through to `Root` — never read from `useBase()`.
 - **Business logic stays in the hook**: Field visibility, conditional requiredness, derived data, and loading states must come from the hook. Flag `useWatch` usage that gates field rendering or sets requiredness — this logic belongs inside the hook's schema or `Fields` selection.
+- **No react-hook-form internals in the component (`[LEARNED-007]`, non-negotiable)**: Hooks are partner-facing; `react-hook-form` is not. Any component-layer use of raw `useForm`, `useWatch`, `setValue`, `watch`, `getValues`, `trigger`, `register`, or access through `hookResult.form.hookFormInternals.formMethods.*` is a **Critical** finding — flag it and surface it explicitly to the user as a non-negotiable issue, regardless of how small the diff looks. Each such site is a signal the hook is missing functionality: either an existing hook return value covers the case (use it) or the hook must be updated to cover it. The only acceptable resolutions are (a) move the logic into the hook, or (b) a written, reviewer-approved justification that no hook can own this case without introducing side effects elsewhere — never a silent merge. `hookFormInternals` exists narrowly as an escape hatch for purely presentational, non-business-logic concerns (see `migrate-sdk-component-to-hooks/SKILL.md → Section 6 → "Watching Form Values"`); even those uses should be reviewed skeptically. Do **not** treat `AdminProfile.tsx`'s `startDate` `useForm` as precedent — it is documented as a non-canonical exception, not a template.
 - **Conditional fields via truthiness**: Fields the hook returns as `undefined` when hidden must be rendered with a truthiness guard (`{Fields.SomeField && <Fields.SomeField ... />}`). Flag explicit `if` conditions based on form values.
 
 #### Multi-Form Composition

--- a/.claude/skills/review-pr/rules/learned.md
+++ b/.claude/skills/review-pr/rules/learned.md
@@ -1,6 +1,6 @@
 ---
 version: 1
-last_updated: 2026-04-22
+last_updated: 2026-05-14
 ---
 
 # Learned Review Rules
@@ -137,6 +137,161 @@ const result = await updateTimeOffPolicy({
 onEvent(componentEvents.TIME_OFF_POLICY_SETTINGS_DONE, result.data)
 ```
 
+---
+
+### LEARNED-006: Partner-Facing Hooks Must Conform to the Canonical Spec
+
+- **Severity:** warning
+- **Rule:** Any new `use*Form` hook intended for the public partner surface — or any SDK component being migrated to consume one — must conform to the canonical specs in `.claude/commands/create-hook.md` (scaffolding/structure) and `.claude/skills/migrate-sdk-component-to-hooks/SKILL.md` (migration playbook). This means the hook lives at `src/components/<Domain>/<Feature>/shared/use<Name>Form/` with the five-file layout (`use*Form.tsx`, `<camelDomain>Schema.ts`, `fields.tsx`, `index.ts`, `use*Form.test.tsx`); the schema follows `ErrorCodes → fieldValidators → requiredFieldsConfig → buildFormSchema` (no inline `.optional()` except the documented enum-placeholder escape hatch); the hook returns the discriminated union with `errorHandling` in both branches and `HookSubmitResult<TEntity>` from `onSubmit`; field components are thin `*HookField` wrappers; partner-facing exports are wired through the feature barrel and `src/index.ts`; and a corresponding `docs/hooks/use<Name>Form.md` is added or updated. "Different but works" is not acceptable — partners rely on the consistency of these patterns. When flagging, cite the specific section of the canonical doc in the suggested fix.
+
+#### Bad Example
+
+```tsx
+// New "partner-facing" hook authored ad hoc:
+// - lives at src/hooks/useNewThingForm.ts (wrong location)
+// - inlines z.object(...) instead of using buildFormSchema
+// - returns { isLoading, isReady, errors, submit } (custom shape, not the discriminated union)
+// - exports buildFormSchema-style internals from the public barrel
+// - no docs/hooks/useNewThingForm.md added
+export function useNewThingForm(props: Props) {
+  const schema = z.object({ name: z.string().min(1), startDate: z.string().optional() })
+  const { handleSubmit, formState } = useForm({ resolver: zodResolver(schema) })
+  return {
+    isLoading: false,
+    isReady: true,
+    errors: formState.errors,
+    submit: handleSubmit(/* ... */),
+  }
+}
+```
+
+#### Good Example
+
+```tsx
+// src/components/Employee/NewThing/shared/useNewThingForm/useNewThingForm.tsx
+// Follows the five-file layout, buildFormSchema-based schema, and the
+// canonical discriminated-union return shape. See create-hook.md for the
+// full template.
+export function useNewThingForm(
+  props: UseNewThingFormProps,
+): HookLoadingResult | UseNewThingFormReady {
+  const [schema, metadataConfig] = useMemo(
+    () => createNewThingSchema({ mode, optionalFieldsToRequire }),
+    [mode, optionalFieldsToRequire],
+  )
+  const formMethods = useForm<NewThingFormData, unknown, NewThingFormOutputs>({
+    resolver: zodResolver(schema),
+    values: resolvedDefaults,
+    resetOptions: { keepDirtyValues: true },
+    shouldFocusError,
+  })
+  const errorHandling = composeErrorHandler(queriesForErrors, { submitError, setSubmitError })
+  const hookFormInternals = useHookFormInternals(formMethods)
+
+  if (isDataLoading) {
+    return { isLoading: true as const, errorHandling }
+  }
+  return {
+    isLoading: false as const,
+    data: { newThing },
+    status: { isPending, mode },
+    actions: { onSubmit },
+    errorHandling,
+    form: { Fields, fieldsMetadata, hookFormInternals, getFormSubmissionValues },
+  }
+}
+```
+
+---
+
+### LEARNED-007: No react-hook-form Internals in SDK Components (Non-Negotiable)
+
+- **Severity:** error
+- **Rule:** SDK components must consume form hooks only through their documented partner-facing surface (`data`, `status`, `actions`, `errorHandling`, `form.Fields`, `form.fieldsMetadata`, `form.getFormSubmissionValues`). Reaching for raw `useForm`, `useWatch`, `setValue`, `watch`, `getValues`, `trigger`, `register`, or `hookResult.form.hookFormInternals.formMethods.*` from the component is non-negotiable — partners should never need to know about `react-hook-form` to consume the SDK. Each such use is a signal the hook is missing functionality; the only acceptable resolutions are (a) move the logic into the hook (existing or newly-scaffolded — see `.claude/commands/create-hook.md`), or (b) a written, reviewer-approved justification that no hook can own the case without side effects. Flag every occurrence as Critical and surface it explicitly to the user; never let it slide silently. `AdminProfile.tsx`'s screen-local `useForm` for `startDate` is a documented historical exception, not a template — do not cite it as precedent for new code.
+
+#### Bad Example
+
+```tsx
+// Component pulls react-hook-form internals to drive cross-field behavior
+function CompensationStep() {
+  const job = useJobForm({ employeeId })
+  const compensation = useCompensationForm({ employeeId })
+
+  if (job.isLoading || compensation.isLoading) return <Spinner />
+
+  // Anti-pattern: reading form values out of the hook to compute requiredness
+  // and submit payload in the component.
+  const hireDate = useWatch({
+    control: job.form.hookFormInternals.formMethods.control,
+    name: 'hireDate',
+  })
+
+  // Anti-pattern: standing up a raw useForm for a field the hook should own
+  const { register, handleSubmit } = useForm<{ startDate: string }>()
+
+  const onSubmit = handleSubmit(async ({ startDate }) => {
+    await job.actions.onSubmit()
+    await compensation.actions.onSubmit({
+      effectiveDate: hireDate ?? startDate, // logic that belongs in the hook
+    })
+  })
+
+  return (
+    <form onSubmit={onSubmit}>
+      <SDKFormProvider hookResult={job}>
+        <job.form.Fields.Title />
+      </SDKFormProvider>
+      <input {...register('startDate')} />
+    </form>
+  )
+}
+```
+
+#### Good Example
+
+```tsx
+// Component consumes only the documented hook surface; cross-field logic
+// lives in the hooks themselves.
+function CompensationStep() {
+  const job = useJobForm({ employeeId, shouldFocusError: false })
+  const compensation = useCompensationForm({
+    employeeId,
+    withEffectiveDateField: false, // hook derives effectiveDate from hireDate
+    shouldFocusError: false,
+  })
+
+  const { handleSubmit, errorHandling } = composeSubmitHandler({
+    activeForms: [
+      { hookResult: job },
+      {
+        hookResult: compensation,
+        // Pass the just-created job's hireDate as a submit-time option.
+        // No useWatch / formMethods access needed — the hook reads it from
+        // its own form state.
+      },
+    ],
+  })
+
+  if (job.isLoading || compensation.isLoading) {
+    return <BaseLayout isLoading error={errorHandling.errors} />
+  }
+
+  return (
+    <BaseLayout error={errorHandling.errors}>
+      <form onSubmit={handleSubmit}>
+        <SDKFormProvider hookResult={job}>
+          <job.form.Fields.Title />
+          <job.form.Fields.HireDate />
+        </SDKFormProvider>
+        <SDKFormProvider hookResult={compensation}>
+          <compensation.form.Fields.Rate />
+        </SDKFormProvider>
+      </form>
+    </BaseLayout>
+  )
+}
+```
+
 ## Adding New Patterns
 
-Use `/learn-review <note>` to append a new entry. The next entry should be `LEARNED-006`.
+Use `/learn-review <note>` to append a new entry. The next entry should be `LEARNED-008`.


### PR DESCRIPTION
## Summary

Brings the Claude hook authoring/migration docs in line with the current canonical hooks (`useEmployeeDetailsForm`, `useHomeAddressForm`, `useWorkAddressForm`, `useJobForm`, `useCompensationForm`, `usePayScheduleForm`) and hardens the `review-pr` skill so it enforces partner-facing hook conventions on incoming PRs.

### `.claude/commands/create-hook.md`

- Updated file-layout, schema, fields, hook, and barrel templates to match current implementations; corrected schema filename to `<camelDomain>Schema.ts`.
- Verified every reference path used in Step 2 actually exists on disk.
- Added a `*HookField` quick-reference table (`TextInput`, `NumberInput`, `Select`, `RadioGroup`, `Checkbox`, `Switch`, `DatePicker`) with typical Zod validators and pointers to canonical example files for each.
- Documented the enum-placeholder `.optional()` escape hatch (`flsaStatus` in `compensationSchema.ts`).
- Moved `useHookFormInternals(formMethods)` call before the loading-gate return so it is unconditional (Rules of Hooks).
- Dropped the misleading `npm run i18n:generate` step from the verify section; explicitly stated hooks must not own translations.

### `.claude/skills/migrate-sdk-component-to-hooks/SKILL.md`

- Reordered the in-tree reference list by complexity (`PayScheduleForm` → `EmployeeProfile` → `EditCompensation`) and split out `AdminProfile.tsx` as an **Advanced / exceptional** reference with an explicit "do not copy" note explaining why its raw `useForm` for `startDate` exists and why it should not be a template.
- Strengthened the Core Principle: hooks are partner-facing, `react-hook-form` is not. Reaching for `useWatch`, raw `useForm`, `setValue`, or `hookFormInternals.formMethods.*` in a component is a signal the hook is missing functionality.
- Cross-linked `.claude/commands/create-hook.md`.

### `.claude/skills/review-pr/SKILL.md`

- Added a **Reference Standards** callout at the top of the SDK component/hook section pointing reviewers at `create-hook.md` and `migrate-sdk-component-to-hooks/SKILL.md` as the source of truth for partner-facing hook PRs.
- Added a non-negotiable **No react-hook-form internals in the component** rule (tagged `[LEARNED-007]`) to be flagged Critical and surfaced explicitly to the user — never a silent merge.

### `.claude/skills/review-pr/rules/learned.md`

- Added `LEARNED-006` (Partner-Facing Hooks Must Conform to the Canonical Spec, severity `warning`).
- Added `LEARNED-007` (No react-hook-form Internals in SDK Components, severity `error`).
- Both rules include bad / good examples derived from real in-tree patterns.
- Bumped `last_updated` and the next-entry counter to `LEARNED-008`.

## Test plan

- [x] Skim each file diff and confirm the templates match what's actually in the canonical hook directories.
- [x] Re-read the reordered reference list in `migrate-sdk-component-to-hooks/SKILL.md` and confirm `AdminProfile`'s framing reads as a do-not-copy exception.
- [x] Verify `LEARNED-007`'s severity (`error`) and the `[LEARNED-007]` tag in `review-pr/SKILL.md` match what the review skill expects.
- [x] No code changes — `npm run build` / `npm run test` not required, but CI will exercise commitlint and markdown formatting.

Made with [Cursor](https://cursor.com)