### PR TITLE
feat(Dashboard): route compensation flow through DashboardFlow state machine

### DIFF
--- a/src/components/Employee/Dashboard/Dashboard.test.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.test.tsx
@@ -453,7 +453,7 @@ describe('Dashboard', () => {
     const addAnother = within(compensationCard).getByRole('button', { name: 'Add another job' })
     await user.click(addAnother)
 
-    expect(onEvent).toHaveBeenCalledWith(componentEvents.EMPLOYEE_JOB_ADD, {
+    expect(onEvent).toHaveBeenCalledWith(componentEvents.EMPLOYEE_JOB_ADD_ANOTHER, {
       employeeId: 'employee-123',
     })
   })
@@ -612,7 +612,7 @@ describe('Dashboard', () => {
     })
   })
 
-  it('emits EMPLOYEE_JOB_ADD when clicking the Add another job CTA in the multi-job view', async () => {
+  it('emits EMPLOYEE_JOB_ADD_ANOTHER when clicking the Add another job CTA in the multi-job view', async () => {
     const user = userEvent.setup()
 
     const multiJobFixture = await getMultiJobFixture()
@@ -629,7 +629,7 @@ describe('Dashboard', () => {
     const addAnother = await screen.findByRole('button', { name: 'Add another job' })
     await user.click(addAnother)
 
-    expect(onEvent).toHaveBeenCalledWith(componentEvents.EMPLOYEE_JOB_ADD, {
+    expect(onEvent).toHaveBeenCalledWith(componentEvents.EMPLOYEE_JOB_ADD_ANOTHER, {
       employeeId: 'employee-123',
     })
   })

--- a/src/components/Employee/Dashboard/Dashboard.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.tsx
@@ -73,6 +73,10 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
     onEvent(componentEvents.EMPLOYEE_JOB_ADD, { employeeId })
   }, [onEvent, employeeId])
 
+  const handleAddAnotherJob = useCallback(() => {
+    onEvent(componentEvents.EMPLOYEE_JOB_ADD_ANOTHER, { employeeId })
+  }, [onEvent, employeeId])
+
   const handleAddDeduction = useCallback(() => {
     onEvent(componentEvents.EMPLOYEE_DEDUCTION_ADD, { employeeId })
   }, [onEvent, employeeId])
@@ -247,6 +251,7 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
               onEvent={onEvent}
               onEditCompensation={handleEditCompensation}
               onAddJob={handleAddJob}
+              onAddAnotherJob={handleAddAnotherJob}
               onAddDeduction={handleAddDeduction}
               onEditDeduction={handleEditDeduction}
               onPaystubDownload={handlePaystubDownload}

--- a/src/components/Employee/Dashboard/DashboardComponents.tsx
+++ b/src/components/Employee/Dashboard/DashboardComponents.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next'
+import type { Job } from '@gusto/embedded-api/models/components/job'
 import { Dashboard } from './Dashboard'
 import { HomeAddress } from '@/components/Employee/HomeAddress/management/HomeAddress'
 import { WorkAddress } from '@/components/Employee/WorkAddress/management/WorkAddress'
@@ -28,6 +29,7 @@ export type DashboardSuccessAlert =
 export interface DashboardContextInterface extends FlowContextInterface {
   employeeId: string
   formId?: string
+  currentJob?: Job | null
   successAlert?: DashboardSuccessAlert | null
   /** Set by the EMPLOYEE_DEDUCTION_EDIT transition; consumed by
    *  DeductionFormContextual to pre-populate the form. */
@@ -153,4 +155,25 @@ export function DeductionFormContextual() {
       />
     </BaseLayout>
   )
+}
+
+export function AddJobPlaceholderContextual() {
+  useI18n('Employee.Dashboard')
+  const { t } = useTranslation('Employee.Dashboard')
+  const Components = useComponentContext()
+  return <Components.Heading as="h2">{t('compensationFlow.addJobTitle')}</Components.Heading>
+}
+
+export function EditCompensationPlaceholderContextual() {
+  useI18n('Employee.Dashboard')
+  const { t } = useTranslation('Employee.Dashboard')
+  const Components = useComponentContext()
+  return <Components.Heading as="h2">{t('compensationFlow.editTitle')}</Components.Heading>
+}
+
+export function AddAnotherJobPlaceholderContextual() {
+  useI18n('Employee.Dashboard')
+  const { t } = useTranslation('Employee.Dashboard')
+  const Components = useComponentContext()
+  return <Components.Heading as="h2">{t('compensationFlow.addAnotherJobTitle')}</Components.Heading>
 }

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -55,6 +55,7 @@ export interface JobAndPayViewProps {
   onEvent: OnEventType<EventType, unknown>
   onEditCompensation?: (job: Job) => void
   onAddJob?: () => void
+  onAddAnotherJob?: () => void
   onAddDeduction?: () => void
   onEditDeduction?: (deduction: Garnishment) => void
   onPaystubDownload?: (payrollUuid: string) => void
@@ -71,6 +72,7 @@ export function JobAndPayView({
   onEvent,
   onEditCompensation,
   onAddJob,
+  onAddAnotherJob,
   onAddDeduction,
   onEditDeduction,
   onPaystubDownload,
@@ -413,7 +415,11 @@ export function JobAndPayView({
           }
           footer={
             canAddAnotherJob ? (
-              <Components.Button variant="secondary" onClick={onAddJob} icon={<PlusCircleIcon />}>
+              <Components.Button
+                variant="secondary"
+                onClick={onAddAnotherJob}
+                icon={<PlusCircleIcon />}
+              >
                 {t('jobAndPay.compensation.addAnotherJobCta')}
               </Components.Button>
             ) : undefined

--- a/src/components/Employee/Dashboard/dashboardStateMachine.ts
+++ b/src/components/Employee/Dashboard/dashboardStateMachine.ts
@@ -1,5 +1,6 @@
 import { transition, reduce, state } from 'robot3'
 import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
+import type { Job } from '@gusto/embedded-api/models/components/job'
 import {
   DashboardViewContextual,
   HomeAddressContextual,
@@ -11,6 +12,9 @@ import {
   PaymentSplitViewContextual,
   DocumentManagerContextual,
   DeductionFormContextual,
+  AddJobPlaceholderContextual,
+  EditCompensationPlaceholderContextual,
+  AddAnotherJobPlaceholderContextual,
   type DashboardContextInterface,
 } from './DashboardComponents'
 import { componentEvents } from '@/shared/constants'
@@ -19,6 +23,7 @@ import type { MachineEventType, MachineTransition } from '@/types/Helpers'
 type EventPayloads = {
   [componentEvents.EMPLOYEE_VIEW_FORM_TO_SIGN]: { employeeId: string; formId: string }
   [componentEvents.EMPLOYEE_DEDUCTION_EDIT]: Garnishment
+  [componentEvents.EMPLOYEE_COMPENSATION_CREATE]: { employeeId: string; job: Job }
 }
 
 const returnToIndex = reduce(
@@ -26,6 +31,7 @@ const returnToIndex = reduce(
     ...ctx,
     component: DashboardViewContextual,
     header: null,
+    currentJob: null,
     successAlert: null,
   }),
 )
@@ -36,6 +42,7 @@ const returnToIndexWithAlert = (alert: DashboardContextInterface['successAlert']
       ...ctx,
       component: DashboardViewContextual,
       header: null,
+      currentJob: null,
       successAlert: alert,
     }),
   )
@@ -143,6 +150,48 @@ export const dashboardStateMachine = {
       ),
     ),
     transition(
+      componentEvents.EMPLOYEE_JOB_ADD,
+      'addJob',
+      reduce(
+        (ctx: DashboardContextInterface): DashboardContextInterface => ({
+          ...ctx,
+          component: AddJobPlaceholderContextual,
+          header: { type: 'minimal' },
+          currentJob: null,
+          successAlert: null,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.EMPLOYEE_COMPENSATION_CREATE,
+      'editCompensation',
+      reduce(
+        (
+          ctx: DashboardContextInterface,
+          ev: MachineEventType<EventPayloads, typeof componentEvents.EMPLOYEE_COMPENSATION_CREATE>,
+        ): DashboardContextInterface => ({
+          ...ctx,
+          component: EditCompensationPlaceholderContextual,
+          header: { type: 'minimal' },
+          currentJob: ev.payload.job,
+          successAlert: null,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.EMPLOYEE_JOB_ADD_ANOTHER,
+      'addAnotherJob',
+      reduce(
+        (ctx: DashboardContextInterface): DashboardContextInterface => ({
+          ...ctx,
+          component: AddAnotherJobPlaceholderContextual,
+          header: { type: 'minimal' },
+          currentJob: null,
+          successAlert: null,
+        }),
+      ),
+    ),
+    transition(
       componentEvents.EMPLOYEE_BANK_ACCOUNT_DELETED,
       'index',
       reduce(
@@ -241,6 +290,13 @@ export const dashboardStateMachine = {
       returnToIndexWithAlert('deductionUpdated'),
     ),
     transition(componentEvents.EMPLOYEE_DEDUCTION_CANCEL, 'index', returnToIndex),
+    transition(componentEvents.CANCEL, 'index', returnToIndex),
+  ),
+  addJob: state<MachineTransition>(transition(componentEvents.CANCEL, 'index', returnToIndex)),
+  editCompensation: state<MachineTransition>(
+    transition(componentEvents.CANCEL, 'index', returnToIndex),
+  ),
+  addAnotherJob: state<MachineTransition>(
     transition(componentEvents.CANCEL, 'index', returnToIndex),
   ),
 }

--- a/src/i18n/en/Employee.Dashboard.json
+++ b/src/i18n/en/Employee.Dashboard.json
@@ -159,5 +159,10 @@
     "deductionAdded": "Deduction successfully added.",
     "deductionUpdated": "Deduction successfully updated.",
     "deductionDeleted": "Deduction successfully deleted."
+  },
+  "compensationFlow": {
+    "addJobTitle": "Add a job",
+    "editTitle": "Edit compensation",
+    "addAnotherJobTitle": "Add another job"
   }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -38,6 +38,7 @@ export const employeeEvents = {
   EMPLOYEE_COMPENSATION_CANCEL: 'employee/compensations/cancel',
   EMPLOYEE_COMPENSATION_RETURN_TO_LIST: 'employee/compensations/returnToList',
   EMPLOYEE_JOB_ADD: 'employee/job/add',
+  EMPLOYEE_JOB_ADD_ANOTHER: 'employee/job/addAnother',
   EMPLOYEE_JOB_EDIT: 'employee/job/edit',
   EMPLOYEE_PAYMENT_METHOD_UPDATED: 'employee/paymentMethod/updated',
   EMPLOYEE_PAYMENT_METHOD_DONE: 'employee/paymentMethod/done',

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1568,6 +1568,11 @@ export interface EmployeeDashboard{
 "deductionUpdated":string;
 "deductionDeleted":string;
 };
+"compensationFlow":{
+"addJobTitle":string;
+"editTitle":string;
+"addAnotherJobTitle":string;
+};
 };
 export interface EmployeeDeductions{
 "pageTitle":string;


### PR DESCRIPTION
## Summary

Stacked on top of #1878. Adds three placeholder destinations to the Employee Dashboard's robot3 state machine for the compensation flow, so the dashboard can navigate to them locally instead of bubbling each CTA out as an event partners have to route themselves. Real screens land in a follow-up commit.

- New transitions out of `index` in [`dashboardStateMachine.ts`](src/components/Employee/Dashboard/dashboardStateMachine.ts):
  - `EMPLOYEE_JOB_ADD` → `addJob` (empty-state "Add a job" path)
  - `EMPLOYEE_COMPENSATION_CREATE` → `editCompensation` (carries the selected `Job` onto flow context as `currentJob`)
  - `EMPLOYEE_JOB_ADD_ANOTHER` → `addAnotherJob` (new event for the "Add another job" CTA)
  - All three return to `index` on `CANCEL`. `returnToIndex`/`returnToIndexWithAlert` clear `currentJob` so it doesn't leak across visits.
- Disambiguated the two job-add paths by adding `EMPLOYEE_JOB_ADD_ANOTHER` ([src/shared/constants.ts](src/shared/constants.ts)). `EMPLOYEE_JOB_ADD` is preserved and now strictly means "add the first job from the empty Compensation card." Not a breaking change — these events haven't shipped to partners.
- Three placeholder contextual components in [`DashboardComponents.tsx`](src/components/Employee/Dashboard/DashboardComponents.tsx) — each renders only `Components.Heading` with the title (back button comes free from the existing minimal header chrome). Titles: **"Add a job"**, **"Edit compensation"**, **"Add another job"**. `DashboardContextInterface` gains `currentJob?: Job | null` so the follow-up can wire the edit form to the captured job without further plumbing.
- `Dashboard.tsx` split `handleAddJob` into `handleAddJob` (emits `EMPLOYEE_JOB_ADD`) and `handleAddAnotherJob` (emits `EMPLOYEE_JOB_ADD_ANOTHER`). `JobAndPayView` takes a new `onAddAnotherJob` prop and routes the "Add another job" footer to it; the empty-state header CTA stays on `onAddJob`.
- New i18n keys under `compensationFlow.*` in [Employee.Dashboard.json](src/i18n/en/Employee.Dashboard.json); translation types regenerated.

## State machine

```mermaid
stateDiagram-v2
    [*] --> index
    index --> addJob: EMPLOYEE_JOB_ADD
    index --> editCompensation: EMPLOYEE_COMPENSATION_CREATE (carries job)
    index --> addAnotherJob: EMPLOYEE_JOB_ADD_ANOTHER
    addJob --> index: CANCEL
    editCompensation --> index: CANCEL
    addAnotherJob --> index: CANCEL
```

## Test plan

- [x] `npm run test -- --run src/components/Employee/Dashboard/` — 18/18. The two existing "Add another job" assertions now expect `EMPLOYEE_JOB_ADD_ANOTHER`; the empty-state assertion still expects `EMPLOYEE_JOB_ADD`.
- [x] `npm run test -- --run src/components/Employee/Compensation/` — 103/103. Confirms the compensation onboarding flow's separate use of `EMPLOYEE_JOB_ADD` is unaffected.
- [x] `npm run lint:check` — 0 errors on touched files.
- [x] `npm run format:check` — clean.
- [x] `npm run i18n:generate` — types regenerated.


https://github.com/user-attachments/assets/91d0e004-ff80-4d16-8b6b-639720461e58

https://github.com/user-attachments/assets/2356ae90-9961-49d8-b772-30ed80246122

Made with [Cursor](https://cursor.com)