### PR TITLE
fix(EditCompensation): omit effective_date from compensation PUT body

### DIFF
--- a/docs/hooks/jobs-and-compensations.md
+++ b/docs/hooks/jobs-and-compensations.md
@@ -158,7 +158,7 @@ const { handleSubmit } = composeSubmitHandler([jobForm, compensationForm], async
 })
 ```
 
-The hook still owns reactive behavior — the `willDeleteSecondaryJobs` carve-out keeps emitting today's date in the submitted PUT body even when `Fields.EffectiveDate` is hidden.
+When `withEffectiveDateField: false`, `useCompensationForm` is strictly options-only — `effective_date` is omitted from the PUT body unless you supply it via submit options. Omit `effectiveDate` from the options entirely to leave the existing date untouched.
 
 ---
 

--- a/docs/hooks/useCompensationForm.md
+++ b/docs/hooks/useCompensationForm.md
@@ -152,10 +152,11 @@ interface CompensationSubmitOptions {
    */
   compensationVersion?: string
   /**
-   * Supply `effectiveDate` at submit time. Takes precedence over the form
-   * value. Most useful with `withEffectiveDateField: false` for screens that
-   * derive the effective date from external context (e.g. the parent job's
-   * `hireDate` during onboarding stub-fill).
+   * Supply `effectiveDate` at submit time. When `withEffectiveDateField`
+   * is `true`, this overrides the form's value. When `withEffectiveDateField`
+   * is `false`, this is the only way to put `effective_date` on the wire —
+   * the form value is not read in that mode (matching the options-only
+   * convention of `useWorkAddressForm` / `useHomeAddressForm` / `useJobForm`).
    */
   effectiveDate?: string
 }
@@ -307,7 +308,7 @@ Use `data.minimumEffectiveDate` and `data.maximumEffectiveDate` to constrain the
 
 This field is automatically **disabled** (and the form value forced to today) while `status.willDeleteSecondaryJobs` is `true` — see [Derived helpers](#derived-helpers). You can render the disabled field as-is, or hide it altogether and key off the flag for a separate inline message.
 
-**Conditional availability:** This field is `undefined` when `withEffectiveDateField: false`. Supply the value via `CompensationSubmitOptions.effectiveDate` at submit time instead — useful when the date is derived from external context (e.g. the parent job's `hireDate` during an onboarding flow). The `willDeleteSecondaryJobs` carve-out still works in this mode: the hook continues to manage the underlying form value and emits it in the submitted PUT body.
+**Conditional availability:** This field is `undefined` when `withEffectiveDateField: false`. In this mode the hook is strictly options-only — `effective_date` is omitted from the request body unless you supply `CompensationSubmitOptions.effectiveDate` at submit time. The `willDeleteSecondaryJobs` carve-out's UI side effects (force form value to today, disable the field) are inert here because there is no field to render; pass the date through submit options if you need to pin one during the carve-out.
 
 ```tsx
 {

--- a/src/components/Employee/Compensation/onboarding/EditCompensation/EditCompensation.tsx
+++ b/src/components/Employee/Compensation/onboarding/EditCompensation/EditCompensation.tsx
@@ -98,11 +98,12 @@ function Root({
     employeeId,
     jobId: resolvedJobId,
     compensationId: resolvedCompensationId,
-    // The Compensation flow does not surface an effective-date field — the
-    // date is derived from the parent job's `hireDate` (= `startDate`),
-    // threaded via submit options below. The hook's `willDeleteSecondaryJobs`
-    // carve-out still works because it manipulates the underlying form value
-    // (which the hook reads at submit time even when the field is hidden).
+    // No effective-date field is surfaced, and no `effectiveDate` is
+    // threaded into `actions.onSubmit` either: the server initializes
+    // `effective_date` on the auto-stub created by the parent job POST,
+    // and subsequent updates omit it from the PUT body so the existing
+    // value is preserved (e.g. a deliberately-set future-dated comp
+    // wouldn't be silently overwritten on an unrelated edit).
     withEffectiveDateField: false,
     // The Compensation flow always presents flsaStatus, rate, and paymentUnit
     // as required, even when editing an existing compensation. The hook's
@@ -149,7 +150,6 @@ function Root({
       jobId: jobResult.data.uuid,
       compensationId: jobResult.data.currentCompensationUuid ?? undefined,
       compensationVersion: stubCompensation?.version ?? undefined,
-      effectiveDate: startDate,
     })
     if (!compensationResult) {
       if (!currentJobId) setResolvedJobId(jobResult.data.uuid)

--- a/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.test.tsx
+++ b/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.test.tsx
@@ -1058,7 +1058,7 @@ describe('useCompensationForm', () => {
       expect(updateBody).toMatchObject({ effective_date: '2026-08-15' })
     })
 
-    it('preserves carve-out: hidden field + Nonexempt → non-Nonexempt with secondaries still submits today', async () => {
+    it('omits effective_date from the wire body even during the carve-out when no submit option is supplied', async () => {
       let updateBody: Record<string, unknown> | null = null
       const updateResolver = vi.fn<HttpResponseResolver>(async ({ request }) => {
         updateBody = (await request.json()) as Record<string, unknown>
@@ -1068,8 +1068,8 @@ describe('useCompensationForm', () => {
           job_uuid: 'job-uuid',
           rate: '20.00',
           payment_unit: 'Hour',
-          flsa_status: updateBody.flsaStatus ?? 'Exempt',
-          effective_date: updateBody.effectiveDate ?? todayISO(),
+          flsa_status: 'Exempt',
+          effective_date: todayISO(),
           adjust_for_minimum_wage: false,
         })
       })
@@ -1115,7 +1115,7 @@ describe('useCompensationForm', () => {
       })
 
       expect(updateResolver).toHaveBeenCalledTimes(1)
-      expect(updateBody).toMatchObject({ effective_date: todayISO() })
+      expect(updateBody).not.toHaveProperty('effective_date')
     })
   })
 })

--- a/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.tsx
+++ b/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.tsx
@@ -55,10 +55,11 @@ export interface CompensationSubmitOptions {
    */
   compensationVersion?: string
   /**
-   * Supply `effectiveDate` at submit time. Takes precedence over the form
-   * value. Most useful with `withEffectiveDateField: false` for screens that
-   * derive the effective date from external context (e.g. the parent job's
-   * `hireDate` during onboarding stub-fill).
+   * Supply `effectiveDate` at submit time. When `withEffectiveDateField`
+   * is `true`, this overrides the form's value. When `withEffectiveDateField`
+   * is `false`, this is the only way to put `effective_date` on the wire —
+   * the form value is not read in that mode (matching the options-only
+   * convention of `useWorkAddressForm` / `useHomeAddressForm` / `useJobForm`).
    */
   effectiveDate?: string
 }
@@ -75,12 +76,15 @@ export interface UseCompensationFormProps {
   shouldFocusError?: boolean
   /**
    * When `false`, hides `Fields.EffectiveDate` (becomes `undefined`) and
-   * removes `effectiveDate` from schema validation. Useful for screens where
-   * the effective date is driven by external context (e.g. the parent job's
-   * `hireDate` during onboarding) rather than user input. The hook still
-   * reads any form value at submit (so the internal "delete secondaries"
-   * carve-out, which sets the value to today, keeps working); partners can
-   * override via `CompensationSubmitOptions.effectiveDate`. Defaults to `true`.
+   * removes `effectiveDate` from schema validation. In this mode the hook
+   * does not read any form value at submit time — `effective_date` is
+   * omitted from the request body unless explicitly supplied via
+   * `CompensationSubmitOptions.effectiveDate`. This matches the
+   * options-only convention of `useWorkAddressForm` /
+   * `useHomeAddressForm` / `useJobForm`, and means the
+   * `willDeleteSecondaryJobs` carve-out's form-state side effects do not
+   * leak onto the wire (there is no field to render them in anyway).
+   * Defaults to `true`.
    */
   withEffectiveDateField?: boolean
 }
@@ -511,20 +515,18 @@ export function useCompensationForm({
             const resolvedCompensationId = options?.compensationId ?? compensationId
             const resolvedMode = resolvedCompensationId ? 'update' : 'create'
 
-            // Submit-time override > form value. Even when
-            // `withEffectiveDateField` is false the form value is honored as
-            // a fallback so the internal `willDeleteSecondaryJobs` carve-out
-            // (which sets the form value to today) keeps emitting a date —
-            // this is a deliberate divergence from `useWorkAddressForm`,
-            // whose hidden-field behavior is strictly options-only.
-            //
-            // When `withEffectiveDateField` is false the schema strips
-            // `effectiveDate` from `payload`, so we read directly from the
-            // form's underlying state instead.
-            const formEffectiveDate = withEffectiveDateField
-              ? payload.effectiveDate
-              : (formMethods.getValues('effectiveDate') ?? undefined)
-            const resolvedEffectiveDate = options?.effectiveDate ?? formEffectiveDate ?? undefined
+            // When the field is rendered, the validated payload value wins
+            // unless an explicit submit-time override is supplied. When the
+            // field is hidden (`withEffectiveDateField: false`) we are
+            // strictly options-only — matching `useWorkAddressForm` and the
+            // hidden-field behavior of `useHomeAddressForm` / `useJobForm`.
+            // The carve-out's form-state side effect (force value to today)
+            // is therefore inert in the hidden-field path; partners who
+            // need a specific date there must supply it via
+            // `CompensationSubmitOptions.effectiveDate`.
+            const resolvedEffectiveDate = withEffectiveDateField
+              ? (options?.effectiveDate ?? payload.effectiveDate ?? undefined)
+              : (options?.effectiveDate ?? undefined)
 
             const requestBodyBase = {
               rate: String(payload.rate),

--- a/src/components/Employee/Deductions/IncludeDeductions/IncludeDeductions.module.scss
+++ b/src/components/Employee/Deductions/IncludeDeductions/IncludeDeductions.module.scss
@@ -1,3 +1,7 @@
+.container {
+  width: 100%;
+}
+
 .emptyStateContainer {
   display: flex;
   justify-content: center;

--- a/src/components/Employee/Deductions/IncludeDeductions/IncludeDeductions.tsx
+++ b/src/components/Employee/Deductions/IncludeDeductions/IncludeDeductions.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 import styles from './IncludeDeductions.module.scss'
 import { Grid } from '@/components/Common/Grid/Grid'
@@ -19,7 +20,7 @@ export function IncludeDeductions({ className, onAdd, onContinue }: IncludeDeduc
   const Components = useComponentContext()
 
   return (
-    <section className={className}>
+    <section className={classNames(styles.container, className)}>
       <Grid gridTemplateColumns="1fr">
         <Flex flexDirection="column" gap={2}>
           <Components.Heading as="h2">{t('pageTitle')}</Components.Heading>


### PR DESCRIPTION
## Summary

Two unrelated fixes bundled on this branch:

### 1. `fix(EditCompensation)` — omit `effective_date` from the compensation PUT body

The hook-based `EditCompensation` was sending `effective_date: startDate` on every compensation PUT (create stub-fill *and* steady-state update), which silently overwrote any deliberately-set future-dated `effective_date` on subsequent edits. Pre-hook `EditCompensation` never touched the field at all — the form schema didn't include it — so the server-side stub initialization (`effective_date = hire_date`) was preserved naturally.

This change restores the pre-hook wire contract by making the hook strictly options-only when `withEffectiveDateField: false`, matching the convention of `useWorkAddressForm` / `useHomeAddressForm` / `useJobForm`:

| Hook | Toggle | When `false` |
|---|---|---|
| `useWorkAddressForm` | `withEffectiveDateField` | options-only |
| `useHomeAddressForm` | `withEffectiveDateField` | options + loaded-entity fallback |
| `useJobForm` | `withHireDateField` | options + loaded-entity fallback |
| `useCompensationForm` | `withEffectiveDateField` | **was: options + form-state fallback** → **now: options-only** |

Specifically:

- `useCompensationForm` submit-time effective-date resolver no longer reads form state when the field is hidden. `getValues('effectiveDate')` is gone from the submit handler. Carve-out's form-state side effects (force value to today, snapshot prior, expose `isDisabled`) stay in place for the visible-field path.
- `EditCompensation` drops `effectiveDate: startDate` from `compensationForm.actions.onSubmit({...})`.
- The hidden-field carve-out test flips: now asserts `effective_date` is omitted from the wire body (was previously asserting today). Visible-field carve-out tests are untouched.
- JSDoc on `withEffectiveDateField` and `CompensationSubmitOptions.effectiveDate` updated; partner docs in `useCompensationForm.md` and `jobs-and-compensations.md` updated.

#### Wire-level result for `onboarding/EditCompensation`

| Scenario | Before | After |
|---|---|---|
| Create chain (POST job → PUT stub comp) | `effective_date: startDate` on PUT | omitted (server stub init keeps it = `hire_date`) |
| Steady-state update | `effective_date: startDate` on PUT | omitted (existing value preserved) |
| Carve-out (FLSA Nonexempt → other w/ secondaries) | `effective_date: startDate` (or today via form-state if no override) | omitted (server applies FLSA delta + delete-secondaries regardless) |

### 2. `fix(IncludeDeductions)` — `width: 100%` on the section root

Empty-state Deductions view rendered without a width applied to its `<section>`, collapsing to intrinsic content width inside flex/grid parents. Mirrors the `f7c2ea37` `EditCompensation` precedent: `.container { width: 100% }` on the existing module.scss, composed via `classNames`.

## Test plan

- [x] `npm run test -- --run src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.test.tsx src/components/Employee/Compensation/onboarding/Compensation.test.tsx` — 61 tests pass
- [x] `npm run lint:check` — 0 errors (only pre-existing warnings)
- [x] Pre-commit `npm run build` succeeded for both commits
- [x] Verified end-to-end against `flows.gusto-demo.com` proxy:
  - New employee onboarding chain — `hire_date == effective_date == startDate` (server-side stub init working as expected)
  - Direct API: PUT compensation without `effective_date` preserves existing value (including a future-dated 2027-01-01 case)
  - Manual carve-out test (FLSA Nonexempt → Salaried Nonexempt with secondary on a fresh employee) — secondary deleted server-side, primary's `effective_date` preserved at `hire_date` rather than bumped to today
- [x] CI green

https://github.com/user-attachments/assets/360eee04-da1d-48bb-968d-bbf57585cd0d



Made with [Cursor](https://cursor.com)