### PR TITLE
ci: require e2e and e2e-demo to gate merges

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,7 +211,6 @@ jobs:
   e2e:
     needs: setup
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
 
@@ -260,7 +259,6 @@ jobs:
   e2e-demo:
     needs: setup
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Removes `continue-on-error: true` from the `e2e` and `e2e-demo` jobs in [.github/workflows/ci.yaml](.github/workflows/ci.yaml) so their CI status reflects actual test outcomes
- Preparation for re-adding `test`, `e2e`, and `e2e-demo` to required status checks on `main` (branch protection will be updated separately after this merges and the jobs are green on `main`)

## Context
A few months ago e2e was temporarily removed as a merge gate. With these jobs reporting their real pass/fail status, we can re-enable the requirement.

## Test plan
- [ ] CI on this PR runs `e2e` and `e2e-demo` and they pass
- [ ] After merge, confirm `e2e` and `e2e-demo` are green on `main` before tightening branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)