### PR TITLE
feat(compensation): wire management Compensation flow root (list ↔ edit ↔ add)

### DIFF
--- a/docs/reference/endpoint-inventory.json
+++ b/docs/reference/endpoint-inventory.json
@@ -654,6 +654,10 @@
           "path": "/v1/compensations/:compensationId"
         },
         {
+          "method": "DELETE",
+          "path": "/v1/compensations/:compensationId"
+        },
+        {
           "method": "GET",
           "path": "/v1/employees/:employeeId"
         },
@@ -1821,6 +1825,10 @@
         },
         {
           "method": "PUT",
+          "path": "/v1/compensations/:compensationId"
+        },
+        {
+          "method": "DELETE",
           "path": "/v1/compensations/:compensationId"
         },
         {

--- a/docs/reference/endpoint-reference.md
+++ b/docs/reference/endpoint-reference.md
@@ -131,6 +131,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/work_addresses/:workAddressUuid` |
 | **Employee.Compensation** | GET | `/v1/companies/:companyId/federal_tax_details` |
 |  | PUT | `/v1/compensations/:compensationId` |
+|  | DELETE | `/v1/compensations/:compensationId` |
 |  | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/jobs` |
 |  | POST | `/v1/employees/:employeeId/jobs` |
@@ -342,6 +343,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/work_addresses/:workAddressUuid` |
 | **EmployeeOnboarding.Compensation** | GET | `/v1/companies/:companyId/federal_tax_details` |
 |  | PUT | `/v1/compensations/:compensationId` |
+|  | DELETE | `/v1/compensations/:compensationId` |
 |  | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/jobs` |
 |  | POST | `/v1/employees/:employeeId/jobs` |

--- a/src/components/Employee/Compensation/management/AddJob/AddJob.module.scss
+++ b/src/components/Employee/Compensation/management/AddJob/AddJob.module.scss
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/src/components/Employee/Compensation/management/AddJob/AddJob.test.tsx
+++ b/src/components/Employee/Compensation/management/AddJob/AddJob.test.tsx
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AddJob } from './AddJob'
+import { server } from '@/test/mocks/server'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { getMinimumWages } from '@/test/mocks/apis/company_locations'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+
+describe('management/AddJob', () => {
+  beforeEach(() => {
+    setupApiTestMocks()
+    server.use(getMinimumWages)
+  })
+
+  it('renders an Add another job heading and Add job submit CTA', async () => {
+    renderWithProviders(
+      <AddJob employeeId="employee-uuid" hireDate="2024-12-24" onEvent={() => {}} />,
+    )
+
+    expect(await screen.findByRole('heading', { name: 'Add another job' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add job' })).toBeInTheDocument()
+  })
+
+  it('hides the hire date field (it is threaded in via the employee hireDate prop)', async () => {
+    renderWithProviders(
+      <AddJob employeeId="employee-uuid" hireDate="2024-12-24" onEvent={() => {}} />,
+    )
+
+    await screen.findByRole('heading', { name: 'Add another job' })
+    expect(screen.queryByLabelText(/hire date/i)).not.toBeInTheDocument()
+  })
+
+  it('exposes a visible effective date field for the new compensation', async () => {
+    renderWithProviders(
+      <AddJob employeeId="employee-uuid" hireDate="2024-12-24" onEvent={() => {}} />,
+    )
+
+    await screen.findByRole('heading', { name: 'Add another job' })
+    expect(screen.getByLabelText('Effective date')).toBeInTheDocument()
+  })
+
+  it('fires onCancel when the cancel button is clicked', async () => {
+    const user = userEvent.setup()
+    const onCancel = vi.fn()
+    renderWithProviders(
+      <AddJob
+        employeeId="employee-uuid"
+        hireDate="2024-12-24"
+        onCancel={onCancel}
+        onEvent={() => {}}
+      />,
+    )
+
+    await screen.findByRole('heading', { name: 'Add another job' })
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/src/components/Employee/Compensation/management/AddJob/AddJob.tsx
+++ b/src/components/Employee/Compensation/management/AddJob/AddJob.tsx
@@ -1,0 +1,291 @@
+import { useState } from 'react'
+import classNames from 'classnames'
+import { Trans, useTranslation } from 'react-i18next'
+import type { PaymentUnit } from '@gusto/embedded-api/models/components/compensation'
+import type { FlsaStatusType } from '@gusto/embedded-api/models/components/flsastatustype'
+import type { MinimumWage } from '@gusto/embedded-api/models/components/minimumwage'
+import { useJobForm, type UseJobFormReady } from '../../shared/useJobForm'
+import {
+  useCompensationForm,
+  type UseCompensationFormReady,
+} from '../../shared/useCompensationForm'
+import styles from './AddJob.module.scss'
+import { BaseBoundaries, BaseLayout, type CommonComponentInterface } from '@/components/Base'
+import type { OnEventType } from '@/components/Base/useBase'
+import { ActionsLayout, Flex } from '@/components/Common'
+import { Form } from '@/components/Common/Form'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { useComponentDictionary, useI18n } from '@/i18n'
+import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
+import { composeSubmitHandler } from '@/partner-hook-utils/form/composeSubmitHandler'
+import { componentEvents, FLSA_OVERTIME_SALARY_LIMIT, type EventType } from '@/shared/constants'
+import useNumberFormatter from '@/hooks/useNumberFormatter'
+
+export interface AddJobProps extends CommonComponentInterface<'Employee.Compensation'> {
+  employeeId: string
+  /**
+   * Hire date written to the new job. Steady-state additional jobs use the
+   * employee's existing hire date so the new job aligns with the rest of their
+   * record. The compensation's `effectiveDate` is captured separately via a
+   * visible field.
+   */
+  hireDate: string
+  onCancel?: () => void
+  /**
+   * Receives:
+   * - `EMPLOYEE_JOB_CREATED` with the saved `Job`
+   * - `EMPLOYEE_COMPENSATION_UPDATED` with the saved `Compensation`
+   * Use `EMPLOYEE_COMPENSATION_UPDATED` to branch on "save complete".
+   */
+  onEvent: OnEventType<EventType, unknown>
+}
+
+export function AddJob({ dictionary, ...props }: AddJobProps) {
+  useComponentDictionary('Employee.Compensation', dictionary)
+  return (
+    <BaseBoundaries componentName="Employee.Compensation.Management.AddJob">
+      <Root {...props} />
+    </BaseBoundaries>
+  )
+}
+
+function Root({ employeeId, hireDate, onCancel, className, onEvent }: AddJobProps) {
+  useI18n('Employee.Compensation')
+
+  // Mirror the onboarding EditCompensation create-mode pattern: if the job
+  // POST succeeds but the compensation POST fails, remember the new jobId so
+  // a retry-submit doesn't double-create the job.
+  const [resolvedJobId, setResolvedJobId] = useState<string | undefined>(undefined)
+
+  // Title lives on the job hook here because we're creating both job and its
+  // first compensation in one shot — there's no "effective-dated title change"
+  // scenario for a brand-new job. Hire date is suppressed; we thread the
+  // employee's hire date in via submit options.
+  const jobForm = useJobForm({
+    employeeId,
+    jobId: resolvedJobId,
+    withHireDateField: false,
+    shouldFocusError: false,
+  })
+
+  const resolvedCompensationId = jobForm.isLoading
+    ? undefined
+    : (jobForm.data.currentJob?.currentCompensationUuid ?? undefined)
+
+  // Effective date IS surfaced for steady-state add: the user explicitly picks
+  // when this new job's pay schedule starts.
+  const compensationForm = useCompensationForm({
+    employeeId,
+    jobId: resolvedJobId,
+    compensationId: resolvedCompensationId,
+    withEffectiveDateField: true,
+    shouldFocusError: false,
+  })
+
+  if (jobForm.isLoading || compensationForm.isLoading) {
+    const loadingErrorHandling = composeErrorHandler([jobForm, compensationForm])
+    return <BaseLayout isLoading error={loadingErrorHandling.errors} />
+  }
+
+  const submitResult = composeSubmitHandler([jobForm, compensationForm], async () => {
+    const jobResult = await jobForm.actions.onSubmit({ employeeId, hireDate })
+    if (!jobResult) return
+
+    onEvent(
+      jobResult.mode === 'create'
+        ? componentEvents.EMPLOYEE_JOB_CREATED
+        : componentEvents.EMPLOYEE_JOB_UPDATED,
+      jobResult.data,
+    )
+
+    const stubCompensation = jobResult.data.compensations?.find(
+      c => c.uuid === jobResult.data.currentCompensationUuid,
+    )
+
+    const compensationResult = await compensationForm.actions.onSubmit({
+      jobId: jobResult.data.uuid,
+      compensationId: jobResult.data.currentCompensationUuid ?? undefined,
+      compensationVersion: stubCompensation?.version ?? undefined,
+    })
+    if (!compensationResult) {
+      setResolvedJobId(jobResult.data.uuid)
+      return
+    }
+
+    onEvent(componentEvents.EMPLOYEE_COMPENSATION_UPDATED, compensationResult.data)
+  })
+
+  const errorHandling = composeErrorHandler([submitResult])
+  const isPending = jobForm.status.isPending || compensationForm.status.isPending
+
+  return (
+    <section className={classNames(styles.container, className)}>
+      <BaseLayout error={errorHandling.errors}>
+        <Form onSubmit={submitResult.handleSubmit}>
+          <FormBody
+            jobForm={jobForm}
+            compensationForm={compensationForm}
+            isPending={isPending}
+            onCancel={onCancel}
+          />
+        </Form>
+      </BaseLayout>
+    </section>
+  )
+}
+
+interface FormBodyProps {
+  jobForm: UseJobFormReady
+  compensationForm: UseCompensationFormReady
+  isPending: boolean
+  onCancel?: () => void
+}
+
+function FormBody({ jobForm, compensationForm, isPending, onCancel }: FormBodyProps) {
+  const { t } = useTranslation('Employee.Compensation')
+  const Components = useComponentContext()
+  const format = useNumberFormatter('currency')
+
+  const JobFields = jobForm.form.Fields
+  const CompFields = compensationForm.form.Fields
+
+  return (
+    <Flex flexDirection="column" gap={32}>
+      <Components.Heading as="h2">{t('management.addJobTitle')}</Components.Heading>
+
+      {JobFields.Title && (
+        <JobFields.Title
+          label={t('management.jobTitleLabel')}
+          validationMessages={{ REQUIRED: t('validations.title') }}
+          formHookResult={jobForm}
+        />
+      )}
+
+      {CompFields.FlsaStatus && (
+        <CompFields.FlsaStatus
+          label={t('employeeClassification')}
+          description={
+            <Trans
+              t={t}
+              i18nKey="classificationLink"
+              components={{ ClassificationLink: <Components.Link /> }}
+            />
+          }
+          validationMessages={{
+            REQUIRED: t('validations.exemptThreshold', {
+              limit: format(FLSA_OVERTIME_SALARY_LIMIT),
+            }),
+          }}
+          getOptionLabel={(status: FlsaStatusType) => t(`flsaStatusLabels.${status}`)}
+          formHookResult={compensationForm}
+        />
+      )}
+
+      <CompFields.Rate
+        label={t('management.wageLabel')}
+        validationMessages={{
+          REQUIRED: t('validations.rate'),
+          RATE_MINIMUM: t('validations.nonZeroRate'),
+          RATE_EXEMPT_THRESHOLD: t('validations.rateExemptThreshold', {
+            limit: format(FLSA_OVERTIME_SALARY_LIMIT),
+          }),
+        }}
+        formHookResult={compensationForm}
+      />
+
+      <CompFields.PaymentUnit
+        label={t('management.wageFrequencyLabel')}
+        description={t('paymentUnitDescription')}
+        validationMessages={{ REQUIRED: t('validations.paymentUnit') }}
+        getOptionLabel={(unit: PaymentUnit) =>
+          t(`management.wageFrequencyOptions.${unit}` as const)
+        }
+        formHookResult={compensationForm}
+      />
+
+      {CompFields.EffectiveDate && (
+        <CompFields.EffectiveDate
+          label={t('effectiveDateLabel')}
+          validationMessages={{
+            REQUIRED: t('validations.effectiveDate'),
+            EFFECTIVE_DATE_BEFORE_HIRE: t('validations.effectiveDateBeforeHire'),
+          }}
+          formHookResult={compensationForm}
+        />
+      )}
+
+      {CompFields.AdjustForMinimumWage && (
+        <CompFields.AdjustForMinimumWage
+          label={t('adjustForMinimumWage')}
+          description={t('adjustForMinimumWageDescription')}
+          formHookResult={compensationForm}
+        />
+      )}
+
+      {CompFields.MinimumWageId && (
+        <CompFields.MinimumWageId
+          label={t('minimumWageLabel')}
+          description={t('minimumWageDescription')}
+          validationMessages={{ REQUIRED: t('validations.minimumWage') }}
+          getOptionLabel={(wage: MinimumWage) =>
+            `${format(Number(wage.wage))} - ${wage.authority}: ${wage.notes ?? ''}`
+          }
+          formHookResult={compensationForm}
+        />
+      )}
+
+      {JobFields.TwoPercentShareholder && (
+        <JobFields.TwoPercentShareholder
+          label={t('management.twoPercentShareholderLabel')}
+          formHookResult={jobForm}
+        />
+      )}
+
+      {JobFields.StateWcCovered && (
+        <JobFields.StateWcCovered
+          label={t('stateWcCoveredLabel')}
+          description={
+            <Trans
+              t={t}
+              i18nKey="stateWcCoveredDescription"
+              components={{
+                wcLink: (
+                  <Components.Link
+                    href="https://www.lni.wa.gov/insurance/rates-risk-classes/risk-classes-for-workers-compensation/risk-class-lookup#/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                ),
+              }}
+            />
+          }
+          getOptionLabel={(covered: boolean) =>
+            covered ? t('stateWcCoveredOptions.yes') : t('stateWcCoveredOptions.no')
+          }
+          formHookResult={jobForm}
+        />
+      )}
+
+      {JobFields.StateWcClassCode && (
+        <JobFields.StateWcClassCode
+          label={t('stateWcClassCodeLabel')}
+          description={t('stateWcClassCodeDescription')}
+          placeholder={t('stateWcClassCodeLabel')}
+          validationMessages={{ REQUIRED: t('validations.stateWcClassCode') }}
+          formHookResult={jobForm}
+        />
+      )}
+
+      <ActionsLayout>
+        {onCancel && (
+          <Components.Button variant="secondary" onClick={onCancel} isDisabled={isPending}>
+            {t('cancelCta')}
+          </Components.Button>
+        )}
+        <Components.Button type="submit" isLoading={isPending}>
+          {t('management.addJobCta')}
+        </Components.Button>
+      </ActionsLayout>
+    </Flex>
+  )
+}

--- a/src/components/Employee/Compensation/management/AddJob/index.ts
+++ b/src/components/Employee/Compensation/management/AddJob/index.ts
@@ -1,0 +1,2 @@
+export { AddJob } from './AddJob'
+export type { AddJobProps } from './AddJob'

--- a/src/components/Employee/Compensation/management/Compensation.test.tsx
+++ b/src/components/Employee/Compensation/management/Compensation.test.tsx
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HttpResponse } from 'msw'
+import { Compensation } from './Compensation'
+import { server } from '@/test/mocks/server'
+import { handleGetEmployeeJobs } from '@/test/mocks/apis/employees'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { getMinimumWages } from '@/test/mocks/apis/company_locations'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import { buildEmployeeWithJobs } from '@/test/factories/jobsAndCompensations'
+
+describe('management/Compensation flow', () => {
+  beforeEach(() => {
+    setupApiTestMocks()
+    server.use(
+      getMinimumWages,
+      handleGetEmployeeJobs(() =>
+        HttpResponse.json(buildEmployeeWithJobs({ scenario: 'singleNonexempt' })),
+      ),
+    )
+  })
+
+  it('starts on the list view', async () => {
+    renderWithProviders(
+      <Compensation employeeId="employee-uuid" hireDate="2024-12-24" onEvent={() => {}} />,
+    )
+
+    expect(await screen.findByText('Primary job')).toBeInTheDocument()
+  })
+
+  it('navigates list -> editCompensation -> list via Cancel', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <Compensation employeeId="employee-uuid" hireDate="2024-12-24" onEvent={() => {}} />,
+    )
+
+    await screen.findByText('Primary job')
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(await screen.findByRole('heading', { name: 'Edit compensation' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(await screen.findByText('Primary job')).toBeInTheDocument()
+  })
+
+  it('navigates list -> addJob -> list via Cancel', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <Compensation employeeId="employee-uuid" hireDate="2024-12-24" onEvent={() => {}} />,
+    )
+
+    await screen.findByText('Primary job')
+    await user.click(screen.getByRole('button', { name: /add another job/i }))
+
+    expect(await screen.findByRole('heading', { name: 'Add another job' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(await screen.findByText('Primary job')).toBeInTheDocument()
+  })
+})

--- a/src/components/Employee/Compensation/management/Compensation.tsx
+++ b/src/components/Employee/Compensation/management/Compensation.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from 'react'
+import { createMachine } from 'robot3'
+import {
+  ListViewContextual,
+  type ManagementCompensationFlowContextInterface,
+} from './CompensationFlowComponents'
+import { managementCompensationStateMachine } from './compensationStateMachine'
+import { ListView } from './ListView'
+import { EditCompensation } from './EditCompensation'
+import { AddJob } from './AddJob'
+import {
+  BaseBoundaries,
+  type BaseComponentInterface,
+  type CommonComponentInterface,
+} from '@/components/Base'
+import { Flow } from '@/components/Flow/Flow'
+import { useComponentDictionary, useI18n } from '@/i18n'
+import type { OnEventType } from '@/components/Base/useBase'
+import type { EventType } from '@/shared/constants'
+
+export interface CompensationProps extends CommonComponentInterface<'Employee.Compensation'> {
+  employeeId: string
+  /**
+   * The employee's hire date. Used as the `hireDate` written to additional
+   * jobs created through the Add another job flow so they align with the
+   * employee record. The new compensation's `effectiveDate` is captured
+   * separately via a visible field on the AddJob screen.
+   */
+  hireDate: string
+  onEvent: OnEventType<EventType, unknown>
+}
+
+function CompensationFlow({ employeeId, hireDate, onEvent }: CompensationProps) {
+  useI18n('Employee.Compensation')
+
+  const machine = useMemo(
+    () =>
+      createMachine(
+        'list',
+        managementCompensationStateMachine,
+        (ctx: ManagementCompensationFlowContextInterface) => ({
+          ...ctx,
+          component: ListViewContextual,
+          employeeId,
+          hireDate,
+          currentJobId: null,
+          currentCompensationId: null,
+        }),
+      ),
+    [employeeId, hireDate],
+  )
+
+  return <Flow machine={machine} onEvent={onEvent} />
+}
+
+export function Compensation({
+  dictionary,
+  FallbackComponent,
+  ...props
+}: CompensationProps & BaseComponentInterface<'Employee.Compensation'>) {
+  useComponentDictionary('Employee.Compensation', dictionary)
+  return (
+    <BaseBoundaries
+      componentName="Employee.Compensation.Management"
+      FallbackComponent={FallbackComponent}
+    >
+      <CompensationFlow {...props} />
+    </BaseBoundaries>
+  )
+}
+
+Compensation.ListView = ListView
+Compensation.EditCompensation = EditCompensation
+Compensation.AddJob = AddJob

--- a/src/components/Employee/Compensation/management/CompensationFlowComponents.tsx
+++ b/src/components/Employee/Compensation/management/CompensationFlowComponents.tsx
@@ -1,0 +1,77 @@
+import type { Job } from '@gusto/embedded-api/models/components/job'
+import type { Compensation } from '@gusto/embedded-api/models/components/compensation'
+import { ListView } from './ListView'
+import { EditCompensation } from './EditCompensation'
+import { AddJob } from './AddJob'
+import { useFlow, type FlowContextInterface } from '@/components/Flow/useFlow'
+import type { OnEventType } from '@/components/Base/useBase'
+import { componentEvents, type EventType } from '@/shared/constants'
+import { ensureRequired } from '@/helpers/ensureRequired'
+
+export type EventPayloads = {
+  [componentEvents.EMPLOYEE_COMPENSATION_EDIT]: { jobId: string; compensationId: string }
+  [componentEvents.EMPLOYEE_COMPENSATION_CHANGE_CANCELLED]: {
+    jobId?: string
+    compensationId: string
+  }
+  [componentEvents.EMPLOYEE_COMPENSATION_UPDATED]: Compensation
+  [componentEvents.EMPLOYEE_COMPENSATION_CANCEL]: undefined
+  [componentEvents.EMPLOYEE_JOB_ADD]: undefined
+  [componentEvents.EMPLOYEE_JOB_CREATED]: Job
+  [componentEvents.EMPLOYEE_JOB_UPDATED]: Job
+  [componentEvents.EMPLOYEE_JOB_DELETED]: { jobId: string }
+}
+
+export interface ManagementCompensationFlowContextInterface extends FlowContextInterface {
+  employeeId: string
+  hireDate: string
+  currentJobId: string | null
+  currentCompensationId: string | null
+}
+
+export function ListViewContextual() {
+  const { employeeId, onEvent } = useFlow<ManagementCompensationFlowContextInterface>()
+  return <ListView employeeId={ensureRequired(employeeId)} onEvent={onEvent} />
+}
+
+export function EditCompensationContextual() {
+  const { employeeId, currentJobId, currentCompensationId, onEvent } =
+    useFlow<ManagementCompensationFlowContextInterface>()
+
+  // After EditCompensation's submit chain emits EMPLOYEE_COMPENSATION_UPDATED,
+  // pop back to the list. The flow's state machine listens for the same event.
+  const handleEvent: OnEventType<EventType, unknown> = (event, data) => {
+    onEvent(event, data)
+  }
+
+  return (
+    <EditCompensation
+      employeeId={ensureRequired(employeeId)}
+      jobId={ensureRequired(currentJobId ?? undefined)}
+      compensationId={ensureRequired(currentCompensationId ?? undefined)}
+      onCancel={() => {
+        onEvent(componentEvents.EMPLOYEE_COMPENSATION_CANCEL)
+      }}
+      onEvent={handleEvent}
+    />
+  )
+}
+
+export function AddJobContextual() {
+  const { employeeId, hireDate, onEvent } = useFlow<ManagementCompensationFlowContextInterface>()
+
+  const handleEvent: OnEventType<EventType, unknown> = (event, data) => {
+    onEvent(event, data)
+  }
+
+  return (
+    <AddJob
+      employeeId={ensureRequired(employeeId)}
+      hireDate={ensureRequired(hireDate)}
+      onCancel={() => {
+        onEvent(componentEvents.EMPLOYEE_COMPENSATION_CANCEL)
+      }}
+      onEvent={handleEvent}
+    />
+  )
+}

--- a/src/components/Employee/Compensation/management/compensationStateMachine.ts
+++ b/src/components/Employee/Compensation/management/compensationStateMachine.ts
@@ -1,0 +1,60 @@
+import { reduce, state, transition } from 'robot3'
+import type { ComponentType } from 'react'
+import {
+  AddJobContextual,
+  EditCompensationContextual,
+  ListViewContextual,
+  type EventPayloads,
+  type ManagementCompensationFlowContextInterface,
+} from './CompensationFlowComponents'
+import { componentEvents } from '@/shared/constants'
+import type { MachineEventType, MachineTransition } from '@/types/Helpers'
+
+type Ctx = ManagementCompensationFlowContextInterface
+
+const toListView = (ctx: Ctx): Ctx => ({
+  ...ctx,
+  component: ListViewContextual as ComponentType,
+  currentJobId: null,
+  currentCompensationId: null,
+})
+
+export const managementCompensationStateMachine = {
+  list: state<MachineTransition>(
+    transition(
+      componentEvents.EMPLOYEE_COMPENSATION_EDIT,
+      'editCompensation',
+      reduce(
+        (
+          ctx: Ctx,
+          ev: MachineEventType<EventPayloads, typeof componentEvents.EMPLOYEE_COMPENSATION_EDIT>,
+        ): Ctx => ({
+          ...ctx,
+          component: EditCompensationContextual as ComponentType,
+          currentJobId: ev.payload.jobId,
+          currentCompensationId: ev.payload.compensationId,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.EMPLOYEE_JOB_ADD,
+      'addJob',
+      reduce(
+        (ctx: Ctx): Ctx => ({
+          ...ctx,
+          component: AddJobContextual as ComponentType,
+          currentJobId: null,
+          currentCompensationId: null,
+        }),
+      ),
+    ),
+  ),
+  editCompensation: state<MachineTransition>(
+    transition(componentEvents.EMPLOYEE_COMPENSATION_UPDATED, 'list', reduce(toListView)),
+    transition(componentEvents.EMPLOYEE_COMPENSATION_CANCEL, 'list', reduce(toListView)),
+  ),
+  addJob: state<MachineTransition>(
+    transition(componentEvents.EMPLOYEE_COMPENSATION_UPDATED, 'list', reduce(toListView)),
+    transition(componentEvents.EMPLOYEE_COMPENSATION_CANCEL, 'list', reduce(toListView)),
+  ),
+}

--- a/src/components/Employee/Compensation/management/index.ts
+++ b/src/components/Employee/Compensation/management/index.ts
@@ -1,5 +1,11 @@
+export { Compensation as ManagementCompensation } from './Compensation'
+export type { CompensationProps as ManagementCompensationProps } from './Compensation'
+
 export { EditCompensation as ManagementEditCompensation } from './EditCompensation'
 export type { EditCompensationProps as ManagementEditCompensationProps } from './EditCompensation'
 
 export { ListView as ManagementListView } from './ListView'
 export type { ListViewProps as ManagementListViewProps } from './ListView'
+
+export { AddJob as ManagementAddJob } from './AddJob'
+export type { AddJobProps as ManagementAddJobProps } from './AddJob'

--- a/src/i18n/en/Employee.Compensation.json
+++ b/src/i18n/en/Employee.Compensation.json
@@ -87,7 +87,9 @@
       "description": "{{jobTitle}} will be removed from this employee. This cannot be undone.",
       "confirmCta": "Delete job",
       "closeCta": "Keep job"
-    }
+    },
+    "addJobTitle": "Add another job",
+    "addJobCta": "Add job"
   },
   "validations": {
     "classificationChangeNotification": "Changing this employee's classification will delete the employee's additional pay rates.",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1429,6 +1429,8 @@ export interface EmployeeCompensation{
 "confirmCta":string;
 "closeCta":string;
 };
+"addJobTitle":string;
+"addJobCta":string;
 };
 "validations":{
 "classificationChangeNotification":string;


### PR DESCRIPTION
## Summary

Fourth PR in the steady-state compensation series. Stacked on top of #1862 (management/ListView).

Builds the Compensation flow root that the Dashboard mounts as a steady-state component. The flow shuttles between three states via composeSubmitHandler-emitted events.

### State machine

\`\`\`
                          EMPLOYEE_COMPENSATION_EDIT
                                  ↓
list  ←  EMPLOYEE_COMPENSATION_UPDATED / CANCEL  ←  editCompensation
  │                                                       ↑
  │  EMPLOYEE_JOB_ADD                                     │
  ↓                                                       │
addJob  →  EMPLOYEE_COMPENSATION_UPDATED / CANCEL  →  list
\`\`\`

### New surface: \`management/AddJob\`

A dedicated screen for adding an additional job to an existing employee.
- \`useJobForm\` create mode, \`withHireDateField: false\` (employee's hireDate is threaded via submit options so the new job aligns with the rest of the record).
- \`useCompensationForm\` create mode, \`withEffectiveDateField: true\` (the user picks when the new pay schedule takes effect).
- POSTs the job first, then PUTs the auto-generated stub compensation with the user's values — same partial-failure-safe pattern as onboarding's EditCompensation (remembers \`resolvedJobId\` if the job POST succeeds but the comp PUT fails, so retry doesn't double-create).

### Why no terminal \`done\` state?

The flow lives on the Dashboard as a long-lived component, not as a wizard step. Mirrors how \`PaymentMethod\` management is structured. Partners drive navigation; the flow just exposes the right CRUD surface at any moment.

### Endpoint inventory

\`endpoint-inventory.json\` + \`endpoint-reference.md\` are auto-regenerated to surface the new \`DELETE /v1/compensations/:id\` reference under Employee.Compensation (added in #1862).

## Test plan

- [x] \`npm run test -- --run src/components/Employee/Compensation/management\` (24 passing — AddJob, Compensation flow integration, EditCompensation, ListView)
- [x] \`npm run test -- --run src/components/Employee/Compensation\` (124 passing — no regressions)
- [x] \`npm run lint:check src/components/Employee/Compensation\` (0 errors)
- [x] \`npx tsc --noEmit\`
- [ ] Visual smoke once wired up in PR 5 (Dashboard integration)

## Follow-up

PR 5 will replace the inline compensation \`Box\` in \`JobAndPayView\` with this flow and add the \`hireDate\` prop wiring.

Made with [Cursor](https://cursor.com)