### PR TITLE
fix: update component header styles with consistent spacing and supporting text variant

### DIFF
--- a/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatoryForm.tsx
+++ b/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatoryForm.tsx
@@ -20,10 +20,14 @@ export const CreateSignatoryForm = () => {
 
   return (
     <Flex flexDirection="column" gap={32}>
-      <Flex flexDirection="column" gap={12}>
+      <Flex flexDirection="column" gap={32} alignItems="stretch">
         <header>
-          <Components.Heading as="h2">{t('signatoryDetails.title')}</Components.Heading>
-          <Components.Text>{t('signatoryDetails.description')}</Components.Text>
+          <Flex flexDirection="column" gap={4}>
+            <Components.Heading as="h2">{t('signatoryDetails.title')}</Components.Heading>
+            <Components.Text variant="supporting">
+              {t('signatoryDetails.description')}
+            </Components.Text>
+          </Flex>
         </header>
 
         <Grid gridTemplateColumns={{ base: '1fr', small: ['1fr', '1fr'] }} gap={20}>
@@ -71,10 +75,12 @@ export const CreateSignatoryForm = () => {
         </Grid>
       </Flex>
 
-      <Flex flexDirection="column" gap={12}>
+      <Flex flexDirection="column" gap={32} alignItems="stretch">
         <header>
-          <Components.Heading as="h2">{t('address.title')}</Components.Heading>
-          <Components.Text>{t('address.description')}</Components.Text>
+          <Flex flexDirection="column" gap={4}>
+            <Components.Heading as="h2">{t('address.title')}</Components.Heading>
+            <Components.Text variant="supporting">{t('address.description')}</Components.Text>
+          </Flex>
         </header>
 
         <Grid gridTemplateColumns={{ base: '1fr', small: ['1fr', '1fr'] }} gap={20}>

--- a/src/components/Company/AssignSignatory/Head.tsx
+++ b/src/components/Company/AssignSignatory/Head.tsx
@@ -1,14 +1,15 @@
 import { useTranslation } from 'react-i18next'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common'
 
 export const Head = () => {
   const { t } = useTranslation('Company.AssignSignatory')
   const Components = useComponentContext()
 
   return (
-    <header>
+    <Flex flexDirection="column" gap={4}>
       <Components.Heading as="h1">{t('title')}</Components.Heading>
-      <Components.Text>{t('description')}</Components.Text>
-    </header>
+      <Components.Text variant="supporting">{t('description')}</Components.Text>
+    </Flex>
   )
 }

--- a/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatoryForm.tsx
+++ b/src/components/Company/AssignSignatory/InviteSignatory/InviteSignatoryForm.tsx
@@ -51,10 +51,12 @@ export const InviteSignatoryForm = () => {
   }
 
   return (
-    <Flex flexDirection="column" gap={12}>
+    <Flex flexDirection="column" gap={32} alignItems="stretch">
       <header>
-        <Components.Heading as="h2">{t('inviteSignatory.title')}</Components.Heading>
-        <Components.Text>{t('inviteSignatory.description')}</Components.Text>
+        <Flex flexDirection="column" gap={4}>
+          <Components.Heading as="h2">{t('inviteSignatory.title')}</Components.Heading>
+          <Components.Text variant="supporting">{t('inviteSignatory.description')}</Components.Text>
+        </Flex>
       </header>
 
       <Grid gridTemplateColumns={{ base: '1fr', small: ['1fr', '1fr'] }} gap={20}>

--- a/src/components/Company/BankAccount/BankAccountForm/Head.tsx
+++ b/src/components/Company/BankAccount/BankAccountForm/Head.tsx
@@ -1,14 +1,15 @@
 import { useTranslation } from 'react-i18next'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common'
 
 export function Head() {
   const { t } = useTranslation('Company.BankAccount')
   const Components = useComponentContext()
 
   return (
-    <header>
+    <Flex flexDirection="column" gap={4}>
       <Components.Heading as="h2">{t('addBankAccountTitle')}</Components.Heading>
-      <Components.Text>{t('addBankAccountDescription')}</Components.Text>
-    </header>
+      <Components.Text variant="supporting">{t('addBankAccountDescription')}</Components.Text>
+    </Flex>
   )
 }

--- a/src/components/Company/BankAccount/BankAccountList/Head.tsx
+++ b/src/components/Company/BankAccount/BankAccountList/Head.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { useBankAccount } from './context'
 import VerificationPendingIcon from '@/assets/icons/verification_pending.svg?react'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common/Flex/Flex'
 
 export function Head() {
   const { bankAccount, showVerifiedMessage, handleVerification } = useBankAccount()
@@ -9,36 +10,40 @@ export function Head() {
   const Components = useComponentContext()
 
   return (
-    <header>
-      <Components.Heading as="h2">{t('addBankAccountTitle')}</Components.Heading>
-      <Components.Text>{t('addBankAccountDescription')}</Components.Text>
-      {bankAccount?.verificationStatus != 'verified' && (
-        <Components.Alert
-          //@ts-expect-error: typescript limitation
-          label={t(`verificationAlert.${bankAccount?.verificationStatus}.label`)}
-          icon={<VerificationPendingIcon />}
-        >
-          <Components.Text>
-            {/*@ts-expect-error: typescript limitation */}
-            {t(`verificationAlert.${bankAccount?.verificationStatus}.description`, {
-              number: bankAccount?.hiddenAccountNumber,
-            })}
-          </Components.Text>
-          <Components.Button
-            variant="secondary"
-            onClick={handleVerification}
-            isDisabled={bankAccount?.verificationStatus !== 'ready_for_verification'}
+    <>
+      <Flex flexDirection="column" gap={4}>
+        <Components.Heading as="h2">{t('addBankAccountTitle')}</Components.Heading>
+        <Components.Text variant="supporting">{t('addBankAccountDescription')}</Components.Text>
+      </Flex>
+      <Flex flexDirection="column" gap={16}>
+        {bankAccount?.verificationStatus != 'verified' && (
+          <Components.Alert
+            //@ts-expect-error: typescript limitation
+            label={t(`verificationAlert.${bankAccount?.verificationStatus}.label`)}
+            icon={<VerificationPendingIcon />}
           >
-            {t('verifyBankAccountCta')}
-          </Components.Button>
-        </Components.Alert>
-      )}
-      {showVerifiedMessage && (
-        <Components.Alert
-          label={t('verificationAlert.verified.label')}
-          status="success"
-        ></Components.Alert>
-      )}
-    </header>
+            <Components.Text>
+              {/*@ts-expect-error: typescript limitation */}
+              {t(`verificationAlert.${bankAccount?.verificationStatus}.description`, {
+                number: bankAccount?.hiddenAccountNumber,
+              })}
+            </Components.Text>
+            <Components.Button
+              variant="secondary"
+              onClick={handleVerification}
+              isDisabled={bankAccount?.verificationStatus !== 'ready_for_verification'}
+            >
+              {t('verifyBankAccountCta')}
+            </Components.Button>
+          </Components.Alert>
+        )}
+        {showVerifiedMessage && (
+          <Components.Alert
+            label={t('verificationAlert.verified.label')}
+            status="success"
+          ></Components.Alert>
+        )}
+      </Flex>
+    </>
   )
 }

--- a/src/components/Company/DocumentSigner/SignatureForm/SignatureForm.tsx
+++ b/src/components/Company/DocumentSigner/SignatureForm/SignatureForm.tsx
@@ -57,32 +57,34 @@ function Root({ formId, children, dictionary }: SignatureFormProps) {
     <BaseLayout error={hookResult.errorHandling.errors}>
       <SDKFormProvider formHookResult={hookResult}>
         <FormLayout onSubmit={handleFormSubmit}>
-          <Flex flexDirection="column" gap={32}>
+          <Flex flexDirection="column" gap={32} alignItems="stretch">
             {children ?? (
               <>
                 <section>
-                  <Components.Heading as="h2">
-                    {t('signatureFormTitle', { formTitle: form.title })}
-                  </Components.Heading>
-                  {pdfUrl && (
-                    <Components.Text>
-                      <Trans
-                        t={t}
-                        i18nKey="downloadPrompt"
-                        values={{ description: form.description }}
-                        components={{
-                          downloadLink: (
-                            <Components.Link
-                              href={pdfUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              download={`${form.title || 'form'}.pdf`}
-                            />
-                          ),
-                        }}
-                      />
-                    </Components.Text>
-                  )}
+                  <Flex flexDirection="column" gap={4}>
+                    <Components.Heading as="h2">
+                      {t('signatureFormTitle', { formTitle: form.title })}
+                    </Components.Heading>
+                    {pdfUrl && (
+                      <Components.Text variant="supporting">
+                        <Trans
+                          t={t}
+                          i18nKey="downloadPrompt"
+                          values={{ description: form.description }}
+                          components={{
+                            downloadLink: (
+                              <Components.Link
+                                href={pdfUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                download={`${form.title || 'form'}.pdf`}
+                              />
+                            ),
+                          }}
+                        />
+                      </Components.Text>
+                    )}
+                  </Flex>
                 </section>
                 <DocumentViewer
                   url={pdfUrl}

--- a/src/components/Company/FederalTaxes/FederalTaxes.tsx
+++ b/src/components/Company/FederalTaxes/FederalTaxes.tsx
@@ -94,7 +94,7 @@ function Root({ companyId, children, className, defaultValues, dictionary }: Fed
       >
         <FormProvider {...formMethods}>
           <HtmlForm onSubmit={formMethods.handleSubmit(handleSubmit)}>
-            <Flex flexDirection="column" gap={32}>
+            <Flex flexDirection="column" gap={32} alignItems="stretch">
               {children ? (
                 children
               ) : (

--- a/src/components/Company/FederalTaxes/Head.tsx
+++ b/src/components/Company/FederalTaxes/Head.tsx
@@ -1,5 +1,6 @@
 import { Trans, useTranslation } from 'react-i18next'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common/Flex/Flex'
 
 export function Head() {
   const { t } = useTranslation('Company.FederalTaxes')
@@ -7,22 +8,24 @@ export function Head() {
 
   return (
     <header>
-      <Components.Heading as="h2">{t('pageTitle')}</Components.Heading>
-      <Components.Text>
-        <Trans
-          t={t}
-          i18nKey="entityTypeAndLegalNameIntro"
-          components={{
-            einLink: (
-              <Components.Link
-                href="https://www.irs.gov/businesses/employer-identification-number#lost"
-                target="_blank"
-                rel="noopener noreferrer"
-              />
-            ),
-          }}
-        />
-      </Components.Text>
+      <Flex flexDirection="column" gap={4}>
+        <Components.Heading as="h2">{t('pageTitle')}</Components.Heading>
+        <Components.Text variant="supporting">
+          <Trans
+            t={t}
+            i18nKey="entityTypeAndLegalNameIntro"
+            components={{
+              einLink: (
+                <Components.Link
+                  href="https://www.irs.gov/businesses/employer-identification-number#lost"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              ),
+            }}
+          />
+        </Components.Text>
+      </Flex>
     </header>
   )
 }

--- a/src/components/Company/Industry/Head.tsx
+++ b/src/components/Company/Industry/Head.tsx
@@ -1,14 +1,15 @@
 import { useTranslation } from 'react-i18next'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common/Flex/Flex'
 
 export const Head = () => {
   const { t } = useTranslation('Company.Industry')
   const Components = useComponentContext()
 
   return (
-    <div>
+    <Flex flexDirection="column" gap={4}>
       <Components.Heading as="h2">{t('title')}</Components.Heading>
-      <Components.Text>{t('description')}</Components.Text>
-    </div>
+      <Components.Text variant="supporting">{t('description')}</Components.Text>
+    </Flex>
   )
 }

--- a/src/components/Company/Industry/IndustrySelect.tsx
+++ b/src/components/Company/Industry/IndustrySelect.tsx
@@ -9,6 +9,7 @@ import type { IndustryFormFields } from './Edit'
 import { Form } from '@/components/Common/Form'
 import { loadAll } from '@/models/NAICSCodes'
 import type { ComboBoxOption } from '@/components/Common/UI/ComboBox/ComboBoxTypes'
+import { Flex } from '@/components/Common'
 
 interface IndustrySelectProps extends PropsWithChildren {
   naics_code?: string | null | undefined
@@ -46,15 +47,17 @@ export function IndustrySelect({
     <IndustryItemsProvider value={{ items }}>
       <FormProvider {...formMethods}>
         <Form onSubmit={handleSubmit(onValid)}>
-          {children ? (
-            children
-          ) : (
-            <>
-              <Head />
-              <Edit />
-              <Actions />
-            </>
-          )}
+          <Flex flexDirection="column" gap={32}>
+            {children ? (
+              children
+            ) : (
+              <>
+                <Head />
+                <Edit />
+                <Actions />
+              </>
+            )}
+          </Flex>
         </Form>
       </FormProvider>
     </IndustryItemsProvider>

--- a/src/components/Company/Locations/LocationForm/Head.tsx
+++ b/src/components/Company/Locations/LocationForm/Head.tsx
@@ -1,14 +1,15 @@
 import { useTranslation } from 'react-i18next'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common/Flex/Flex'
 
 export function Head() {
   const { t } = useTranslation('Company.Locations')
   const Components = useComponentContext()
 
   return (
-    <header>
+    <Flex flexDirection="column" gap={4}>
       <Components.Heading as="h2">{t('locationsListTitle')}</Components.Heading>
-      <Components.Text>{t('locationsListDescription')}</Components.Text>
-    </header>
+      <Components.Text variant="supporting">{t('locationsListDescription')}</Components.Text>
+    </Flex>
   )
 }

--- a/src/components/Company/Locations/LocationsList/Head.tsx
+++ b/src/components/Company/Locations/LocationsList/Head.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common/Flex/Flex'
 
 export function Head() {
   const { t } = useTranslation('Company.Locations')
@@ -7,8 +8,10 @@ export function Head() {
 
   return (
     <header>
-      <Components.Heading as="h2">{t('locationsListTitle')}</Components.Heading>
-      <Components.Text>{t('locationsListDescription')}</Components.Text>
+      <Flex flexDirection="column" gap={4}>
+        <Components.Heading as="h2">{t('locationsListTitle')}</Components.Heading>
+        <Components.Text variant="supporting">{t('locationsListDescription')}</Components.Text>
+      </Flex>
     </header>
   )
 }

--- a/src/components/Company/Locations/LocationsList/LocationsList.tsx
+++ b/src/components/Company/Locations/LocationsList/LocationsList.tsx
@@ -53,7 +53,7 @@ function Root({ companyId, className, children }: LocationsListProps) {
           handleContinue,
         }}
       >
-        <Flex flexDirection="column" gap={32}>
+        <Flex flexDirection="column" gap={32} alignItems="stretch">
           {children ? (
             children
           ) : (

--- a/src/components/Company/PaySchedule/PayScheduleList.tsx
+++ b/src/components/Company/PaySchedule/PayScheduleList.tsx
@@ -77,27 +77,29 @@ export function PayScheduleList({ companyId, onEvent }: PayScheduleListProps) {
   })
 
   return (
-    <Flex flexDirection="column">
-      <Flex justifyContent="space-between" flexDirection="column" gap={4}>
+    <Flex flexDirection="column" gap={32}>
+      <Flex justifyContent="space-between" flexDirection="column" gap={4} alignItems="stretch">
         <header>
-          <Components.Heading as="h2">{t('headings.pageTitle')}</Components.Heading>
-          <Components.Text>
-            <Trans
-              i18nKey="listDescription"
-              t={t}
-              components={{ ScheduleLink: <Components.Link /> }}
-            />
-          </Components.Text>
-          <Components.Text>
-            <Trans
-              i18nKey="listDescription2"
-              t={t}
-              components={{ PaymentLawLink: <Components.Link /> }}
-            />
-          </Components.Text>
+          <Flex flexDirection="column" gap={4}>
+            <Components.Heading as="h2">{t('headings.pageTitle')}</Components.Heading>
+            <Components.Text variant="supporting">
+              <Trans
+                i18nKey="listDescription"
+                t={t}
+                components={{ ScheduleLink: <Components.Link /> }}
+              />
+            </Components.Text>
+            <Components.Text variant="supporting">
+              <Trans
+                i18nKey="listDescription2"
+                t={t}
+                components={{ PaymentLawLink: <Components.Link /> }}
+              />
+            </Components.Text>
+          </Flex>
         </header>
       </Flex>
-      <DataView label="test" {...dataViewProps} />
+      <DataView label={t('payScheduleListLabel')} {...dataViewProps} />
       <ActionsLayout>
         <Components.Button
           variant="secondary"

--- a/src/components/Contractor/Payments/CreatePayment/CreatePaymentPresentation.tsx
+++ b/src/components/Contractor/Payments/CreatePayment/CreatePaymentPresentation.tsx
@@ -78,7 +78,7 @@ export const CreatePaymentPresentation = ({
   return (
     <Flex flexDirection="column" gap={32}>
       <Flex justifyContent="flex-end" gap={16}>
-        <Flex flexDirection="column" gap={16}>
+        <Flex flexDirection="column" gap={4}>
           <Heading as="h2">{t('title')}</Heading>
           <Text variant="supporting">
             {t('paymentSpeedNotice', {

--- a/src/components/Contractor/Payments/CreatePayment/EditContractorPaymentPresentation.tsx
+++ b/src/components/Contractor/Payments/CreatePayment/EditContractorPaymentPresentation.tsx
@@ -98,9 +98,9 @@ export const EditContractorPaymentPresentation = ({
       <FormProvider {...formMethods}>
         <Form id={formId} onSubmit={formMethods.handleSubmit(onSubmit)}>
           <Flex flexDirection="column" gap={32}>
-            <Flex flexDirection="column" gap={16}>
+            <Flex flexDirection="column" gap={4}>
               <Heading as="h2">{t('title')}</Heading>
-              <Text>{t('subtitle')}</Text>
+              <Text variant="supporting">{t('subtitle')}</Text>
               <Text weight="bold">
                 {t('totalPay')}: {currencyFormatter(totalAmount)}
               </Text>

--- a/src/components/Contractor/Payments/PaymentsList/PaymentsListPresentation.tsx
+++ b/src/components/Contractor/Payments/PaymentsList/PaymentsListPresentation.tsx
@@ -89,7 +89,9 @@ export const PaymentsListPresentation = ({
   return (
     <Flex flexDirection="column" gap={24}>
       <Flex flexDirection="column" gap={16}>
-        <Heading as="h1">{t('title')}</Heading>
+        <Heading as="h1" styledAs="h2">
+          {t('title')}
+        </Heading>
       </Flex>
 
       {hasUnresolvedWireInRequests && (
@@ -134,7 +136,9 @@ export const PaymentsListPresentation = ({
         }}
         justifyContent="space-between"
       >
-        <Heading as="h2">{t('subtitle')}</Heading>
+        <Heading as="h2" styledAs="h4">
+          {t('subtitle')}
+        </Heading>
         <div className={styles.actionsContainer}>
           <Select
             id="date-range-select"

--- a/src/components/Employee/Deductions/IncludeDeductions/IncludeDeductions.module.scss
+++ b/src/components/Employee/Deductions/IncludeDeductions/IncludeDeductions.module.scss
@@ -11,7 +11,12 @@
 .coinHandsIconContainer {
   border: 1px solid var(--g-colorBorderPrimary);
   border-radius: toRem(11);
-  padding: toRem(11);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+  width: toRem(48);
+  height: toRem(48);
   box-shadow: var(--g-shadowResting);
 }
 

--- a/src/components/Employee/Deductions/IncludeDeductions/IncludeDeductions.tsx
+++ b/src/components/Employee/Deductions/IncludeDeductions/IncludeDeductions.tsx
@@ -30,9 +30,9 @@ export function IncludeDeductions({ className, onAdd, onContinue }: IncludeDeduc
 
         <section className={styles.emptyStateContainer}>
           <Flex flexDirection="column" gap={16} justifyContent="center" alignItems="center">
-            <section className={styles.coinHandsIconContainer}>
+            <div className={styles.coinHandsIconContainer}>
               <CoinsHandsIcon width={24} height={24} />
-            </section>
+            </div>
             <Components.Text weight="bold">{t('includeDeductionsEmptyState')}</Components.Text>
             <Components.Button
               type="button"

--- a/src/components/Employee/EmployeeDocuments/EmployeeDocumentsPresentation.tsx
+++ b/src/components/Employee/EmployeeDocuments/EmployeeDocumentsPresentation.tsx
@@ -47,10 +47,10 @@ export const EmployeeDocumentsPresentation = ({
     <FormProvider {...formMethods}>
       <Form id={EMPLOYEE_DOCUMENTS_FORM_ID} onSubmit={formMethods.handleSubmit(onSubmit)}>
         <Flex flexDirection="column" gap={16}>
-          <FlexItem>
+          <Flex flexDirection="column" gap={4}>
             <Heading as="h2">{t('selfOnboarding.title')}</Heading>
             <Text variant="supporting">{t('selfOnboarding.description')}</Text>
-          </FlexItem>
+          </Flex>
 
           <Heading as="h3">{t('selfOnboarding.documentsIncludedLabel')}</Heading>
           <FlexItem>
@@ -104,27 +104,28 @@ export const EmployeeDocumentsPresentation = ({
   )
 
   const renderNotSelfOnboarding = () => (
-    <Flex flexDirection="column" gap={16}>
-      <FlexItem>
+    <Flex flexDirection="column" gap={32}>
+      <Flex flexDirection="column" gap={4}>
         <Heading as="h2">{t('notSelfOnboarding.title')}</Heading>
-        <Text>{t('notSelfOnboarding.description')}</Text>
-      </FlexItem>
+        <Text variant="supporting">{t('notSelfOnboarding.description')}</Text>
+      </Flex>
+      <Flex flexDirection="column" gap={20}>
+        <FlexItem>
+          <Text weight="medium">{t('notSelfOnboarding.employmentEligibilityLabel')}</Text>
+          <Text variant="supporting">
+            {t('notSelfOnboarding.employmentEligibilityDescription')}
+          </Text>
+        </FlexItem>
 
-      <FlexItem>
-        <Text weight="medium">{t('notSelfOnboarding.employmentEligibilityLabel')}</Text>
-        <Text>{t('notSelfOnboarding.employmentEligibilityDescription')}</Text>
-      </FlexItem>
-
-      <FlexItem>
-        <Text weight="medium">{t('notSelfOnboarding.taxWithholdingLabel')}</Text>
-        <Text>{t('notSelfOnboarding.taxWithholdingDescription')}</Text>
-      </FlexItem>
-
-      <FlexItem>
-        <Text weight="medium">{t('notSelfOnboarding.directDepositLabel')}</Text>
-        <Text>{t('notSelfOnboarding.directDepositDescription')}</Text>
-      </FlexItem>
-
+        <FlexItem>
+          <Text weight="medium">{t('notSelfOnboarding.taxWithholdingLabel')}</Text>
+          <Text variant="supporting">{t('notSelfOnboarding.taxWithholdingDescription')}</Text>
+        </FlexItem>
+        <FlexItem>
+          <Text weight="medium">{t('notSelfOnboarding.directDepositLabel')}</Text>
+          <Text variant="supporting">{t('notSelfOnboarding.directDepositDescription')}</Text>
+        </FlexItem>
+      </Flex>
       <Alert status="info" label={t('notSelfOnboarding.alertTitle')} disableScrollIntoView></Alert>
     </Flex>
   )

--- a/src/components/Employee/FederalTaxes/shared/FederalTaxesView.tsx
+++ b/src/components/Employee/FederalTaxes/shared/FederalTaxesView.tsx
@@ -3,6 +3,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { type useFederalTaxesForm, type FilingStatusValue } from './useFederalTaxesForm'
 import { BaseLayout } from '@/components/Base'
 import { Form } from '@/components/Common/Form'
+import { Flex } from '@/components/Common/Flex'
 import { SDKFormProvider } from '@/partner-hook-utils/form/SDKFormProvider'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
@@ -43,70 +44,76 @@ export function FederalTaxesView({
   }
 
   return (
-    <section className={className}>
-      <BaseLayout error={federalTaxes.errorHandling.errors}>
-        <SDKFormProvider formHookResult={federalTaxes}>
-          <Form onSubmit={onSubmit}>
-            {children ?? (
-              <>
-                {alert}
+    <Flex flexDirection="column" gap={32} alignItems="stretch">
+      <section className={className}>
+        <BaseLayout error={federalTaxes.errorHandling.errors}>
+          <SDKFormProvider formHookResult={federalTaxes}>
+            <Form onSubmit={onSubmit}>
+              {children ?? (
+                <>
+                  {alert}
+                  <Flex flexDirection="column" gap={32}>
+                    <Flex flexDirection="column" gap={4}>
+                      <Components.Heading as="h2">{t('federalTaxesTitle')}</Components.Heading>
+                      <Components.Text variant="supporting">
+                        <Trans
+                          i18nKey="irsCalculator"
+                          t={t}
+                          components={{
+                            IrsCalculatorLink: <Components.Link />,
+                            HelpCenterLink: <Components.Link />,
+                          }}
+                        />
+                      </Components.Text>
+                    </Flex>
+                    <Flex flexDirection="column" gap={20}>
+                      <Fields.FilingStatus
+                        label={t('federalFilingStatus1c')}
+                        placeholder={t('federalFilingStatusPlaceholder')}
+                        description={t('selectWithholdingDescription')}
+                        validationMessages={{ REQUIRED: t('validations.federalFilingStatus') }}
+                        getOptionLabel={filingStatusLabel}
+                      />
+                      <Fields.TwoJobs
+                        label={t('multipleJobs2c')}
+                        description={
+                          <Trans
+                            i18nKey="includesSpouseExplanation"
+                            t={t}
+                            components={{
+                              IrsLink: <Components.Link />,
+                            }}
+                          />
+                        }
+                        validationMessages={{ REQUIRED: t('validations.federalTwoJobs') }}
+                        getOptionLabel={value => (value ? t('twoJobYesLabel') : t('twoJobNoLabel'))}
+                      />
+                      <Fields.DependentsAmount
+                        label={t('dependentsTotalIfApplicable')}
+                        validationMessages={{ REQUIRED: t('fieldIsRequired') }}
+                      />
+                      <Fields.OtherIncome
+                        label={t('otherIncome')}
+                        validationMessages={{ REQUIRED: t('fieldIsRequired') }}
+                      />
+                      <Fields.Deductions
+                        label={t('deductions')}
+                        validationMessages={{ REQUIRED: t('fieldIsRequired') }}
+                      />
+                      <Fields.ExtraWithholding
+                        label={t('extraWithholding')}
+                        validationMessages={{ REQUIRED: t('fieldIsRequired') }}
+                      />
+                    </Flex>
 
-                <Components.Heading as="h1">{t('federalTaxesTitle')}</Components.Heading>
-                <Components.Text>
-                  <Trans
-                    i18nKey="irsCalculator"
-                    t={t}
-                    components={{
-                      IrsCalculatorLink: <Components.Link />,
-                      HelpCenterLink: <Components.Link />,
-                    }}
-                  />
-                </Components.Text>
-
-                <Fields.FilingStatus
-                  label={t('federalFilingStatus1c')}
-                  placeholder={t('federalFilingStatusPlaceholder')}
-                  description={t('selectWithholdingDescription')}
-                  validationMessages={{ REQUIRED: t('validations.federalFilingStatus') }}
-                  getOptionLabel={filingStatusLabel}
-                />
-                <Fields.TwoJobs
-                  label={t('multipleJobs2c')}
-                  description={
-                    <Trans
-                      i18nKey="includesSpouseExplanation"
-                      t={t}
-                      components={{
-                        IrsLink: <Components.Link />,
-                      }}
-                    />
-                  }
-                  validationMessages={{ REQUIRED: t('validations.federalTwoJobs') }}
-                  getOptionLabel={value => (value ? t('twoJobYesLabel') : t('twoJobNoLabel'))}
-                />
-                <Fields.DependentsAmount
-                  label={t('dependentsTotalIfApplicable')}
-                  validationMessages={{ REQUIRED: t('fieldIsRequired') }}
-                />
-                <Fields.OtherIncome
-                  label={t('otherIncome')}
-                  validationMessages={{ REQUIRED: t('fieldIsRequired') }}
-                />
-                <Fields.Deductions
-                  label={t('deductions')}
-                  validationMessages={{ REQUIRED: t('fieldIsRequired') }}
-                />
-                <Fields.ExtraWithholding
-                  label={t('extraWithholding')}
-                  validationMessages={{ REQUIRED: t('fieldIsRequired') }}
-                />
-
-                {actions}
-              </>
-            )}
-          </Form>
-        </SDKFormProvider>
-      </BaseLayout>
-    </section>
+                    {actions}
+                  </Flex>
+                </>
+              )}
+            </Form>
+          </SDKFormProvider>
+        </BaseLayout>
+      </section>
+    </Flex>
   )
 }

--- a/src/components/Employee/FederalTaxes/shared/FederalTaxesView.tsx
+++ b/src/components/Employee/FederalTaxes/shared/FederalTaxesView.tsx
@@ -54,7 +54,9 @@ export function FederalTaxesView({
                   {alert}
                   <Flex flexDirection="column" gap={32}>
                     <Flex flexDirection="column" gap={4}>
-                      <Components.Heading as="h2">{t('federalTaxesTitle')}</Components.Heading>
+                      <Components.Heading as="h1" styledAs="h2">
+                        {t('federalTaxesTitle')}
+                      </Components.Heading>
                       <Components.Text variant="supporting">
                         <Trans
                           i18nKey="irsCalculator"

--- a/src/components/Employee/FederalTaxes/shared/FederalTaxesView.tsx
+++ b/src/components/Employee/FederalTaxes/shared/FederalTaxesView.tsx
@@ -44,7 +44,7 @@ export function FederalTaxesView({
   }
 
   return (
-    <Flex flexDirection="column" gap={32} alignItems="stretch">
+    <Flex flexDirection="column" alignItems="stretch">
       <section className={className}>
         <BaseLayout error={federalTaxes.errorHandling.errors}>
           <SDKFormProvider formHookResult={federalTaxes}>

--- a/src/components/Employee/HomeAddress/management/HomeAddressView.tsx
+++ b/src/components/Employee/HomeAddress/management/HomeAddressView.tsx
@@ -310,8 +310,10 @@ export function HomeAddressView({
 
   return (
     <Flex flexDirection="column" gap={24}>
-      <Flex flexDirection="column" gap={8} alignItems="flex-start">
-        <Components.Heading as="h1">{t('title')}</Components.Heading>
+      <Flex flexDirection="column" gap={4} alignItems="flex-start">
+        <Components.Heading as="h1" styledAs="h2">
+          {t('title')}
+        </Components.Heading>
         <Components.Text variant="supporting">{t('description')}</Components.Text>
       </Flex>
 
@@ -386,7 +388,9 @@ export function HomeAddressView({
       </Components.Box>
 
       <Flex flexDirection="column" gap={12}>
-        <Components.Heading as="h2">{t('historySectionTitle')}</Components.Heading>
+        <Components.Heading as="h2" styledAs="h4">
+          {t('historySectionTitle')}
+        </Components.Heading>
         <DataView label={t('historySectionTitle')} {...historyDataView} />
       </Flex>
 
@@ -417,13 +421,15 @@ export function HomeAddressView({
           </Flex>
         }
       >
-        <Flex flexDirection="column" gap={16}>
-          <Components.Heading as="h2">
-            {addressModal === 'edit' ? t('editModalTitle') : t('createModalTitle')}
-          </Components.Heading>
-          <Components.Text variant="supporting">
-            {addressModal === 'edit' ? t('editModalDescription') : t('createModalDescription')}
-          </Components.Text>
+        <Flex flexDirection="column" gap={32}>
+          <Flex flexDirection="column" gap={4}>
+            <Components.Heading as="h2">
+              {addressModal === 'edit' ? t('editModalTitle') : t('createModalTitle')}
+            </Components.Heading>
+            <Components.Text variant="supporting">
+              {addressModal === 'edit' ? t('editModalDescription') : t('createModalDescription')}
+            </Components.Text>
+          </Flex>
           {addressModal === 'edit' ? (
             <SDKFormProvider formHookResult={editHomeAddressForm}>
               <Grid

--- a/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
+++ b/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
@@ -119,7 +119,7 @@ const Root = ({ employeeId, className, isAdmin = false }: SummaryProps) => {
                     {t('onboardedSelfDescription')}
                   </Components.Text>
                 </Flex>
-                <ActionsLayout justifyContent="center">
+                <ActionsLayout justifyContent={isOnboardingCompleted ? 'center' : 'start'}>
                   <Components.Button
                     variant="secondary"
                     onClick={() => {

--- a/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
+++ b/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
@@ -64,21 +64,21 @@ const Root = ({ employeeId, className, isAdmin = false }: SummaryProps) => {
 
   return (
     <section className={className}>
-      <Flex flexDirection="column" gap={32}>
+      <Flex flexDirection="column" gap={20}>
         <Flex alignItems="center" flexDirection="column" gap={8}>
           {isAdmin ? (
             isOnboardingCompleted ? (
-              <>
+              <Flex flexDirection="column" gap={4} alignItems="center">
                 <Components.Heading as="h2" textAlign="center">
                   {t('onboardedAdminSubtitle', {
                     name: `${sanitizedFirstName} ${sanitizedLastName}`,
                     interpolation: { escapeValue: false },
                   })}
                 </Components.Heading>
-                <Components.Text className={styles.description}>
+                <Components.Text variant="supporting" className={styles.description}>
                   {t('onboardedAdminDescription')}
                 </Components.Text>
-              </>
+              </Flex>
             ) : (
               <Flex flexDirection="column" alignItems="flex-start" gap={8}>
                 <Components.Heading as="h2">{t('missingRequirementsSubtitle')}</Components.Heading>
@@ -110,22 +110,26 @@ const Root = ({ employeeId, className, isAdmin = false }: SummaryProps) => {
             )
           ) : (
             <>
-              <Components.Heading as="h2" textAlign="center">
-                {t('onboardedSelfSubtitle')}
-              </Components.Heading>
-              <Components.Text className={styles.description}>
-                {t('onboardedSelfDescription')}
-              </Components.Text>
-              <ActionsLayout justifyContent={isOnboardingCompleted ? 'center' : 'start'}>
-                <Components.Button
-                  variant="secondary"
-                  onClick={() => {
-                    onEvent(componentEvents.EMPLOYEE_ONBOARDING_DONE)
-                  }}
-                >
-                  {t('doneCta')}
-                </Components.Button>
-              </ActionsLayout>
+              <Flex flexDirection="column" gap={20} alignItems="center">
+                <Flex flexDirection="column" gap={4} alignItems="center">
+                  <Components.Heading as="h2" textAlign="center">
+                    {t('onboardedSelfSubtitle')}
+                  </Components.Heading>
+                  <Components.Text variant="supporting" className={styles.description}>
+                    {t('onboardedSelfDescription')}
+                  </Components.Text>
+                </Flex>
+                <ActionsLayout justifyContent="center">
+                  <Components.Button
+                    variant="secondary"
+                    onClick={() => {
+                      onEvent(componentEvents.EMPLOYEE_ONBOARDING_DONE)
+                    }}
+                  >
+                    {t('doneCta')}
+                  </Components.Button>
+                </ActionsLayout>
+              </Flex>
             </>
           )}
         </Flex>

--- a/src/components/Employee/Profile/onboarding/AdminProfile.tsx
+++ b/src/components/Employee/Profile/onboarding/AdminProfile.tsx
@@ -16,7 +16,7 @@ import { SDKFormProvider } from '@/partner-hook-utils/form/SDKFormProvider'
 import { composeSubmitHandler } from '@/partner-hook-utils/form/composeSubmitHandler'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
 import { Grid } from '@/components/Common/Grid/Grid'
-import { ActionsLayout, DatePickerField } from '@/components/Common'
+import { ActionsLayout, DatePickerField, Flex } from '@/components/Common'
 import { Form } from '@/components/Common/Form'
 import { BaseLayout } from '@/components/Base'
 import { useI18n } from '@/i18n'
@@ -262,10 +262,10 @@ function AdminProfileReady({
       <BaseLayout error={errorHandling.errors}>
         <Form onSubmit={handleSubmit}>
           <Grid gridTemplateColumns="1fr" gap={24}>
-            <div>
+            <Flex flexDirection="column" gap={4}>
               <Components.Heading as="h2">{t('title')}</Components.Heading>
-              <Components.Text>{t('description')}</Components.Text>
-            </div>
+              <Components.Text variant="supporting">{t('description')}</Components.Text>
+            </Flex>
 
             {isSelfOnboardingEnabled && EmployeeFields.SelfOnboarding && (
               <div className={styles.switchFieldContainer}>
@@ -351,10 +351,11 @@ function AdminProfileReady({
 
             {shouldShowHomeAddress && (
               <SDKFormProvider formHookResult={homeAddress}>
-                <div>
+                <Flex flexDirection="column" gap={4}>
                   <Components.Heading as="h2">{tHome('formTitle')}</Components.Heading>
-                  <Components.Text>{tHome('desc')}</Components.Text>
-                </div>
+                  <Components.Text variant="supporting">{tHome('desc')}</Components.Text>
+                </Flex>
+
                 <Grid
                   gridTemplateColumns={{
                     base: '1fr',

--- a/src/components/Employee/Taxes/FederalForm.tsx
+++ b/src/components/Employee/Taxes/FederalForm.tsx
@@ -1,6 +1,6 @@
 import { Trans, useTranslation } from 'react-i18next'
 import { z } from 'zod'
-import { NumberInputField, RadioGroupField, SelectField } from '@/components/Common'
+import { Flex, NumberInputField, RadioGroupField, SelectField } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 const Rev2020Schema = z.object({
@@ -30,67 +30,69 @@ export function FederalForm() {
 
   return (
     <>
-      <SelectField
-        name="filingStatus"
-        label={t('federalFilingStatus1c')}
-        placeholder={t('federalFilingStatusPlaceholder')}
-        options={filingStatusOptions}
-        isRequired
-        errorMessage={t('validations.federalFilingStatus')}
-      />
-      <RadioGroupField
-        name="twoJobs"
-        isRequired
-        label={t('multipleJobs2c')}
-        errorMessage={t('validations.federalTwoJobs')}
-        description={
-          <Components.Text>
-            <Trans
-              i18nKey={'includesSpouseExplanation'}
-              t={t}
-              components={{
-                IrsLink: <Components.Link />,
-              }}
-            />
-          </Components.Text>
-        }
-        options={[
-          { value: 'true', label: t('twoJobYesLabel') },
-          { value: 'false', label: t('twoJobNoLabel') },
-        ]}
-      />
-      <NumberInputField
-        name="dependentsAmount"
-        isRequired
-        label={t('dependentsTotalIfApplicable')}
-        format="currency"
-        min={0}
-        errorMessage={t('fieldIsRequired')}
-      />
-      <NumberInputField
-        name="otherIncome"
-        isRequired
-        label={t('otherIncome')}
-        format="currency"
-        min={0}
-        errorMessage={t('fieldIsRequired')}
-      />
-      <NumberInputField
-        name="deductions"
-        isRequired
-        label={t('deductions')}
-        format="currency"
-        min={0}
-        errorMessage={t('fieldIsRequired')}
-      />
-      <NumberInputField
-        name="extraWithholding"
-        isRequired
-        label={t('extraWithholding')}
-        format="currency"
-        min={0}
-        errorMessage={t('fieldIsRequired')}
-      />
+      <Flex flexDirection="column" gap={20}>
+        <SelectField
+          name="filingStatus"
+          label={t('federalFilingStatus1c')}
+          placeholder={t('federalFilingStatusPlaceholder')}
+          options={filingStatusOptions}
+          isRequired
+          errorMessage={t('validations.federalFilingStatus')}
+        />
+        <RadioGroupField
+          name="twoJobs"
+          isRequired
+          label={t('multipleJobs2c')}
+          errorMessage={t('validations.federalTwoJobs')}
+          description={
+            <Components.Text>
+              <Trans
+                i18nKey={'includesSpouseExplanation'}
+                t={t}
+                components={{
+                  IrsLink: <Components.Link />,
+                }}
+              />
+            </Components.Text>
+          }
+          options={[
+            { value: 'true', label: t('twoJobYesLabel') },
+            { value: 'false', label: t('twoJobNoLabel') },
+          ]}
+        />
+        <NumberInputField
+          name="dependentsAmount"
+          isRequired
+          label={t('dependentsTotalIfApplicable')}
+          format="currency"
+          min={0}
+          errorMessage={t('fieldIsRequired')}
+        />
+        <NumberInputField
+          name="otherIncome"
+          isRequired
+          label={t('otherIncome')}
+          format="currency"
+          min={0}
+          errorMessage={t('fieldIsRequired')}
+        />
+        <NumberInputField
+          name="deductions"
+          isRequired
+          label={t('deductions')}
+          format="currency"
+          min={0}
+          errorMessage={t('fieldIsRequired')}
+        />
+        <NumberInputField
+          name="extraWithholding"
+          isRequired
+          label={t('extraWithholding')}
+          format="currency"
+          min={0}
+          errorMessage={t('fieldIsRequired')}
+        />
+      </Flex>
     </>
   )
 }

--- a/src/components/Employee/Taxes/FederalHead.tsx
+++ b/src/components/Employee/Taxes/FederalHead.tsx
@@ -1,14 +1,15 @@
 import { Trans, useTranslation } from 'react-i18next'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common'
 
 export function FederalHead() {
   const { t } = useTranslation('Employee.Taxes')
   const Components = useComponentContext()
 
   return (
-    <>
+    <Flex flexDirection="column" gap={4}>
       <Components.Heading as="h2">{t('federalTaxesTitle')}</Components.Heading>
-      <Components.Text>
+      <Components.Text variant="supporting">
         <Trans
           i18nKey={'irsCalculator'}
           t={t}
@@ -18,6 +19,6 @@ export function FederalHead() {
           }}
         />
       </Components.Text>
-    </>
+    </Flex>
   )
 }

--- a/src/components/Employee/Taxes/StateForm.tsx
+++ b/src/components/Employee/Taxes/StateForm.tsx
@@ -5,6 +5,7 @@ import { useTaxes } from './useTaxes'
 import type { STATES_ABBR } from '@/shared/constants'
 import { snakeCaseToCamelCase } from '@/helpers/formattedStrings'
 import { QuestionInput } from '@/components/Common/TaxInputs/TaxInputs'
+import { Flex } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export const StateFormSchema = z.object({
@@ -25,21 +26,23 @@ export const StateForm = () => {
         <Components.Heading as="h2">
           {t('stateTaxesTitle', { state: statesHash(state as (typeof STATES_ABBR)[number]) })}
         </Components.Heading>
-        {questions.map(question => {
-          if (question.isQuestionForAdminOnly && !isAdmin) return null
-          return (
-            <QuestionInput
-              question={{
-                ...question,
-                key: `states.${state}.${snakeCaseToCamelCase(question.key)}`, // Its important not to convert state as it must maintain two capital letters
-              }}
-              questionType={
-                question.key === 'fileNewHireReport' ? 'Radio' : question.inputQuestionFormat.type
-              }
-              key={question.key}
-            />
-          )
-        })}
+        <Flex flexDirection="column" gap={20}>
+          {questions.map(question => {
+            if (question.isQuestionForAdminOnly && !isAdmin) return null
+            return (
+              <QuestionInput
+                question={{
+                  ...question,
+                  key: `states.${state}.${snakeCaseToCamelCase(question.key)}`, // Its important not to convert state as it must maintain two capital letters
+                }}
+                questionType={
+                  question.key === 'fileNewHireReport' ? 'Radio' : question.inputQuestionFormat.type
+                }
+                key={question.key}
+              />
+            )
+          })}
+        </Flex>
       </Fragment>
     ) : null,
   )

--- a/src/components/Employee/Taxes/Taxes.tsx
+++ b/src/components/Employee/Taxes/Taxes.tsx
@@ -24,6 +24,7 @@ import {
   type BaseComponentInterface,
   type CommonComponentInterface,
 } from '@/components/Base'
+import { Flex } from '@/components/Common'
 import { useFlow } from '@/components/Flow/useFlow'
 import { useI18n } from '@/i18n'
 import { componentEvents } from '@/shared/constants'
@@ -213,10 +214,16 @@ const Root = (props: TaxesProps) => {
               children
             ) : (
               <>
-                <FederalHead />
-                <FederalForm />
-                <StateForm />
-                <Actions />
+                <Flex flexDirection="column" gap={32}>
+                  <FederalHead />
+                  <Flex flexDirection="column" gap={20}>
+                    <Flex flexDirection="column" gap={32}>
+                      <FederalForm />
+                      <StateForm />
+                    </Flex>
+                    <Actions />
+                  </Flex>
+                </Flex>
               </>
             )}
           </Form>

--- a/src/components/Employee/WorkAddress/management/WorkAddressView.tsx
+++ b/src/components/Employee/WorkAddress/management/WorkAddressView.tsx
@@ -271,8 +271,10 @@ export function WorkAddressView({
 
   return (
     <Flex flexDirection="column" gap={24}>
-      <Flex flexDirection="column" gap={8} alignItems="flex-start">
-        <Components.Heading as="h1">{t('title')}</Components.Heading>
+      <Flex flexDirection="column" gap={4} alignItems="flex-start">
+        <Components.Heading as="h1" styledAs="h2">
+          {t('title')}
+        </Components.Heading>
         <Components.Text variant="supporting">{t('description')}</Components.Text>
       </Flex>
 
@@ -357,7 +359,9 @@ export function WorkAddressView({
       </Components.Box>
 
       <Flex flexDirection="column" gap={12}>
-        <Components.Heading as="h2">{t('historySectionTitle')}</Components.Heading>
+        <Components.Heading as="h2" styledAs="h4">
+          {t('historySectionTitle')}
+        </Components.Heading>
         <DataView label={t('historySectionTitle')} {...historyDataView} />
       </Flex>
 

--- a/src/i18n/en/Company.PaySchedule.json
+++ b/src/i18n/en/Company.PaySchedule.json
@@ -12,6 +12,7 @@
     "inactive": "Inactive",
     "edit": "Edit"
   },
+  "payScheduleListLabel": "Pay schedules",
   "headings": {
     "addPaySchedule": "Add pay schedule",
     "editPaySchedule": "Edit pay schedule",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -259,6 +259,7 @@ export interface CompanyPaySchedule{
 "inactive":string;
 "edit":string;
 };
+"payScheduleListLabel":string;
 "headings":{
 "addPaySchedule":string;
 "editPaySchedule":string;


### PR DESCRIPTION
## Summary

Standardizes section headers across Company, Employee, and Contractor SDK components to use a consistent spacing/typography pattern. Heading + description pairs are wrapped in `<Flex gap={4}>` and description text uses `variant="supporting"`, with parent layout containers updated to `alignItems="stretch"` for consistent alignment.

These changes were originally landed in #1656 but were lost in a subsequent branch operation; this PR restores them.

## Changes

- Wrap heading/description pairs in `Flex` with `gap={4}` across Company, Employee, and Contractor components
- Apply `variant="supporting"` to description Text components
- Add `alignItems="stretch"` to parent layout containers for consistent alignment
- Apply `styledAs` to several Heading elements for proper visual hierarchy
- Add new `Company.PaySchedule` i18n key + corresponding type

## Demo

<!-- Screenshots/recording to be added -->

## Related

- Restores changes from #1656

## Testing

- Visual check in Storybook for affected components (AssignSignatory, BankAccount, DocumentSigner, FederalTaxes, Industry, Locations, PaySchedule, Contractor Payments, EmployeeDocuments, Employee FederalTaxes/HomeAddress/WorkAddress, OnboardingSummary, AdminProfile, Employee Taxes, IncludeDeductions)
- `npm run test -- --run`