### PR TITLE
feat(Dashboard): empty state for Compensation card with Add job CTA

### DIFF
--- a/docs/integration-guide/event-types.md
+++ b/docs/integration-guide/event-types.md
@@ -75,6 +75,7 @@ All of the events emitted by sdk components are listed in the following table:
 | EMPLOYEE_HOME_ADDRESS                 | employee/addresses/home                       |
 | EMPLOYEE_HOME_ADDRESS_CREATED         | employee/addresses/home/created               |
 | EMPLOYEE_HOME_ADDRESS_UPDATED         | employee/addresses/home/updated               |
+| EMPLOYEE_JOB_ADD                      | employee/job/add                              |
 | EMPLOYEE_JOB_CREATED                  | employee/job/created                          |
 | EMPLOYEE_JOB_DELETED                  | employee/job/deleted                          |
 | EMPLOYEE_JOB_UPDATED                  | employee/job/updated                          |

--- a/docs/workflows-overview/employee-dashboard.md
+++ b/docs/workflows-overview/employee-dashboard.md
@@ -30,17 +30,18 @@ function MyApp() {
 
 #### Events
 
-| Event type                   | Description                      | Data                                                     |
-| ---------------------------- | -------------------------------- | -------------------------------------------------------- |
-| EMPLOYEE_UPDATE              | Fired when editing basic details | { employeeId: string }                                   |
-| EMPLOYEE_HOME_ADDRESS        | Fired when managing home address | { employeeId: string }                                   |
-| EMPLOYEE_WORK_ADDRESS        | Fired when managing work address | { employeeId: string }                                   |
-| EMPLOYEE_COMPENSATION_UPDATE | Fired when editing compensation  | { employeeId: string, job: Job }                         |
-| EMPLOYEE_BANK_ACCOUNT_CREATE | Fired when adding a bank account | { employeeId: string }                                   |
-| EMPLOYEE_DEDUCTION_ADD       | Fired when adding a deduction    | { employeeId: string }                                   |
-| EMPLOYEE_FEDERAL_TAXES_EDIT  | Fired when editing federal taxes | { employeeId: string, federalTaxes: EmployeeFederalTax } |
-| EMPLOYEE_STATE_TAXES_EDIT    | Fired when editing state taxes   | { employeeId: string, state: string }                    |
-| EMPLOYEE_VIEW_FORM_TO_SIGN   | Fired when viewing a form        | { employeeId: string, formUuid: string }                 |
+| Event type                   | Description                                              | Data                                                     |
+| ---------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
+| EMPLOYEE_UPDATE              | Fired when editing basic details                         | { employeeId: string }                                   |
+| EMPLOYEE_HOME_ADDRESS        | Fired when managing home address                         | { employeeId: string }                                   |
+| EMPLOYEE_WORK_ADDRESS        | Fired when managing work address                         | { employeeId: string }                                   |
+| EMPLOYEE_COMPENSATION_UPDATE | Fired when editing compensation                          | { employeeId: string, job: Job }                         |
+| EMPLOYEE_JOB_ADD             | Fired when adding a job from the empty Compensation card | { employeeId: string }                                   |
+| EMPLOYEE_BANK_ACCOUNT_CREATE | Fired when adding a bank account                         | { employeeId: string }                                   |
+| EMPLOYEE_DEDUCTION_ADD       | Fired when adding a deduction                            | { employeeId: string }                                   |
+| EMPLOYEE_FEDERAL_TAXES_EDIT  | Fired when editing federal taxes                         | { employeeId: string, federalTaxes: EmployeeFederalTax } |
+| EMPLOYEE_STATE_TAXES_EDIT    | Fired when editing state taxes                           | { employeeId: string, state: string }                    |
+| EMPLOYEE_VIEW_FORM_TO_SIGN   | Fired when viewing a form                                | { employeeId: string, formUuid: string }                 |
 
 ## Using Dashboard Subcomponents
 
@@ -274,6 +275,7 @@ Loading states are handled per-tab, showing a loading spinner while data is bein
 
 Each section gracefully handles missing data:
 
+- **Compensation**: Empty state with description; the header CTA switches from "Edit" to "Add job" and emits `EMPLOYEE_JOB_ADD`
 - **Payment methods**: "No payment method on file" message with "Add bank account" CTA
 - **Deductions**: Empty state with description and "Add deduction" CTA
 - **Paystubs**: Empty state indicating paystubs appear after payroll is run

--- a/src/components/Employee/Dashboard/Dashboard.test.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.test.tsx
@@ -1,14 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { HttpResponse } from 'msw'
 import { Dashboard } from './Dashboard'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
 import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { server } from '@/test/mocks/server'
+import { handleGetEmployee } from '@/test/mocks/apis/employees'
+import { getFixture } from '@/test/mocks/fixtures/getFixture'
 import { componentEvents } from '@/shared/constants'
 
-vi.mock('@/hooks/useContainerBreakpoints/useContainerBreakpoints', () => ({
-  useContainerBreakpoints: () => ['small', 'medium', 'large'],
-}))
+vi.mock('@/hooks/useContainerBreakpoints/useContainerBreakpoints', () => {
+  const useContainerBreakpoints = () => ['small', 'medium', 'large']
+  return {
+    useContainerBreakpoints,
+    default: useContainerBreakpoints,
+  }
+})
 
 describe('Dashboard', () => {
   const onEvent = vi.fn()
@@ -95,6 +103,38 @@ describe('Dashboard', () => {
     await user.click(manageButtons[1]!)
 
     expect(onEvent).toHaveBeenCalledWith(componentEvents.EMPLOYEE_WORK_ADDRESS, {
+      employeeId: 'employee-123',
+    })
+  })
+
+  it('shows an empty Compensation card with Add job CTA when the employee has no jobs', async () => {
+    const user = userEvent.setup()
+
+    const employeeFixture = (await getFixture('get-v1-employees')) as Record<string, unknown>
+    server.use(handleGetEmployee(() => HttpResponse.json({ ...employeeFixture, jobs: [] })))
+
+    renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Legal name')).toBeTruthy()
+    })
+
+    await user.click(screen.getByRole('tab', { name: 'Job and pay' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Compensation' })).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('No compensation')).toBeInTheDocument()
+    expect(screen.getByText('Compensation will appear here once added')).toBeInTheDocument()
+
+    const addJobButton = screen.getByRole('button', { name: 'Add job' })
+    expect(addJobButton).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull()
+
+    await user.click(addJobButton)
+
+    expect(onEvent).toHaveBeenCalledWith(componentEvents.EMPLOYEE_JOB_ADD, {
       employeeId: 'employee-123',
     })
   })

--- a/src/components/Employee/Dashboard/Dashboard.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.tsx
@@ -65,6 +65,10 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
     onEvent(componentEvents.EMPLOYEE_COMPENSATION_UPDATE, { employeeId, job: primaryJob })
   }, [onEvent, employeeId, primaryJob])
 
+  const handleAddJob = useCallback(() => {
+    onEvent(componentEvents.EMPLOYEE_JOB_ADD, { employeeId })
+  }, [onEvent, employeeId])
+
   const handleAddDeduction = useCallback(() => {
     onEvent(componentEvents.EMPLOYEE_DEDUCTION_ADD, { employeeId })
   }, [onEvent, employeeId])
@@ -231,6 +235,7 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
               isLoading={isLoadingJobAndPay}
               onEvent={onEvent}
               onEditCompensation={handleEditCompensation}
+              onAddJob={handleAddJob}
               onAddDeduction={handleAddDeduction}
               onPaystubDownload={handlePaystubDownload}
               downloadingPayrollUuids={downloadingPayrollUuids}

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -38,6 +38,7 @@ export interface JobAndPayViewProps {
   isLoading?: boolean
   onEvent: OnEventType<EventType, unknown>
   onEditCompensation?: () => void
+  onAddJob?: () => void
   onAddDeduction?: () => void
   onPaystubDownload?: (payrollUuid: string) => void
   downloadingPayrollUuids?: ReadonlySet<string>
@@ -52,6 +53,7 @@ export function JobAndPayView({
   isLoading = false,
   onEvent,
   onEditCompensation,
+  onAddJob,
   onAddDeduction,
   onPaystubDownload,
   downloadingPayrollUuids,
@@ -231,62 +233,80 @@ export function JobAndPayView({
     <BaseLayout error={paymentMethodList.errorHandling.errors}>
       <Flex flexDirection="column" gap={24}>
         <Components.Box
+          withPadding={!!job}
           header={
             <Components.BoxHeader
               title={t('jobAndPay.compensation.title')}
               action={
-                <Components.Button variant="secondary" onClick={onEditCompensation}>
-                  {t('jobAndPay.compensation.editCta')}
-                </Components.Button>
+                job ? (
+                  <Components.Button variant="secondary" onClick={onEditCompensation}>
+                    {t('jobAndPay.compensation.editCta')}
+                  </Components.Button>
+                ) : (
+                  <Components.Button
+                    variant="secondary"
+                    onClick={onAddJob}
+                    icon={<PlusCircleIcon />}
+                  >
+                    {t('jobAndPay.compensation.addJobCta')}
+                  </Components.Button>
+                )
               }
             />
           }
         >
-          <Flex flexDirection="column" gap={16}>
-            <Flex flexDirection="column" gap={12}>
-              {job?.title && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('jobAndPay.compensation.jobTitle')}
-                  </Components.Text>
-                  <Components.Text>{job.title}</Components.Text>
-                </Flex>
-              )}
+          {job ? (
+            <Flex flexDirection="column" gap={16}>
+              <Flex flexDirection="column" gap={12}>
+                {job.title && (
+                  <Flex flexDirection="column" gap={0}>
+                    <Components.Text variant="supporting">
+                      {t('jobAndPay.compensation.jobTitle')}
+                    </Components.Text>
+                    <Components.Text>{job.title}</Components.Text>
+                  </Flex>
+                )}
 
-              {job?.paymentUnit && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('jobAndPay.compensation.type')}
-                  </Components.Text>
-                  <Components.Text>
-                    {job.paymentUnit === 'Hour'
-                      ? t('jobAndPay.compensation.types.hourly')
-                      : job.paymentUnit === 'Salary' || job.paymentUnit === 'Year'
-                        ? t('jobAndPay.compensation.types.salary')
-                        : job.paymentUnit}
-                  </Components.Text>
-                </Flex>
-              )}
+                {job.paymentUnit && (
+                  <Flex flexDirection="column" gap={0}>
+                    <Components.Text variant="supporting">
+                      {t('jobAndPay.compensation.type')}
+                    </Components.Text>
+                    <Components.Text>
+                      {job.paymentUnit === 'Hour'
+                        ? t('jobAndPay.compensation.types.hourly')
+                        : job.paymentUnit === 'Salary' || job.paymentUnit === 'Year'
+                          ? t('jobAndPay.compensation.types.salary')
+                          : job.paymentUnit}
+                    </Components.Text>
+                  </Flex>
+                )}
 
-              {job?.rate && job.paymentUnit && typeof job.rate === 'number' && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('jobAndPay.compensation.wage')}
-                  </Components.Text>
-                  <Components.Text>{formatPayRate(job.rate, job.paymentUnit)}</Components.Text>
-                </Flex>
-              )}
+                {job.rate && job.paymentUnit && typeof job.rate === 'number' && (
+                  <Flex flexDirection="column" gap={0}>
+                    <Components.Text variant="supporting">
+                      {t('jobAndPay.compensation.wage')}
+                    </Components.Text>
+                    <Components.Text>{formatPayRate(job.rate, job.paymentUnit)}</Components.Text>
+                  </Flex>
+                )}
 
-              {job?.hireDate && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('jobAndPay.compensation.startDate')}
-                  </Components.Text>
-                  <Components.Text>{formatDateLongWithYear(job.hireDate)}</Components.Text>
-                </Flex>
-              )}
+                {job.hireDate && (
+                  <Flex flexDirection="column" gap={0}>
+                    <Components.Text variant="supporting">
+                      {t('jobAndPay.compensation.startDate')}
+                    </Components.Text>
+                    <Components.Text>{formatDateLongWithYear(job.hireDate)}</Components.Text>
+                  </Flex>
+                )}
+              </Flex>
             </Flex>
-          </Flex>
+          ) : (
+            <EmptyData
+              title={t('jobAndPay.compensation.emptyState.title')}
+              description={t('jobAndPay.compensation.emptyState.description')}
+            />
+          )}
         </Components.Box>
 
         <Components.Box

