### PR TITLE
test: fix unlimited-policy SelectEmployeesTimeOff test missing add-confirm click

### DIFF
--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
@@ -692,6 +692,7 @@ describe('SelectEmployeesTimeOff', () => {
 
       await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
       await user.click(screen.getByRole('button', { name: 'continueCta' }))
+      await user.click(await screen.findByRole('button', { name: 'addConfirmDialog.confirmCta' }))
 
       await waitFor(() => {
         expect(mockAddEmployees).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary

Fixes a failing test on `main`: `SelectEmployeesTimeOff > unlimited policy > submits balance "0" for unlimited policies instead of carry-over values`.

The standalone-mode add flow now opens an `addConfirmDialog` confirmation step before firing the add-employees mutation (introduced in #1798). The unlimited-policy test added later in #1822 was missing that second click, so `mockAddEmployees` was never called and `waitFor` timed out.

This change adds the `addConfirmDialog.confirmCta` click, mirroring the pattern used by every other standalone add test in the file (lines 296, 325, 352, 375, 400, 437, 461, 465, 539).

No production code changes — test-only fix.

## Test plan

- [x] `npm run test -- --run src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx` — 28/28 pass

Made with [Cursor](https://cursor.com)