### PR TITLE
fix(PayrollOverview): remove Text wrapper from check payment warning alert

### DIFF
--- a/src/components/Payroll/PayrollOverview/PayrollOverviewPresentation.tsx
+++ b/src/components/Payroll/PayrollOverview/PayrollOverviewPresentation.tsx
@@ -799,7 +799,7 @@ export const PayrollOverviewPresentation = ({
                 status="warning"
                 label={t('alerts.checkPaymentWarning', { count: checkPaymentsCount })}
               >
-                <Text>{t('alerts.checkPaymentWarningDescription')}</Text>
+                {t('alerts.checkPaymentWarningDescription')}
               </Alert>
             )}
             <Tabs


### PR DESCRIPTION
## Summary

Removes the nested `<Text>` component from the check payment warning `Alert` in `PayrollOverviewPresentation`. When a partner overrides the `Alert` component via an adapter, the embedded `<Text>` element breaks rendering — adapters expect plain text children, not internal SDK UI primitives.

## Changes

- Pass `t('alerts.checkPaymentWarningDescription')` directly as the `Alert` child instead of wrapping it in `<Text>`.

## Demo

<img width="833" height="112" alt="Screenshot 2026-05-20 at 2 28 05 PM" src="https://github.com/user-attachments/assets/def41bbf-ed7a-425d-a0dd-0f7fe7a74258" />
<img width="944" height="140" alt="Screenshot 2026-05-20 at 2 28 27 PM" src="https://github.com/user-attachments/assets/0def7ae0-c53d-4fbf-aa53-f06477b996d5" />


## Related

N/A

## Testing

- Verify the check payment warning alert still renders correctly in `PayrollOverview` when there are check payments.
- Verify that overriding `Alert` via a `ComponentsProvider` adapter no longer breaks on this surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)