### PR TITLE
fix(TimeOff): validate waiting period as integer in policy settings

### DIFF
--- a/src/components/TimeOff/PolicySettings/PolicySettingsPresentation.test.tsx
+++ b/src/components/TimeOff/PolicySettings/PolicySettingsPresentation.test.tsx
@@ -246,6 +246,57 @@ describe('PolicySettingsPresentation', () => {
     })
   })
 
+  describe('waiting period integer validation', () => {
+    it('blocks submission and shows an error when waiting period is a decimal', async () => {
+      const user = userEvent.setup()
+      renderHoursWorked({
+        defaultValues: {
+          waitingPeriodEnabled: true,
+          waitingPeriod: 1.5,
+        },
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Save' }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Waiting period must be a whole number of days'),
+        ).toBeInTheDocument()
+      })
+
+      expect(handlers.onContinue).not.toHaveBeenCalled()
+    })
+
+    it('allows submission when waiting period is an integer', async () => {
+      const user = userEvent.setup()
+      renderHoursWorked({
+        defaultValues: {
+          waitingPeriodEnabled: true,
+          waitingPeriod: 30,
+        },
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Save' }))
+
+      await waitFor(() => {
+        expect(handlers.onContinue).toHaveBeenCalledWith(
+          expect.objectContaining({
+            waitingPeriodEnabled: true,
+            waitingPeriod: 30,
+          }),
+        )
+      })
+    })
+  })
+
   describe('accessibility', () => {
     it('should not have any accessibility violations - hours worked variant', async () => {
       const { container } = renderHoursWorked()

--- a/src/components/TimeOff/PolicySettings/PolicySettingsPresentation.tsx
+++ b/src/components/TimeOff/PolicySettings/PolicySettingsPresentation.tsx
@@ -158,6 +158,15 @@ export function PolicySettingsPresentation({
                       isDisabled={!waitingPeriodEnabled}
                       min={0}
                       max={20000}
+                      maximumFractionDigits={0}
+                      rules={{
+                        validate: (value: number) => {
+                          if (waitingPeriodEnabled && !isNaN(value) && !Number.isInteger(value)) {
+                            return t('policySettings.errors.waitingPeriodMustBeWholeNumber')
+                          }
+                          return true
+                        },
+                      }}
                     />
                     <div className={styles.toggleCell}>
                       <SwitchField

--- a/src/i18n/en/Company.TimeOff.CreateTimeOffPolicy.json
+++ b/src/i18n/en/Company.TimeOff.CreateTimeOffPolicy.json
@@ -61,7 +61,8 @@
     "numberOfDaysPlaceholder": "0",
     "continueCta": "Save",
     "errors": {
-      "balanceExceedsMaximum": "The balance maximum cannot be lower than an employee's current balance. Reduce the employee's balance first, or increase the maximum."
+      "balanceExceedsMaximum": "The balance maximum cannot be lower than an employee's current balance. Reduce the employee's balance first, or increase the maximum.",
+      "waitingPeriodMustBeWholeNumber": "Waiting period must be a whole number of days"
     }
   },
   "startingBalances": {

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -428,6 +428,7 @@ export interface CompanyTimeOffCreateTimeOffPolicy{
 "continueCta":string;
 "errors":{
 "balanceExceedsMaximum":string;
+"waitingPeriodMustBeWholeNumber":string;
 };
 };
 "startingBalances":{


### PR DESCRIPTION
## Summary

The API requires `accrualWaitingPeriodDays` to be an integer, but the form allowed decimal input, causing an unhandled Zod validation error. This change:

- Sets `maximumFractionDigits={0}` on the waiting-period `NumberInputField` to prevent decimal entry at the input level.
- Adds a form-level `validate` rule as a safety net that surfaces a clear error message when a decimal sneaks through.
- Adds the i18n key `policySettings.errors.waitingPeriodMustBeWholeNumber`.

Extracted from #1879 (Kristine's Time Off e2e work) so it can ship independently. Credit via `Co-authored-by:` trailer.

## Test plan

- [x] \`npm run test -- --run src/components/TimeOff/PolicySettings\` — 34 tests pass (2 new under \`describe('waiting period integer validation')\`)
- [x] \`npm run i18n:generate\` updates \`src/types/i18next.d.ts\`
- [x] Prettier + ESLint clean on the changed files

Made with [Cursor](https://cursor.com)