### PR TITLE
feat(Dashboard): add Deductions block to the Job and Pay tab

### DIFF
--- a/docs/reference/endpoint-inventory.json
+++ b/docs/reference/endpoint-inventory.json
@@ -831,10 +831,6 @@
         },
         {
           "method": "GET",
-          "path": "/v1/employees/:employeeId/garnishments"
-        },
-        {
-          "method": "GET",
           "path": "/v1/employees/:employeeId/home_addresses"
         },
         {
@@ -1978,10 +1974,6 @@
         },
         {
           "method": "GET",
-          "path": "/v1/employees/:employeeId/garnishments"
-        },
-        {
-          "method": "GET",
           "path": "/v1/employees/:employeeId/home_addresses"
         },
         {
@@ -2589,6 +2581,7 @@
     },
     "Employee.DashboardFlow": {
       "blocks": [
+        "Employee.Deductions",
         "Employee.HomeAddress",
         "Employee.PaymentMethod",
         "Employee.WorkAddress",
@@ -2640,6 +2633,7 @@
         "EmployeeManagement.Profile",
         "EmployeeManagement.StateTaxes",
         "EmployeeManagement.WorkAddress",
+        "EmployeeOnboarding.Deductions",
         "EmployeeOnboarding.PaymentMethod"
       ]
     },

--- a/docs/reference/endpoint-reference.md
+++ b/docs/reference/endpoint-reference.md
@@ -161,7 +161,6 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/employees/:employeeId/onboarding_documents_config` |
 | **Employee.DashboardFlow** | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/forms` |
-|  | GET | `/v1/employees/:employeeId/garnishments` |
 |  | GET | `/v1/employees/:employeeId/home_addresses` |
 |  | GET | `/v1/employees/:employeeId/pay_stubs` |
 |  | GET | `/v1/employees/:employeeId/work_addresses` |
@@ -373,7 +372,6 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/employees/:employeeId/forms/:formId/sign` |
 | **EmployeeManagement.DashboardFlow** | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/forms` |
-|  | GET | `/v1/employees/:employeeId/garnishments` |
 |  | GET | `/v1/employees/:employeeId/home_addresses` |
 |  | GET | `/v1/employees/:employeeId/pay_stubs` |
 |  | GET | `/v1/employees/:employeeId/work_addresses` |
@@ -483,11 +481,11 @@ Flows compose multiple blocks into a single workflow. The endpoint list for a fl
 | **Contractor.OnboardingFlow** | Contractor.Address, Contractor.ContractorList, Contractor.ContractorProfile, Contractor.ContractorSubmit, Contractor.NewHireReport, Contractor.PaymentMethod |
 | **Contractor.PaymentFlow** | Contractor.CreatePayment, Contractor.PaymentHistory, Contractor.PaymentStatement, Contractor.PaymentSummary, Contractor.PaymentsList, InformationRequests.InformationRequestsFlow |
 | **ContractorOnboarding.OnboardingFlow** | ContractorOnboarding.Address, ContractorOnboarding.ContractorList, ContractorOnboarding.ContractorProfile, ContractorOnboarding.ContractorSubmit, ContractorOnboarding.NewHireReport, ContractorOnboarding.PaymentMethod |
-| **Employee.DashboardFlow** | Employee.HomeAddress, Employee.PaymentMethod, Employee.WorkAddress, EmployeeManagement.DocumentManager, EmployeeManagement.FederalTaxes, EmployeeManagement.Profile, EmployeeManagement.StateTaxes, EmployeeOnboarding.PaymentMethod |
+| **Employee.DashboardFlow** | Employee.Deductions, Employee.HomeAddress, Employee.PaymentMethod, Employee.WorkAddress, EmployeeManagement.DocumentManager, EmployeeManagement.FederalTaxes, EmployeeManagement.Profile, EmployeeManagement.StateTaxes, EmployeeOnboarding.PaymentMethod |
 | **Employee.OnboardingFlow** | Employee.Compensation, Employee.Deductions, Employee.EmployeeDocuments, Employee.EmployeeList, Employee.OnboardingSummary, Employee.PaymentMethod, Employee.Profile, EmployeeOnboarding.FederalTaxes, EmployeeOnboarding.StateTaxes |
 | **Employee.SelfOnboardingFlow** | Employee.DocumentSigner, Employee.Landing, Employee.OnboardingSummary, Employee.PaymentMethod, Employee.Profile, EmployeeOnboarding.FederalTaxes, EmployeeOnboarding.StateTaxes |
 | **Employee.TerminationFlow** | Employee.TerminateEmployee, Employee.TerminationSummary, Payroll.DismissalFlow, Payroll.PayrollLanding |
-| **EmployeeManagement.DashboardFlow** | Employee.HomeAddress, Employee.PaymentMethod, EmployeeManagement.DocumentManager, EmployeeManagement.FederalTaxes, EmployeeManagement.Profile, EmployeeManagement.StateTaxes, EmployeeManagement.WorkAddress, EmployeeOnboarding.PaymentMethod |
+| **EmployeeManagement.DashboardFlow** | Employee.HomeAddress, Employee.PaymentMethod, EmployeeManagement.DocumentManager, EmployeeManagement.FederalTaxes, EmployeeManagement.Profile, EmployeeManagement.StateTaxes, EmployeeManagement.WorkAddress, EmployeeOnboarding.Deductions, EmployeeOnboarding.PaymentMethod |
 | **EmployeeManagement.TerminationFlow** | EmployeeManagement.TerminateEmployee, EmployeeManagement.TerminationSummary, Payroll.DismissalFlow, Payroll.PayrollLanding |
 | **EmployeeOnboarding.OnboardingFlow** | Employee.EmployeeDocuments, Employee.PaymentMethod, EmployeeOnboarding.Compensation, EmployeeOnboarding.Deductions, EmployeeOnboarding.EmployeeList, EmployeeOnboarding.FederalTaxes, EmployeeOnboarding.OnboardingSummary, EmployeeOnboarding.Profile, EmployeeOnboarding.StateTaxes |
 | **EmployeeOnboarding.SelfOnboardingFlow** | Employee.PaymentMethod, EmployeeOnboarding.DocumentSigner, EmployeeOnboarding.FederalTaxes, EmployeeOnboarding.Landing, EmployeeOnboarding.OnboardingSummary, EmployeeOnboarding.Profile, EmployeeOnboarding.StateTaxes |

