### PR TITLE
docs(SDK-897): include journey namespaces in endpoint inventory

### DIFF
--- a/build/deriveEndpointInventory.ts
+++ b/build/deriveEndpointInventory.ts
@@ -61,7 +61,6 @@ interface Inventory {
 interface DerivationResult {
   inventory: Inventory
   funcLookup: Map<string, Endpoint>
-  deprecatedNamespaces: Map<string, string>
 }
 
 function createApiProject(): Project {
@@ -270,12 +269,9 @@ function normalizeEndpointPath(openApiPath: string, paramNameMap: Record<string,
   })
 }
 
-interface NamespaceInfo {
-  domainDir: string
-  deprecated: boolean
-  /** The text after "@deprecated" in the JSDoc comment, if present. */
-  deprecationMessage: string | undefined
-}
+type NamespaceInfo =
+  | { domainDir: string; deprecated: true; deprecationMessage: string }
+  | { domainDir: string; deprecated: false }
 
 function parseNamespaceExports(): Map<string, NamespaceInfo> {
   const indexPath = join(COMPONENTS_DIR, 'index.ts')
@@ -292,13 +288,14 @@ function parseNamespaceExports(): Map<string, NamespaceInfo> {
     for (const [_fullMatch, jsdoc, namespaceName, domainDir] of content.matchAll(
       namespacePattern,
     )) {
-      let deprecationMessage: string | undefined
       if (jsdoc) {
         // Extract the text that follows "@deprecated" inside the JSDoc block.
         const match = /@deprecated\s+([\s\S]*?)\s*\*\//.exec(jsdoc)
-        deprecationMessage = match ? match[1].replace(/\s*\*\s*/g, ' ').trim() : ''
+        const deprecationMessage = match ? match[1].replace(/\s*\*\s*/g, ' ').trim() : ''
+        namespaces.set(namespaceName, { domainDir, deprecated: true, deprecationMessage })
+      } else {
+        namespaces.set(namespaceName, { domainDir, deprecated: false })
       }
-      namespaces.set(namespaceName, { domainDir, deprecated: !!jsdoc, deprecationMessage })
     }
   } catch (err) {
     console.error(`ERROR: Could not read ${indexPath}`)
@@ -371,11 +368,10 @@ function discoverBlocks(): {
   const namespaces = parseNamespaceExports()
   const deprecatedNamespaces = new Map<string, string>()
 
-  for (const [
-    namespaceName,
-    { domainDir: domainDirName, deprecated: nsDeprecated, deprecationMessage },
-  ] of namespaces.entries()) {
-    if (nsDeprecated) deprecatedNamespaces.set(namespaceName, deprecationMessage ?? '')
+  for (const [namespaceName, namespaceInfo] of namespaces.entries()) {
+    if (namespaceInfo.deprecated)
+      deprecatedNamespaces.set(namespaceName, namespaceInfo.deprecationMessage)
+    const { domainDir: domainDirName, deprecated: nsDeprecated } = namespaceInfo
     const domainDir = join(COMPONENTS_DIR, domainDirName)
     const componentExports = parseComponentExports(domainDir)
 
@@ -584,7 +580,7 @@ function deduplicateEndpoints(endpoints: Endpoint[]): Endpoint[] {
 function deriveInventory(): DerivationResult {
   const project = createApiProject()
   const funcLookup = buildFuncLookup(project)
-  const { blocks: blockMappings, deprecatedNamespaces } = discoverBlocks()
+  const { blocks: blockMappings } = discoverBlocks()
   const allBlockDirs = new Set(blockMappings.map(m => m.componentDir))
 
   const blocks: Record<string, BlockEntry> = {}
@@ -625,7 +621,7 @@ function deriveInventory(): DerivationResult {
     Object.entries(flows).sort(([a], [b]) => a.localeCompare(b)),
   )
 
-  return { inventory: { blocks, flows: sortedFlows }, funcLookup, deprecatedNamespaces }
+  return { inventory: { blocks, flows: sortedFlows }, funcLookup }
 }
 
 function generateMarkdown(inventory: Inventory): string {

--- a/build/deriveEndpointInventory.ts
+++ b/build/deriveEndpointInventory.ts
@@ -42,6 +42,10 @@ interface FlowEntry {
 interface BlockMapping {
   blockName: string
   componentDir: string
+  /** true if the namespace itself is annotated as deprecated in index.ts */
+  namespaceDeprecated: boolean
+  /** true if the specific export within the barrel file is annotated as deprecated */
+  exportDeprecated: boolean
 }
 
 interface FlowMapping {
@@ -57,6 +61,7 @@ interface Inventory {
 interface DerivationResult {
   inventory: Inventory
   funcLookup: Map<string, Endpoint>
+  deprecatedNamespaces: Map<string, string>
 }
 
 function createApiProject(): Project {
@@ -265,18 +270,35 @@ function normalizeEndpointPath(openApiPath: string, paramNameMap: Record<string,
   })
 }
 
-function parseNamespaceExports(): Map<string, string> {
+interface NamespaceInfo {
+  domainDir: string
+  deprecated: boolean
+  /** The text after "@deprecated" in the JSDoc comment, if present. */
+  deprecationMessage: string | undefined
+}
+
+function parseNamespaceExports(): Map<string, NamespaceInfo> {
   const indexPath = join(COMPONENTS_DIR, 'index.ts')
-  const namespaces = new Map<string, string>()
+  const namespaces = new Map<string, NamespaceInfo>()
 
   try {
     const content = readFileSync(indexPath, 'utf-8')
     // export * as EmployeeManagement from './Employee/exports/employeeManagement'  →
     //   namespaceName = "EmployeeManagement"
     //   domainDir = "Employee/exports/employeeManagement"
-    const namespacePattern = /export\s+\*\s+as\s+(\w+)\s+from\s+['"]\.\/([^'"]+)['"]/g
-    for (const [_fullMatch, namespaceName, domainDir] of content.matchAll(namespacePattern)) {
-      namespaces.set(namespaceName, domainDir)
+    // Captures the optional /** @deprecated ... */ JSDoc comment that may precede the export.
+    const namespacePattern =
+      /(\/\*\*[\s\S]*?@deprecated[\s\S]*?\*\/\s*)?export\s+\*\s+as\s+(\w+)\s+from\s+['"]\.\/([^'"]+)['"]/g
+    for (const [_fullMatch, jsdoc, namespaceName, domainDir] of content.matchAll(
+      namespacePattern,
+    )) {
+      let deprecationMessage: string | undefined
+      if (jsdoc) {
+        // Extract the text that follows "@deprecated" inside the JSDoc block.
+        const match = /@deprecated\s+([\s\S]*?)\s*\*\//.exec(jsdoc)
+        deprecationMessage = match ? match[1].replace(/\s*\*\s*/g, ' ').trim() : ''
+      }
+      namespaces.set(namespaceName, { domainDir, deprecated: !!jsdoc, deprecationMessage })
     }
   } catch (err) {
     console.error(`ERROR: Could not read ${indexPath}`)
@@ -286,23 +308,34 @@ function parseNamespaceExports(): Map<string, string> {
   return namespaces
 }
 
-function parseComponentExports(domainDir: string): Map<string, string> {
-  const exports = new Map<string, string>()
-  const possibleBarrelFiles = [join(domainDir, 'index.ts'), join(domainDir, 'index.tsx')]
+interface ComponentExport {
+  importPath: string
+  deprecated: boolean
+}
+
+function parseComponentExports(domainDir: string): Map<string, ComponentExport> {
+  const exports = new Map<string, ComponentExport>()
+  const possibleBarrelFiles = [
+    join(domainDir, 'index.ts'),
+    join(domainDir, 'index.tsx'),
+    domainDir + '.ts',
+    domainDir + '.tsx',
+  ]
 
   for (const barrelPath of possibleBarrelFiles) {
     try {
       const content = readFileSync(barrelPath, 'utf-8')
+      // Optionally captures a /** @deprecated */ JSDoc comment that may precede the export.
       // export { EmployeeDocuments as Documents } from './Documents'  →
       //   nameToken = "EmployeeDocuments as Documents"
       //   importPath = "./Documents"
       // Uses the alias when present so the map key matches the public export name.
       const exportPattern =
-        /export\s+\{\s*(\w+(?:\s+as\s+\w+)?)[^}]*?\}\s+from\s+['"](\.[^'"]+)['"]/g
-      for (const [_fullMatch, nameToken, importPath] of content.matchAll(exportPattern)) {
+        /(\/\*\*[\s\S]*?@deprecated[\s\S]*?\*\/\s*)?export\s+\{\s*(\w+(?:\s+as\s+\w+)?)[^}]*?\}\s+from\s+['"](\.[^'"]+)['"]/g
+      for (const [_fullMatch, jsdoc, nameToken, importPath] of content.matchAll(exportPattern)) {
         const asIndex = nameToken.indexOf(' as ')
         const componentName = asIndex >= 0 ? nameToken.slice(asIndex + 4).trim() : nameToken.trim()
-        exports.set(componentName, importPath)
+        exports.set(componentName, { importPath, deprecated: !!jsdoc })
       }
       break
     } catch {
@@ -314,7 +347,9 @@ function parseComponentExports(domainDir: string): Map<string, string> {
 }
 
 function resolveComponentDirectory(domainDir: string, importPath: string): string {
-  const resolved = resolve(domainDir, importPath)
+  const effectiveBase =
+    existsSync(domainDir) && statSync(domainDir).isDirectory() ? domainDir : dirname(domainDir)
+  const resolved = resolve(effectiveBase, importPath)
 
   if (existsSync(resolved + '.tsx') || existsSync(resolved + '.ts')) {
     return dirname(resolved)
@@ -327,32 +362,49 @@ function resolveComponentDirectory(domainDir: string, importPath: string): strin
   return resolved
 }
 
-function discoverBlocks(): BlockMapping[] {
+function discoverBlocks(): {
+  blocks: BlockMapping[]
+  /** Maps namespace name to its deprecation message (empty string if no message). */
+  deprecatedNamespaces: Map<string, string>
+} {
   const blocks: BlockMapping[] = []
   const namespaces = parseNamespaceExports()
+  const deprecatedNamespaces = new Map<string, string>()
 
-  for (const [namespaceName, domainDirName] of namespaces.entries()) {
+  for (const [
+    namespaceName,
+    { domainDir: domainDirName, deprecated: nsDeprecated, deprecationMessage },
+  ] of namespaces.entries()) {
+    if (nsDeprecated) deprecatedNamespaces.set(namespaceName, deprecationMessage ?? '')
     const domainDir = join(COMPONENTS_DIR, domainDirName)
     const componentExports = parseComponentExports(domainDir)
 
-    for (const [componentName, importPath] of componentExports.entries()) {
+    for (const [
+      componentName,
+      { importPath, deprecated: exportDeprecated },
+    ] of componentExports.entries()) {
       const componentDir = resolveComponentDirectory(domainDir, importPath)
-      blocks.push({ blockName: `${namespaceName}.${componentName}`, componentDir })
+      blocks.push({
+        blockName: `${namespaceName}.${componentName}`,
+        componentDir,
+        namespaceDeprecated: nsDeprecated,
+        exportDeprecated,
+      })
     }
   }
 
-  return blocks
+  return { blocks, deprecatedNamespaces }
 }
 
 function discoverFlows(): FlowMapping[] {
   const flows: FlowMapping[] = []
   const namespaces = parseNamespaceExports()
 
-  for (const [namespaceName, domainDirName] of namespaces.entries()) {
+  for (const [namespaceName, { domainDir: domainDirName }] of namespaces.entries()) {
     const domainDir = join(COMPONENTS_DIR, domainDirName)
     const componentExports = parseComponentExports(domainDir)
 
-    for (const [componentName, importPath] of componentExports.entries()) {
+    for (const [componentName, { importPath }] of componentExports.entries()) {
       if (!componentName.endsWith('Flow')) continue
       const flowDir = resolveComponentDirectory(domainDir, importPath)
       flows.push({ flowName: `${namespaceName}.${componentName}`, flowDir })
@@ -366,6 +418,8 @@ function deriveBlocksFromImport(
   resolvedImportPath: string,
   rawImportedNames: string,
   dirToBlocks: Map<string, string[]>,
+  preferredNamespace?: string,
+  blockDeprecationLevel?: Map<string, number>,
 ): string[] {
   // Find the most specific directory that matches this import path
   let matchingDir: string | undefined
@@ -390,27 +444,62 @@ function deriveBlocksFromImport(
       .trim(),
   )
 
-  const blockNames = new Set<string>()
+  const nameMatchedBlocks = new Set<string>()
   for (const blockName of blocks) {
     const componentName = blockName.split('.').pop()
     if (componentName && importedNames.includes(componentName)) {
-      blockNames.add(blockName)
+      nameMatchedBlocks.add(blockName)
     }
   }
 
-  return [...blockNames]
+  // When imports use contextual wrappers (e.g. CompensationContextual) that don't
+  // match the block's component name, name matching returns nothing. Fall back to
+  // all blocks for this dir so the namespace-preference step below can still filter.
+  const candidates = nameMatchedBlocks.size > 0 ? [...nameMatchedBlocks] : blocks
+
+  if (candidates.length <= 1) return candidates
+
+  // Prefer blocks from the flow's own namespace first.
+  if (preferredNamespace) {
+    const sameNamespaceBlocks = candidates.filter(b => b.startsWith(preferredNamespace + '.'))
+    if (sameNamespaceBlocks.length > 0) return sameNamespaceBlocks
+  }
+
+  // No same-namespace match. Prefer least-deprecated blocks using a tiered approach:
+  //   level 0 = fully active
+  //   level 1 = namespace deprecated (whole namespace is being phased out)
+  //   level 2 = export deprecated (explicit "don't use this" on the specific export)
+  // Export-deprecated loses to namespace-deprecated because a targeted export @deprecated
+  // is a stronger signal to avoid that specific block than a namespace-wide deprecation.
+  if (blockDeprecationLevel) {
+    const minLevel = Math.min(...candidates.map(b => blockDeprecationLevel.get(b) ?? 0))
+    const leastDeprecated = candidates.filter(b => (blockDeprecationLevel.get(b) ?? 0) === minLevel)
+    if (leastDeprecated.length < candidates.length) return leastDeprecated
+  }
+
+  return candidates
 }
 
-function deriveFlowBlocks(flowDir: string, blockMappings: BlockMapping[]): string[] {
+function deriveFlowBlocks(
+  flowDir: string,
+  blockMappings: BlockMapping[],
+  flowNamespace: string,
+): string[] {
   const files = walkDir(flowDir)
   const blockNames = new Set<string>()
 
   const dirToBlocks = new Map<string, string[]>()
+  // Deprecation level: 0 = active, 1 = namespace deprecated, 2 = export deprecated.
+  // Export-deprecated is ranked worst because it's an explicit "don't use this" on
+  // a specific export (vs. a whole namespace being phased out).
+  const blockDeprecationLevel = new Map<string, number>()
   for (const mapping of blockMappings) {
     if (!dirToBlocks.has(mapping.componentDir)) {
       dirToBlocks.set(mapping.componentDir, [])
     }
     dirToBlocks.get(mapping.componentDir)!.push(mapping.blockName)
+    const level = mapping.exportDeprecated ? 2 : mapping.namespaceDeprecated ? 1 : 0
+    blockDeprecationLevel.set(mapping.blockName, level)
   }
 
   // import { EmployeeForm } from '@/components/Employee/Form'  →
@@ -439,6 +528,8 @@ function deriveFlowBlocks(flowDir: string, blockMappings: BlockMapping[]): strin
         join(COMPONENTS_DIR, importPath),
         allImportedNames,
         dirToBlocks,
+        flowNamespace,
+        blockDeprecationLevel,
       ).forEach(blockName => blockNames.add(blockName))
     }
 
@@ -452,6 +543,8 @@ function deriveFlowBlocks(flowDir: string, blockMappings: BlockMapping[]): strin
         resolve(dirname(filePath), importPath),
         allImportedNames,
         dirToBlocks,
+        flowNamespace,
+        blockDeprecationLevel,
       ).forEach(blockName => blockNames.add(blockName))
     }
   }
@@ -491,7 +584,7 @@ function deduplicateEndpoints(endpoints: Endpoint[]): Endpoint[] {
 function deriveInventory(): DerivationResult {
   const project = createApiProject()
   const funcLookup = buildFuncLookup(project)
-  const blockMappings = discoverBlocks()
+  const { blocks: blockMappings, deprecatedNamespaces } = discoverBlocks()
   const allBlockDirs = new Set(blockMappings.map(m => m.componentDir))
 
   const blocks: Record<string, BlockEntry> = {}
@@ -521,7 +614,10 @@ function deriveInventory(): DerivationResult {
   const flows: Record<string, FlowEntry> = {}
 
   for (const { flowName, flowDir } of flowMappings) {
-    const blockNames = deriveFlowBlocks(flowDir, blockMappings).filter(b => b !== flowName)
+    const flowNamespace = flowName.split('.')[0]!
+    const blockNames = deriveFlowBlocks(flowDir, blockMappings, flowNamespace).filter(
+      b => b !== flowName,
+    )
     flows[flowName] = { blocks: blockNames }
   }
 
@@ -529,7 +625,7 @@ function deriveInventory(): DerivationResult {
     Object.entries(flows).sort(([a], [b]) => a.localeCompare(b)),
   )
 
-  return { inventory: { blocks, flows: sortedFlows }, funcLookup }
+  return { inventory: { blocks, flows: sortedFlows }, funcLookup, deprecatedNamespaces }
 }
 
 function generateMarkdown(inventory: Inventory): string {

--- a/docs/reference/endpoint-inventory.json
+++ b/docs/reference/endpoint-inventory.json
@@ -1648,6 +1648,866 @@
         "companyId",
         "timeOffPolicyUuid"
       ]
+    },
+    "EmployeeOnboarding.EmployeeList": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/employees"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/onboarding_status"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "employeeId"
+      ]
+    },
+    "EmployeeOnboarding.OnboardingSummary": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/onboarding_status"
+        }
+      ],
+      "variables": [
+        "employeeId"
+      ]
+    },
+    "EmployeeOnboarding.Landing": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "employeeId"
+      ]
+    },
+    "EmployeeOnboarding.DocumentSigner": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/forms"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/forms/:formId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/forms/:formId/pdf"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/forms/:formId/sign"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/i9_authorization"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/i9_authorization"
+        }
+      ],
+      "variables": [
+        "employeeId",
+        "formId"
+      ]
+    },
+    "EmployeeOnboarding.EmploymentEligibility": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/i9_authorization"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/i9_authorization"
+        }
+      ],
+      "variables": [
+        "employeeId"
+      ]
+    },
+    "EmployeeOnboarding.Profile": {
+      "endpoints": [
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/employees"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/locations"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/home_addresses"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/home_addresses"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/onboarding_status"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/work_addresses"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/work_addresses"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/home_addresses/:homeAddressUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/home_addresses/:homeAddressUuid"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/work_addresses/:workAddressUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/work_addresses/:workAddressUuid"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "employeeId",
+        "homeAddressUuid",
+        "workAddressUuid"
+      ]
+    },
+    "EmployeeOnboarding.Compensation": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/federal_tax_details"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/compensations/:compensationId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/jobs"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/jobs"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/work_addresses"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/jobs/:jobId"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/jobs/:jobId"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/jobs/:jobId/compensations"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/locations/:locationUuid/minimum_wages"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "compensationId",
+        "employeeId",
+        "jobId",
+        "locationUuid"
+      ]
+    },
+    "EmployeeOnboarding.Deductions": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/garnishments"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/garnishments"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/garnishments/:garnishmentId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/garnishments/child_support"
+        }
+      ],
+      "variables": [
+        "employeeId",
+        "garnishmentId"
+      ]
+    },
+    "EmployeeOnboarding.Taxes": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeUuid/federal_taxes"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeUuid/federal_taxes"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeUuid/state_taxes"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeUuid/state_taxes"
+        }
+      ],
+      "variables": [
+        "employeeUuid"
+      ]
+    },
+    "EmployeeManagement.EmployeeList": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/employees"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/onboarding_status"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "employeeId"
+      ]
+    },
+    "EmployeeManagement.EmployeeDocuments": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/onboarding_documents_config"
+        }
+      ],
+      "variables": [
+        "employeeId"
+      ]
+    },
+    "EmployeeManagement.DashboardFlow": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/forms"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/garnishments"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/home_addresses"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/pay_stubs"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/work_addresses"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeUuid/federal_taxes"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeUuid/state_taxes"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/payrolls/:payrollId/employees/:employeeId/pay_stub"
+        }
+      ],
+      "variables": [
+        "employeeId",
+        "employeeUuid",
+        "payrollId"
+      ]
+    },
+    "EmployeeManagement.WorkAddress": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/work_addresses"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/work_addresses/:workAddressUuid"
+        }
+      ],
+      "variables": [
+        "employeeId",
+        "workAddressUuid"
+      ]
+    },
+    "EmployeeManagement.Profile": {
+      "endpoints": [
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/employees"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/employees/:employeeId/onboarding_status"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "employeeId"
+      ]
+    },
+    "EmployeeManagement.TerminateEmployee": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/payrolls"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/payrolls"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/terminations"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/employees/:employeeId/terminations"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/terminations/:employeeId"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "employeeId"
+      ]
+    },
+    "EmployeeManagement.TerminationSummary": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/employees"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/terminations"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/employees/:employeeId/terminations"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "employeeId"
+      ]
+    },
+    "CompanyOnboarding.OnboardingOverview": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/onboarding_status"
+        }
+      ],
+      "variables": [
+        "companyUuid"
+      ]
+    },
+    "CompanyOnboarding.DocumentSigner": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/forms"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/signatories"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/forms/:formId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/forms/:formId/pdf"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/forms/:formId/sign"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "companyUuid",
+        "formId"
+      ]
+    },
+    "CompanyOnboarding.DocumentList": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/forms"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/signatories"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "companyUuid"
+      ]
+    },
+    "CompanyOnboarding.Industry": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/industry_selection"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/industry_selection"
+        }
+      ],
+      "variables": [
+        "companyId"
+      ]
+    },
+    "CompanyOnboarding.BankAccount": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/bank_accounts"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/bank_accounts"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/bank_accounts/:bankAccountUuid/verify"
+        }
+      ],
+      "variables": [
+        "bankAccountUuid",
+        "companyId"
+      ]
+    },
+    "CompanyOnboarding.Locations": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/locations"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/locations"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/locations/:locationId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/locations/:locationId"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "locationId"
+      ]
+    },
+    "CompanyOnboarding.LocationForm": {
+      "endpoints": [
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/locations"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/locations/:locationId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/locations/:locationId"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "locationId"
+      ]
+    },
+    "CompanyOnboarding.PaySchedule": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/pay_schedules"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyId/pay_schedules"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/pay_schedules/:payScheduleId"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/pay_schedules/preview"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/payment_configs"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "companyUuid",
+        "payScheduleId"
+      ]
+    },
+    "CompanyOnboarding.FederalTaxes": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/federal_tax_details"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyId/federal_tax_details"
+        }
+      ],
+      "variables": [
+        "companyId"
+      ]
+    },
+    "CompanyOnboarding.StateTaxes": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/tax_requirements"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
+        }
+      ],
+      "variables": [
+        "companyUuid",
+        "state"
+      ]
+    },
+    "CompanyOnboarding.StateTaxesForm": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyUuid/tax_requirements/:state"
+        }
+      ],
+      "variables": [
+        "companyUuid",
+        "state"
+      ]
+    },
+    "CompanyOnboarding.StateTaxesList": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/tax_requirements"
+        }
+      ],
+      "variables": [
+        "companyUuid"
+      ]
+    },
+    "CompanyOnboarding.AssignSignatory": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/signatories"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/signatories"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyUuid/signatories/:signatoryUuid"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/companies/:companyUuid/signatories/:signatoryUuid"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/signatories/invite"
+        }
+      ],
+      "variables": [
+        "companyUuid",
+        "signatoryUuid"
+      ]
+    },
+    "CompanyOnboarding.CreateSignatory": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/signatories"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/signatories"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/companies/:companyUuid/signatories/:signatoryUuid"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/companies/:companyUuid/signatories/:signatoryUuid"
+        }
+      ],
+      "variables": [
+        "companyUuid",
+        "signatoryUuid"
+      ]
+    },
+    "CompanyOnboarding.InviteSignatory": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/signatories"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/companies/:companyUuid/signatories/:signatoryUuid"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/signatories/invite"
+        }
+      ],
+      "variables": [
+        "companyUuid",
+        "signatoryUuid"
+      ]
+    },
+    "ContractorOnboarding.ContractorList": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyUuid/contractors"
+        },
+        {
+          "method": "DELETE",
+          "path": "/v1/contractors/:contractorUuid"
+        }
+      ],
+      "variables": [
+        "companyUuid",
+        "contractorUuid"
+      ]
+    },
+    "ContractorOnboarding.ContractorProfile": {
+      "endpoints": [
+        {
+          "method": "POST",
+          "path": "/v1/companies/:companyUuid/contractors"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/contractors/:contractorUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/contractors/:contractorUuid"
+        }
+      ],
+      "variables": [
+        "companyUuid",
+        "contractorUuid"
+      ]
+    },
+    "ContractorOnboarding.Address": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/contractors/:contractorUuid"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/contractors/:contractorUuid/address"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/contractors/:contractorUuid/address"
+        }
+      ],
+      "variables": [
+        "contractorUuid"
+      ]
+    },
+    "ContractorOnboarding.PaymentMethod": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/contractors/:contractorUuid/bank_accounts"
+        },
+        {
+          "method": "POST",
+          "path": "/v1/contractors/:contractorUuid/bank_accounts"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/contractors/:contractorUuid/payment_method"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/contractors/:contractorUuid/payment_method"
+        }
+      ],
+      "variables": [
+        "contractorUuid"
+      ]
+    },
+    "ContractorOnboarding.NewHireReport": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/contractors/:contractorUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/contractors/:contractorUuid"
+        }
+      ],
+      "variables": [
+        "contractorUuid"
+      ]
+    },
+    "ContractorOnboarding.ContractorSubmit": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/contractors/:contractorUuid"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/contractors/:contractorUuid/onboarding_status"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/contractors/:contractorUuid/onboarding_status"
+        }
+      ],
+      "variables": [
+        "contractorUuid"
+      ]
     }
   },
   "flows": {
@@ -1661,7 +2521,20 @@
         "Company.OnboardingOverview",
         "Company.PaySchedule",
         "Company.StateTaxes",
-        "Employee.OnboardingFlow"
+        "EmployeeOnboarding.OnboardingFlow"
+      ]
+    },
+    "CompanyOnboarding.OnboardingFlow": {
+      "blocks": [
+        "CompanyOnboarding.BankAccount",
+        "CompanyOnboarding.DocumentSigner",
+        "CompanyOnboarding.FederalTaxes",
+        "CompanyOnboarding.Industry",
+        "CompanyOnboarding.Locations",
+        "CompanyOnboarding.OnboardingOverview",
+        "CompanyOnboarding.PaySchedule",
+        "CompanyOnboarding.StateTaxes",
+        "EmployeeOnboarding.OnboardingFlow"
       ]
     },
     "Contractor.OnboardingFlow": {
@@ -1684,13 +2557,25 @@
         "InformationRequests.InformationRequestsFlow"
       ]
     },