--- a/src/i18n/en/Employee.Dashboard.json
+++ b/src/i18n/en/Employee.Dashboard.json
@@ -39,7 +39,12 @@
         "salary": "Salary/No overtime"
       },
       "wage": "Wage",
-      "startDate": "Start date"
+      "startDate": "Start date",
+      "addJobCta": "Add job",
+      "emptyState": {
+        "title": "No compensation",
+        "description": "Compensation will appear here once added"
+      }
     },
     "payment": {
       "title": "Payment",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1447,6 +1447,11 @@ export interface EmployeeDashboard{
 };
 "wage":string;
 "startDate":string;
+"addJobCta":string;
+"emptyState":{
+"title":string;
+"description":string;
+};
 };
 "payment":{
 "title":string;


### PR DESCRIPTION
## Summary

- When an employee has no jobs, the Compensation card on the Dashboard's **Job and pay** tab now renders the magnifying-glass empty state used elsewhere (matches the Deductions card pattern), and the header CTA switches from **Edit** to **Add job** (`PlusCircleIcon`, matching **Add bank account** / **Add deduction**).
- Clicking **Add job** emits a new top-level `EMPLOYEE_JOB_ADD` event with `{ employeeId }`, which integrators route the same way as `EMPLOYEE_DEDUCTION_ADD` / `EMPLOYEE_BANK_ACCOUNT_CREATE`. The `EMPLOYEE_JOB_ADD` constant already existed (used inside the compensation flow's internal state machine); this just promotes it to a partner-facing Dashboard event.
- Added partner-facing docs entries (`docs/workflows-overview/employee-dashboard.md`, `docs/integration-guide/event-types.md`) and a test that covers the empty-state copy, the CTA swap, and the event payload.

## Test plan

- [x] `npm run test -- --run src/components/Employee/Dashboard/Dashboard.test.tsx` — 7/7 (added `shows an empty Compensation card with Add job CTA when the employee has no jobs`)
- [x] `npm run lint:check` — no new warnings on touched files
- [x] `npm run format:check` — clean (Prettier applied to docs + test)
- [x] `npm run i18n:generate` — types regenerated
- [x] Manual: render Dashboard against an employee with no jobs; confirm empty state copy and **Add job** CTA fire the event with the right payload.

### With a job

<img width="1168" height="319" alt="Screenshot 2026-05-19 at 3 02 21 PM" src="https://github.com/user-attachments/assets/345e5ce4-fe0c-492d-aafa-40a96c99ec5f" />

### With no jobs

<img width="1170" height="331" alt="Screenshot 2026-05-19 at 3 02 03 PM" src="https://github.com/user-attachments/assets/5856cf7e-6509-4d10-8146-46702d897e20" />

Made with [Cursor](https://cursor.com)