### PR TITLE
docs(SDK-897): harden endpoint inventory derivation script

### DIFF
--- a/build/deriveEndpointInventory.ts
+++ b/build/deriveEndpointInventory.ts
@@ -1,12 +1,22 @@
-import { readFileSync, readdirSync, writeFileSync, mkdirSync, statSync, existsSync } from 'fs'
+import {
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  mkdirSync,
+  statSync,
+  existsSync,
+  rmSync,
+} from 'fs'
 import { join, dirname, relative, resolve } from 'path'
 import { fileURLToPath } from 'url'
-import { Project, SyntaxKind } from 'ts-morph'
+import { spawnSync } from 'child_process'
+import { Project, SourceFile, SyntaxKind } from 'ts-morph'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 const ROOT = join(__dirname, '..')
+const SRC_DIR = join(ROOT, 'src')
 const FUNCS_DIR = join(ROOT, 'node_modules/@gusto/embedded-api/src/funcs')
 const OPS_DIR = join(ROOT, 'node_modules/@gusto/embedded-api/src/models/operations')
 const COMPONENTS_DIR = join(ROOT, 'src/components')
@@ -14,8 +24,6 @@ const JSON_OUTPUT_PATH = join(ROOT, 'docs/reference/endpoint-inventory.json')
 const MD_OUTPUT_PATH = join(ROOT, 'docs/reference/endpoint-reference.md')
 
 const isVerifyMode = process.argv.includes('--verify')