--- a/src/components/Employee/Dashboard/Dashboard.test.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.test.tsx
@@ -1,17 +1,68 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { HttpResponse } from 'msw'
+import { http, HttpResponse, type HttpResponseResolver } from 'msw'
 import type { DashboardProps } from './Dashboard'
 import { Dashboard } from './Dashboard'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
 import { setupApiTestMocks } from '@/test/mocks/apiServer'
 import { server } from '@/test/mocks/server'
+import { API_BASE_URL } from '@/test/constants'
 import { handleGetEmployeeForms, i9Form } from '@/test/mocks/apis/employee_forms'
 import { componentEvents } from '@/shared/constants'
 import { assertDefined } from '@/test-utils/assertions'
 import { getFixture } from '@/test/mocks/fixtures/getFixture'
 import { handleGetEmployee } from '@/test/mocks/apis/employees'
+
+type GarnishmentFixture = {
+  uuid: string
+  version: string
+  active: boolean
+  amount: string
+  description: string
+  recurring: boolean
+  deduct_as_percentage: boolean
+  court_ordered: boolean
+  times: number | null
+  annual_maximum: string | null
+  pay_period_maximum: string | null
+  total_amount: string | null
+}
+
+const buildGarnishment = (
+  overrides: Partial<GarnishmentFixture> & { uuid: string },
+): GarnishmentFixture => ({
+  active: true,
+  amount: '50',
+  description: 'Health Insurance',
+  recurring: true,
+  deduct_as_percentage: false,
+  court_ordered: false,
+  times: null,
+  annual_maximum: null,
+  pay_period_maximum: null,
+  total_amount: null,
+  version: `version-${overrides.uuid}`,
+  ...overrides,
+})
+
+const stubGarnishmentsList = (garnishments: GarnishmentFixture[]) => {
+  server.use(
+    http.get(`${API_BASE_URL}/v1/employees/:employee_id/garnishments`, () =>
+      HttpResponse.json(garnishments),
+    ),
+  )
+}
+
+const openJobAndPayTab = async (user: ReturnType<typeof userEvent.setup>) => {
+  await waitFor(() => {
+    expect(screen.getByText('Legal name')).toBeTruthy()
+  })
+  await user.click(screen.getByRole('tab', { name: 'Job and pay' }))
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: 'Deductions' })).toBeInTheDocument()
+  })
+}
 
 vi.mock('@/hooks/useContainerBreakpoints/useContainerBreakpoints', () => {
   const useContainerBreakpoints = () => ['small', 'medium', 'large']
@@ -126,6 +177,100 @@ describe('Dashboard', () => {
 
     expect(onEvent).toHaveBeenCalledWith(componentEvents.EMPLOYEE_JOB_ADD, {
       employeeId: 'employee-123',
+    })
+  })
+
+  describe('Job and pay > Deductions', () => {
+    it('renders active deduction rows with formatted withheld amount', async () => {
+      stubGarnishmentsList([
+        buildGarnishment({ uuid: 'd-1', description: 'Health Insurance', amount: '120' }),
+        buildGarnishment({
+          uuid: 'd-2',
+          description: 'Parking Fee',
+          amount: '5',
+          deduct_as_percentage: true,
+        }),
+        buildGarnishment({
+          uuid: 'd-inactive',
+          description: 'Old Deduction',
+          active: false,
+        }),
+      ])
+      const user = userEvent.setup()
+
+      renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+      await openJobAndPayTab(user)
+
+      expect(screen.getByText('Health Insurance')).toBeInTheDocument()
+      expect(screen.getByText('Parking Fee')).toBeInTheDocument()
+      // Inactive rows are filtered out by the hook
+      expect(screen.queryByText('Old Deduction')).toBeNull()
+    })
+
+    it('emits EMPLOYEE_DEDUCTION_ADD when clicking the Add deduction button', async () => {
+      stubGarnishmentsList([])
+      const user = userEvent.setup()
+
+      renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+      await openJobAndPayTab(user)
+
+      await user.click(screen.getByRole('button', { name: 'Add deduction' }))
+
+      expect(onEvent).toHaveBeenCalledWith(componentEvents.EMPLOYEE_DEDUCTION_ADD, {
+        employeeId: 'employee-123',
+      })
+    })
+
+    it('emits EMPLOYEE_DEDUCTION_EDIT with the garnishment when clicking Edit', async () => {
+      stubGarnishmentsList([
+        buildGarnishment({ uuid: 'd-1', description: 'Health Insurance', amount: '120' }),
+      ])
+      const user = userEvent.setup()
+
+      renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+      await openJobAndPayTab(user)
+
+      await user.click(screen.getByRole('button', { name: 'Deduction actions menu' }))
+      await user.click(await screen.findByRole('menuitem', { name: 'Edit deduction' }))
+
+      expect(onEvent).toHaveBeenCalledWith(
+        componentEvents.EMPLOYEE_DEDUCTION_EDIT,
+        expect.objectContaining({ uuid: 'd-1', description: 'Health Insurance' }),
+      )
+    })
+
+    it('soft-deletes via PUT and emits EMPLOYEE_DEDUCTION_DELETED on confirm', async () => {
+      const target = buildGarnishment({ uuid: 'd-1', description: 'Health Insurance' })
+      stubGarnishmentsList([target])
+
+      let updatePath: string | null = null
+      let updateBody: Record<string, unknown> | null = null
+      const updateResolver = vi.fn<HttpResponseResolver>(async ({ request }) => {
+        updatePath = new URL(request.url).pathname
+        updateBody = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json({ ...target, active: false })
+      })
+      server.use(http.put(`${API_BASE_URL}/v1/garnishments/:garnishment_id`, updateResolver))
+
+      const user = userEvent.setup()
+      renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+      await openJobAndPayTab(user)
+
+      await user.click(screen.getByRole('button', { name: 'Deduction actions menu' }))
+      await user.click(await screen.findByRole('menuitem', { name: 'Delete deduction' }))
+
+      const dialog = await screen.findByRole('dialog')
+      await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+      await waitFor(() => {
+        expect(updateResolver).toHaveBeenCalledTimes(1)
+      })
+      expect(updatePath).toBe('/v1/garnishments/d-1')
+      expect(updateBody).toMatchObject({ active: false, version: 'version-d-1' })
+      expect(onEvent).toHaveBeenCalledWith(
+        componentEvents.EMPLOYEE_DEDUCTION_DELETED,
+        expect.objectContaining({ uuid: 'd-1', active: false }),
+      )
     })
   })
 

--- a/src/components/Employee/Dashboard/Dashboard.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useGustoEmbeddedContext } from '@gusto/embedded-api/react-query/_context'
 import { payrollsGetPayStub } from '@gusto/embedded-api/funcs/payrollsGetPayStub'
 import { useErrorBoundary } from 'react-error-boundary'
+import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
 import {
   useEmployeeBasicDetails,
   useEmployeeCompensation,
@@ -72,6 +73,13 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
   const handleAddDeduction = useCallback(() => {
     onEvent(componentEvents.EMPLOYEE_DEDUCTION_ADD, { employeeId })
   }, [onEvent, employeeId])
+
+  const handleEditDeduction = useCallback(
+    (deduction: Garnishment) => {
+      onEvent(componentEvents.EMPLOYEE_DEDUCTION_EDIT, deduction)
+    },
+    [onEvent],
+  )
 
   const handlePaystubDownload = useCallback(
     async (payrollUuid: string) => {
@@ -164,7 +172,7 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
   }
 
   const { employee, currentHomeAddress, currentWorkAddress } = basicDetails.data
-  const { garnishmentList, payStubs } = compensation.data
+  const { payStubs } = compensation.data
   const { employeeStateTaxesList } = taxes.data
   const { formList } = forms.data
 
@@ -229,7 +237,6 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
             <JobAndPayView
               employeeId={employeeId}
               job={primaryJob}
-              garnishments={garnishmentList}
               payStubs={payStubs}
               payStubsPagination={payStubsPagination}
               isLoading={isLoadingJobAndPay}
@@ -237,6 +244,7 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
               onEditCompensation={handleEditCompensation}
               onAddJob={handleAddJob}
               onAddDeduction={handleAddDeduction}
+              onEditDeduction={handleEditDeduction}
               onPaystubDownload={handlePaystubDownload}
               downloadingPayrollUuids={downloadingPayrollUuids}
             />

--- a/src/components/Employee/Dashboard/DashboardComponents.tsx
+++ b/src/components/Employee/Dashboard/DashboardComponents.tsx
@@ -8,19 +8,30 @@ import { Profile } from '@/components/Employee/Profile/management/Profile'
 import { BankForm } from '@/components/Employee/PaymentMethod/onboarding/BankForm'
 import { SplitView } from '@/components/Employee/PaymentMethod/onboarding/SplitView'
 import { DocumentManager } from '@/components/Employee/Documents/management/DocumentManager'
+import { DeductionsForm } from '@/components/Employee/Deductions/DeductionsForm/DeductionsForm'
+import { useDeductionsList } from '@/components/Employee/Deductions/shared'
 import { useFlow, type FlowContextInterface } from '@/components/Flow/useFlow'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
-import { BaseComponent } from '@/components/Base'
+import { BaseComponent, BaseLayout } from '@/components/Base'
 import { ensureRequired } from '@/helpers/ensureRequired'
 import { useI18n } from '@/i18n'
 import { componentEvents } from '@/shared/constants'
 
-export type DashboardSuccessAlert = 'bankAccountAdded' | 'bankAccountDeleted' | 'splitUpdated'
+export type DashboardSuccessAlert =
+  | 'bankAccountAdded'
+  | 'bankAccountDeleted'
+  | 'splitUpdated'
+  | 'deductionAdded'
+  | 'deductionUpdated'
+  | 'deductionDeleted'
 
 export interface DashboardContextInterface extends FlowContextInterface {
   employeeId: string
   formId?: string
   successAlert?: DashboardSuccessAlert | null
+  /** Set by the EMPLOYEE_DEDUCTION_EDIT transition; consumed by
+   *  DeductionFormContextual to pre-populate the form. */
+  editingDeductionId?: string
 }
 
 export function DashboardViewContextual() {
@@ -33,6 +44,9 @@ export function DashboardViewContextual() {
     bankAccountAdded: t('alerts.bankAccountAdded'),
     bankAccountDeleted: t('alerts.bankAccountDeleted'),
     splitUpdated: t('alerts.splitUpdated'),
+    deductionAdded: t('alerts.deductionAdded'),
+    deductionUpdated: t('alerts.deductionUpdated'),
+    deductionDeleted: t('alerts.deductionDeleted'),
   }
 
   return (
@@ -103,5 +117,40 @@ export function DocumentManagerContextual() {
       formId={ensureRequired(formId)}
       onEvent={onEvent}
     />
+  )
+}
+
+export function DeductionFormContextual() {
+  const { employeeId, editingDeductionId, onEvent } = useFlow<DashboardContextInterface>()
+  // The same list query the form hooks use internally — React Query dedupes,
+  // so this just looks up the loaded row to pre-populate edit mode.
+  const list = useDeductionsList({ employeeId: ensureRequired(employeeId) })
+
+  if (list.isLoading) {
+    return <BaseLayout isLoading error={list.errorHandling.errors} />
+  }
+
+  const deduction = editingDeductionId
+    ? (list.data.deductions.find(d => d.uuid === editingDeductionId) ?? null)
+    : null
+
+  return (
+    <BaseLayout error={list.errorHandling.errors}>
+      <DeductionsForm
+        employeeId={ensureRequired(employeeId)}
+        deduction={deduction}
+        onSaved={(saved, mode) => {
+          onEvent(
+            mode === 'create'
+              ? componentEvents.EMPLOYEE_DEDUCTION_CREATED
+              : componentEvents.EMPLOYEE_DEDUCTION_UPDATED,
+            saved,
+          )
+        }}
+        onCancel={() => {
+          onEvent(componentEvents.CANCEL)
+        }}
+      />
+    </BaseLayout>
   )
 }

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -9,6 +9,7 @@ import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentCon
 import { DataView, useDataView, EmptyData, Loading } from '@/components/Common'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import { BaseLayout } from '@/components/Base/Base'
+import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
 import { formatDateLongWithYear } from '@/helpers/dateFormatting'
 import { useFormatPayRate } from '@/helpers/formattedStrings'
 import useNumberFormatter from '@/hooks/useNumberFormatter'
@@ -18,8 +19,14 @@ import {
   useDeleteBankAccount,
   DeleteBankAccountDialog,
 } from '@/components/Employee/PaymentMethod/shared'
+import {
+  useDeductionsList,
+  useDeleteDeduction,
+  DeleteDeductionDialog,
+} from '@/components/Employee/Deductions/shared'
 import { componentEvents, PAYMENT_METHODS, type EventType } from '@/shared/constants'
 import type { OnEventType } from '@/components/Base/useBase'
+import PencilSvg from '@/assets/icons/pencil.svg?react'
 import PlusCircleIcon from '@/assets/icons/plus-circle.svg?react'
 import PercentCircleIcon from '@/assets/icons/percent-circle.svg?react'
 import DownloadCloudIcon from '@/assets/icons/download-cloud.svg?react'
@@ -32,7 +39,6 @@ type EmployeePayStub = NonNullable<
 export interface JobAndPayViewProps {
   employeeId: string
   job?: Job
-  garnishments?: Garnishment[]
   payStubs?: EmployeePayStub[]
   payStubsPagination?: PaginationControlProps
   isLoading?: boolean
@@ -40,6 +46,7 @@ export interface JobAndPayViewProps {
   onEditCompensation?: () => void
   onAddJob?: () => void
   onAddDeduction?: () => void
+  onEditDeduction?: (deduction: Garnishment) => void
   onPaystubDownload?: (payrollUuid: string) => void
   downloadingPayrollUuids?: ReadonlySet<string>
 }
@@ -47,7 +54,6 @@ export interface JobAndPayViewProps {
 export function JobAndPayView({
   employeeId,
   job,
-  garnishments = [],
   payStubs = [],
   payStubsPagination,
   isLoading = false,
@@ -55,15 +61,19 @@ export function JobAndPayView({
   onEditCompensation,
   onAddJob,
   onAddDeduction,
+  onEditDeduction,
   onPaystubDownload,
   downloadingPayrollUuids,
 }: JobAndPayViewProps) {
   useI18n('Employee.PaymentMethod')
+  useI18n('Employee.Deductions')
   const { t } = useTranslation('Employee.Dashboard')
   const { t: tPayment } = useTranslation('Employee.PaymentMethod')
+  const { t: tDeductions } = useTranslation('Employee.Deductions')
   const Components = useComponentContext()
   const formatPayRate = useFormatPayRate()
   const formatCurrency = useNumberFormatter('currency')
+  const formatPercent = useNumberFormatter('percent')
 
   const paymentMethodList = usePaymentMethodList({ employeeId })
   const paymentMethod = paymentMethodList.isLoading
@@ -82,6 +92,28 @@ export function JobAndPayView({
         onEvent(componentEvents.EMPLOYEE_BANK_ACCOUNT_DELETED, result.data)
       }
     })
+
+  const deductionsList = useDeductionsList({ employeeId })
+  const deductions = deductionsList.isLoading ? [] : deductionsList.data.deductions
+  const deletingGarnishmentUuid = deductionsList.isLoading
+    ? undefined
+    : deductionsList.status.deletingGarnishmentUuid
+
+  const {
+    pendingDeleteDeduction,
+    setPendingDeleteDeduction,
+    handleConfirmDelete: handleConfirmDeleteDeduction,
+  } = useDeleteDeduction(async garnishment => {
+    if (deductionsList.isLoading) return
+    const result = await deductionsList.actions.onDelete(garnishment)
+    if (result) {
+      onEvent(componentEvents.EMPLOYEE_DEDUCTION_DELETED, result.data.garnishment)
+    }
+  })
+
+  // Both hooks own a submit error state; merge into one error surface so
+  // the BaseLayout below shows whatever failed.
+  const errorHandling = composeErrorHandler([paymentMethodList, deductionsList])
 
   const bankAccountsColumns = [
     {
@@ -111,19 +143,25 @@ export function JobAndPayView({
       key: 'frequency',
       title: t('jobAndPay.deductions.frequency'),
       render: (garnishment: Garnishment) =>
-        garnishment.recurring ? t('jobAndPay.deductions.recurring') : '-',
+        garnishment.recurring
+          ? t('jobAndPay.deductions.recurring')
+          : t('jobAndPay.deductions.oneTime'),
     },
     {
       key: 'amount',
       title: t('jobAndPay.deductions.withhold'),
       render: (garnishment: Garnishment) => {
-        if (garnishment.amount && typeof garnishment.amount === 'number') {
-          return formatCurrency(garnishment.amount)
-        }
-        if (garnishment.annualMaximum) {
-          return `${garnishment.annualMaximum}% per paycheck`
-        }
-        return '-'
+        // `amount` is a string per the API. `deductAsPercentage` switches
+        // between currency and percent formatting; `recurring` adds the
+        // "{value} per paycheck" suffix. Mirrors the legacy DeductionsList.
+        const numericAmount = Number(garnishment.amount)
+        if (Number.isNaN(numericAmount)) return '-'
+        const formatted = garnishment.deductAsPercentage
+          ? formatPercent(numericAmount)
+          : formatCurrency(numericAmount)
+        return garnishment.recurring
+          ? t('jobAndPay.deductions.amountPerPaycheck', { value: formatted })
+          : formatted
       },
     },
   ]
@@ -182,8 +220,28 @@ export function JobAndPayView({
   })
 
   const garnishmentsDataView = useDataView({
-    data: garnishments,
+    data: deductions,
     columns: garnishmentsColumns,
+    itemMenu: (garnishment: Garnishment) => (
+      <HamburgerMenu
+        isLoading={deletingGarnishmentUuid === garnishment.uuid}
+        items={[
+          {
+            label: tDeductions('editCta'),
+            onClick: () => onEditDeduction?.(garnishment),
+            icon: <PencilSvg aria-hidden />,
+          },
+          {
+            label: tDeductions('deleteCta'),
+            onClick: () => {
+              setPendingDeleteDeduction(garnishment)
+            },
+            icon: <TrashCanSvg aria-hidden />,
+          },
+        ]}
+        triggerLabel={tDeductions('hamburgerTitle')}
+      />
+    ),
     emptyState: () => (
       <EmptyData
         title={t('jobAndPay.deductions.emptyState.title')}
@@ -223,14 +281,14 @@ export function JobAndPayView({
     ),
   })
 
-  if (isLoading || paymentMethodList.isLoading) {
+  if (isLoading || paymentMethodList.isLoading || deductionsList.isLoading) {
     return <Loading />
   }
 
   const isDirectDeposit = paymentMethod?.type === PAYMENT_METHODS.directDeposit
 
   return (
-    <BaseLayout error={paymentMethodList.errorHandling.errors}>
+    <BaseLayout error={errorHandling.errors}>
       <Flex flexDirection="column" gap={24}>
         <Components.Box
           withPadding={!!job}
@@ -398,6 +456,17 @@ export function JobAndPayView({
           }}
           onConfirm={() => {
             void handleConfirmDelete()
+          }}
+        />
+
+        <DeleteDeductionDialog
+          pendingDeleteDeduction={pendingDeleteDeduction}
+          isPrimaryActionLoading={deletingGarnishmentUuid === pendingDeleteDeduction?.uuid}
+          onClose={() => {
+            setPendingDeleteDeduction(null)
+          }}
+          onConfirm={() => {
+            void handleConfirmDeleteDeduction()
           }}
         />
       </Flex>

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -6,7 +6,7 @@ import type { GetV1EmployeesEmployeeUuidPayStubsResponse } from '@gusto/embedded
 import type { PaginationControlProps } from '@/components/Common/PaginationControl/PaginationControlTypes'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
-import { DataView, useDataView, EmptyData, Loading } from '@/components/Common'
+import { DataView, useDataView, EmptyData } from '@/components/Common'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import { BaseLayout } from '@/components/Base/Base'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
@@ -282,7 +282,7 @@ export function JobAndPayView({
   })
 
   if (isLoading || paymentMethodList.isLoading || deductionsList.isLoading) {
-    return <Loading />
+    return <BaseLayout isLoading error={errorHandling.errors} />
   }
 
   const isDirectDeposit = paymentMethod?.type === PAYMENT_METHODS.directDeposit

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -23,6 +23,7 @@ import {
   useDeductionsList,
   useDeleteDeduction,
   DeleteDeductionDialog,
+  formatDeductionAmount,
 } from '@/components/Employee/Deductions/shared'
 import { componentEvents, PAYMENT_METHODS, type EventType } from '@/shared/constants'
 import type { OnEventType } from '@/components/Base/useBase'
@@ -150,19 +151,13 @@ export function JobAndPayView({
     {
       key: 'amount',
       title: t('jobAndPay.deductions.withhold'),
-      render: (garnishment: Garnishment) => {
-        // `amount` is a string per the API. `deductAsPercentage` switches
-        // between currency and percent formatting; `recurring` adds the
-        // "{value} per paycheck" suffix. Mirrors the legacy DeductionsList.
-        const numericAmount = Number(garnishment.amount)
-        if (Number.isNaN(numericAmount)) return '-'
-        const formatted = garnishment.deductAsPercentage
-          ? formatPercent(numericAmount)
-          : formatCurrency(numericAmount)
-        return garnishment.recurring
-          ? t('jobAndPay.deductions.amountPerPaycheck', { value: formatted })
-          : formatted
-      },
+      render: (garnishment: Garnishment) =>
+        formatDeductionAmount(garnishment, {
+          formatCurrency,
+          formatPercent,
+          formatPerPaycheck: (value: string) =>
+            t('jobAndPay.deductions.amountPerPaycheck', { value }),
+        }),
     },
   ]
 

--- a/src/components/Employee/Dashboard/dashboardStateMachine.ts
+++ b/src/components/Employee/Dashboard/dashboardStateMachine.ts
@@ -1,4 +1,5 @@
 import { transition, reduce, state } from 'robot3'
+import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
 import {
   DashboardViewContextual,
   HomeAddressContextual,
@@ -9,6 +10,7 @@ import {
   PaymentBankFormContextual,
   PaymentSplitViewContextual,
   DocumentManagerContextual,
+  DeductionFormContextual,
   type DashboardContextInterface,
 } from './DashboardComponents'
 import { componentEvents } from '@/shared/constants'
@@ -16,6 +18,7 @@ import type { MachineEventType, MachineTransition } from '@/types/Helpers'
 
 type EventPayloads = {
   [componentEvents.EMPLOYEE_VIEW_FORM_TO_SIGN]: { employeeId: string; formId: string }
+  [componentEvents.EMPLOYEE_DEDUCTION_EDIT]: Garnishment
 }
 
 const returnToIndex = reduce(
@@ -150,6 +153,45 @@ export const dashboardStateMachine = {
       ),
     ),
     transition(
+      componentEvents.EMPLOYEE_DEDUCTION_ADD,
+      'deductionForm',
+      reduce(
+        (ctx: DashboardContextInterface): DashboardContextInterface => ({
+          ...ctx,
+          component: DeductionFormContextual,
+          header: { type: 'minimal' },
+          successAlert: null,
+          editingDeductionId: undefined,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.EMPLOYEE_DEDUCTION_EDIT,
+      'deductionForm',
+      reduce(
+        (
+          ctx: DashboardContextInterface,
+          ev: MachineEventType<EventPayloads, typeof componentEvents.EMPLOYEE_DEDUCTION_EDIT>,
+        ): DashboardContextInterface => ({
+          ...ctx,
+          component: DeductionFormContextual,
+          header: { type: 'minimal' },
+          successAlert: null,
+          editingDeductionId: ev.payload.uuid,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.EMPLOYEE_DEDUCTION_DELETED,
+      'index',
+      reduce(
+        (ctx: DashboardContextInterface): DashboardContextInterface => ({
+          ...ctx,
+          successAlert: 'deductionDeleted',
+        }),
+      ),
+    ),
+    transition(
       componentEvents.EMPLOYEE_DISMISS,
       'index',
       reduce(
@@ -185,6 +227,20 @@ export const dashboardStateMachine = {
     transition(componentEvents.CANCEL, 'index', returnToIndex),
   ),
   documentManager: state<MachineTransition>(
+    transition(componentEvents.CANCEL, 'index', returnToIndex),
+  ),
+  deductionForm: state<MachineTransition>(
+    transition(
+      componentEvents.EMPLOYEE_DEDUCTION_CREATED,
+      'index',
+      returnToIndexWithAlert('deductionAdded'),
+    ),
+    transition(
+      componentEvents.EMPLOYEE_DEDUCTION_UPDATED,
+      'index',
+      returnToIndexWithAlert('deductionUpdated'),
+    ),
+    transition(componentEvents.EMPLOYEE_DEDUCTION_CANCEL, 'index', returnToIndex),
     transition(componentEvents.CANCEL, 'index', returnToIndex),
   ),
 }

--- a/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
@@ -1,9 +1,7 @@
 import { useMemo } from 'react'
 import { useEmployeesGetSuspense } from '@gusto/embedded-api/react-query/employeesGet'
-import { useGarnishmentsListSuspense } from '@gusto/embedded-api/react-query/garnishmentsList'
 import { usePayrollsGetPayStubsSuspense } from '@gusto/embedded-api/react-query/payrollsGetPayStubs'
 import type { Job } from '@gusto/embedded-api/models/components/job'
-import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
 import type { GetV1EmployeesEmployeeUuidPayStubsResponse } from '@gusto/embedded-api/models/operations/getv1employeesemployeeuuidpaystubs'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
 import { usePagination } from '@/hooks/usePagination/usePagination'
@@ -21,7 +19,6 @@ export interface UseEmployeeCompensationProps {
 interface UseEmployeeCompensationReady extends BaseHookReady<
   {
     primaryJob?: Job
-    garnishmentList: Garnishment[]
     payStubs: EmployeePayStub[]
   },
   { isPending: boolean }
@@ -41,7 +38,9 @@ export function useEmployeeCompensation({
   })
 
   const employeeQuery = useEmployeesGetSuspense({ employeeId })
-  const garnishmentsQuery = useGarnishmentsListSuspense({ employeeId })
+  // Garnishments are no longer fetched here — the consumer (JobAndPayView)
+  // owns its own fetch via `useDeductionsList`, which also handles the
+  // soft-delete mutation + error surface for the deductions section.
   const payStubsQuery = usePayrollsGetPayStubsSuspense({
     employeeId,
     page: currentPage,
@@ -49,7 +48,6 @@ export function useEmployeeCompensation({
   })
 
   const employee = employeeQuery.data.employee
-  const garnishmentList = garnishmentsQuery.data.garnishments
   const payStubsData = payStubsQuery.data
 
   const primaryJob = useMemo(() => {
@@ -63,12 +61,11 @@ export function useEmployeeCompensation({
     return getPaginationProps(headers, payStubsQuery.isFetching)
   }, [payStubsData.httpMeta.response.headers, payStubsQuery.isFetching, getPaginationProps])
 
-  const isPending =
-    employeeQuery.isFetching || garnishmentsQuery.isFetching || payStubsQuery.isFetching
+  const isPending = employeeQuery.isFetching || payStubsQuery.isFetching
 
   const isLoading = !employee && isPending
 
-  const errorHandling = composeErrorHandler([employeeQuery, garnishmentsQuery, payStubsQuery])
+  const errorHandling = composeErrorHandler([employeeQuery, payStubsQuery])
 
   if (isLoading) {
     return {
@@ -81,7 +78,6 @@ export function useEmployeeCompensation({
     isLoading: false,
     data: {
       primaryJob,
-      garnishmentList: garnishmentList || [],
       payStubs,
     },
     status: {

--- a/src/components/Employee/Deductions/DeductionsList/DeductionsList.tsx
+++ b/src/components/Employee/Deductions/DeductionsList/DeductionsList.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
 import type { UseDeductionsListReady } from '../shared/useDeductionsList'
+import { formatDeductionAmount } from '../shared/formatDeductionAmount'
 import { useDataView, DataView } from '@/components/Common'
 import { ActionsLayout } from '@/components/Common'
 import { Flex } from '@/components/Common/Flex/Flex'
@@ -55,14 +56,12 @@ export function DeductionsList({
       {
         key: 'amount',
         title: t('withheldColumn'),
-        render: deduction => {
-          const formattedAmount = deduction.deductAsPercentage
-            ? formatPercent(Number(deduction.amount))
-            : formatCurrency(Number(deduction.amount))
-          return deduction.recurring
-            ? t('recurringAmount', { value: formattedAmount })
-            : formattedAmount
-        },
+        render: deduction =>
+          formatDeductionAmount(deduction, {
+            formatCurrency,
+            formatPercent,
+            formatPerPaycheck: (value: string) => t('recurringAmount', { value }),
+          }),
       },
     ],
     itemMenu: deduction => {

--- a/src/components/Employee/Deductions/deductionsContextualComponents.tsx
+++ b/src/components/Employee/Deductions/deductionsContextualComponents.tsx
@@ -41,7 +41,15 @@ export function IncludeDeductionsContextual() {
     onEvent(componentEvents.EMPLOYEE_DEDUCTION_DONE)
   }
 
-  return <IncludeDeductions onAdd={onAdd} onContinue={onContinue} />
+  // BaseLayout's inner FadeIn (width: 100%) is the canonical "page" container
+  // for content rendered inside <Flow>. Without it the outer row-direction
+  // Flex in Flow collapses to the intrinsic content width of its single
+  // child, producing the "squashed" layout for narrow content.
+  return (
+    <BaseLayout>
+      <IncludeDeductions onAdd={onAdd} onContinue={onContinue} />
+    </BaseLayout>
+  )
 }
 
 export function DeductionsListContextual() {

--- a/src/components/Employee/Deductions/shared/DeleteDeductionDialog.tsx
+++ b/src/components/Employee/Deductions/shared/DeleteDeductionDialog.tsx
@@ -1,0 +1,35 @@
+import { useTranslation } from 'react-i18next'
+import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+export function DeleteDeductionDialog({
+  pendingDeleteDeduction,
+  isPrimaryActionLoading,
+  onClose,
+  onConfirm,
+}: {
+  pendingDeleteDeduction: Garnishment | null
+  isPrimaryActionLoading: boolean
+  onClose: () => void
+  onConfirm: () => void
+}) {
+  const { t } = useTranslation('Employee.Deductions')
+  const Components = useComponentContext()
+  return (
+    <Components.Dialog
+      isOpen={pendingDeleteDeduction !== null}
+      onClose={onClose}
+      onPrimaryActionClick={onConfirm}
+      isPrimaryActionLoading={isPrimaryActionLoading}
+      isDestructive
+      title={t('deleteDeductionDialog.title')}
+      primaryActionLabel={t('deleteDeductionDialog.confirmCta')}
+      closeActionLabel={t('deleteDeductionDialog.cancelCta')}
+    >
+      {pendingDeleteDeduction &&
+        t('deleteDeductionDialog.description', {
+          deduction: pendingDeleteDeduction.description ?? '',
+        })}
+    </Components.Dialog>
+  )
+}

--- a/src/components/Employee/Deductions/shared/formatDeductionAmount.test.ts
+++ b/src/components/Employee/Deductions/shared/formatDeductionAmount.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
+import { formatDeductionAmount } from './formatDeductionAmount'
+
+const formatters = {
+  formatCurrency: (n: number) => `$${n.toFixed(2)}`,
+  formatPercent: (n: number) => `${n}%`,
+  formatPerPaycheck: (value: string) => `${value} per paycheck`,
+}
+
+const baseDeduction: Pick<Garnishment, 'amount' | 'deductAsPercentage' | 'recurring'> = {
+  amount: '50',
+  deductAsPercentage: false,
+  recurring: false,
+}
+
+describe('formatDeductionAmount', () => {
+  it('formats a one-time fixed-dollar deduction as currency without suffix', () => {
+    expect(formatDeductionAmount(baseDeduction, formatters)).toBe('$50.00')
+  })
+
+  it('formats a recurring fixed-dollar deduction with per-paycheck suffix', () => {
+    expect(formatDeductionAmount({ ...baseDeduction, recurring: true }, formatters)).toBe(
+      '$50.00 per paycheck',
+    )
+  })
+
+  it('formats a one-time percentage deduction as percent without suffix', () => {
+    expect(
+      formatDeductionAmount(
+        { ...baseDeduction, amount: '5', deductAsPercentage: true },
+        formatters,
+      ),
+    ).toBe('5%')
+  })
+
+  it('formats a recurring percentage deduction as percent with per-paycheck suffix', () => {
+    expect(
+      formatDeductionAmount({ amount: '5', deductAsPercentage: true, recurring: true }, formatters),
+    ).toBe('5% per paycheck')
+  })
+
+  it('returns "-" when amount is missing', () => {
+    expect(formatDeductionAmount({ ...baseDeduction, amount: undefined }, formatters)).toBe('-')
+  })
+
+  it('returns "-" when amount cannot be parsed as a number', () => {
+    expect(formatDeductionAmount({ ...baseDeduction, amount: 'not-a-number' }, formatters)).toBe(
+      '-',
+    )
+  })
+
+  it('routes the suffix through formatPerPaycheck so the caller owns the i18n template', () => {
+    const formatPerPaycheck = vi.fn((value: string) => `${value} per paycheck`)
+    formatDeductionAmount(
+      { amount: '100', deductAsPercentage: false, recurring: true },
+      { ...formatters, formatPerPaycheck },
+    )
+    expect(formatPerPaycheck).toHaveBeenCalledWith('$100.00')
+  })
+})

--- a/src/components/Employee/Deductions/shared/formatDeductionAmount.ts
+++ b/src/components/Employee/Deductions/shared/formatDeductionAmount.ts
@@ -1,0 +1,19 @@
+import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
+
+export interface DeductionAmountFormatters {
+  formatCurrency: (value: number) => string
+  formatPercent: (value: number) => string
+  formatPerPaycheck: (value: string) => string
+}
+
+export function formatDeductionAmount(
+  deduction: Pick<Garnishment, 'amount' | 'deductAsPercentage' | 'recurring'>,
+  { formatCurrency, formatPercent, formatPerPaycheck }: DeductionAmountFormatters,
+): string {
+  const numericAmount = Number(deduction.amount)
+  if (Number.isNaN(numericAmount)) return '-'
+  const formatted = deduction.deductAsPercentage
+    ? formatPercent(numericAmount)
+    : formatCurrency(numericAmount)
+  return deduction.recurring ? formatPerPaycheck(formatted) : formatted
+}

--- a/src/components/Employee/Deductions/shared/index.ts
+++ b/src/components/Employee/Deductions/shared/index.ts
@@ -5,5 +5,7 @@ export {
   type UseDeductionsListReady,
   type DeductionsListDeleteResult,
 } from './useDeductionsList'
+export { useDeleteDeduction } from './useDeleteDeduction'
+export { DeleteDeductionDialog } from './DeleteDeductionDialog'
 export * from './useDeductionForm'
 export * from './useChildSupportGarnishmentForm'

--- a/src/components/Employee/Deductions/shared/index.ts
+++ b/src/components/Employee/Deductions/shared/index.ts
@@ -7,5 +7,6 @@ export {
 } from './useDeductionsList'
 export { useDeleteDeduction } from './useDeleteDeduction'
 export { DeleteDeductionDialog } from './DeleteDeductionDialog'
+export { formatDeductionAmount, type DeductionAmountFormatters } from './formatDeductionAmount'
 export * from './useDeductionForm'
 export * from './useChildSupportGarnishmentForm'

--- a/src/components/Employee/Deductions/shared/useDeleteDeduction.ts
+++ b/src/components/Employee/Deductions/shared/useDeleteDeduction.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
+
+/**
+ * Pending-state + confirm-handler companion for `DeleteDeductionDialog`.
+ * Mirrors `useDeleteBankAccount` — the contract is: a row's menu calls
+ * `setPendingDeleteDeduction(...)` to open the dialog, and the dialog's
+ * confirm calls `handleConfirmDelete`, which in turn invokes the
+ * caller-supplied `handleDelete(garnishment)`.
+ */
+export function useDeleteDeduction(handleDelete: (garnishment: Garnishment) => Promise<void>) {
+  const [pendingDeleteDeduction, setPendingDeleteDeduction] = useState<Garnishment | null>(null)
+
+  const handleConfirmDelete = async () => {
+    if (!pendingDeleteDeduction) return
+    const target = pendingDeleteDeduction
+    setPendingDeleteDeduction(null)
+    await handleDelete(target)
+  }
+
+  return {
+    pendingDeleteDeduction,
+    setPendingDeleteDeduction,
+    handleConfirmDelete,
+  }
+}

--- a/src/i18n/en/Employee.Dashboard.json
+++ b/src/i18n/en/Employee.Dashboard.json
@@ -65,8 +65,10 @@
       "listLabel": "List of deductions",
       "deduction": "Deduction",
       "frequency": "Frequency",
-      "withhold": "Withhold",
+      "withhold": "Withheld",
       "recurring": "Recurring",
+      "oneTime": "One-time",
+      "amountPerPaycheck": "{{value}} per paycheck",
       "emptyState": {
         "title": "No deductions",
         "description": "Employee deductions will appear here"
@@ -137,6 +139,9 @@
   "alerts": {
     "bankAccountAdded": "Bank account successfully added.",
     "bankAccountDeleted": "Bank account successfully deleted.",
-    "splitUpdated": "Split payment successfully updated."
+    "splitUpdated": "Split payment successfully updated.",
+    "deductionAdded": "Deduction successfully added.",
+    "deductionUpdated": "Deduction successfully updated.",
+    "deductionDeleted": "Deduction successfully deleted."
   }
 }

--- a/src/i18n/en/Employee.Deductions.json
+++ b/src/i18n/en/Employee.Deductions.json
@@ -74,6 +74,12 @@
   "hamburgerTitle": "Deduction actions menu",
   "editCta": "Edit deduction",
   "deleteCta": "Delete deduction",
+  "deleteDeductionDialog": {
+    "title": "Delete this deduction?",
+    "description": "{{deduction}} will no longer be deducted from this employee's paycheck.",
+    "confirmCta": "Delete",
+    "cancelCta": "Cancel"
+  },
   "addDeductionCta": "Add another deduction",
   "cancelCta": "Cancel",
   "validations": {

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1474,6 +1474,8 @@ export interface EmployeeDashboard{
 "frequency":string;
 "withhold":string;
 "recurring":string;
+"oneTime":string;
+"amountPerPaycheck":string;
 "emptyState":{
 "title":string;
 "description":string;
@@ -1545,6 +1547,9 @@ export interface EmployeeDashboard{
 "bankAccountAdded":string;
 "bankAccountDeleted":string;
 "splitUpdated":string;
+"deductionAdded":string;
+"deductionUpdated":string;
+"deductionDeleted":string;
 };
 };
 export interface EmployeeDeductions{
@@ -1623,6 +1628,12 @@ export interface EmployeeDeductions{
 "hamburgerTitle":string;
 "editCta":string;
 "deleteCta":string;
+"deleteDeductionDialog":{
+"title":string;
+"description":string;
+"confirmCta":string;
+"cancelCta":string;
+};
 "addDeductionCta":string;
 "cancelCta":string;
 "validations":{


### PR DESCRIPTION
## Summary

Adds a Deductions block to `JobAndPayView` in the Employee Dashboard. Users can now see all active deductions, add a new one, edit an existing one, and delete with a confirmation dialog — all flowing through the existing Dashboard state machine. Bundles a small earlier fix for the standalone Deductions page's empty-state layout.

## Changes

- **Deductions block in JobAndPayView**: `useDeductionsList` is consumed directly inside the view (mirroring how `usePaymentMethodList` is wired) — `garnishments` prop drilling from Dashboard is gone. Each row has a HamburgerMenu (Edit / Delete). Delete opens a new `DeleteDeductionDialog`.
- **`useDeleteDeduction` + `DeleteDeductionDialog`** — small parallels of the bank-account counterparts; live in `Deductions/shared/`.
- **`dashboardStateMachine`**: new `deductionForm` state. From `index`: `EMPLOYEE_DEDUCTION_ADD` / `EMPLOYEE_DEDUCTION_EDIT` → `deductionForm`; `EMPLOYEE_DEDUCTION_DELETED` → `index` with `successAlert: 'deductionDeleted'`. From `deductionForm`: `EMPLOYEE_DEDUCTION_CREATED` / `UPDATED` → `index` with the matching alert; `CANCEL` / `EMPLOYEE_DEDUCTION_CANCEL` → `index`.
- **`DeductionFormContextual`** mounts the existing `DeductionsForm` picker (Standard vs Child Support) so both custom deductions and any court-ordered garnishment type are handled from the Dashboard.
- **`useEmployeeCompensation`** drops `useGarnishmentsListSuspense` + `garnishmentList` — JobAndPayView fetches via the deductions hook directly, and React Query dedupes so there's no extra network call.
- **Withheld-column bug fix**: the legacy column rendered nothing useful — `amount` is a string per the API but the branch checked `typeof === 'number'` (never true) and fell back to `${annualMaximum}% per paycheck` (wrong field). Now matches the legacy DeductionsList: currency / percent driven by `deductAsPercentage`, with the "{value} per paycheck" suffix for recurring rows.
- **Error handling**: errors from both `paymentMethodList` and `deductionsList` are merged with `composeErrorHandler`, so the existing JobAndPayView `BaseLayout` surfaces either hook's failure (read or delete).
- **Standalone `/employee/Deductions` layout fix** (bundled from earlier work): wraps `IncludeDeductions` in `<BaseLayout>` inside the contextual so `<Flow>`'s outer row-Flex gets a definite width context — un-squashes the empty-state CTA.

## Testing

- `npx tsc --noEmit` — clean
- `npm run format` + `npm run lint` — clean (0 errors; only pre-existing warnings in unrelated files)
- `npm run test -- --run src/components/Employee/Dashboard src/components/Employee/Deductions` — 8 files, 34 tests pass
- Manual validation via Playwright against the dev app:
  - `/employee/DashboardFlow` → Job and pay tab → Deductions section renders with title + "Add deduction" button + Deduction/Frequency/Withheld/Actions columns.
  - Empty state shows the "No deductions" placeholder.
  - Clicking "Add deduction" fires `employee/deductions/add` (verified in Events Log) and the state machine mounts the DeductionsForm picker with the minimal header / Back button.
  - `/employee/Deductions` (standalone) no longer renders the empty-state at ~200px width; full content width restored.