+    "ContractorOnboarding.OnboardingFlow": {
+      "blocks": [
+        "ContractorOnboarding.Address",
+        "ContractorOnboarding.ContractorList",
+        "ContractorOnboarding.ContractorProfile",
+        "ContractorOnboarding.ContractorSubmit",
+        "ContractorOnboarding.NewHireReport",
+        "ContractorOnboarding.PaymentMethod"
+      ]
+    },
     "Employee.DashboardFlow": {
       "blocks": [
-        "Employee.FederalTaxes",
         "Employee.HomeAddress",
         "Employee.PaymentMethod",
-        "Employee.StateTaxes",
-        "Employee.WorkAddress"
+        "Employee.WorkAddress",
+        "EmployeeManagement.FederalTaxes",
+        "EmployeeManagement.Profile",
+        "EmployeeManagement.StateTaxes",
+        "EmployeeOnboarding.PaymentMethod"
       ]
     },
     "Employee.OnboardingFlow": {
@@ -1699,22 +2584,22 @@
         "Employee.Deductions",
         "Employee.EmployeeDocuments",
         "Employee.EmployeeList",
-        "Employee.FederalTaxes",
         "Employee.OnboardingSummary",
         "Employee.PaymentMethod",
         "Employee.Profile",
-        "Employee.StateTaxes"
+        "EmployeeOnboarding.FederalTaxes",
+        "EmployeeOnboarding.StateTaxes"
       ]
     },
     "Employee.SelfOnboardingFlow": {
       "blocks": [
         "Employee.DocumentSigner",
-        "Employee.FederalTaxes",
         "Employee.Landing",
         "Employee.OnboardingSummary",
         "Employee.PaymentMethod",
         "Employee.Profile",
-        "Employee.StateTaxes"
+        "EmployeeOnboarding.FederalTaxes",
+        "EmployeeOnboarding.StateTaxes"
       ]
     },
     "Employee.TerminationFlow": {
@@ -1723,6 +2608,49 @@
         "Employee.TerminationSummary",
         "Payroll.DismissalFlow",
         "Payroll.PayrollLanding"
+      ]
+    },
+    "EmployeeManagement.DashboardFlow": {
+      "blocks": [
+        "Employee.HomeAddress",
+        "Employee.PaymentMethod",
+        "EmployeeManagement.FederalTaxes",
+        "EmployeeManagement.Profile",
+        "EmployeeManagement.StateTaxes",
+        "EmployeeManagement.WorkAddress",
+        "EmployeeOnboarding.PaymentMethod"
+      ]
+    },
+    "EmployeeManagement.TerminationFlow": {
+      "blocks": [
+        "EmployeeManagement.TerminateEmployee",
+        "EmployeeManagement.TerminationSummary",
+        "Payroll.DismissalFlow",
+        "Payroll.PayrollLanding"
+      ]
+    },
+    "EmployeeOnboarding.OnboardingFlow": {
+      "blocks": [
+        "Employee.PaymentMethod",
+        "EmployeeManagement.EmployeeDocuments",
+        "EmployeeOnboarding.Compensation",
+        "EmployeeOnboarding.Deductions",
+        "EmployeeOnboarding.EmployeeList",
+        "EmployeeOnboarding.FederalTaxes",
+        "EmployeeOnboarding.OnboardingSummary",
+        "EmployeeOnboarding.Profile",
+        "EmployeeOnboarding.StateTaxes"
+      ]
+    },
+    "EmployeeOnboarding.SelfOnboardingFlow": {
+      "blocks": [
+        "Employee.PaymentMethod",
+        "EmployeeOnboarding.DocumentSigner",
+        "EmployeeOnboarding.FederalTaxes",
+        "EmployeeOnboarding.Landing",
+        "EmployeeOnboarding.OnboardingSummary",
+        "EmployeeOnboarding.Profile",
+        "EmployeeOnboarding.StateTaxes"
       ]
     },
     "InformationRequests.InformationRequestsFlow": {

--- a/docs/reference/endpoint-inventory.json
+++ b/docs/reference/endpoint-inventory.json
@@ -2631,8 +2631,8 @@
     },
     "EmployeeOnboarding.OnboardingFlow": {
       "blocks": [
+        "Employee.EmployeeDocuments",
         "Employee.PaymentMethod",
-        "EmployeeManagement.EmployeeDocuments",
         "EmployeeOnboarding.Compensation",
         "EmployeeOnboarding.Deductions",
         "EmployeeOnboarding.EmployeeList",

--- a/docs/reference/endpoint-reference.md
+++ b/docs/reference/endpoint-reference.md
@@ -307,19 +307,187 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 
+## EmployeeOnboarding components
+
+| Component | Method | Path |
+| --- | --- | --- |
+| **EmployeeOnboarding.EmployeeList** | GET | `/v1/companies/:companyId/employees` |
+|  | DELETE | `/v1/employees/:employeeId` |
+|  | PUT | `/v1/employees/:employeeId/onboarding_status` |
+| **EmployeeOnboarding.OnboardingSummary** | GET | `/v1/employees/:employeeId` |
+|  | GET | `/v1/employees/:employeeId/onboarding_status` |
+| **EmployeeOnboarding.Landing** | GET | `/v1/companies/:companyId` |
+|  | GET | `/v1/employees/:employeeId` |
+| **EmployeeOnboarding.DocumentSigner** | GET | `/v1/employees/:employeeId` |
+|  | GET | `/v1/employees/:employeeId/forms` |
+|  | GET | `/v1/employees/:employeeId/forms/:formId` |
+|  | GET | `/v1/employees/:employeeId/forms/:formId/pdf` |
+|  | PUT | `/v1/employees/:employeeId/forms/:formId/sign` |
+|  | GET | `/v1/employees/:employeeId/i9_authorization` |
+|  | PUT | `/v1/employees/:employeeId/i9_authorization` |
+| **EmployeeOnboarding.EmploymentEligibility** | GET | `/v1/employees/:employeeId/i9_authorization` |
+|  | PUT | `/v1/employees/:employeeId/i9_authorization` |
+| **EmployeeOnboarding.Profile** | POST | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/companies/:companyId/locations` |
+|  | GET | `/v1/employees/:employeeId` |
+|  | PUT | `/v1/employees/:employeeId` |
+|  | GET | `/v1/employees/:employeeId/home_addresses` |
+|  | POST | `/v1/employees/:employeeId/home_addresses` |
+|  | PUT | `/v1/employees/:employeeId/onboarding_status` |
+|  | GET | `/v1/employees/:employeeId/work_addresses` |
+|  | POST | `/v1/employees/:employeeId/work_addresses` |
+|  | GET | `/v1/home_addresses/:homeAddressUuid` |
+|  | PUT | `/v1/home_addresses/:homeAddressUuid` |
+|  | GET | `/v1/work_addresses/:workAddressUuid` |
+|  | PUT | `/v1/work_addresses/:workAddressUuid` |
+| **EmployeeOnboarding.Compensation** | GET | `/v1/companies/:companyId/federal_tax_details` |
+|  | PUT | `/v1/compensations/:compensationId` |
+|  | GET | `/v1/employees/:employeeId` |
+|  | GET | `/v1/employees/:employeeId/jobs` |
+|  | POST | `/v1/employees/:employeeId/jobs` |
+|  | GET | `/v1/employees/:employeeId/work_addresses` |
+|  | PUT | `/v1/jobs/:jobId` |
+|  | DELETE | `/v1/jobs/:jobId` |
+|  | POST | `/v1/jobs/:jobId/compensations` |
+|  | GET | `/v1/locations/:locationUuid/minimum_wages` |
+| **EmployeeOnboarding.Deductions** | GET | `/v1/employees/:employeeId/garnishments` |
+|  | POST | `/v1/employees/:employeeId/garnishments` |
+|  | PUT | `/v1/garnishments/:garnishmentId` |
+|  | GET | `/v1/garnishments/child_support` |
+| **EmployeeOnboarding.Taxes** | GET | `/v1/employees/:employeeUuid/federal_taxes` |
+|  | PUT | `/v1/employees/:employeeUuid/federal_taxes` |
+|  | GET | `/v1/employees/:employeeUuid/state_taxes` |
+|  | PUT | `/v1/employees/:employeeUuid/state_taxes` |
+
+## EmployeeManagement components
+
+| Component | Method | Path |
+| --- | --- | --- |
+| **EmployeeManagement.EmployeeList** | GET | `/v1/companies/:companyId/employees` |
+|  | DELETE | `/v1/employees/:employeeId` |
+|  | PUT | `/v1/employees/:employeeId/onboarding_status` |
+| **EmployeeManagement.EmployeeDocuments** | GET | `/v1/employees/:employeeId` |
+|  | PUT | `/v1/employees/:employeeId/onboarding_documents_config` |
+| **EmployeeManagement.DashboardFlow** | GET | `/v1/employees/:employeeId` |
+|  | GET | `/v1/employees/:employeeId/forms` |
+|  | GET | `/v1/employees/:employeeId/garnishments` |
+|  | GET | `/v1/employees/:employeeId/home_addresses` |
+|  | GET | `/v1/employees/:employeeId/pay_stubs` |
+|  | GET | `/v1/employees/:employeeId/work_addresses` |
+|  | GET | `/v1/employees/:employeeUuid/federal_taxes` |
+|  | GET | `/v1/employees/:employeeUuid/state_taxes` |
+|  | GET | `/v1/payrolls/:payrollId/employees/:employeeId/pay_stub` |
+| **EmployeeManagement.WorkAddress** | GET | `/v1/employees/:employeeId` |
+|  | GET | `/v1/employees/:employeeId/work_addresses` |
+|  | DELETE | `/v1/work_addresses/:workAddressUuid` |
+| **EmployeeManagement.Profile** | POST | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/employees/:employeeId` |
+|  | PUT | `/v1/employees/:employeeId` |
+|  | PUT | `/v1/employees/:employeeId/onboarding_status` |
+| **EmployeeManagement.TerminateEmployee** | GET | `/v1/companies/:companyId/pay_periods/unprocessed_termination_pay_periods` |
+|  | GET | `/v1/companies/:companyId/payrolls` |
+|  | POST | `/v1/companies/:companyId/payrolls` |
+|  | GET | `/v1/employees/:employeeId` |
+|  | GET | `/v1/employees/:employeeId/terminations` |
+|  | POST | `/v1/employees/:employeeId/terminations` |
+|  | PUT | `/v1/terminations/:employeeId` |
+| **EmployeeManagement.TerminationSummary** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/employees/:employeeId` |
+|  | GET | `/v1/employees/:employeeId/terminations` |
+|  | DELETE | `/v1/employees/:employeeId/terminations` |
+
+## CompanyOnboarding components
+
+| Component | Method | Path |
+| --- | --- | --- |
+| **CompanyOnboarding.OnboardingOverview** | GET | `/v1/companies/:companyUuid/onboarding_status` |
+| **CompanyOnboarding.DocumentSigner** | GET | `/v1/companies/:companyId/forms` |
+|  | GET | `/v1/companies/:companyUuid/signatories` |
+|  | GET | `/v1/forms/:formId` |
+|  | GET | `/v1/forms/:formId/pdf` |
+|  | PUT | `/v1/forms/:formId/sign` |
+| **CompanyOnboarding.DocumentList** | GET | `/v1/companies/:companyId/forms` |
+|  | GET | `/v1/companies/:companyUuid/signatories` |
+| **CompanyOnboarding.Industry** | GET | `/v1/companies/:companyId/industry_selection` |
+|  | PUT | `/v1/companies/:companyId/industry_selection` |
+| **CompanyOnboarding.BankAccount** | GET | `/v1/companies/:companyId/bank_accounts` |
+|  | POST | `/v1/companies/:companyId/bank_accounts` |
+|  | PUT | `/v1/companies/:companyId/bank_accounts/:bankAccountUuid/verify` |
+| **CompanyOnboarding.Locations** | GET | `/v1/companies/:companyId/locations` |
+|  | POST | `/v1/companies/:companyId/locations` |
+|  | GET | `/v1/locations/:locationId` |
+|  | PUT | `/v1/locations/:locationId` |
+| **CompanyOnboarding.LocationForm** | POST | `/v1/companies/:companyId/locations` |
+|  | GET | `/v1/locations/:locationId` |
+|  | PUT | `/v1/locations/:locationId` |
+| **CompanyOnboarding.PaySchedule** | GET | `/v1/companies/:companyId/pay_schedules` |
+|  | POST | `/v1/companies/:companyId/pay_schedules` |
+|  | GET | `/v1/companies/:companyId/pay_schedules/:payScheduleId` |
+|  | PUT | `/v1/companies/:companyId/pay_schedules/:payScheduleId` |
+|  | GET | `/v1/companies/:companyId/pay_schedules/preview` |
+|  | GET | `/v1/companies/:companyUuid/payment_configs` |
+| **CompanyOnboarding.FederalTaxes** | GET | `/v1/companies/:companyId/federal_tax_details` |
+|  | PUT | `/v1/companies/:companyId/federal_tax_details` |
+| **CompanyOnboarding.StateTaxes** | GET | `/v1/companies/:companyUuid/tax_requirements` |
+|  | GET | `/v1/companies/:companyUuid/tax_requirements/:state` |
+|  | PUT | `/v1/companies/:companyUuid/tax_requirements/:state` |
+| **CompanyOnboarding.StateTaxesForm** | GET | `/v1/companies/:companyUuid/tax_requirements/:state` |
+|  | PUT | `/v1/companies/:companyUuid/tax_requirements/:state` |
+| **CompanyOnboarding.StateTaxesList** | GET | `/v1/companies/:companyUuid/tax_requirements` |
+| **CompanyOnboarding.AssignSignatory** | GET | `/v1/companies/:companyUuid/signatories` |
+|  | POST | `/v1/companies/:companyUuid/signatories` |
+|  | PUT | `/v1/companies/:companyUuid/signatories/:signatoryUuid` |
+|  | DELETE | `/v1/companies/:companyUuid/signatories/:signatoryUuid` |
+|  | POST | `/v1/companies/:companyUuid/signatories/invite` |
+| **CompanyOnboarding.CreateSignatory** | GET | `/v1/companies/:companyUuid/signatories` |
+|  | POST | `/v1/companies/:companyUuid/signatories` |
+|  | PUT | `/v1/companies/:companyUuid/signatories/:signatoryUuid` |
+|  | DELETE | `/v1/companies/:companyUuid/signatories/:signatoryUuid` |
+| **CompanyOnboarding.InviteSignatory** | GET | `/v1/companies/:companyUuid/signatories` |
+|  | DELETE | `/v1/companies/:companyUuid/signatories/:signatoryUuid` |
+|  | POST | `/v1/companies/:companyUuid/signatories/invite` |
+
+## ContractorOnboarding components
+
+| Component | Method | Path |
+| --- | --- | --- |
+| **ContractorOnboarding.ContractorList** | GET | `/v1/companies/:companyUuid/contractors` |
+|  | DELETE | `/v1/contractors/:contractorUuid` |
+| **ContractorOnboarding.ContractorProfile** | POST | `/v1/companies/:companyUuid/contractors` |
+|  | GET | `/v1/contractors/:contractorUuid` |
+|  | PUT | `/v1/contractors/:contractorUuid` |
+| **ContractorOnboarding.Address** | GET | `/v1/contractors/:contractorUuid` |
+|  | GET | `/v1/contractors/:contractorUuid/address` |
+|  | PUT | `/v1/contractors/:contractorUuid/address` |
+| **ContractorOnboarding.PaymentMethod** | GET | `/v1/contractors/:contractorUuid/bank_accounts` |
+|  | POST | `/v1/contractors/:contractorUuid/bank_accounts` |
+|  | GET | `/v1/contractors/:contractorUuid/payment_method` |
+|  | PUT | `/v1/contractors/:contractorUuid/payment_method` |
+| **ContractorOnboarding.NewHireReport** | GET | `/v1/contractors/:contractorUuid` |
+|  | PUT | `/v1/contractors/:contractorUuid` |
+| **ContractorOnboarding.ContractorSubmit** | GET | `/v1/contractors/:contractorUuid` |
+|  | GET | `/v1/contractors/:contractorUuid/onboarding_status` |
+|  | PUT | `/v1/contractors/:contractorUuid/onboarding_status` |
+
 ## Flows
 
 Flows compose multiple blocks into a single workflow. The endpoint list for a flow is the union of all its block endpoints.
 
 | Flow | Blocks included |
 | --- | --- |
-| **Company.OnboardingFlow** | Company.BankAccount, Company.DocumentSigner, Company.FederalTaxes, Company.Industry, Company.Locations, Company.OnboardingOverview, Company.PaySchedule, Company.StateTaxes, Employee.OnboardingFlow |
+| **Company.OnboardingFlow** | Company.BankAccount, Company.DocumentSigner, Company.FederalTaxes, Company.Industry, Company.Locations, Company.OnboardingOverview, Company.PaySchedule, Company.StateTaxes, EmployeeOnboarding.OnboardingFlow |
+| **CompanyOnboarding.OnboardingFlow** | CompanyOnboarding.BankAccount, CompanyOnboarding.DocumentSigner, CompanyOnboarding.FederalTaxes, CompanyOnboarding.Industry, CompanyOnboarding.Locations, CompanyOnboarding.OnboardingOverview, CompanyOnboarding.PaySchedule, CompanyOnboarding.StateTaxes, EmployeeOnboarding.OnboardingFlow |
 | **Contractor.OnboardingFlow** | Contractor.Address, Contractor.ContractorList, Contractor.ContractorProfile, Contractor.ContractorSubmit, Contractor.NewHireReport, Contractor.PaymentMethod |
 | **Contractor.PaymentFlow** | Contractor.CreatePayment, Contractor.PaymentHistory, Contractor.PaymentStatement, Contractor.PaymentSummary, Contractor.PaymentsList, InformationRequests.InformationRequestsFlow |
-| **Employee.DashboardFlow** | Employee.FederalTaxes, Employee.HomeAddress, Employee.PaymentMethod, Employee.StateTaxes, Employee.WorkAddress |
-| **Employee.OnboardingFlow** | Employee.Compensation, Employee.Deductions, Employee.EmployeeDocuments, Employee.EmployeeList, Employee.FederalTaxes, Employee.OnboardingSummary, Employee.PaymentMethod, Employee.Profile, Employee.StateTaxes |
-| **Employee.SelfOnboardingFlow** | Employee.DocumentSigner, Employee.FederalTaxes, Employee.Landing, Employee.OnboardingSummary, Employee.PaymentMethod, Employee.Profile, Employee.StateTaxes |
+| **ContractorOnboarding.OnboardingFlow** | ContractorOnboarding.Address, ContractorOnboarding.ContractorList, ContractorOnboarding.ContractorProfile, ContractorOnboarding.ContractorSubmit, ContractorOnboarding.NewHireReport, ContractorOnboarding.PaymentMethod |
+| **Employee.DashboardFlow** | Employee.HomeAddress, Employee.PaymentMethod, Employee.WorkAddress, EmployeeManagement.FederalTaxes, EmployeeManagement.Profile, EmployeeManagement.StateTaxes, EmployeeOnboarding.PaymentMethod |
+| **Employee.OnboardingFlow** | Employee.Compensation, Employee.Deductions, Employee.EmployeeDocuments, Employee.EmployeeList, Employee.OnboardingSummary, Employee.PaymentMethod, Employee.Profile, EmployeeOnboarding.FederalTaxes, EmployeeOnboarding.StateTaxes |
+| **Employee.SelfOnboardingFlow** | Employee.DocumentSigner, Employee.Landing, Employee.OnboardingSummary, Employee.PaymentMethod, Employee.Profile, EmployeeOnboarding.FederalTaxes, EmployeeOnboarding.StateTaxes |
 | **Employee.TerminationFlow** | Employee.TerminateEmployee, Employee.TerminationSummary, Payroll.DismissalFlow, Payroll.PayrollLanding |
+| **EmployeeManagement.DashboardFlow** | Employee.HomeAddress, Employee.PaymentMethod, EmployeeManagement.FederalTaxes, EmployeeManagement.Profile, EmployeeManagement.StateTaxes, EmployeeManagement.WorkAddress, EmployeeOnboarding.PaymentMethod |
+| **EmployeeManagement.TerminationFlow** | EmployeeManagement.TerminateEmployee, EmployeeManagement.TerminationSummary, Payroll.DismissalFlow, Payroll.PayrollLanding |
+| **EmployeeOnboarding.OnboardingFlow** | Employee.PaymentMethod, EmployeeManagement.EmployeeDocuments, EmployeeOnboarding.Compensation, EmployeeOnboarding.Deductions, EmployeeOnboarding.EmployeeList, EmployeeOnboarding.FederalTaxes, EmployeeOnboarding.OnboardingSummary, EmployeeOnboarding.Profile, EmployeeOnboarding.StateTaxes |
+| **EmployeeOnboarding.SelfOnboardingFlow** | Employee.PaymentMethod, EmployeeOnboarding.DocumentSigner, EmployeeOnboarding.FederalTaxes, EmployeeOnboarding.Landing, EmployeeOnboarding.OnboardingSummary, EmployeeOnboarding.Profile, EmployeeOnboarding.StateTaxes |
 | **InformationRequests.InformationRequestsFlow** | InformationRequests.InformationRequestForm, InformationRequests.InformationRequestList |
 | **Payroll.DismissalFlow** | Payroll.PayrollExecutionFlow |
 | **Payroll.OffCycleFlow** | Payroll.OffCycleCreation, Payroll.PayrollExecutionFlow |

--- a/docs/reference/endpoint-reference.md
+++ b/docs/reference/endpoint-reference.md
@@ -486,7 +486,7 @@ Flows compose multiple blocks into a single workflow. The endpoint list for a fl
 | **Employee.TerminationFlow** | Employee.TerminateEmployee, Employee.TerminationSummary, Payroll.DismissalFlow, Payroll.PayrollLanding |
 | **EmployeeManagement.DashboardFlow** | Employee.HomeAddress, Employee.PaymentMethod, EmployeeManagement.FederalTaxes, EmployeeManagement.Profile, EmployeeManagement.StateTaxes, EmployeeManagement.WorkAddress, EmployeeOnboarding.PaymentMethod |
 | **EmployeeManagement.TerminationFlow** | EmployeeManagement.TerminateEmployee, EmployeeManagement.TerminationSummary, Payroll.DismissalFlow, Payroll.PayrollLanding |
-| **EmployeeOnboarding.OnboardingFlow** | Employee.PaymentMethod, EmployeeManagement.EmployeeDocuments, EmployeeOnboarding.Compensation, EmployeeOnboarding.Deductions, EmployeeOnboarding.EmployeeList, EmployeeOnboarding.FederalTaxes, EmployeeOnboarding.OnboardingSummary, EmployeeOnboarding.Profile, EmployeeOnboarding.StateTaxes |
+| **EmployeeOnboarding.OnboardingFlow** | Employee.EmployeeDocuments, Employee.PaymentMethod, EmployeeOnboarding.Compensation, EmployeeOnboarding.Deductions, EmployeeOnboarding.EmployeeList, EmployeeOnboarding.FederalTaxes, EmployeeOnboarding.OnboardingSummary, EmployeeOnboarding.Profile, EmployeeOnboarding.StateTaxes |
 | **EmployeeOnboarding.SelfOnboardingFlow** | Employee.PaymentMethod, EmployeeOnboarding.DocumentSigner, EmployeeOnboarding.FederalTaxes, EmployeeOnboarding.Landing, EmployeeOnboarding.OnboardingSummary, EmployeeOnboarding.Profile, EmployeeOnboarding.StateTaxes |
 | **InformationRequests.InformationRequestsFlow** | InformationRequests.InformationRequestForm, InformationRequests.InformationRequestList |
 | **Payroll.DismissalFlow** | Payroll.PayrollExecutionFlow |


### PR DESCRIPTION
## Summary

The endpoint inventory script was omitting all the journey-based namespaces (`EmployeeOnboarding` and `EmployeeManagement`) because their barrel files didn't match `domain/index.ts` but instead are `domain.ts`

## Changes

- Include `domain.ts` style barrel files
- Include deprecation status and calculation in the endpoint inventory script
  - This is used to de-duplicate and choose the best namespace for the component, _not_ to surface deprecation warnings in the inventory output (yet)
- **Behavioral change for existing flows**: `Employee.DashboardFlow`, `Employee.OnboardingFlow`, and `Employee.SelfOnboardingFlow` now list some blocks under `EmployeeOnboarding.*` and `EmployeeManagement.*` instead of `Employee.*` — this is intentional and correct; the de-duplication logic prefers the non-deprecated namespace when the same component dir appears in both

## Testing

- Ran `npm run endpoints:derive` and confirmed `EmployeeOnboarding` and `EmployeeManagement` blocks now appear in the output
- Ran `npm run endpoints:verify` to confirm the generated files match the committed output
- Spot-checked de-duplication: blocks shared between deprecated and non-deprecated namespaces (e.g. `EmployeeDocuments`) resolve to the preferred non-deprecated entry

## Related

- Jira ticket: [SDK-897](https://gustohq.atlassian.net/browse/SDK-897)

[SDK-897]: https://gustohq.atlassian.net/browse/SDK-897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