-
-// Removed NON_DOMAIN_DIRS - no longer needed with export-based discovery
 
 interface Endpoint {
   method: string
@@ -29,11 +37,27 @@ interface BlockEntry {
 
 interface FlowEntry {
   blocks: string[]
-  endpoints: Endpoint[]
-  variables: string[]
 }
 
-// --- AST-based extraction from @gusto/embedded-api ---
+interface BlockMapping {
+  blockName: string
+  componentDir: string
+}
+
+interface FlowMapping {
+  flowName: string
+  flowDir: string
+}
+
+interface Inventory {
+  blocks: Record<string, BlockEntry>
+  flows: Record<string, FlowEntry>
+}
+
+interface DerivationResult {
+  inventory: Inventory
+  funcLookup: Map<string, Endpoint>
+}
 
 function createApiProject(): Project {
   return new Project({
@@ -94,8 +118,6 @@ function buildParamNameMap(project: Project, funcPaths: string[]): Record<string
   return paramNameMap
 }
 
-// --- Build a lookup from func name -> { method, path } ---
-
 function collectRawFuncPaths(
   project: Project,
 ): { funcName: string; path: string; method: string }[] {
@@ -136,8 +158,7 @@ function collectRawFuncPaths(
   return results
 }
 
-function buildFuncLookup(): Map<string, Endpoint> {
-  const project = createApiProject()
+function buildFuncLookup(project: Project): Map<string, Endpoint> {
   const rawFuncs = collectRawFuncPaths(project)
   const paramNameMap = buildParamNameMap(
     project,
@@ -154,8 +175,6 @@ function buildFuncLookup(): Map<string, Endpoint> {
 
   return lookup
 }
-
-// --- Recursively find source files in a directory ---
 
 function walkDir(dir: string): string[] {
   const results: string[] = []
@@ -175,33 +194,64 @@ function walkDir(dir: string): string[] {
   return results
 }
 
-// --- Extract @gusto/embedded-api imports from component files ---
-
-function extractApiImports(filePaths: string[]): Set<string> {
+function collectTransitiveApiImports(
+  project: Project,
+  entryFilePaths: string[],
+  componentDir: string,
+  otherBlockDirs: Set<string>,
+): Set<string> {
+  const visited = new Set<string>()
   const funcNames = new Set<string>()
 
-  const hookImportPattern = /from\s+['"]@gusto\/embedded-api\/react-query\/([^'"]+)['"]/g
-  const funcImportPattern = /from\s+['"]@gusto\/embedded-api\/funcs\/([^'"]+)['"]/g
+  function followSpec(spec: string, getResolved: () => SourceFile | undefined) {
+    if (spec.startsWith('@gusto/embedded-api/react-query/')) {
+      const name = spec.slice('@gusto/embedded-api/react-query/'.length)
+      if (!name.startsWith('_')) funcNames.add(name)
+    } else if (spec.startsWith('@gusto/embedded-api/funcs/')) {
+      funcNames.add(spec.slice('@gusto/embedded-api/funcs/'.length))
+    } else if (spec.startsWith('.') || spec.startsWith('@/hooks/')) {
+      // Follow relative imports (catches ../shared/ hooks) and cross-cutting utility hooks.
+      // Deliberately skip @/components/, @/contexts/, @/helpers/ etc. to avoid
+      // cascading through UI primitives and cross-domain components.
+      // Also stop at other blocks' directories so flow orchestrators don't absorb
+      // their sub-blocks' endpoints (those are already inventoried separately).
+      const resolved = getResolved()
+      if (!resolved) return
+      const targetPath = resolved.getFilePath()
+      if (!targetPath.startsWith(SRC_DIR + '/')) return
+      const isOtherBlock = [...otherBlockDirs].some(
+        dir => dir !== componentDir && targetPath.startsWith(dir + '/'),
+      )
+      if (!isOtherBlock) visitFile(targetPath)
+    }
+  }
 
-  for (const filePath of filePaths) {
-    const content = readFileSync(filePath, 'utf-8')
+  function visitFile(filePath: string) {
+    if (visited.has(filePath)) return
+    visited.add(filePath)
 
-    for (const match of content.matchAll(hookImportPattern)) {
-      const moduleName = match[1]
-      if (!moduleName.startsWith('_')) {
-        funcNames.add(moduleName)
+    const sourceFile = project.addSourceFileAtPathIfExists(filePath)
+    if (!sourceFile) return
+
+    for (const decl of sourceFile.getImportDeclarations()) {
+      if (decl.isTypeOnly()) continue
+      followSpec(decl.getModuleSpecifierValue(), () => decl.getModuleSpecifierSourceFile())
+    }
+    for (const decl of sourceFile.getExportDeclarations()) {
+      if (decl.isTypeOnly()) continue
+      const spec = decl.getModuleSpecifierValue()
+      if (spec) {
+        followSpec(spec, () => decl.getModuleSpecifierSourceFile())
       }
     }
+  }
 
-    for (const match of content.matchAll(funcImportPattern)) {
-      funcNames.add(match[1])
-    }
+  for (const filePath of entryFilePaths) {
+    visitFile(filePath)
   }
 
   return funcNames
 }
-
-// --- Normalize OpenAPI-style {param} paths to Express-style :param ---
 
 function normalizeEndpointPath(openApiPath: string, paramNameMap: Record<string, string>): string {
   return openApiPath.replace(/\{([^}]+)\}/g, (_match, paramName: string) => {
@@ -214,25 +264,15 @@ function normalizeEndpointPath(openApiPath: string, paramNameMap: Record<string,
   })
 }
 
-// --- Map export chain to block names ---
-
-interface BlockMapping {
-  blockName: string
-  componentDir: string
-}
-
 function parseNamespaceExports(): Map<string, string> {
   const indexPath = join(COMPONENTS_DIR, 'index.ts')
   const namespaces = new Map<string, string>()
 
   try {
     const content = readFileSync(indexPath, 'utf-8')
-    // Match: export * as Namespace from './DomainDir'
     const namespacePattern = /export\s+\*\s+as\s+(\w+)\s+from\s+['"]\.\/([^'"]+)['"]/g
     for (const match of content.matchAll(namespacePattern)) {
-      const namespaceName = match[1]
-      const domainDir = match[2]
-      namespaces.set(namespaceName, domainDir)
+      namespaces.set(match[1], match[2])
     }
   } catch (err) {
     console.error(`ERROR: Could not read ${indexPath}`)
@@ -244,22 +284,22 @@ function parseNamespaceExports(): Map<string, string> {
 
 function parseComponentExports(domainDir: string): Map<string, string> {
   const exports = new Map<string, string>()
-
-  // Try both .ts and .tsx extensions
   const possibleBarrelFiles = [join(domainDir, 'index.ts'), join(domainDir, 'index.tsx')]
 
   for (const barrelPath of possibleBarrelFiles) {
     try {
       const content = readFileSync(barrelPath, 'utf-8')
-      // Match: export { Component } from './SomeDir/Component'
-      // Or: export { Component } from './Component'
-      const exportPattern = /export\s+\{\s*(\w+).*?\}\s+from\s+['"](\.[^'"]+)['"]/g
+      // Uses the alias when present so the map key matches the public export name.
+      const exportPattern =
+        /export\s+\{\s*(\w+(?:\s+as\s+\w+)?)[^}]*?\}\s+from\s+['"](\.[^'"]+)['"]/g
       for (const match of content.matchAll(exportPattern)) {
-        const componentName = match[1]
+        const nameToken = match[1]
         const importPath = match[2]
+        const asIndex = nameToken.indexOf(' as ')
+        const componentName = asIndex >= 0 ? nameToken.slice(asIndex + 4).trim() : nameToken.trim()
         exports.set(componentName, importPath)
       }
-      break // Found a barrel file, stop looking
+      break
     } catch {
       // barrel file doesn't exist, try next
     }
@@ -269,30 +309,16 @@ function parseComponentExports(domainDir: string): Map<string, string> {
 }
 
 function resolveComponentDirectory(domainDir: string, importPath: string): string {
-  // importPath is like './ContractorList' or './Payments/PaymentFlow'
   const resolved = resolve(domainDir, importPath)
 
-  // If it's a direct file import, get the directory
   if (existsSync(resolved + '.tsx') || existsSync(resolved + '.ts')) {
-    const dir = dirname(resolved)
-    // Feature module pattern: if a sibling shared/ directory exists, use the
-    // parent (feature module root) so walkDir picks up shared hooks with API imports
-    const parentDir = dirname(dir)
-    if (
-      existsSync(join(parentDir, 'shared')) &&
-      statSync(join(parentDir, 'shared')).isDirectory()
-    ) {
-      return parentDir
-    }
-    return dir
+    return dirname(resolved)
   }
 
-  // If it's a directory with an index file, use the directory
   if (existsSync(resolved) && statSync(resolved).isDirectory()) {
     return resolved
   }
 
-  // Fallback: assume it's the directory
   return resolved
 }
 
@@ -302,26 +328,15 @@ function discoverBlocks(): BlockMapping[] {
 
   for (const [namespaceName, domainDirName] of namespaces.entries()) {
     const domainDir = join(COMPONENTS_DIR, domainDirName)
-
     const componentExports = parseComponentExports(domainDir)
 
     for (const [componentName, importPath] of componentExports.entries()) {
       const componentDir = resolveComponentDirectory(domainDir, importPath)
-      blocks.push({
-        blockName: `${namespaceName}.${componentName}`,
-        componentDir,
-      })
+      blocks.push({ blockName: `${namespaceName}.${componentName}`, componentDir })
     }
   }
 
   return blocks
-}
-
-// --- Discover flow composition by scanning flow directory imports ---
-
-interface FlowMapping {
-  flowName: string
-  flowDir: string
 }
 
 function discoverFlows(): FlowMapping[] {
@@ -330,53 +345,61 @@ function discoverFlows(): FlowMapping[] {
 
   for (const [namespaceName, domainDirName] of namespaces.entries()) {
     const domainDir = join(COMPONENTS_DIR, domainDirName)
+    const componentExports = parseComponentExports(domainDir)
 
-    try {
-      const entries = readdirSync(domainDir)
-
-      // Look for direct Flow directories in the domain
-      for (const entry of entries) {
-        const fullPath = join(domainDir, entry)
-        if (!statSync(fullPath).isDirectory()) continue
-        if (!entry.endsWith('Flow')) continue
-        flows.push({ flowName: `${namespaceName}.${entry}`, flowDir: fullPath })
-      }
-
-      // Look for nested Flow directories (e.g., Contractor.Payments.PaymentFlow)
-      for (const entry of entries) {
-        const subDir = join(domainDir, entry)
-        if (!statSync(subDir).isDirectory()) continue
-        if (entry.endsWith('Flow')) continue
-
-        try {
-          const nestedEntries = readdirSync(subDir)
-          for (const nestedEntry of nestedEntries) {
-            const nestedPath = join(subDir, nestedEntry)
-            if (!statSync(nestedPath).isDirectory()) continue
-            if (!nestedEntry.endsWith('Flow')) continue
-            flows.push({
-              flowName: `${namespaceName}.${entry}.${nestedEntry}`,
-              flowDir: nestedPath,
-            })
-          }
-        } catch {
-          // nested dir doesn't exist or can't be read
-        }
-      }
-    } catch {
-      // domain dir doesn't exist
-      continue
+    for (const [componentName, importPath] of componentExports.entries()) {
+      if (!componentName.endsWith('Flow')) continue
+      const flowDir = resolveComponentDirectory(domainDir, importPath)
+      flows.push({ flowName: `${namespaceName}.${componentName}`, flowDir })
     }
   }
 
   return flows
 }
 
+function deriveBlocksFromImport(
+  resolvedImportPath: string,
+  rawImportedNames: string,
+  dirToBlocks: Map<string, string[]>,
+): string[] {
+  // Find the most specific directory that matches this import path
+  let matchingDir: string | undefined
+  for (const dir of dirToBlocks.keys()) {
+    if (resolvedImportPath === dir || resolvedImportPath.startsWith(dir + '/')) {
+      if (!matchingDir || dir.length > matchingDir.length) {
+        matchingDir = dir
+      }
+    }
+  }
+
+  if (!matchingDir) return []
+
+  const blocks = dirToBlocks.get(matchingDir)!
+  if (blocks.length === 1) return blocks
+
+  const importedNames = rawImportedNames.split(',').map((name: string) =>
+    name
+      .trim()
+      // Look at the export name only, ignore any `x as y`
+      .split(/\s+as\s+/)[0]
+      .trim(),
+  )
+
+  const blockNames = new Set<string>()
+  for (const blockName of blocks) {
+    const componentName = blockName.split('.').pop()
+    if (componentName && importedNames.includes(componentName)) {
+      blockNames.add(blockName)
+    }
+  }
+
+  return [...blockNames]
+}
+
 function deriveFlowBlocks(flowDir: string, blockMappings: BlockMapping[]): string[] {
   const files = walkDir(flowDir)
   const blockNames = new Set<string>()
 
-  // Build a map of component directory to all block names for that directory
   const dirToBlocks = new Map<string, string[]>()
   for (const mapping of blockMappings) {
     if (!dirToBlocks.has(mapping.componentDir)) {
@@ -392,82 +415,38 @@ function deriveFlowBlocks(flowDir: string, blockMappings: BlockMapping[]): strin
     const content = readFileSync(filePath, 'utf-8')
 
     for (const match of content.matchAll(absoluteImportPattern)) {
-      const importedNames = match[1].split(',').map(name =>
-        name
-          .trim()
-          .split(/\s+as\s+/)[0]
-          .trim(),
-      )
-      const importPath = match[2]
+      const [_fullMatch, allImportedNames, importPath] = match
       if (
         importPath.startsWith('Flow/') ||
         importPath.startsWith('Base') ||
         importPath.startsWith('Common/')
-      )
+      ) {
         continue
-      const segments = importPath.split('/')
-      const candidateDirs = [
-        join(COMPONENTS_DIR, segments[0], segments[1] ?? ''),
-        join(COMPONENTS_DIR, segments[0], segments[1] ?? '', segments[2] ?? ''),
-      ]
-      for (const dir of candidateDirs) {
-        const blocks = dirToBlocks.get(dir)
-        if (blocks) {
-          if (blocks.length === 1) {
-            blockNames.add(blocks[0])
-          } else {
-            // Multiple blocks for this directory - match by component name
-            for (const blockName of blocks) {
-              const componentName = blockName.split('.').pop()
-              if (componentName && importedNames.includes(componentName)) {
-                blockNames.add(blockName)
-              }
-            }
-          }
-          break
-        }
       }
+
+      deriveBlocksFromImport(
+        join(COMPONENTS_DIR, importPath),
+        allImportedNames,
+        dirToBlocks,
+      ).forEach(blockName => blockNames.add(blockName))
     }
 
     for (const match of content.matchAll(relativeImportPattern)) {
-      const importedNames = match[1].split(',').map(name =>
-        name
-          .trim()
-          .split(/\s+as\s+/)[0]
-          .trim(),
-      )
-      const importPath = match[2]
-      if (importPath.includes('/Flow/') || importPath.includes('useFlow')) continue
-      const resolved = resolve(dirname(filePath), importPath)
-      const segments = relative(COMPONENTS_DIR, resolved).split('/')
-      const candidateDirs = [
-        join(COMPONENTS_DIR, segments[0], segments[1] ?? ''),
-        join(COMPONENTS_DIR, segments[0], segments[1] ?? '', segments[2] ?? ''),
-      ]
-      for (const dir of candidateDirs) {
-        const blocks = dirToBlocks.get(dir)
-        if (blocks) {
-          if (blocks.length === 1) {
-            blockNames.add(blocks[0])
-          } else {
-            // Multiple blocks for this directory - match by component name
-            for (const blockName of blocks) {
-              const componentName = blockName.split('.').pop()
-              if (componentName && importedNames.includes(componentName)) {
-                blockNames.add(blockName)
-              }
-            }
-          }
-          break
-        }
+      const [_fullMatch, allImportedNames, importPath] = match
+      if (importPath.includes('/Flow/') || importPath.includes('useFlow')) {
+        continue
       }
+
+      deriveBlocksFromImport(
+        resolve(dirname(filePath), importPath),
+        allImportedNames,
+        dirToBlocks,
+      ).forEach(blockName => blockNames.add(blockName))
     }
   }
 
   return [...blockNames].sort()
 }
-
-// --- Extract variables from endpoint paths ---
 
 function extractVariables(endpoints: Endpoint[]): string[] {
   const variables = new Set<string>()
@@ -479,32 +458,35 @@ function extractVariables(endpoints: Endpoint[]): string[] {
   return [...variables].sort()
 }
 
-// --- Core derivation logic ---
+const METHOD_RANK: Record<string, number> = { GET: 0, POST: 1, PUT: 2, PATCH: 3, DELETE: 4 }
 
-interface Inventory {
-  blocks: Record<string, BlockEntry>
-  flows: Record<string, FlowEntry>
-}
-
-interface DerivationResult {
-  inventory: Inventory
-  funcLookup: Map<string, Endpoint>
+function deduplicateEndpoints(endpoints: Endpoint[]): Endpoint[] {
+  const seen = new Set<string>()
+  return endpoints
+    .filter(ep => {
+      const key = `${ep.method} ${ep.path}`
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+    .sort((a, b) => {
+      const pathOrder = a.path.localeCompare(b.path)
+      if (pathOrder !== 0) return pathOrder
+      return (METHOD_RANK[a.method] ?? 99) - (METHOD_RANK[b.method] ?? 99)
+    })
 }
 
 function deriveInventory(): DerivationResult {
-  const funcLookup = buildFuncLookup()
+  const project = createApiProject()
+  const funcLookup = buildFuncLookup(project)
   const blockMappings = discoverBlocks()
-
-  const blockDirToName = new Map<string, string>()
-  for (const { blockName, componentDir } of blockMappings) {
-    blockDirToName.set(componentDir, blockName)
-  }
+  const allBlockDirs = new Set(blockMappings.map(m => m.componentDir))
 
   const blocks: Record<string, BlockEntry> = {}
 
   for (const { blockName, componentDir } of blockMappings) {
     const files = walkDir(componentDir)
-    const funcNames = extractApiImports(files)
+    const funcNames = collectTransitiveApiImports(project, files, componentDir, allBlockDirs)
 
     const endpoints: Endpoint[] = []
     for (const funcName of funcNames) {
@@ -527,21 +509,8 @@ function deriveInventory(): DerivationResult {
   const flows: Record<string, FlowEntry> = {}
 
   for (const { flowName, flowDir } of flowMappings) {
-    const blockNames = deriveFlowBlocks(flowDir, blockMappings)
-
-    const endpoints: Endpoint[] = []
-    for (const blockName of blockNames) {
-      const blockEntry = blocks[blockName]
-      if (blockEntry) {
-        endpoints.push(...blockEntry.endpoints)
-      }
-    }
-    const deduped = deduplicateEndpoints(endpoints)
-    flows[flowName] = {
-      blocks: blockNames,
-      endpoints: deduped,
-      variables: extractVariables(deduped),
-    }
+    const blockNames = deriveFlowBlocks(flowDir, blockMappings).filter(b => b !== flowName)
+    flows[flowName] = { blocks: blockNames }
   }
 
   const sortedFlows = Object.fromEntries(
@@ -550,26 +519,6 @@ function deriveInventory(): DerivationResult {
 
   return { inventory: { blocks, flows: sortedFlows }, funcLookup }
 }
-
-const METHOD_RANK: Record<string, number> = { GET: 0, POST: 1, PUT: 2, PATCH: 3, DELETE: 4 }
-
-function deduplicateEndpoints(endpoints: Endpoint[]): Endpoint[] {
-  const seen = new Set<string>()
-  return endpoints
-    .filter(ep => {
-      const key = `${ep.method} ${ep.path}`
-      if (seen.has(key)) return false
-      seen.add(key)
-      return true
-    })
-    .sort((a, b) => {
-      const pathOrder = a.path.localeCompare(b.path)
-      if (pathOrder !== 0) return pathOrder
-      return (METHOD_RANK[a.method] ?? 99) - (METHOD_RANK[b.method] ?? 99)
-    })
-}
-
-// --- Generate endpoint-reference.md from inventory ---
 
 function generateMarkdown(inventory: Inventory): string {
   const lines: string[] = [
@@ -600,8 +549,7 @@ function generateMarkdown(inventory: Inventory): string {
   }
 
   for (const [domain, domainBlocks] of blocksByDomain) {
-    const sectionTitle = `${domain} components`
-    lines.push(`## ${sectionTitle}`, '')
+    lines.push(`## ${domain} components`, '')
     lines.push('| Component | Method | Path |')
     lines.push('| --- | --- | --- |')
 
@@ -634,8 +582,6 @@ function generateMarkdown(inventory: Inventory): string {
   return lines.join('\n')
 }
 
-// --- Validate all inventory endpoints exist in @gusto/embedded-api ---
-
 function validateEndpoints(
   inventory: { blocks: Record<string, BlockEntry> },
   funcLookup: Map<string, Endpoint>,
@@ -664,8 +610,6 @@ function validateEndpoints(
   return invalid.length
 }
 
-// --- Generate mode: write files ---
-
 function generate() {
   const { inventory, funcLookup } = deriveInventory()
 
@@ -686,7 +630,21 @@ function generate() {
   }
 }
 
-// --- Verify mode: compare against committed files, exit 1 if stale ---
+function printDiff(committedPath: string, freshContent: string): void {
+  const tmpPath = committedPath + '.tmp'
+  try {
+    writeFileSync(tmpPath, freshContent, 'utf-8')
+    const rel = relative(ROOT, committedPath)
+    const result = spawnSync(
+      'diff',
+      ['-u', '--label', `a/${rel}`, '--label', `b/${rel}`, committedPath, tmpPath],
+      { encoding: 'utf-8' },
+    )
+    if (result.stdout) process.stderr.write(result.stdout)
+  } finally {
+    rmSync(tmpPath, { force: true })
+  }
+}
 
 function verify() {
   const filesToCheck = [JSON_OUTPUT_PATH, MD_OUTPUT_PATH]
@@ -717,13 +675,13 @@ function verify() {
   console.error('  - A component added or removed an API hook/function import')
   console.error('  - A flow added or removed a block component')
   console.error('  - The @gusto/embedded-api package was updated')
-  console.error('  - The pre-commit hook was bypassed (--no-verify)')
+  console.error('')
+  if (committedJson !== freshJson) printDiff(JSON_OUTPUT_PATH, freshJson)
+  if (committedMd !== freshMd) printDiff(MD_OUTPUT_PATH, freshMd)
   console.error('')
   console.error('Fix: run "npm run endpoints:derive" and commit the updated files.')
   process.exit(1)
 }
-
-// --- Entry point ---
 
 if (isVerifyMode) {
   verify()

--- a/build/deriveEndpointInventory.ts
+++ b/build/deriveEndpointInventory.ts
@@ -372,11 +372,7 @@ function discoverFlows(): FlowMapping[] {
   return flows
 }
 
-function deriveFlowBlocks(
-  flowDir: string,
-  blockDirToName: Map<string, string>,
-  blockMappings: BlockMapping[],
-): string[] {
+function deriveFlowBlocks(flowDir: string, blockMappings: BlockMapping[]): string[] {
   const files = walkDir(flowDir)
   const blockNames = new Set<string>()
 
@@ -531,7 +527,7 @@ function deriveInventory(): DerivationResult {
   const flows: Record<string, FlowEntry> = {}
 
   for (const { flowName, flowDir } of flowMappings) {
-    const blockNames = deriveFlowBlocks(flowDir, blockDirToName, blockMappings)
+    const blockNames = deriveFlowBlocks(flowDir, blockMappings)
 
     const endpoints: Endpoint[] = []
     for (const blockName of blockNames) {
@@ -548,17 +544,29 @@ function deriveInventory(): DerivationResult {
     }
   }
 
-  return { inventory: { blocks, flows }, funcLookup }
+  const sortedFlows = Object.fromEntries(
+    Object.entries(flows).sort(([a], [b]) => a.localeCompare(b)),
+  )
+
+  return { inventory: { blocks, flows: sortedFlows }, funcLookup }
 }
+
+const METHOD_RANK: Record<string, number> = { GET: 0, POST: 1, PUT: 2, PATCH: 3, DELETE: 4 }
 
 function deduplicateEndpoints(endpoints: Endpoint[]): Endpoint[] {
   const seen = new Set<string>()
-  return endpoints.filter(ep => {
-    const key = `${ep.method} ${ep.path}`
-    if (seen.has(key)) return false
-    seen.add(key)
-    return true
-  })
+  return endpoints
+    .filter(ep => {
+      const key = `${ep.method} ${ep.path}`
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+    .sort((a, b) => {
+      const pathOrder = a.path.localeCompare(b.path)
+      if (pathOrder !== 0) return pathOrder
+      return (METHOD_RANK[a.method] ?? 99) - (METHOD_RANK[b.method] ?? 99)
+    })
 }
 
 // --- Generate endpoint-reference.md from inventory ---

--- a/build/deriveEndpointInventory.ts
+++ b/build/deriveEndpointInventory.ts
@@ -107,8 +107,8 @@ function buildParamNameMap(project: Project, funcPaths: string[]): Record<string
   const paramNameMap: Record<string, string> = {}
 
   for (const path of funcPaths) {
-    for (const match of path.matchAll(/\{([^}]+)\}/g)) {
-      const snakeParam = match[1]
+    // {employee_id}  →  snakeParam = "employee_id"
+    for (const [_fullMatch, snakeParam] of path.matchAll(/\{([^}]+)\}/g)) {
       if (!paramNameMap[snakeParam]) {
         paramNameMap[snakeParam] = snakeToCamelLookup.get(snakeParam) ?? snakeToCamel(snakeParam)
       }
@@ -254,6 +254,7 @@ function collectTransitiveApiImports(
 }
 
 function normalizeEndpointPath(openApiPath: string, paramNameMap: Record<string, string>): string {
+  // {employee_id}  →  paramName = "employee_id"
   return openApiPath.replace(/\{([^}]+)\}/g, (_match, paramName: string) => {
     const normalized = paramNameMap[paramName]
     if (!normalized) {
@@ -270,9 +271,12 @@ function parseNamespaceExports(): Map<string, string> {
 
   try {
     const content = readFileSync(indexPath, 'utf-8')
+    // export * as EmployeeManagement from './Employee/exports/employeeManagement'  →
+    //   namespaceName = "EmployeeManagement"
+    //   domainDir = "Employee/exports/employeeManagement"
     const namespacePattern = /export\s+\*\s+as\s+(\w+)\s+from\s+['"]\.\/([^'"]+)['"]/g
-    for (const match of content.matchAll(namespacePattern)) {
-      namespaces.set(match[1], match[2])
+    for (const [_fullMatch, namespaceName, domainDir] of content.matchAll(namespacePattern)) {
+      namespaces.set(namespaceName, domainDir)
     }
   } catch (err) {
     console.error(`ERROR: Could not read ${indexPath}`)
@@ -289,12 +293,13 @@ function parseComponentExports(domainDir: string): Map<string, string> {
   for (const barrelPath of possibleBarrelFiles) {
     try {
       const content = readFileSync(barrelPath, 'utf-8')
+      // export { EmployeeDocuments as Documents } from './Documents'  →
+      //   nameToken = "EmployeeDocuments as Documents"
+      //   importPath = "./Documents"
       // Uses the alias when present so the map key matches the public export name.
       const exportPattern =
         /export\s+\{\s*(\w+(?:\s+as\s+\w+)?)[^}]*?\}\s+from\s+['"](\.[^'"]+)['"]/g
-      for (const match of content.matchAll(exportPattern)) {
-        const nameToken = match[1]
-        const importPath = match[2]
+      for (const [_fullMatch, nameToken, importPath] of content.matchAll(exportPattern)) {
         const asIndex = nameToken.indexOf(' as ')
         const componentName = asIndex >= 0 ? nameToken.slice(asIndex + 4).trim() : nameToken.trim()
         exports.set(componentName, importPath)
@@ -408,7 +413,13 @@ function deriveFlowBlocks(flowDir: string, blockMappings: BlockMapping[]): strin
     dirToBlocks.get(mapping.componentDir)!.push(mapping.blockName)
   }
 
+  // import { EmployeeForm } from '@/components/Employee/Form'  →
+  //   allImportedNames = " EmployeeForm "
+  //   importPath = "Employee/Form"
   const absoluteImportPattern = /import\s+\{([^}]+)\}\s+from\s+['"]@\/components\/([^'"]+)['"]/g
+  // import { EmployeeForm, AnotherImport } from '../shared/EmployeeForm'  →
+  //   allImportedNames = " EmployeeForm, AnotherImport "
+  //   importPath = "../shared/EmployeeForm"
   const relativeImportPattern = /import\s+\{([^}]+)\}\s+from\s+['"](\.[^'"]+)['"]/g
 
   for (const filePath of files) {
@@ -451,8 +462,9 @@ function deriveFlowBlocks(flowDir: string, blockMappings: BlockMapping[]): strin
 function extractVariables(endpoints: Endpoint[]): string[] {
   const variables = new Set<string>()
   for (const ep of endpoints) {
-    for (const match of ep.path.matchAll(/:([a-zA-Z]+)/g)) {
-      variables.add(match[1])
+    // :companyId  →  varName = "companyId"
+    for (const [_fullMatch, varName] of ep.path.matchAll(/:([a-zA-Z]+)/g)) {
+      variables.add(varName)
     }
   }
   return [...variables].sort()

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["./*.ts"],
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  }
+}

--- a/docs/reference/endpoint-inventory.json
+++ b/docs/reference/endpoint-inventory.json
@@ -74,12 +74,12 @@
           "path": "/v1/companies/:companyUuid/signatories"
         },
         {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/signatories/invite"
-        },
-        {
           "method": "DELETE",
           "path": "/v1/companies/:companyUuid/signatories/:signatoryUuid"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/signatories/invite"
         }
       ],
       "variables": [
@@ -146,12 +146,8 @@
     "Company.Locations": {
       "endpoints": [
         {
-          "method": "PUT",
-          "path": "/v1/locations/:locationId"
-        },
-        {
           "method": "GET",
-          "path": "/v1/locations/:locationId"
+          "path": "/v1/companies/:companyId/locations"
         },
         {
           "method": "POST",
@@ -159,7 +155,11 @@
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/locations"
+          "path": "/v1/locations/:locationId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/locations/:locationId"
         }
       ],
       "variables": [
@@ -170,16 +170,16 @@
     "Company.LocationForm": {
       "endpoints": [
         {
-          "method": "PUT",
-          "path": "/v1/locations/:locationId"
+          "method": "POST",
+          "path": "/v1/companies/:companyId/locations"
         },
         {
           "method": "GET",
           "path": "/v1/locations/:locationId"
         },
         {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/locations"
+          "method": "PUT",
+          "path": "/v1/locations/:locationId"
         }
       ],
       "variables": [
@@ -194,20 +194,20 @@
           "path": "/v1/companies/:companyId/pay_schedules"
         },
         {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/pay_schedules"
+        },
+        {
           "method": "GET",
+          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
         },
         {
           "method": "GET",
           "path": "/v1/companies/:companyId/pay_schedules/preview"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/pay_schedules"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
         },
         {
           "method": "GET",
@@ -223,11 +223,11 @@
     "Company.FederalTaxes": {
       "endpoints": [
         {
-          "method": "PUT",
+          "method": "GET",
           "path": "/v1/companies/:companyId/federal_tax_details"
         },
         {
-          "method": "GET",
+          "method": "PUT",
           "path": "/v1/companies/:companyId/federal_tax_details"
         }
       ],
@@ -269,11 +269,11 @@
     "Company.StateTaxesForm": {
       "endpoints": [
         {
-          "method": "PUT",
+          "method": "GET",
           "path": "/v1/companies/:companyUuid/tax_requirements/:state"
         },
         {
-          "method": "GET",
+          "method": "PUT",
           "path": "/v1/companies/:companyUuid/tax_requirements/:state"
         }
       ],
@@ -285,16 +285,16 @@
     "Company.StateTaxes": {
       "endpoints": [
         {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
-        },
-        {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/tax_requirements"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
         }
       ],
       "variables": [
@@ -306,15 +306,15 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/contractors/:contractorUuid/payment_method"
-        },
-        {
-          "method": "GET",
           "path": "/v1/contractors/:contractorUuid/bank_accounts"
         },
         {
           "method": "POST",
           "path": "/v1/contractors/:contractorUuid/bank_accounts"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/contractors/:contractorUuid/payment_method"
         },
         {
           "method": "PUT",
@@ -347,12 +347,12 @@
     "Contractor.ContractorList": {
       "endpoints": [
         {
-          "method": "DELETE",
-          "path": "/v1/contractors/:contractorUuid"
-        },
-        {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/contractors"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/contractors/:contractorUuid"
         }
       ],
       "variables": [
@@ -378,16 +378,16 @@
     "Contractor.ContractorSubmit": {
       "endpoints": [
         {
-          "method": "PUT",
-          "path": "/v1/contractors/:contractorUuid/onboarding_status"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/contractors/:contractorUuid/onboarding_status"
-        },
-        {
           "method": "GET",
           "path": "/v1/contractors/:contractorUuid"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/contractors/:contractorUuid/onboarding_status"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/contractors/:contractorUuid/onboarding_status"
         }
       ],
       "variables": [
@@ -397,12 +397,12 @@
     "Contractor.ContractorProfile": {
       "endpoints": [
         {
-          "method": "GET",
-          "path": "/v1/contractors/:contractorUuid"
-        },
-        {
           "method": "POST",
           "path": "/v1/companies/:companyUuid/contractors"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/contractors/:contractorUuid"
         },
         {
           "method": "PUT",
@@ -434,7 +434,7 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/contractors"
+          "path": "/v1/companies/:companyId/bank_accounts"
         },
         {
           "method": "POST",
@@ -446,7 +446,7 @@
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/bank_accounts"
+          "path": "/v1/companies/:companyUuid/contractors"
         }
       ],
       "variables": [
@@ -457,16 +457,16 @@
     "Contractor.PaymentHistory": {
       "endpoints": [
         {
-          "method": "GET",
-          "path": "/v1/contractor_payment_groups/:contractorPaymentGroupUuid"
+          "method": "DELETE",
+          "path": "/v1/companies/:companyId/contractor_payments/:contractorPaymentId"
         },
         {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/contractors"
         },
         {
-          "method": "DELETE",
-          "path": "/v1/companies/:companyId/contractor_payments/:contractorPaymentId"
+          "method": "GET",
+          "path": "/v1/contractor_payment_groups/:contractorPaymentGroupUuid"
         }
       ],
       "variables": [
@@ -480,7 +480,7 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/contractor_payment_groups/:contractorPaymentGroupUuid"
+          "path": "/v1/companies/:companyId/bank_accounts"
         },
         {
           "method": "GET",
@@ -488,7 +488,7 @@
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/bank_accounts"
+          "path": "/v1/contractor_payment_groups/:contractorPaymentGroupUuid"
         }
       ],
       "variables": [
@@ -501,11 +501,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/contractor_payment_groups/:contractorPaymentGroupUuid"
+          "path": "/v1/companies/:companyUuid/contractors"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/contractors"
+          "path": "/v1/contractor_payment_groups/:contractorPaymentGroupUuid"
         },
         {
           "method": "GET",
@@ -580,40 +580,8 @@
     "Employee.Profile": {
       "endpoints": [
         {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/work_addresses"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
           "method": "POST",
           "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/onboarding_status"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/home_addresses"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/home_addresses/:homeAddressUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/home_addresses"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/home_addresses/:homeAddressUuid"
         },
         {
           "method": "GET",
@@ -621,11 +589,43 @@
         },
         {
           "method": "GET",
-          "path": "/v1/work_addresses/:workAddressUuid"
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/home_addresses"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/home_addresses"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/onboarding_status"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/work_addresses"
         },
         {
           "method": "POST",
           "path": "/v1/employees/:employeeId/work_addresses"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/home_addresses/:homeAddressUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/home_addresses/:homeAddressUuid"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/work_addresses/:workAddressUuid"
         },
         {
           "method": "PUT",
@@ -643,7 +643,31 @@
       "endpoints": [
         {
           "method": "GET",
+          "path": "/v1/companies/:companyId/federal_tax_details"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/compensations/:compensationId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "GET",
           "path": "/v1/employees/:employeeId/jobs"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/jobs"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/work_addresses"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/jobs/:jobId"
         },
         {
           "method": "DELETE",
@@ -654,32 +678,8 @@
           "path": "/v1/jobs/:jobId/compensations"
         },
         {
-          "method": "PUT",
-          "path": "/v1/compensations/:compensationId"
-        },
-        {
           "method": "GET",
           "path": "/v1/locations/:locationUuid/minimum_wages"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/work_addresses"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/jobs"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/jobs/:jobId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/federal_tax_details"
         }
       ],
       "variables": [
@@ -723,8 +723,16 @@
     "Employee.PaymentMethod": {
       "endpoints": [
         {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/bank_accounts"
+        },
+        {
           "method": "POST",
           "path": "/v1/employees/:employeeId/bank_accounts"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/employees/:employeeId/bank_accounts/:bankAccountUuid"
         },
         {
           "method": "GET",
@@ -733,14 +741,6 @@
         {
           "method": "PUT",
           "path": "/v1/employees/:employeeId/payment_method"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/employees/:employeeId/bank_accounts/:bankAccountUuid"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/bank_accounts"
         }
       ],
       "variables": [
@@ -752,11 +752,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/employees/:employeeId"
+          "path": "/v1/companies/:companyId"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId"
+          "path": "/v1/employees/:employeeId"
         }
       ],
       "variables": [
@@ -768,19 +768,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/employees/:employeeId/forms"
-        },
-        {
-          "method": "GET",
           "path": "/v1/employees/:employeeId"
         },
         {
           "method": "GET",
-          "path": "/v1/employees/:employeeId/i9_authorization"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/i9_authorization"
+          "path": "/v1/employees/:employeeId/forms"
         },
         {
           "method": "GET",
@@ -793,6 +785,14 @@
         {
           "method": "PUT",
           "path": "/v1/employees/:employeeId/forms/:formId/sign"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/i9_authorization"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/i9_authorization"
         }
       ],
       "variables": [
@@ -819,19 +819,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/payrolls/:payrollId/employees/:employeeId/pay_stub"
-        },
-        {
-          "method": "GET",
           "path": "/v1/employees/:employeeId"
         },
         {
           "method": "GET",
-          "path": "/v1/employees/:employeeId/home_addresses"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/work_addresses"
+          "path": "/v1/employees/:employeeId/forms"
         },
         {
           "method": "GET",
@@ -839,11 +831,15 @@
         },
         {
           "method": "GET",
+          "path": "/v1/employees/:employeeId/home_addresses"
+        },
+        {
+          "method": "GET",
           "path": "/v1/employees/:employeeId/pay_stubs"
         },
         {
           "method": "GET",
-          "path": "/v1/employees/:employeeId/forms"
+          "path": "/v1/employees/:employeeId/work_addresses"
         },
         {
           "method": "GET",
@@ -852,6 +848,10 @@
         {
           "method": "GET",
           "path": "/v1/employees/:employeeUuid/state_taxes"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/payrolls/:payrollId/employees/:employeeId/pay_stub"
         }
       ],
       "variables": [
@@ -863,16 +863,16 @@
     "Employee.HomeAddress": {
       "endpoints": [
         {
-          "method": "DELETE",
-          "path": "/v1/home_addresses/:homeAddressUuid"
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
         },
         {
           "method": "GET",
           "path": "/v1/employees/:employeeId/home_addresses"
         },
         {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId"
+          "method": "DELETE",
+          "path": "/v1/home_addresses/:homeAddressUuid"
         }
       ],
       "variables": [
@@ -899,6 +899,18 @@
       "endpoints": [
         {
           "method": "GET",
+          "path": "/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/payrolls"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/payrolls"
+        },
+        {
+          "method": "GET",
           "path": "/v1/employees/:employeeId"
         },
         {
@@ -912,18 +924,6 @@
         {
           "method": "PUT",
           "path": "/v1/terminations/:employeeId"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/payrolls"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls"
         }
       ],
       "variables": [
@@ -935,6 +935,10 @@
       "endpoints": [
         {
           "method": "GET",
+          "path": "/v1/companies/:companyId/employees"
+        },
+        {
+          "method": "GET",
           "path": "/v1/employees/:employeeId"
         },
         {
@@ -944,10 +948,6 @@
         {
           "method": "DELETE",
           "path": "/v1/employees/:employeeId/terminations"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
         }
       ],
       "variables": [
@@ -958,16 +958,16 @@
     "Employee.WorkAddress": {
       "endpoints": [
         {
-          "method": "DELETE",
-          "path": "/v1/work_addresses/:workAddressUuid"
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
         },
         {
           "method": "GET",
           "path": "/v1/employees/:employeeId/work_addresses"
         },
         {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId"
+          "method": "DELETE",
+          "path": "/v1/work_addresses/:workAddressUuid"
         }
       ],
       "variables": [
@@ -1045,26 +1045,6 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/payrolls/:payrollUuid/gross_up"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/payrolls/blockers"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId/calculate"
-        },
-        {
-          "method": "GET",
           "path": "/v1/companies/:companyId/employees"
         },
         {
@@ -1072,12 +1052,32 @@
           "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
         },
         {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId/calculate"
+        },
+        {
           "method": "PUT",
           "path": "/v1/companies/:companyId/payrolls/:payrollId/prepare"
         },
         {
           "method": "GET",
+          "path": "/v1/companies/:companyUuid/payrolls/blockers"
+        },
+        {
+          "method": "GET",
           "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/payrolls/:payrollUuid/gross_up"
         }
       ],
       "variables": [
@@ -1092,16 +1092,16 @@
     "Payroll.PayrollEditEmployee": {
       "endpoints": [
         {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId"
+        },
+        {
           "method": "GET",
           "path": "/v1/employees/:employeeId"
         },
         {
           "method": "GET",
           "path": "/v1/employees/:employeeId/bank_accounts"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
         }
       ],
       "variables": [
@@ -1135,11 +1135,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/wire_in_requests"
+          "path": "/v1/companies/:companyUuid/payrolls/blockers"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/payrolls/blockers"
+          "path": "/v1/companies/:companyUuid/wire_in_requests"
         }
       ],
       "variables": [
@@ -1150,15 +1150,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls"
-        },
-        {
-          "method": "GET",
           "path": "/v1/companies/:companyId/pay_schedules"
         },
         {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/payrolls/skip"
+          "method": "GET",
+          "path": "/v1/companies/:companyId/payrolls"
         },
         {
           "method": "DELETE",
@@ -1167,6 +1163,10 @@
         {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/payrolls/blockers"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/payrolls/skip"
         },
         {
           "method": "GET",
@@ -1182,18 +1182,6 @@
     "Payroll.PayrollOverview": {
       "endpoints": [
         {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId/submit"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId/cancel"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
-        },
-        {
           "method": "GET",
           "path": "/v1/companies/:companyId/bank_accounts"
         },
@@ -1203,11 +1191,23 @@
         },
         {
           "method": "GET",
-          "path": "/v1/wire_in_requests/:wireInRequestUuid"
+          "path": "/v1/companies/:companyId/payrolls/:payrollId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId/cancel"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId/submit"
         },
         {
           "method": "GET",
           "path": "/v1/payrolls/:payrollId/employees/:employeeId/pay_stub"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/wire_in_requests/:wireInRequestUuid"
         }
       ],
       "variables": [
@@ -1221,11 +1221,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
+          "path": "/v1/companies/:companyId/payrolls"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls"
+          "path": "/v1/companies/:companyId/payrolls/:payrollId"
         }
       ],
       "variables": [
@@ -1248,18 +1248,18 @@
       "endpoints": [
         {
           "method": "GET",
+          "path": "/v1/companies/:companyId/payrolls"
+        },
+        {
+          "method": "GET",
           "path": "/v1/companies/:companyUuid/wire_in_requests"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls"
-        },
-        {
-          "method": "PUT",
           "path": "/v1/wire_in_requests/:wireInRequestUuid"
         },
         {
-          "method": "GET",
+          "method": "PUT",
           "path": "/v1/wire_in_requests/:wireInRequestUuid"
         }
       ],
@@ -1273,15 +1273,15 @@
       "endpoints": [
         {
           "method": "GET",
+          "path": "/v1/companies/:companyUuid/information_requests"
+        },
+        {
+          "method": "GET",
           "path": "/v1/companies/:companyUuid/payrolls/blockers"
         },
         {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/recovery_cases"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/information_requests"
         }
       ],
       "variables": [
@@ -1307,12 +1307,12 @@
     "Payroll.OffCycleCreation": {
       "endpoints": [
         {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/payrolls"
-        },
-        {
           "method": "GET",
           "path": "/v1/companies/:companyId/employees"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/payrolls"
         }
       ],
       "variables": [
@@ -1335,15 +1335,15 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
-        },
-        {
-          "method": "GET",
           "path": "/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods"
         },
         {
           "method": "POST",
           "path": "/v1/companies/:companyId/payrolls"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId"
         }
       ],
       "variables": [
@@ -1366,12 +1366,12 @@
     "Payroll.TransitionCreation": {
       "endpoints": [
         {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/payrolls"
-        },
-        {
           "method": "GET",
           "path": "/v1/companies/:companyId/pay_schedules"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/payrolls"
         }
       ],
       "variables": [
@@ -1382,15 +1382,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
           "method": "POST",
@@ -1399,30 +1395,10 @@
         {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
         },
         {
           "method": "DELETE",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
         },
         {
           "method": "PUT",
@@ -1430,15 +1406,39 @@
         },
         {
           "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
@@ -1451,15 +1451,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
           "method": "POST",
@@ -1468,30 +1464,10 @@
         {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
         },
         {
           "method": "DELETE",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
         },
         {
           "method": "PUT",
@@ -1499,15 +1475,39 @@
         },
         {
           "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
@@ -1523,11 +1523,11 @@
           "path": "/v1/companies/:companyUuid/time_off_policies"
         },
         {
-          "method": "PUT",
+          "method": "GET",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid"
         },
         {
-          "method": "GET",
+          "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid"
         }
       ],
@@ -1540,15 +1540,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
           "method": "POST",
@@ -1557,30 +1553,10 @@
         {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
         },
         {
           "method": "DELETE",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
         },
         {
           "method": "PUT",
@@ -1588,15 +1564,39 @@
         },
         {
           "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
@@ -1609,15 +1609,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
           "method": "POST",
@@ -1626,30 +1622,10 @@
         {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
         },
         {
           "method": "DELETE",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
         },
         {
           "method": "PUT",
@@ -1657,15 +1633,39 @@
         },
         {
           "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
@@ -1678,15 +1678,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
           "method": "POST",
@@ -1695,30 +1691,10 @@
         {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
         },
         {
           "method": "DELETE",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
         },
         {
           "method": "PUT",
@@ -1726,15 +1702,39 @@
         },
         {
           "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
@@ -1747,15 +1747,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
           "method": "POST",
@@ -1764,30 +1760,10 @@
         {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
         },
         {
           "method": "DELETE",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
         },
         {
           "method": "PUT",
@@ -1795,15 +1771,39 @@
         },
         {
           "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
@@ -1816,15 +1816,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
           "method": "POST",
@@ -1833,30 +1829,10 @@
         {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
         },
         {
           "method": "DELETE",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
         },
         {
           "method": "PUT",
@@ -1864,15 +1840,39 @@
         },
         {
           "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
@@ -1885,15 +1885,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
           "method": "POST",
@@ -1902,30 +1898,10 @@
         {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
         },
         {
           "method": "DELETE",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
         },
         {
           "method": "PUT",
@@ -1933,15 +1909,39 @@
         },
         {
           "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
@@ -1954,15 +1954,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
           "method": "POST",
@@ -1971,30 +1967,10 @@
         {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
         },
         {
           "method": "DELETE",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
         },
         {
           "method": "PUT",
@@ -2002,15 +1978,39 @@
         },
         {
           "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
@@ -2023,19 +2023,19 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
         },
         {
           "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
@@ -2047,15 +2047,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
           "method": "POST",
@@ -2064,30 +2060,10 @@
         {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
         },
         {
           "method": "DELETE",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
         },
         {
           "method": "PUT",
@@ -2095,15 +2071,39 @@
         },
         {
           "method": "PUT",
+          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
@@ -2142,11 +2142,75 @@
         },
         {
           "method": "GET",
+          "path": "/v1/companies/:companyId/federal_tax_details"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/federal_tax_details"
+        },
+        {
+          "method": "GET",
           "path": "/v1/companies/:companyId/forms"
         },
         {
           "method": "GET",
+          "path": "/v1/companies/:companyId/industry_selection"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/industry_selection"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/locations"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/locations"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/pay_schedules"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/pay_schedules"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/pay_schedules/preview"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/onboarding_status"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/payment_configs"
+        },
+        {
+          "method": "GET",
           "path": "/v1/companies/:companyUuid/signatories"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/tax_requirements"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
         },
         {
           "method": "GET",
@@ -2161,76 +2225,12 @@
           "path": "/v1/forms/:formId/sign"
         },
         {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/federal_tax_details"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/federal_tax_details"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/industry_selection"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/industry_selection"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/locations/:locationId"
-        },
-        {
           "method": "GET",
           "path": "/v1/locations/:locationId"
         },
         {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/locations"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/locations"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/onboarding_status"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/pay_schedules"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/pay_schedules/preview"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/pay_schedules"
-        },
-        {
           "method": "PUT",
-          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/payment_configs"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/tax_requirements"
+          "path": "/v1/locations/:locationId"
         }
       ],
       "variables": [
@@ -2256,15 +2256,19 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/contractors/:contractorUuid"
+          "path": "/v1/companies/:companyUuid/contractors"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/contractors"
         },
         {
           "method": "GET",
-          "path": "/v1/contractors/:contractorUuid/address"
+          "path": "/v1/contractors/:contractorUuid"
         },
         {
           "method": "PUT",
-          "path": "/v1/contractors/:contractorUuid/address"
+          "path": "/v1/contractors/:contractorUuid"
         },
         {
           "method": "DELETE",
@@ -2272,35 +2276,31 @@
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/contractors"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/contractors"
+          "path": "/v1/contractors/:contractorUuid/address"
         },
         {
           "method": "PUT",
-          "path": "/v1/contractors/:contractorUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/contractors/:contractorUuid/onboarding_status"
+          "path": "/v1/contractors/:contractorUuid/address"
         },
         {
           "method": "GET",
+          "path": "/v1/contractors/:contractorUuid/bank_accounts"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/contractors/:contractorUuid/bank_accounts"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/contractors/:contractorUuid/onboarding_status"
+        },
+        {
+          "method": "PUT",
           "path": "/v1/contractors/:contractorUuid/onboarding_status"
         },
         {
           "method": "GET",
           "path": "/v1/contractors/:contractorUuid/payment_method"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/contractors/:contractorUuid/bank_accounts"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/contractors/:contractorUuid/bank_accounts"
         },
         {
           "method": "PUT",
@@ -2325,7 +2325,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/contractors"
+          "path": "/v1/companies/:companyId/bank_accounts"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/contractor_payment_groups"
         },
         {
           "method": "POST",
@@ -2336,28 +2340,24 @@
           "path": "/v1/companies/:companyId/contractor_payment_groups/preview"
         },
         {
+          "method": "DELETE",
+          "path": "/v1/companies/:companyId/contractor_payments/:contractorPaymentId"
+        },
+        {
           "method": "GET",
-          "path": "/v1/companies/:companyId/bank_accounts"
+          "path": "/v1/companies/:companyUuid/contractors"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/information_requests"
         },
         {
           "method": "GET",
           "path": "/v1/contractor_payment_groups/:contractorPaymentGroupUuid"
         },
         {
-          "method": "DELETE",
-          "path": "/v1/companies/:companyId/contractor_payments/:contractorPaymentId"
-        },
-        {
           "method": "GET",
           "path": "/v1/contractor_payments/:contractorPaymentUuid/receipt"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/contractor_payment_groups"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/information_requests"
         },
         {
           "method": "PUT",
@@ -2389,39 +2389,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/employees/:employeeId/jobs"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/jobs/:jobId"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
           "method": "POST",
-          "path": "/v1/jobs/:jobId/compensations"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/compensations/:compensationId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/locations/:locationUuid/minimum_wages"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/work_addresses"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/jobs"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/jobs/:jobId"
+          "path": "/v1/companies/:companyId/employees"
         },
         {
           "method": "GET",
@@ -2429,11 +2401,103 @@
         },
         {
           "method": "GET",
+          "path": "/v1/companies/:companyId/locations"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/compensations/:compensationId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/bank_accounts"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/bank_accounts"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/employees/:employeeId/bank_accounts/:bankAccountUuid"
+        },
+        {
+          "method": "GET",
           "path": "/v1/employees/:employeeId/garnishments"
         },
         {
           "method": "POST",
           "path": "/v1/employees/:employeeId/garnishments"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/home_addresses"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/home_addresses"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/jobs"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/jobs"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/onboarding_documents_config"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/onboarding_status"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/onboarding_status"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/payment_method"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/payment_method"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/work_addresses"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/work_addresses"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeUuid/federal_taxes"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeUuid/federal_taxes"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeUuid/state_taxes"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeUuid/state_taxes"
         },
         {
           "method": "PUT",
@@ -2444,100 +2508,36 @@
           "path": "/v1/garnishments/child_support"
         },
         {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/onboarding_documents_config"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/onboarding_status"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeUuid/federal_taxes"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeUuid/federal_taxes"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/onboarding_status"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/bank_accounts"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/payment_method"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/payment_method"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/employees/:employeeId/bank_accounts/:bankAccountUuid"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/bank_accounts"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/home_addresses"
-        },
-        {
           "method": "GET",
           "path": "/v1/home_addresses/:homeAddressUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/home_addresses"
         },
         {
           "method": "PUT",
           "path": "/v1/home_addresses/:homeAddressUuid"
         },
         {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/locations"
+          "method": "PUT",
+          "path": "/v1/jobs/:jobId"
         },
         {
-          "method": "GET",
-          "path": "/v1/work_addresses/:workAddressUuid"
+          "method": "DELETE",
+          "path": "/v1/jobs/:jobId"
         },
         {
           "method": "POST",
-          "path": "/v1/employees/:employeeId/work_addresses"
+          "path": "/v1/jobs/:jobId/compensations"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/locations/:locationUuid/minimum_wages"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/work_addresses/:workAddressUuid"
         },
         {
           "method": "PUT",
           "path": "/v1/work_addresses/:workAddressUuid"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeUuid/state_taxes"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeUuid/state_taxes"
         }
       ],
       "variables": [
@@ -2567,19 +2567,39 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/employees/:employeeId/forms"
+          "path": "/v1/companies/:companyId"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/employees"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/locations"
         },
         {
           "method": "GET",
           "path": "/v1/employees/:employeeId"
         },
         {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/i9_authorization"
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId"
         },
         {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/i9_authorization"
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/bank_accounts"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/bank_accounts"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/employees/:employeeId/bank_accounts/:bankAccountUuid"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/forms"
         },
         {
           "method": "GET",
@@ -2595,23 +2615,27 @@
         },
         {
           "method": "GET",
-          "path": "/v1/employees/:employeeUuid/federal_taxes"
+          "path": "/v1/employees/:employeeId/home_addresses"
         },
         {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeUuid/federal_taxes"
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/home_addresses"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId"
+          "path": "/v1/employees/:employeeId/i9_authorization"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/i9_authorization"
         },
         {
           "method": "GET",
           "path": "/v1/employees/:employeeId/onboarding_status"
         },
         {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/bank_accounts"
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/onboarding_status"
         },
         {
           "method": "GET",
@@ -2622,60 +2646,20 @@
           "path": "/v1/employees/:employeeId/payment_method"
         },
         {
-          "method": "DELETE",
-          "path": "/v1/employees/:employeeId/bank_accounts/:bankAccountUuid"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/bank_accounts"
-        },
-        {
           "method": "GET",
           "path": "/v1/employees/:employeeId/work_addresses"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/onboarding_status"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/home_addresses"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/home_addresses/:homeAddressUuid"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/home_addresses"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/home_addresses/:homeAddressUuid"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/locations"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/work_addresses/:workAddressUuid"
         },
         {
           "method": "POST",
           "path": "/v1/employees/:employeeId/work_addresses"
         },
         {
+          "method": "GET",
+          "path": "/v1/employees/:employeeUuid/federal_taxes"
+        },
+        {
           "method": "PUT",
-          "path": "/v1/work_addresses/:workAddressUuid"
+          "path": "/v1/employees/:employeeUuid/federal_taxes"
         },
         {
           "method": "GET",
@@ -2684,6 +2668,22 @@
         {
           "method": "PUT",
           "path": "/v1/employees/:employeeUuid/state_taxes"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/home_addresses/:homeAddressUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/home_addresses/:homeAddressUuid"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/work_addresses/:workAddressUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/work_addresses/:workAddressUuid"
         }
       ],
       "variables": [
@@ -2707,6 +2707,34 @@
       "endpoints": [
         {
           "method": "GET",
+          "path": "/v1/companies/:companyId/employees"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/payrolls"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/payrolls"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/payrolls/blockers"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/wire_in_requests"
+        },
+        {
+          "method": "GET",
           "path": "/v1/employees/:employeeId"
         },
         {
@@ -2718,40 +2746,12 @@
           "path": "/v1/employees/:employeeId/terminations"
         },
         {
-          "method": "PUT",
-          "path": "/v1/terminations/:employeeId"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/payrolls"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls"
-        },
-        {
           "method": "DELETE",
           "path": "/v1/employees/:employeeId/terminations"
         },
         {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/wire_in_requests"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/payrolls/blockers"
+          "method": "PUT",
+          "path": "/v1/terminations/:employeeId"
         }
       ],
       "variables": [
@@ -2768,11 +2768,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
+          "path": "/v1/companies/:companyId/payrolls"
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls"
+          "path": "/v1/companies/:companyId/payrolls/:payrollId"
         }
       ],
       "variables": [
@@ -2795,7 +2795,47 @@
       "endpoints": [
         {
           "method": "GET",
+          "path": "/v1/companies/:companyId/bank_accounts"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/employees"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/payrolls"
+        },
+        {
+          "method": "GET",
           "path": "/v1/companies/:companyId/payrolls/:payrollId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId/calculate"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId/cancel"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId/prepare"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId/submit"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/information_requests"
         },
         {
           "method": "GET",
@@ -2807,31 +2847,7 @@
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/information_requests"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/payrolls/:payrollUuid/gross_up"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId/calculate"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId/prepare"
+          "path": "/v1/companies/:companyUuid/wire_in_requests"
         },
         {
           "method": "GET",
@@ -2843,35 +2859,19 @@
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/wire_in_requests"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId/submit"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId/cancel"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/bank_accounts"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/wire_in_requests/:wireInRequestUuid"
-        },
-        {
-          "method": "GET",
           "path": "/v1/payrolls/:payrollId/employees/:employeeId/pay_stub"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/payrolls/:payrollUuid/gross_up"
         },
         {
           "method": "GET",
           "path": "/v1/payrolls/:payrollUuid/receipt"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/wire_in_requests/:wireInRequestUuid"
         }
       ],
       "variables": [
@@ -2891,12 +2891,12 @@
       ],
       "endpoints": [
         {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
+          "method": "GET",
+          "path": "/v1/companies/:companyId/employees"
         },
         {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/time_off_policies"
         },
         {
           "method": "GET",
@@ -2904,15 +2904,15 @@
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
         },
         {
           "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [

--- a/docs/reference/endpoint-inventory.json
+++ b/docs/reference/endpoint-inventory.json
@@ -447,6 +447,10 @@
         {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/contractors"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/payment_configs"
         }
       ],
       "variables": [
@@ -1092,8 +1096,16 @@
     "Payroll.PayrollEditEmployee": {
       "endpoints": [
         {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
+        },
+        {
           "method": "PUT",
           "path": "/v1/companies/:companyId/payrolls/:payrollId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/payrolls/:payrollId/prepare"
         },
         {
           "method": "GET",
@@ -1107,6 +1119,7 @@
       "variables": [
         "companyId",
         "employeeId",
+        "payScheduleId",
         "payrollId"
       ]
     },
@@ -1135,7 +1148,19 @@
       "endpoints": [
         {
           "method": "GET",
+          "path": "/v1/companies/:companyId/pay_periods"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/pay_schedules"
+        },
+        {
+          "method": "GET",
           "path": "/v1/companies/:companyUuid/payrolls/blockers"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/payrolls/skip"
         },
         {
           "method": "GET",
@@ -1143,6 +1168,7 @@
         }
       ],
       "variables": [
+        "companyId",
         "companyUuid"
       ]
     },
@@ -1203,6 +1229,10 @@
         },
         {
           "method": "GET",
+          "path": "/v1/companies/:companyUuid/payment_configs"
+        },
+        {
+          "method": "GET",
           "path": "/v1/payrolls/:payrollId/employees/:employeeId/pay_stub"
         },
         {
@@ -1212,6 +1242,7 @@
       ],
       "variables": [
         "companyId",
+        "companyUuid",
         "employeeId",
         "payrollId",
         "wireInRequestUuid"
@@ -1313,10 +1344,15 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyId/payrolls"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/payment_configs"
         }
       ],
       "variables": [
-        "companyId"
+        "companyId",
+        "companyUuid"
       ]
     },
     "Payroll.OffCycleFlow": {
@@ -1372,10 +1408,15 @@
         {
           "method": "POST",
           "path": "/v1/companies/:companyId/payrolls"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/payment_configs"
         }
       ],
       "variables": [
-        "companyId"
+        "companyId",
+        "companyUuid"
       ]
     },
     "TimeOff.PolicyList": {
@@ -1389,56 +1430,16 @@
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
           "method": "DELETE",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/add"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
-        },
-        {
           "method": "GET",
           "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
         },
         {
           "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
@@ -1451,69 +1452,11 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "GET",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/add"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
-        "companyId",
-        "companyUuid",
-        "timeOffPolicyUuid"
+        "companyUuid"
       ]
     },
     "TimeOff.PolicyConfigurationForm": {
@@ -1536,72 +1479,18 @@
         "timeOffPolicyUuid"
       ]
     },
-    "TimeOff.PolicySettingsPresentation": {
+    "TimeOff.PolicySettings": {
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/add"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "GET",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid"
         },
         {
           "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
-        "companyId",
-        "companyUuid",
         "timeOffPolicyUuid"
       ]
     },
@@ -1613,38 +1502,6 @@
         },
         {
           "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/add"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "GET",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid"
         },
         {
@@ -1657,20 +1514,11 @@
         },
         {
           "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
-        },
-        {
-          "method": "PUT",
           "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
         "companyId",
-        "companyUuid",
         "timeOffPolicyUuid"
       ]
     },
@@ -1678,10 +1526,6 @@
       "endpoints": [
         {
           "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "GET",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
@@ -1691,56 +1535,10 @@
         {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/add"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
-        "companyId",
-        "companyUuid",
-        "timeOffPolicyUuid"
+        "companyUuid"
       ]
     },
     "TimeOff.AddEmployeesHoliday": {
@@ -1754,62 +1552,17 @@
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy/add"
         },
         {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
         "companyId",
-        "companyUuid",
-        "timeOffPolicyUuid"
+        "companyUuid"
       ]
     },
     "TimeOff.ViewHolidayEmployees": {
@@ -1823,62 +1576,13 @@
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/add"
-        },
-        {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
         "companyId",
-        "companyUuid",
-        "timeOffPolicyUuid"
+        "companyUuid"
       ]
     },
     "TimeOff.ViewHolidayPolicyDetails": {
@@ -1892,62 +1596,13 @@
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/add"
-        },
-        {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
         "companyId",
-        "companyUuid",
-        "timeOffPolicyUuid"
+        "companyUuid"
       ]
     },
     "TimeOff.ViewHolidaySchedule": {
@@ -1961,62 +1616,13 @@
           "path": "/v1/companies/:companyUuid/holiday_pay_policy"
         },
         {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/add"
-        },
-        {
           "method": "PUT",
           "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
         }
       ],
       "variables": [
         "companyId",
-        "companyUuid",
-        "timeOffPolicyUuid"
+        "companyUuid"
       ]
     },
     "TimeOff.TimeOffPolicyDetailPresentation": {
@@ -2042,75 +1648,6 @@
         "companyId",
         "timeOffPolicyUuid"
       ]
-    },
-    "TimeOff.TimeOffFlow": {
-      "endpoints": [
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/add"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/holiday_pay_policy/remove"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/add_employees"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/deactivate"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
-        }
-      ],
-      "variables": [
-        "companyId",
-        "companyUuid",
-        "timeOffPolicyUuid"
-      ]
     }
   },
   "flows": {
@@ -2121,126 +1658,10 @@
         "Company.FederalTaxes",
         "Company.Industry",
         "Company.Locations",
-        "Company.OnboardingFlow",
         "Company.OnboardingOverview",
         "Company.PaySchedule",
         "Company.StateTaxes",
         "Employee.OnboardingFlow"
-      ],
-      "endpoints": [
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/bank_accounts"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/bank_accounts"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/bank_accounts/:bankAccountUuid/verify"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/federal_tax_details"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/federal_tax_details"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/forms"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/industry_selection"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/industry_selection"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/locations"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/locations"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/pay_schedules"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/pay_schedules"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/pay_schedules/preview"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/onboarding_status"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/payment_configs"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/signatories"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/tax_requirements"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/forms/:formId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/forms/:formId/pdf"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/forms/:formId/sign"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/locations/:locationId"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/locations/:locationId"
-        }
-      ],
-      "variables": [
-        "bankAccountUuid",
-        "companyId",
-        "companyUuid",
-        "formId",
-        "locationId",
-        "payScheduleId",
-        "state"
       ]
     },
     "Contractor.OnboardingFlow": {
@@ -2250,127 +1671,26 @@
         "Contractor.ContractorProfile",
         "Contractor.ContractorSubmit",
         "Contractor.NewHireReport",
-        "Contractor.OnboardingFlow",
         "Contractor.PaymentMethod"
-      ],
-      "endpoints": [
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/contractors"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/contractors"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/contractors/:contractorUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/contractors/:contractorUuid"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/contractors/:contractorUuid"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/contractors/:contractorUuid/address"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/contractors/:contractorUuid/address"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/contractors/:contractorUuid/bank_accounts"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/contractors/:contractorUuid/bank_accounts"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/contractors/:contractorUuid/onboarding_status"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/contractors/:contractorUuid/onboarding_status"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/contractors/:contractorUuid/payment_method"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/contractors/:contractorUuid/payment_method"
-        }
-      ],
-      "variables": [
-        "companyUuid",
-        "contractorUuid"
       ]
     },
-    "Contractor.Payments.PaymentFlow": {
+    "Contractor.PaymentFlow": {
       "blocks": [
         "Contractor.CreatePayment",
-        "Contractor.PaymentFlow",
         "Contractor.PaymentHistory",
         "Contractor.PaymentStatement",
         "Contractor.PaymentSummary",
         "Contractor.PaymentsList",
         "InformationRequests.InformationRequestsFlow"
-      ],
-      "endpoints": [
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/bank_accounts"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/contractor_payment_groups"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/contractor_payment_groups"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/contractor_payment_groups/preview"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/companies/:companyId/contractor_payments/:contractorPaymentId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/contractors"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/information_requests"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/contractor_payment_groups/:contractorPaymentGroupUuid"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/contractor_payments/:contractorPaymentUuid/receipt"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/information_requests/:informationRequestUuid/submit"
-        }
-      ],
-      "variables": [
-        "companyId",
-        "companyUuid",
-        "contractorPaymentGroupUuid",
-        "contractorPaymentId",
-        "contractorPaymentUuid",
-        "informationRequestUuid"
+      ]
+    },
+    "Employee.DashboardFlow": {
+      "blocks": [
+        "Employee.FederalTaxes",
+        "Employee.HomeAddress",
+        "Employee.PaymentMethod",
+        "Employee.StateTaxes",
+        "Employee.WorkAddress"
       ]
     },
     "Employee.OnboardingFlow": {
@@ -2380,177 +1700,10 @@
         "Employee.EmployeeDocuments",
         "Employee.EmployeeList",
         "Employee.FederalTaxes",
-        "Employee.OnboardingFlow",
         "Employee.OnboardingSummary",
         "Employee.PaymentMethod",
         "Employee.Profile",
         "Employee.StateTaxes"
-      ],
-      "endpoints": [
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/federal_tax_details"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/locations"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/compensations/:compensationId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/bank_accounts"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/bank_accounts"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/employees/:employeeId/bank_accounts/:bankAccountUuid"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/garnishments"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/garnishments"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/home_addresses"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/home_addresses"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/jobs"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/jobs"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/onboarding_documents_config"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/onboarding_status"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/onboarding_status"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/payment_method"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/payment_method"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/work_addresses"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/work_addresses"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeUuid/federal_taxes"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeUuid/federal_taxes"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeUuid/state_taxes"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeUuid/state_taxes"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/garnishments/:garnishmentId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/garnishments/child_support"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/home_addresses/:homeAddressUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/home_addresses/:homeAddressUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/jobs/:jobId"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/jobs/:jobId"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/jobs/:jobId/compensations"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/locations/:locationUuid/minimum_wages"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/work_addresses/:workAddressUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/work_addresses/:workAddressUuid"
-        }
-      ],
-      "variables": [
-        "bankAccountUuid",
-        "companyId",
-        "compensationId",
-        "employeeId",
-        "employeeUuid",
-        "garnishmentId",
-        "homeAddressUuid",
-        "jobId",
-        "locationUuid",
-        "workAddressUuid"
       ]
     },
     "Employee.SelfOnboardingFlow": {
@@ -2561,223 +1714,37 @@
         "Employee.OnboardingSummary",
         "Employee.PaymentMethod",
         "Employee.Profile",
-        "Employee.SelfOnboardingFlow",
         "Employee.StateTaxes"
-      ],
-      "endpoints": [
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/locations"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/bank_accounts"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/bank_accounts"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/employees/:employeeId/bank_accounts/:bankAccountUuid"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/forms"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/forms/:formId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/forms/:formId/pdf"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/forms/:formId/sign"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/home_addresses"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/home_addresses"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/i9_authorization"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/i9_authorization"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/onboarding_status"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/onboarding_status"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/payment_method"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeId/payment_method"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/work_addresses"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/work_addresses"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeUuid/federal_taxes"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeUuid/federal_taxes"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeUuid/state_taxes"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/employees/:employeeUuid/state_taxes"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/home_addresses/:homeAddressUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/home_addresses/:homeAddressUuid"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/work_addresses/:workAddressUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/work_addresses/:workAddressUuid"
-        }
-      ],
-      "variables": [
-        "bankAccountUuid",
-        "companyId",
-        "employeeId",
-        "employeeUuid",
-        "formId",
-        "homeAddressUuid",
-        "workAddressUuid"
       ]
     },
-    "Employee.Terminations.TerminationFlow": {
+    "Employee.TerminationFlow": {
       "blocks": [
         "Employee.TerminateEmployee",
-        "Employee.TerminationFlow",
         "Employee.TerminationSummary",
         "Payroll.DismissalFlow",
         "Payroll.PayrollLanding"
-      ],
-      "endpoints": [
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyId/payrolls"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/payrolls/blockers"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/wire_in_requests"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/terminations"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/employees/:employeeId/terminations"
-        },
-        {
-          "method": "DELETE",
-          "path": "/v1/employees/:employeeId/terminations"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/terminations/:employeeId"
-        }
-      ],
-      "variables": [
-        "companyId",
-        "companyUuid",
-        "employeeId",
-        "payrollId"
+      ]
+    },
+    "InformationRequests.InformationRequestsFlow": {
+      "blocks": [
+        "InformationRequests.InformationRequestForm",
+        "InformationRequests.InformationRequestList"
+      ]
+    },
+    "Payroll.DismissalFlow": {
+      "blocks": [
+        "Payroll.PayrollExecutionFlow"
+      ]
+    },
+    "Payroll.OffCycleFlow": {
+      "blocks": [
+        "Payroll.OffCycleCreation",
+        "Payroll.PayrollExecutionFlow"
       ]
     },
     "Payroll.PayrollExecutionFlow": {
       "blocks": [
         "Payroll.PayrollFlow"
-      ],
-      "endpoints": [
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
-        }
-      ],
-      "variables": [
-        "companyId",
-        "payrollId"
       ]
     },
     "Payroll.PayrollFlow": {
@@ -2786,139 +1753,31 @@
         "Payroll.PayrollBlockerList",
         "Payroll.PayrollConfiguration",
         "Payroll.PayrollEditEmployee",
-        "Payroll.PayrollFlow",
+        "Payroll.PayrollExecutionFlow",
         "Payroll.PayrollLanding",
         "Payroll.PayrollOverview",
         "Payroll.PayrollReceipts",
         "Payroll.TransitionFlow"
-      ],
-      "endpoints": [
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/bank_accounts"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId/calculate"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId/cancel"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId/prepare"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/companies/:companyId/payrolls/:payrollId/submit"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/information_requests"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/payrolls/blockers"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/recovery_cases"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyUuid/wire_in_requests"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/employees/:employeeId/bank_accounts"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/payrolls/:payrollId/employees/:employeeId/pay_stub"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/payrolls/:payrollUuid/gross_up"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/payrolls/:payrollUuid/receipt"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/wire_in_requests/:wireInRequestUuid"
-        }
-      ],
-      "variables": [
-        "companyId",
-        "companyUuid",
-        "employeeId",
-        "payScheduleId",
-        "payrollId",
-        "payrollUuid",
-        "wireInRequestUuid"
+      ]
+    },
+    "Payroll.TransitionFlow": {
+      "blocks": [
+        "Payroll.PayrollExecutionFlow",
+        "Payroll.TransitionCreation"
       ]
     },
     "TimeOff.TimeOffFlow": {
       "blocks": [
+        "TimeOff.AddEmployeesHoliday",
+        "TimeOff.AddEmployeesToPolicy",
+        "TimeOff.HolidaySelectionForm",
         "TimeOff.PolicyConfigurationForm",
-        "TimeOff.TimeOffPolicyDetailPresentation"
-      ],
-      "endpoints": [
-        {
-          "method": "GET",
-          "path": "/v1/companies/:companyId/employees"
-        },
-        {
-          "method": "POST",
-          "path": "/v1/companies/:companyUuid/time_off_policies"
-        },
-        {
-          "method": "GET",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
-        },
-        {
-          "method": "PUT",
-          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
-        }
-      ],
-      "variables": [
-        "companyId",
-        "companyUuid",
-        "timeOffPolicyUuid"
+        "TimeOff.PolicyList",
+        "TimeOff.PolicySettings",
+        "TimeOff.PolicyTypeSelector",
+        "TimeOff.TimeOffPolicyDetailPresentation",
+        "TimeOff.ViewHolidayEmployees",
+        "TimeOff.ViewHolidaySchedule"
       ]
     }
   }

--- a/docs/reference/endpoint-reference.md
+++ b/docs/reference/endpoint-reference.md
@@ -92,6 +92,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | POST | `/v1/companies/:companyId/contractor_payment_groups` |
 |  | POST | `/v1/companies/:companyId/contractor_payment_groups/preview` |
 |  | GET | `/v1/companies/:companyUuid/contractors` |
+|  | GET | `/v1/companies/:companyUuid/payment_configs` |
 | **Contractor.PaymentHistory** | DELETE | `/v1/companies/:companyId/contractor_payments/:contractorPaymentId` |
 |  | GET | `/v1/companies/:companyUuid/contractors` |
 |  | GET | `/v1/contractor_payment_groups/:contractorPaymentGroupUuid` |
@@ -214,13 +215,18 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/companies/:companyUuid/payrolls/blockers` |
 |  | GET | `/v1/employees/:employeeId` |
 |  | POST | `/v1/payrolls/:payrollUuid/gross_up` |
-| **Payroll.PayrollEditEmployee** | PUT | `/v1/companies/:companyId/payrolls/:payrollId` |
+| **Payroll.PayrollEditEmployee** | GET | `/v1/companies/:companyId/pay_schedules/:payScheduleId` |
+|  | PUT | `/v1/companies/:companyId/payrolls/:payrollId` |
+|  | PUT | `/v1/companies/:companyId/payrolls/:payrollId/prepare` |
 |  | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/bank_accounts` |
 | **Payroll.PayrollHistory** | GET | `/v1/companies/:companyId/payrolls` |
 |  | PUT | `/v1/companies/:companyId/payrolls/:payrollId/cancel` |
 |  | GET | `/v1/companies/:companyUuid/wire_in_requests` |
-| **Payroll.PayrollLanding** | GET | `/v1/companies/:companyUuid/payrolls/blockers` |
+| **Payroll.PayrollLanding** | GET | `/v1/companies/:companyId/pay_periods` |
+|  | GET | `/v1/companies/:companyId/pay_schedules` |
+|  | GET | `/v1/companies/:companyUuid/payrolls/blockers` |
+|  | POST | `/v1/companies/:companyUuid/payrolls/skip` |
 |  | GET | `/v1/companies/:companyUuid/wire_in_requests` |
 | **Payroll.PayrollList** | GET | `/v1/companies/:companyId/pay_schedules` |
 |  | GET | `/v1/companies/:companyId/payrolls` |
@@ -233,6 +239,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
 |  | PUT | `/v1/companies/:companyId/payrolls/:payrollId/cancel` |
 |  | PUT | `/v1/companies/:companyId/payrolls/:payrollId/submit` |
+|  | GET | `/v1/companies/:companyUuid/payment_configs` |
 |  | GET | `/v1/payrolls/:payrollId/employees/:employeeId/pay_stub` |
 |  | GET | `/v1/wire_in_requests/:wireInRequestUuid` |
 | **Payroll.PayrollFlow** | GET | `/v1/companies/:companyId/payrolls` |
@@ -249,6 +256,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/recovery_cases/:recoveryCaseUuid/redebit` |
 | **Payroll.OffCycleCreation** | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyId/payrolls` |
+|  | GET | `/v1/companies/:companyUuid/payment_configs` |
 | **Payroll.OffCycleFlow** | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
 | **Payroll.DismissalFlow** | GET | `/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods` |
 |  | POST | `/v1/companies/:companyId/payrolls` |
@@ -256,6 +264,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 | **Payroll.TransitionFlow** | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
 | **Payroll.TransitionCreation** | GET | `/v1/companies/:companyId/pay_schedules` |
 |  | POST | `/v1/companies/:companyId/payrolls` |
+|  | GET | `/v1/companies/:companyUuid/payment_configs` |
 
 ## TimeOff components
 
@@ -263,160 +272,39 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 | --- | --- | --- |
 | **TimeOff.PolicyList** | GET | `/v1/companies/:companyId/employees` |
 |  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
 |  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
-| **TimeOff.PolicyTypeSelector** | GET | `/v1/companies/:companyId/employees` |
-|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
+| **TimeOff.PolicyTypeSelector** | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 | **TimeOff.PolicyConfigurationForm** | POST | `/v1/companies/:companyUuid/time_off_policies` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-| **TimeOff.PolicySettingsPresentation** | GET | `/v1/companies/:companyId/employees` |
-|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
+| **TimeOff.PolicySettings** | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 | **TimeOff.AddEmployeesToPolicy** | GET | `/v1/companies/:companyId/employees` |
-|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
-| **TimeOff.HolidaySelectionForm** | GET | `/v1/companies/:companyId/employees` |
-|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
+| **TimeOff.HolidaySelectionForm** | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 | **TimeOff.AddEmployeesHoliday** | GET | `/v1/companies/:companyId/employees` |
 |  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 | **TimeOff.ViewHolidayEmployees** | GET | `/v1/companies/:companyId/employees` |
 |  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 | **TimeOff.ViewHolidayPolicyDetails** | GET | `/v1/companies/:companyId/employees` |
 |  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 | **TimeOff.ViewHolidaySchedule** | GET | `/v1/companies/:companyId/employees` |
 |  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 | **TimeOff.TimeOffPolicyDetailPresentation** | GET | `/v1/companies/:companyId/employees` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
-| **TimeOff.TimeOffFlow** | GET | `/v1/companies/:companyId/employees` |
-|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 
 ## Flows
@@ -425,12 +313,17 @@ Flows compose multiple blocks into a single workflow. The endpoint list for a fl
 
 | Flow | Blocks included |
 | --- | --- |
-| **Company.OnboardingFlow** | Company.BankAccount, Company.DocumentSigner, Company.FederalTaxes, Company.Industry, Company.Locations, Company.OnboardingFlow, Company.OnboardingOverview, Company.PaySchedule, Company.StateTaxes, Employee.OnboardingFlow |
-| **Contractor.OnboardingFlow** | Contractor.Address, Contractor.ContractorList, Contractor.ContractorProfile, Contractor.ContractorSubmit, Contractor.NewHireReport, Contractor.OnboardingFlow, Contractor.PaymentMethod |
-| **Contractor.Payments.PaymentFlow** | Contractor.CreatePayment, Contractor.PaymentFlow, Contractor.PaymentHistory, Contractor.PaymentStatement, Contractor.PaymentSummary, Contractor.PaymentsList, InformationRequests.InformationRequestsFlow |
-| **Employee.OnboardingFlow** | Employee.Compensation, Employee.Deductions, Employee.EmployeeDocuments, Employee.EmployeeList, Employee.FederalTaxes, Employee.OnboardingFlow, Employee.OnboardingSummary, Employee.PaymentMethod, Employee.Profile, Employee.StateTaxes |
-| **Employee.SelfOnboardingFlow** | Employee.DocumentSigner, Employee.FederalTaxes, Employee.Landing, Employee.OnboardingSummary, Employee.PaymentMethod, Employee.Profile, Employee.SelfOnboardingFlow, Employee.StateTaxes |
-| **Employee.Terminations.TerminationFlow** | Employee.TerminateEmployee, Employee.TerminationFlow, Employee.TerminationSummary, Payroll.DismissalFlow, Payroll.PayrollLanding |
+| **Company.OnboardingFlow** | Company.BankAccount, Company.DocumentSigner, Company.FederalTaxes, Company.Industry, Company.Locations, Company.OnboardingOverview, Company.PaySchedule, Company.StateTaxes, Employee.OnboardingFlow |
+| **Contractor.OnboardingFlow** | Contractor.Address, Contractor.ContractorList, Contractor.ContractorProfile, Contractor.ContractorSubmit, Contractor.NewHireReport, Contractor.PaymentMethod |
+| **Contractor.PaymentFlow** | Contractor.CreatePayment, Contractor.PaymentHistory, Contractor.PaymentStatement, Contractor.PaymentSummary, Contractor.PaymentsList, InformationRequests.InformationRequestsFlow |
+| **Employee.DashboardFlow** | Employee.FederalTaxes, Employee.HomeAddress, Employee.PaymentMethod, Employee.StateTaxes, Employee.WorkAddress |
+| **Employee.OnboardingFlow** | Employee.Compensation, Employee.Deductions, Employee.EmployeeDocuments, Employee.EmployeeList, Employee.FederalTaxes, Employee.OnboardingSummary, Employee.PaymentMethod, Employee.Profile, Employee.StateTaxes |
+| **Employee.SelfOnboardingFlow** | Employee.DocumentSigner, Employee.FederalTaxes, Employee.Landing, Employee.OnboardingSummary, Employee.PaymentMethod, Employee.Profile, Employee.StateTaxes |
+| **Employee.TerminationFlow** | Employee.TerminateEmployee, Employee.TerminationSummary, Payroll.DismissalFlow, Payroll.PayrollLanding |
+| **InformationRequests.InformationRequestsFlow** | InformationRequests.InformationRequestForm, InformationRequests.InformationRequestList |
+| **Payroll.DismissalFlow** | Payroll.PayrollExecutionFlow |
+| **Payroll.OffCycleFlow** | Payroll.OffCycleCreation, Payroll.PayrollExecutionFlow |
 | **Payroll.PayrollExecutionFlow** | Payroll.PayrollFlow |
-| **Payroll.PayrollFlow** | Payroll.OffCycleFlow, Payroll.PayrollBlockerList, Payroll.PayrollConfiguration, Payroll.PayrollEditEmployee, Payroll.PayrollFlow, Payroll.PayrollLanding, Payroll.PayrollOverview, Payroll.PayrollReceipts, Payroll.TransitionFlow |
-| **TimeOff.TimeOffFlow** | TimeOff.PolicyConfigurationForm, TimeOff.TimeOffPolicyDetailPresentation |
+| **Payroll.PayrollFlow** | Payroll.OffCycleFlow, Payroll.PayrollBlockerList, Payroll.PayrollConfiguration, Payroll.PayrollEditEmployee, Payroll.PayrollExecutionFlow, Payroll.PayrollLanding, Payroll.PayrollOverview, Payroll.PayrollReceipts, Payroll.TransitionFlow |
+| **Payroll.TransitionFlow** | Payroll.PayrollExecutionFlow, Payroll.TransitionCreation |
+| **TimeOff.TimeOffFlow** | TimeOff.AddEmployeesHoliday, TimeOff.AddEmployeesToPolicy, TimeOff.HolidaySelectionForm, TimeOff.PolicyConfigurationForm, TimeOff.PolicyList, TimeOff.PolicySettings, TimeOff.PolicyTypeSelector, TimeOff.TimeOffPolicyDetailPresentation, TimeOff.ViewHolidayEmployees, TimeOff.ViewHolidaySchedule |

--- a/docs/reference/endpoint-reference.md
+++ b/docs/reference/endpoint-reference.md
@@ -30,8 +30,8 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/companies/:companyUuid/signatories/:signatoryUuid` |
 |  | DELETE | `/v1/companies/:companyUuid/signatories/:signatoryUuid` |
 | **Company.InviteSignatory** | GET | `/v1/companies/:companyUuid/signatories` |
-|  | POST | `/v1/companies/:companyUuid/signatories/invite` |
 |  | DELETE | `/v1/companies/:companyUuid/signatories/:signatoryUuid` |
+|  | POST | `/v1/companies/:companyUuid/signatories/invite` |
 | **Company.DocumentList** | GET | `/v1/companies/:companyId/forms` |
 |  | GET | `/v1/companies/:companyUuid/signatories` |
 | **Company.DocumentSigner** | GET | `/v1/companies/:companyId/forms` |
@@ -40,66 +40,66 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/forms/:formId/pdf` |
 |  | PUT | `/v1/forms/:formId/sign` |
 | **Company.OnboardingOverview** | GET | `/v1/companies/:companyUuid/onboarding_status` |
-| **Company.Locations** | PUT | `/v1/locations/:locationId` |
-|  | GET | `/v1/locations/:locationId` |
+| **Company.Locations** | GET | `/v1/companies/:companyId/locations` |
 |  | POST | `/v1/companies/:companyId/locations` |
-|  | GET | `/v1/companies/:companyId/locations` |
-| **Company.LocationForm** | PUT | `/v1/locations/:locationId` |
 |  | GET | `/v1/locations/:locationId` |
-|  | POST | `/v1/companies/:companyId/locations` |
+|  | PUT | `/v1/locations/:locationId` |
+| **Company.LocationForm** | POST | `/v1/companies/:companyId/locations` |
+|  | GET | `/v1/locations/:locationId` |
+|  | PUT | `/v1/locations/:locationId` |
 | **Company.PaySchedule** | GET | `/v1/companies/:companyId/pay_schedules` |
-|  | GET | `/v1/companies/:companyId/pay_schedules/:payScheduleId` |
-|  | GET | `/v1/companies/:companyId/pay_schedules/preview` |
 |  | POST | `/v1/companies/:companyId/pay_schedules` |
+|  | GET | `/v1/companies/:companyId/pay_schedules/:payScheduleId` |
 |  | PUT | `/v1/companies/:companyId/pay_schedules/:payScheduleId` |
+|  | GET | `/v1/companies/:companyId/pay_schedules/preview` |
 |  | GET | `/v1/companies/:companyUuid/payment_configs` |
-| **Company.FederalTaxes** | PUT | `/v1/companies/:companyId/federal_tax_details` |
-|  | GET | `/v1/companies/:companyId/federal_tax_details` |
+| **Company.FederalTaxes** | GET | `/v1/companies/:companyId/federal_tax_details` |
+|  | PUT | `/v1/companies/:companyId/federal_tax_details` |
 | **Company.BankAccount** | GET | `/v1/companies/:companyId/bank_accounts` |
 |  | POST | `/v1/companies/:companyId/bank_accounts` |
 |  | PUT | `/v1/companies/:companyId/bank_accounts/:bankAccountUuid/verify` |
 | **Company.StateTaxesList** | GET | `/v1/companies/:companyUuid/tax_requirements` |
-| **Company.StateTaxesForm** | PUT | `/v1/companies/:companyUuid/tax_requirements/:state` |
+| **Company.StateTaxesForm** | GET | `/v1/companies/:companyUuid/tax_requirements/:state` |
+|  | PUT | `/v1/companies/:companyUuid/tax_requirements/:state` |
+| **Company.StateTaxes** | GET | `/v1/companies/:companyUuid/tax_requirements` |
 |  | GET | `/v1/companies/:companyUuid/tax_requirements/:state` |
-| **Company.StateTaxes** | PUT | `/v1/companies/:companyUuid/tax_requirements/:state` |
-|  | GET | `/v1/companies/:companyUuid/tax_requirements/:state` |
-|  | GET | `/v1/companies/:companyUuid/tax_requirements` |
+|  | PUT | `/v1/companies/:companyUuid/tax_requirements/:state` |
 
 ## Contractor components
 
 | Component | Method | Path |
 | --- | --- | --- |
-| **Contractor.PaymentMethod** | GET | `/v1/contractors/:contractorUuid/payment_method` |
-|  | GET | `/v1/contractors/:contractorUuid/bank_accounts` |
+| **Contractor.PaymentMethod** | GET | `/v1/contractors/:contractorUuid/bank_accounts` |
 |  | POST | `/v1/contractors/:contractorUuid/bank_accounts` |
+|  | GET | `/v1/contractors/:contractorUuid/payment_method` |
 |  | PUT | `/v1/contractors/:contractorUuid/payment_method` |
 | **Contractor.Address** | GET | `/v1/contractors/:contractorUuid` |
 |  | GET | `/v1/contractors/:contractorUuid/address` |
 |  | PUT | `/v1/contractors/:contractorUuid/address` |
-| **Contractor.ContractorList** | DELETE | `/v1/contractors/:contractorUuid` |
-|  | GET | `/v1/companies/:companyUuid/contractors` |
+| **Contractor.ContractorList** | GET | `/v1/companies/:companyUuid/contractors` |
+|  | DELETE | `/v1/contractors/:contractorUuid` |
 | **Contractor.NewHireReport** | GET | `/v1/contractors/:contractorUuid` |
 |  | PUT | `/v1/contractors/:contractorUuid` |
-| **Contractor.ContractorSubmit** | PUT | `/v1/contractors/:contractorUuid/onboarding_status` |
+| **Contractor.ContractorSubmit** | GET | `/v1/contractors/:contractorUuid` |
 |  | GET | `/v1/contractors/:contractorUuid/onboarding_status` |
+|  | PUT | `/v1/contractors/:contractorUuid/onboarding_status` |
+| **Contractor.ContractorProfile** | POST | `/v1/companies/:companyUuid/contractors` |
 |  | GET | `/v1/contractors/:contractorUuid` |
-| **Contractor.ContractorProfile** | GET | `/v1/contractors/:contractorUuid` |
-|  | POST | `/v1/companies/:companyUuid/contractors` |
 |  | PUT | `/v1/contractors/:contractorUuid` |
 | **Contractor.PaymentsList** | GET | `/v1/companies/:companyId/contractor_payment_groups` |
 |  | GET | `/v1/companies/:companyUuid/information_requests` |
-| **Contractor.CreatePayment** | GET | `/v1/companies/:companyUuid/contractors` |
+| **Contractor.CreatePayment** | GET | `/v1/companies/:companyId/bank_accounts` |
 |  | POST | `/v1/companies/:companyId/contractor_payment_groups` |
 |  | POST | `/v1/companies/:companyId/contractor_payment_groups/preview` |
-|  | GET | `/v1/companies/:companyId/bank_accounts` |
-| **Contractor.PaymentHistory** | GET | `/v1/contractor_payment_groups/:contractorPaymentGroupUuid` |
 |  | GET | `/v1/companies/:companyUuid/contractors` |
-|  | DELETE | `/v1/companies/:companyId/contractor_payments/:contractorPaymentId` |
-| **Contractor.PaymentSummary** | GET | `/v1/contractor_payment_groups/:contractorPaymentGroupUuid` |
+| **Contractor.PaymentHistory** | DELETE | `/v1/companies/:companyId/contractor_payments/:contractorPaymentId` |
 |  | GET | `/v1/companies/:companyUuid/contractors` |
-|  | GET | `/v1/companies/:companyId/bank_accounts` |
-| **Contractor.PaymentStatement** | GET | `/v1/contractor_payment_groups/:contractorPaymentGroupUuid` |
+|  | GET | `/v1/contractor_payment_groups/:contractorPaymentGroupUuid` |
+| **Contractor.PaymentSummary** | GET | `/v1/companies/:companyId/bank_accounts` |
 |  | GET | `/v1/companies/:companyUuid/contractors` |
+|  | GET | `/v1/contractor_payment_groups/:contractorPaymentGroupUuid` |
+| **Contractor.PaymentStatement** | GET | `/v1/companies/:companyUuid/contractors` |
+|  | GET | `/v1/contractor_payment_groups/:contractorPaymentGroupUuid` |
 |  | GET | `/v1/contractor_payments/:contractorPaymentUuid/receipt` |
 
 ## Employee components
@@ -115,77 +115,77 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/garnishments/child_support` |
 | **Employee.OnboardingSummary** | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/onboarding_status` |
-| **Employee.Profile** | GET | `/v1/employees/:employeeId/work_addresses` |
-|  | GET | `/v1/employees/:employeeId` |
-|  | POST | `/v1/companies/:companyId/employees` |
-|  | PUT | `/v1/employees/:employeeId` |
-|  | PUT | `/v1/employees/:employeeId/onboarding_status` |
-|  | GET | `/v1/employees/:employeeId/home_addresses` |
-|  | GET | `/v1/home_addresses/:homeAddressUuid` |
-|  | POST | `/v1/employees/:employeeId/home_addresses` |
-|  | PUT | `/v1/home_addresses/:homeAddressUuid` |
+| **Employee.Profile** | POST | `/v1/companies/:companyId/employees` |
 |  | GET | `/v1/companies/:companyId/locations` |
-|  | GET | `/v1/work_addresses/:workAddressUuid` |
+|  | GET | `/v1/employees/:employeeId` |
+|  | PUT | `/v1/employees/:employeeId` |
+|  | GET | `/v1/employees/:employeeId/home_addresses` |
+|  | POST | `/v1/employees/:employeeId/home_addresses` |
+|  | PUT | `/v1/employees/:employeeId/onboarding_status` |
+|  | GET | `/v1/employees/:employeeId/work_addresses` |
 |  | POST | `/v1/employees/:employeeId/work_addresses` |
+|  | GET | `/v1/home_addresses/:homeAddressUuid` |
+|  | PUT | `/v1/home_addresses/:homeAddressUuid` |
+|  | GET | `/v1/work_addresses/:workAddressUuid` |
 |  | PUT | `/v1/work_addresses/:workAddressUuid` |
-| **Employee.Compensation** | GET | `/v1/employees/:employeeId/jobs` |
+| **Employee.Compensation** | GET | `/v1/companies/:companyId/federal_tax_details` |
+|  | PUT | `/v1/compensations/:compensationId` |
+|  | GET | `/v1/employees/:employeeId` |
+|  | GET | `/v1/employees/:employeeId/jobs` |
+|  | POST | `/v1/employees/:employeeId/jobs` |
+|  | GET | `/v1/employees/:employeeId/work_addresses` |
+|  | PUT | `/v1/jobs/:jobId` |
 |  | DELETE | `/v1/jobs/:jobId` |
 |  | POST | `/v1/jobs/:jobId/compensations` |
-|  | PUT | `/v1/compensations/:compensationId` |
 |  | GET | `/v1/locations/:locationUuid/minimum_wages` |
-|  | GET | `/v1/employees/:employeeId/work_addresses` |
-|  | GET | `/v1/employees/:employeeId` |
-|  | POST | `/v1/employees/:employeeId/jobs` |
-|  | PUT | `/v1/jobs/:jobId` |
-|  | GET | `/v1/companies/:companyId/federal_tax_details` |
 | **Employee.FederalTaxes** | GET | `/v1/employees/:employeeUuid/federal_taxes` |
 |  | PUT | `/v1/employees/:employeeUuid/federal_taxes` |
 | **Employee.StateTaxes** | GET | `/v1/employees/:employeeUuid/state_taxes` |
 |  | PUT | `/v1/employees/:employeeUuid/state_taxes` |
-| **Employee.PaymentMethod** | POST | `/v1/employees/:employeeId/bank_accounts` |
+| **Employee.PaymentMethod** | GET | `/v1/employees/:employeeId/bank_accounts` |
+|  | POST | `/v1/employees/:employeeId/bank_accounts` |
+|  | DELETE | `/v1/employees/:employeeId/bank_accounts/:bankAccountUuid` |
 |  | GET | `/v1/employees/:employeeId/payment_method` |
 |  | PUT | `/v1/employees/:employeeId/payment_method` |
-|  | DELETE | `/v1/employees/:employeeId/bank_accounts/:bankAccountUuid` |
-|  | GET | `/v1/employees/:employeeId/bank_accounts` |
-| **Employee.Landing** | GET | `/v1/employees/:employeeId` |
-|  | GET | `/v1/companies/:companyId` |
-| **Employee.DocumentSigner** | GET | `/v1/employees/:employeeId/forms` |
+| **Employee.Landing** | GET | `/v1/companies/:companyId` |
 |  | GET | `/v1/employees/:employeeId` |
-|  | GET | `/v1/employees/:employeeId/i9_authorization` |
-|  | PUT | `/v1/employees/:employeeId/i9_authorization` |
+| **Employee.DocumentSigner** | GET | `/v1/employees/:employeeId` |
+|  | GET | `/v1/employees/:employeeId/forms` |
 |  | GET | `/v1/employees/:employeeId/forms/:formId` |
 |  | GET | `/v1/employees/:employeeId/forms/:formId/pdf` |
 |  | PUT | `/v1/employees/:employeeId/forms/:formId/sign` |
+|  | GET | `/v1/employees/:employeeId/i9_authorization` |
+|  | PUT | `/v1/employees/:employeeId/i9_authorization` |
 | **Employee.EmployeeDocuments** | GET | `/v1/employees/:employeeId` |
 |  | PUT | `/v1/employees/:employeeId/onboarding_documents_config` |
-| **Employee.DashboardFlow** | GET | `/v1/payrolls/:payrollId/employees/:employeeId/pay_stub` |
-|  | GET | `/v1/employees/:employeeId` |
-|  | GET | `/v1/employees/:employeeId/home_addresses` |
-|  | GET | `/v1/employees/:employeeId/work_addresses` |
-|  | GET | `/v1/employees/:employeeId/garnishments` |
-|  | GET | `/v1/employees/:employeeId/pay_stubs` |
+| **Employee.DashboardFlow** | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/forms` |
+|  | GET | `/v1/employees/:employeeId/garnishments` |
+|  | GET | `/v1/employees/:employeeId/home_addresses` |
+|  | GET | `/v1/employees/:employeeId/pay_stubs` |
+|  | GET | `/v1/employees/:employeeId/work_addresses` |
 |  | GET | `/v1/employees/:employeeUuid/federal_taxes` |
 |  | GET | `/v1/employees/:employeeUuid/state_taxes` |
-| **Employee.HomeAddress** | DELETE | `/v1/home_addresses/:homeAddressUuid` |
+|  | GET | `/v1/payrolls/:payrollId/employees/:employeeId/pay_stub` |
+| **Employee.HomeAddress** | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/home_addresses` |
-|  | GET | `/v1/employees/:employeeId` |
+|  | DELETE | `/v1/home_addresses/:homeAddressUuid` |
 | **Employee.EmploymentEligibility** | GET | `/v1/employees/:employeeId/i9_authorization` |
 |  | PUT | `/v1/employees/:employeeId/i9_authorization` |
-| **Employee.TerminateEmployee** | GET | `/v1/employees/:employeeId` |
+| **Employee.TerminateEmployee** | GET | `/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods` |
+|  | GET | `/v1/companies/:companyId/payrolls` |
+|  | POST | `/v1/companies/:companyId/payrolls` |
+|  | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/terminations` |
 |  | POST | `/v1/employees/:employeeId/terminations` |
 |  | PUT | `/v1/terminations/:employeeId` |
-|  | POST | `/v1/companies/:companyId/payrolls` |
-|  | GET | `/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods` |
-|  | GET | `/v1/companies/:companyId/payrolls` |
-| **Employee.TerminationSummary** | GET | `/v1/employees/:employeeId` |
+| **Employee.TerminationSummary** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/terminations` |
 |  | DELETE | `/v1/employees/:employeeId/terminations` |
-|  | GET | `/v1/companies/:companyId/employees` |
-| **Employee.WorkAddress** | DELETE | `/v1/work_addresses/:workAddressUuid` |
+| **Employee.WorkAddress** | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/work_addresses` |
-|  | GET | `/v1/employees/:employeeId` |
+|  | DELETE | `/v1/work_addresses/:workAddressUuid` |
 | **Employee.Taxes** | GET | `/v1/employees/:employeeUuid/federal_taxes` |
 |  | PUT | `/v1/employees/:employeeUuid/federal_taxes` |
 |  | GET | `/v1/employees/:employeeUuid/state_taxes` |
@@ -205,219 +205,219 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 
 | Component | Method | Path |
 | --- | --- | --- |
-| **Payroll.PayrollConfiguration** | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
-|  | PUT | `/v1/companies/:companyId/payrolls/:payrollId` |
-|  | POST | `/v1/payrolls/:payrollUuid/gross_up` |
-|  | GET | `/v1/companies/:companyUuid/payrolls/blockers` |
-|  | PUT | `/v1/companies/:companyId/payrolls/:payrollId/calculate` |
-|  | GET | `/v1/companies/:companyId/employees` |
+| **Payroll.PayrollConfiguration** | GET | `/v1/companies/:companyId/employees` |
 |  | GET | `/v1/companies/:companyId/pay_schedules/:payScheduleId` |
-|  | PUT | `/v1/companies/:companyId/payrolls/:payrollId/prepare` |
-|  | GET | `/v1/employees/:employeeId` |
-| **Payroll.PayrollEditEmployee** | GET | `/v1/employees/:employeeId` |
-|  | GET | `/v1/employees/:employeeId/bank_accounts` |
+|  | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
 |  | PUT | `/v1/companies/:companyId/payrolls/:payrollId` |
+|  | PUT | `/v1/companies/:companyId/payrolls/:payrollId/calculate` |
+|  | PUT | `/v1/companies/:companyId/payrolls/:payrollId/prepare` |
+|  | GET | `/v1/companies/:companyUuid/payrolls/blockers` |
+|  | GET | `/v1/employees/:employeeId` |
+|  | POST | `/v1/payrolls/:payrollUuid/gross_up` |
+| **Payroll.PayrollEditEmployee** | PUT | `/v1/companies/:companyId/payrolls/:payrollId` |
+|  | GET | `/v1/employees/:employeeId` |
+|  | GET | `/v1/employees/:employeeId/bank_accounts` |
 | **Payroll.PayrollHistory** | GET | `/v1/companies/:companyId/payrolls` |
 |  | PUT | `/v1/companies/:companyId/payrolls/:payrollId/cancel` |
 |  | GET | `/v1/companies/:companyUuid/wire_in_requests` |
-| **Payroll.PayrollLanding** | GET | `/v1/companies/:companyUuid/wire_in_requests` |
-|  | GET | `/v1/companies/:companyUuid/payrolls/blockers` |
-| **Payroll.PayrollList** | GET | `/v1/companies/:companyId/payrolls` |
-|  | GET | `/v1/companies/:companyId/pay_schedules` |
-|  | POST | `/v1/companies/:companyUuid/payrolls/skip` |
+| **Payroll.PayrollLanding** | GET | `/v1/companies/:companyUuid/payrolls/blockers` |
+|  | GET | `/v1/companies/:companyUuid/wire_in_requests` |
+| **Payroll.PayrollList** | GET | `/v1/companies/:companyId/pay_schedules` |
+|  | GET | `/v1/companies/:companyId/payrolls` |
 |  | DELETE | `/v1/companies/:companyId/payrolls/:payrollId` |
 |  | GET | `/v1/companies/:companyUuid/payrolls/blockers` |
+|  | POST | `/v1/companies/:companyUuid/payrolls/skip` |
 |  | GET | `/v1/companies/:companyUuid/wire_in_requests` |
-| **Payroll.PayrollOverview** | PUT | `/v1/companies/:companyId/payrolls/:payrollId/submit` |
-|  | PUT | `/v1/companies/:companyId/payrolls/:payrollId/cancel` |
-|  | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
-|  | GET | `/v1/companies/:companyId/bank_accounts` |
+| **Payroll.PayrollOverview** | GET | `/v1/companies/:companyId/bank_accounts` |
 |  | GET | `/v1/companies/:companyId/employees` |
-|  | GET | `/v1/wire_in_requests/:wireInRequestUuid` |
+|  | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
+|  | PUT | `/v1/companies/:companyId/payrolls/:payrollId/cancel` |
+|  | PUT | `/v1/companies/:companyId/payrolls/:payrollId/submit` |
 |  | GET | `/v1/payrolls/:payrollId/employees/:employeeId/pay_stub` |
-| **Payroll.PayrollFlow** | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
-|  | GET | `/v1/companies/:companyId/payrolls` |
-| **Payroll.PayrollReceipts** | GET | `/v1/payrolls/:payrollUuid/receipt` |
-| **Payroll.ConfirmWireDetails** | GET | `/v1/companies/:companyUuid/wire_in_requests` |
-|  | GET | `/v1/companies/:companyId/payrolls` |
-|  | PUT | `/v1/wire_in_requests/:wireInRequestUuid` |
 |  | GET | `/v1/wire_in_requests/:wireInRequestUuid` |
-| **Payroll.PayrollBlockerList** | GET | `/v1/companies/:companyUuid/payrolls/blockers` |
+| **Payroll.PayrollFlow** | GET | `/v1/companies/:companyId/payrolls` |
+|  | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
+| **Payroll.PayrollReceipts** | GET | `/v1/payrolls/:payrollUuid/receipt` |
+| **Payroll.ConfirmWireDetails** | GET | `/v1/companies/:companyId/payrolls` |
+|  | GET | `/v1/companies/:companyUuid/wire_in_requests` |
+|  | GET | `/v1/wire_in_requests/:wireInRequestUuid` |
+|  | PUT | `/v1/wire_in_requests/:wireInRequestUuid` |
+| **Payroll.PayrollBlockerList** | GET | `/v1/companies/:companyUuid/information_requests` |
+|  | GET | `/v1/companies/:companyUuid/payrolls/blockers` |
 |  | GET | `/v1/companies/:companyUuid/recovery_cases` |
-|  | GET | `/v1/companies/:companyUuid/information_requests` |
 | **Payroll.RecoveryCases** | GET | `/v1/companies/:companyUuid/recovery_cases` |
 |  | PUT | `/v1/recovery_cases/:recoveryCaseUuid/redebit` |
-| **Payroll.OffCycleCreation** | POST | `/v1/companies/:companyId/payrolls` |
-|  | GET | `/v1/companies/:companyId/employees` |
-| **Payroll.OffCycleFlow** | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
-| **Payroll.DismissalFlow** | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
-|  | GET | `/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods` |
+| **Payroll.OffCycleCreation** | GET | `/v1/companies/:companyId/employees` |
 |  | POST | `/v1/companies/:companyId/payrolls` |
+| **Payroll.OffCycleFlow** | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
+| **Payroll.DismissalFlow** | GET | `/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods` |
+|  | POST | `/v1/companies/:companyId/payrolls` |
+|  | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
 | **Payroll.TransitionFlow** | GET | `/v1/companies/:companyId/payrolls/:payrollId` |
-| **Payroll.TransitionCreation** | POST | `/v1/companies/:companyId/payrolls` |
-|  | GET | `/v1/companies/:companyId/pay_schedules` |
+| **Payroll.TransitionCreation** | GET | `/v1/companies/:companyId/pay_schedules` |
+|  | POST | `/v1/companies/:companyId/payrolls` |
 
 ## TimeOff components
 
 | Component | Method | Path |
 | --- | --- | --- |
-| **TimeOff.PolicyList** | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyId/employees` |
+| **TimeOff.PolicyList** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
+|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
+|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-| **TimeOff.PolicyTypeSelector** | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyId/employees` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
+| **TimeOff.PolicyTypeSelector** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
+|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
+|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 | **TimeOff.PolicyConfigurationForm** | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
-| **TimeOff.PolicySettingsPresentation** | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyId/employees` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
+| **TimeOff.PolicySettingsPresentation** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
+|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
+|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-| **TimeOff.AddEmployeesToPolicy** | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyId/employees` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
+| **TimeOff.AddEmployeesToPolicy** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
+|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
+|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-| **TimeOff.HolidaySelectionForm** | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyId/employees` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
+| **TimeOff.HolidaySelectionForm** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
+|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
+|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-| **TimeOff.AddEmployeesHoliday** | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyId/employees` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
+| **TimeOff.AddEmployeesHoliday** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
+|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
+|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-| **TimeOff.ViewHolidayEmployees** | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyId/employees` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
+| **TimeOff.ViewHolidayEmployees** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
+|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
+|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-| **TimeOff.ViewHolidayPolicyDetails** | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyId/employees` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
+| **TimeOff.ViewHolidayPolicyDetails** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
+|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
+|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-| **TimeOff.ViewHolidaySchedule** | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyId/employees` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
+| **TimeOff.ViewHolidaySchedule** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
+|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
+|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-| **TimeOff.TimeOffPolicyDetailPresentation** | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
+| **TimeOff.TimeOffPolicyDetailPresentation** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
-|  | GET | `/v1/companies/:companyId/employees` |
-| **TimeOff.TimeOffFlow** | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
-|  | GET | `/v1/companies/:companyId/employees` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
+| **TimeOff.TimeOffFlow** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | POST | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy` |
-|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
 |  | DELETE | `/v1/companies/:companyUuid/holiday_pay_policy` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
+|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
+|  | GET | `/v1/companies/:companyUuid/time_off_policies` |
+|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
-|  | POST | `/v1/companies/:companyUuid/time_off_policies` |
-|  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/add` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/add_employees` |
-|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/deactivate` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 
 ## Flows
 

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -20,8 +20,4 @@ export default {
     'npm run format:staged -- docs/component-adapter/component-inventory.md',
     'git add docs/component-adapter/component-inventory.md',
   ],
-  'src/components/**/*.{ts,tsx}': () => [
-    'npm run endpoints:derive',
-    'git add docs/reference/endpoint-inventory.json docs/reference/endpoint-reference.md',
-  ],
 }


### PR DESCRIPTION
## Summary

We auto-generate `docs/reference/endpoint-inventory.json` and `docs/reference/endpoint-reference.md` by walking all the components exported by the SDK and determining which embedded API endpoints they call.

Harden this script so that it emits more stable and reliable results.

## Changes

Easiest to look at the diffs for the generated code commit by commit.

- Sort blocks and their endpoints (alphabetically by path, then GET → POST → PUT → PATCH → DELETE)         
- Ensure component names match SDK usage
  - Fix flow names to use the correct top-level namespace (`Contractor.PaymentFlow` instead of `Contractor.Payments.PaymentFlow`)
  - Use the public export alias when a component is re-exported under a different name (`TimeOff.PolicySettings` instead of `TimeOff.PolicySettingsPresentation`)      
- Discover previously missing flows that were nested more than three directories deep (`Employee.DashboardFlow`, `Payroll.DismissalFlow`, etc.)
- Ensure flows are not duplicated in the blocks section (`TimeOff.TimeOffFlow`)

## Related

- Jira ticket: [SDK-897](https://gustohq.atlassian.net/browse/SDK-897)
- Figma: [Design link]
- Related PRs: #1844 first exposed the issue when moving directories accidentally deleted endpoint docs

[SDK-897]: https://gustohq.atlassian.net/browse/SDK-897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