### PR TITLE
feat: add useClientPagination hook for in-memory list pagination

### DIFF
--- a/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.test.tsx
+++ b/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.test.tsx
@@ -48,6 +48,20 @@ const mockEmployees = [
   },
 ]
 
+// 12 enrolled employees → exercises the 10-per-page client pager (2 pages).
+const manyEnrolledEmployees = Array.from({ length: 12 }, (_, i) => ({
+  uuid: `many-emp-${i}`,
+  first_name: `Person${i.toString().padStart(2, '0')}`,
+  last_name: 'Roster',
+  email: `person${i}@example.com`,
+  jobs: [{ uuid: `many-job-${i}`, primary: true, title: 'Engineer' }],
+}))
+
+const mockHolidayPayPolicyManyEmployees = {
+  ...mockHolidayPayPolicy,
+  employees: manyEnrolledEmployees.map(e => ({ uuid: e.uuid })),
+}
+
 describe('HolidayPolicyDetail', () => {
   const onEvent = vi.fn()
   const user = userEvent.setup()
@@ -135,6 +149,79 @@ describe('HolidayPolicyDetail', () => {
 
       expect(screen.getByText('Alice Smith')).toBeInTheDocument()
       expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('pagination', () => {
+    it('does not render the pagination control when the policy roster is below the page threshold', async () => {
+      renderWithProviders(<HolidayPolicyDetail {...defaultProps} defaultTab="employees" />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+      })
+
+      expect(screen.queryByTestId('pagination-control')).not.toBeInTheDocument()
+    })
+
+    it('paginates the roster at 10 per page and navigates between pages', async () => {
+      server.use(
+        http.get(`${API_BASE_URL}/v1/companies/:companyUuid/holiday_pay_policy`, () => {
+          return HttpResponse.json(mockHolidayPayPolicyManyEmployees)
+        }),
+        http.get(`${API_BASE_URL}/v1/companies/:companyId/employees`, () => {
+          return HttpResponse.json(manyEnrolledEmployees)
+        }),
+      )
+
+      renderWithProviders(<HolidayPolicyDetail {...defaultProps} defaultTab="employees" />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Person00 Roster')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText('Person09 Roster')).toBeInTheDocument()
+      expect(screen.queryByText('Person10 Roster')).not.toBeInTheDocument()
+      expect(screen.queryByText('Person11 Roster')).not.toBeInTheDocument()
+      expect(screen.getByTestId('pagination-control')).toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: 'Navigate to next page' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Person10 Roster')).toBeInTheDocument()
+      })
+      expect(screen.getByText('Person11 Roster')).toBeInTheDocument()
+      expect(screen.queryByText('Person00 Roster')).not.toBeInTheDocument()
+    })
+
+    it('resets to page 1 when a search filters the roster below the page threshold', async () => {
+      server.use(
+        http.get(`${API_BASE_URL}/v1/companies/:companyUuid/holiday_pay_policy`, () => {
+          return HttpResponse.json(mockHolidayPayPolicyManyEmployees)
+        }),
+        http.get(`${API_BASE_URL}/v1/companies/:companyId/employees`, () => {
+          return HttpResponse.json(manyEnrolledEmployees)
+        }),
+      )
+
+      renderWithProviders(<HolidayPolicyDetail {...defaultProps} defaultTab="employees" />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Person00 Roster')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: 'Navigate to next page' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Person10 Roster')).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByRole('searchbox'), 'Person00')
+
+      await waitFor(() => {
+        expect(screen.getByText('Person00 Roster')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('Person10 Roster')).not.toBeInTheDocument()
+      expect(screen.queryByText('Person11 Roster')).not.toBeInTheDocument()
     })
   })
 

--- a/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.test.tsx
+++ b/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.test.tsx
@@ -147,8 +147,10 @@ describe('HolidayPolicyDetail', () => {
       const searchInput = screen.getByRole('searchbox')
       await user.type(searchInput, 'Alice')
 
+      await waitFor(() => {
+        expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
+      })
       expect(screen.getByText('Alice Smith')).toBeInTheDocument()
-      expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
     })
   })
 
@@ -218,9 +220,9 @@ describe('HolidayPolicyDetail', () => {
       await user.type(screen.getByRole('searchbox'), 'Person00')
 
       await waitFor(() => {
-        expect(screen.getByText('Person00 Roster')).toBeInTheDocument()
+        expect(screen.queryByText('Person10 Roster')).not.toBeInTheDocument()
       })
-      expect(screen.queryByText('Person10 Roster')).not.toBeInTheDocument()
+      expect(screen.getByText('Person00 Roster')).toBeInTheDocument()
       expect(screen.queryByText('Person11 Roster')).not.toBeInTheDocument()
     })
   })

--- a/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.tsx
+++ b/src/components/TimeOff/HolidayPolicyDetail/HolidayPolicyDetail.tsx
@@ -10,6 +10,7 @@ import { useEmployeesListSuspense } from '@gusto/embedded-api/react-query/employ
 import { getDefaultHolidayItems } from '../shared/holidayHelpers'
 import { HolidayPolicyDetailPresentation } from './HolidayPolicyDetailPresentation'
 import type { HolidayPolicyDetailEmployee } from './HolidayPolicyDetailTypes'
+import { useClientPagination } from '@/hooks/useClientPagination/useClientPagination'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import { BaseComponent, type BaseComponentInterface } from '@/components/Base'
 import { useBase } from '@/components/Base/useBase'
@@ -51,7 +52,6 @@ function Root({ companyId, defaultTab = 'holidays' }: HolidayPolicyDetailProps) 
   const { onEvent, baseSubmitHandler } = useBase()
 
   const [selectedTabId, setSelectedTabId] = useState<string>(defaultTab)
-  const [searchValue, setSearchValue] = useState('')
   const [successAlert, setSuccessAlert] = useState<string | null>(null)
   const [removeDialogTarget, setRemoveDialogTarget] = useState<RemoveDialogTarget | null>(null)
 
@@ -91,17 +91,16 @@ function Root({ companyId, defaultTab = 'holidays' }: HolidayPolicyDetailProps) 
       }))
   }, [employeesData.showEmployees, policyEmployeeUuids])
 
-  const filteredEmployees = useMemo(() => {
-    if (!searchValue) return employees
-    const query = searchValue.toLowerCase()
-    return employees.filter(emp => {
-      const name = firstLastName({
-        first_name: emp.firstName,
-        last_name: emp.lastName,
-      }).toLowerCase()
-      return name.includes(query)
-    })
-  }, [employees, searchValue])
+  const {
+    data: pagedEmployees,
+    pagination,
+    searchValue,
+    actions: paginationActions,
+  } = useClientPagination(employees, {
+    defaultItemsPerPage: 10,
+    searchPredicate: (emp, query) =>
+      `${emp.firstName ?? ''} ${emp.lastName ?? ''}`.toLowerCase().includes(query.toLowerCase()),
+  })
 
   const handleRemoveEmployee = async () => {
     if (!removeDialogTarget) return
@@ -167,12 +166,11 @@ function Root({ companyId, defaultTab = 'holidays' }: HolidayPolicyDetailProps) 
       selectedTabId={selectedTabId}
       onTabChange={setSelectedTabId}
       employees={{
-        data: filteredEmployees,
+        data: pagedEmployees,
         searchValue,
-        onSearchChange: setSearchValue,
-        onSearchClear: () => {
-          setSearchValue('')
-        },
+        onSearchChange: paginationActions.onSearchChange,
+        onSearchClear: paginationActions.onSearchClear,
+        pagination,
         itemMenu: employee => (
           <HamburgerMenu
             items={[

--- a/src/hooks/useClientPagination/useClientPagination.test.ts
+++ b/src/hooks/useClientPagination/useClientPagination.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react'
-import { describe, test, expect, vi } from 'vitest'
+import { afterEach, beforeEach, describe, test, expect, vi } from 'vitest'
 import { useClientPagination } from './useClientPagination'
 
 interface FakeItem {
@@ -15,8 +15,25 @@ function makeItem(index: number): FakeItem {
 const matchesName = (item: FakeItem, query: string) =>
   `${item.firstName} ${item.lastName}`.toLowerCase().includes(query.toLowerCase())
 
+// Default debounce is 120ms; flush it inside act() so React processes the
+// resulting state update before assertions.
+const DEBOUNCE_MS = 120
+function flushSearchDebounce() {
+  act(() => {
+    vi.advanceTimersByTime(DEBOUNCE_MS)
+  })
+}
+
 // 12 items fits cleanly into "5 per page" → 3 pages (5/5/2).
 const items = Array.from({ length: 12 }, (_, i) => makeItem(i))
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 describe('useClientPagination', () => {
   test('initial state: page 1, default 5 per page, totalCount = items.length', () => {
@@ -144,6 +161,7 @@ describe('useClientPagination', () => {
     act(() => {
       result.current.actions.onSearchChange('First0 Last0')
     })
+    flushSearchDebounce()
 
     expect(result.current.searchValue).toBe('First0 Last0')
     expect(result.current.pagination.totalCount).toBe(1)
@@ -161,11 +179,13 @@ describe('useClientPagination', () => {
     act(() => {
       result.current.actions.onSearchChange('First9 Last9')
     })
+    flushSearchDebounce()
     expect(result.current.pagination.totalCount).toBe(1)
 
     act(() => {
       result.current.actions.onSearchClear()
     })
+    flushSearchDebounce()
     expect(result.current.searchValue).toBe('')
     expect(result.current.pagination.totalCount).toBe(12)
     expect(result.current.pagination.currentPage).toBe(1)
@@ -317,6 +337,7 @@ describe('useClientPagination — search', () => {
     act(() => {
       result.current.actions.onSearchChange('nope-not-a-real-name')
     })
+    flushSearchDebounce()
 
     expect(result.current.pagination.totalCount).toBe(0)
     expect(result.current.pagination.totalPages).toBe(1)
@@ -338,6 +359,7 @@ describe('useClientPagination — search', () => {
     act(() => {
       result.current.actions.onSearchChange('First1')
     })
+    flushSearchDebounce()
 
     expect(result.current.pagination.currentPage).toBe(1)
     expect(result.current.pagination.totalCount).toBe(11)
@@ -353,6 +375,7 @@ describe('useClientPagination — search', () => {
     act(() => {
       result.current.actions.onSearchChange('  Smith  ')
     })
+    flushSearchDebounce()
 
     expect(predicate).toHaveBeenCalled()
     for (const call of predicate.mock.calls) {
@@ -368,6 +391,7 @@ describe('useClientPagination — search', () => {
     act(() => {
       result.current.actions.onSearchChange('   ')
     })
+    flushSearchDebounce()
 
     expect(predicate).not.toHaveBeenCalled()
     expect(result.current.pagination.totalCount).toBe(12)
@@ -383,22 +407,26 @@ describe('useClientPagination — search', () => {
     act(() => {
       result.current.actions.onSearchChange('First1')
     })
+    flushSearchDebounce()
     expect(result.current.pagination.totalCount).toBe(3)
 
     act(() => {
       result.current.actions.onSearchChange('First11')
     })
+    flushSearchDebounce()
     expect(result.current.pagination.totalCount).toBe(1)
     expect(result.current.data[0]?.uuid).toBe('uuid-11')
 
     act(() => {
       result.current.actions.onSearchChange('zzz-no-match')
     })
+    flushSearchDebounce()
     expect(result.current.pagination.totalCount).toBe(0)
 
     act(() => {
       result.current.actions.onSearchChange('First2')
     })
+    flushSearchDebounce()
     expect(result.current.pagination.totalCount).toBe(1)
     expect(result.current.data[0]?.uuid).toBe('uuid-2')
   })
@@ -410,6 +438,7 @@ describe('useClientPagination — search', () => {
     act(() => {
       result.current.actions.onSearchChange('First1')
     })
+    flushSearchDebounce()
     expect(result.current.pagination.totalCount).toBe(11)
     expect(result.current.pagination.totalPages).toBe(3)
 
@@ -433,12 +462,99 @@ describe('useClientPagination — search', () => {
     act(() => {
       result.current.actions.onSearchChange('First1')
     })
+    flushSearchDebounce()
     expect(result.current.pagination.totalCount).toBe(11)
 
     rerender({ predicate: () => false })
 
     expect(result.current.pagination.totalCount).toBe(0)
     expect(result.current.data).toHaveLength(0)
+  })
+
+  test('searchValue is controlled-input instant; predicate is gated by debounce', () => {
+    const predicate = vi.fn<(item: FakeItem, query: string) => boolean>((item, query) =>
+      matchesName(item, query),
+    )
+    const { result } = renderHook(() => useClientPagination(items, { searchPredicate: predicate }))
+
+    act(() => {
+      result.current.actions.onSearchChange('F')
+    })
+    expect(result.current.searchValue).toBe('F')
+    expect(predicate).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.actions.onSearchChange('Fi')
+    })
+    act(() => {
+      result.current.actions.onSearchChange('Fir')
+    })
+    expect(result.current.searchValue).toBe('Fir')
+    expect(predicate).not.toHaveBeenCalled()
+
+    flushSearchDebounce()
+    expect(predicate).toHaveBeenCalled()
+  })
+
+  test('rapid typing coalesces into a single predicate pass per settle', () => {
+    const predicate = vi.fn<(item: FakeItem, query: string) => boolean>(() => true)
+    const { result } = renderHook(() => useClientPagination(items, { searchPredicate: predicate }))
+
+    for (const query of ['A', 'AB', 'ABC', 'ABCD', 'ABCDE']) {
+      act(() => {
+        result.current.actions.onSearchChange(query)
+      })
+      act(() => {
+        vi.advanceTimersByTime(DEBOUNCE_MS - 1)
+      })
+    }
+    expect(predicate).not.toHaveBeenCalled()
+
+    flushSearchDebounce()
+
+    const seenQueries = new Set(predicate.mock.calls.map(call => call[1]))
+    expect(seenQueries).toEqual(new Set(['ABCDE']))
+  })
+
+  test('searchDebounceMs: 0 disables debouncing (synchronous filter)', () => {
+    const predicate = vi.fn<(item: FakeItem, query: string) => boolean>((item, query) =>
+      matchesName(item, query),
+    )
+    const { result } = renderHook(() =>
+      useClientPagination(items, { searchPredicate: predicate, searchDebounceMs: 0 }),
+    )
+
+    act(() => {
+      result.current.actions.onSearchChange('First0')
+    })
+
+    expect(predicate).toHaveBeenCalled()
+    expect(result.current.pagination.totalCount).toBe(1)
+    expect(result.current.data[0]?.uuid).toBe('uuid-0')
+  })
+
+  test('respects a custom debounce window', () => {
+    const customDebounce = 300
+    const predicate = vi.fn<(item: FakeItem, query: string) => boolean>(() => true)
+    const { result } = renderHook(() =>
+      useClientPagination(items, {
+        searchPredicate: predicate,
+        searchDebounceMs: customDebounce,
+      }),
+    )
+
+    act(() => {
+      result.current.actions.onSearchChange('hi')
+    })
+    act(() => {
+      vi.advanceTimersByTime(customDebounce - 1)
+    })
+    expect(predicate).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(predicate).toHaveBeenCalled()
   })
 })
 

--- a/src/hooks/useClientPagination/useClientPagination.test.ts
+++ b/src/hooks/useClientPagination/useClientPagination.test.ts
@@ -1,0 +1,477 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, test, expect, vi } from 'vitest'
+import { useClientPagination } from './useClientPagination'
+
+interface FakeItem {
+  uuid: string
+  firstName: string
+  lastName: string
+}
+
+function makeItem(index: number): FakeItem {
+  return { uuid: `uuid-${index}`, firstName: `First${index}`, lastName: `Last${index}` }
+}
+
+const matchesName = (item: FakeItem, query: string) =>
+  `${item.firstName} ${item.lastName}`.toLowerCase().includes(query.toLowerCase())
+
+// 12 items fits cleanly into "5 per page" → 3 pages (5/5/2).
+const items = Array.from({ length: 12 }, (_, i) => makeItem(i))
+
+describe('useClientPagination', () => {
+  test('initial state: page 1, default 5 per page, totalCount = items.length', () => {
+    const { result } = renderHook(() => useClientPagination(items))
+
+    expect(result.current.pagination.currentPage).toBe(1)
+    expect(result.current.pagination.itemsPerPage).toBe(5)
+    expect(result.current.pagination.totalCount).toBe(12)
+    expect(result.current.pagination.totalPages).toBe(3)
+    expect(result.current.data).toHaveLength(5)
+    expect(result.current.data[0]?.uuid).toBe('uuid-0')
+    expect(result.current.searchValue).toBe('')
+  })
+
+  test('accepts a custom defaultItemsPerPage', () => {
+    const { result } = renderHook(() => useClientPagination(items, { defaultItemsPerPage: 10 }))
+
+    expect(result.current.pagination.itemsPerPage).toBe(10)
+    expect(result.current.pagination.totalPages).toBe(2)
+    expect(result.current.data).toHaveLength(10)
+  })
+
+  test('handleNextPage advances by one and clamps at totalPages', () => {
+    const { result } = renderHook(() => useClientPagination(items))
+
+    act(() => {
+      result.current.pagination.handleNextPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(2)
+    expect(result.current.data[0]?.uuid).toBe('uuid-5')
+
+    act(() => {
+      result.current.pagination.handleNextPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(3)
+    expect(result.current.data).toHaveLength(2)
+
+    act(() => {
+      result.current.pagination.handleNextPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(3)
+  })
+
+  test('handlePreviousPage decrements by one and clamps at 1', () => {
+    const { result } = renderHook(() => useClientPagination(items))
+
+    act(() => {
+      result.current.pagination.handleLastPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(3)
+
+    act(() => {
+      result.current.pagination.handlePreviousPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(2)
+
+    act(() => {
+      result.current.pagination.handlePreviousPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(1)
+
+    act(() => {
+      result.current.pagination.handlePreviousPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(1)
+  })
+
+  test('handleFirstPage and handleLastPage jump to the boundaries', () => {
+    const { result } = renderHook(() => useClientPagination(items))
+
+    act(() => {
+      result.current.pagination.handleLastPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(3)
+    expect(result.current.data).toHaveLength(2)
+
+    act(() => {
+      result.current.pagination.handleFirstPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(1)
+    expect(result.current.data[0]?.uuid).toBe('uuid-0')
+  })
+
+  test('handleItemsPerPageChange resets to page 1 and recomputes totalPages', () => {
+    const { result } = renderHook(() => useClientPagination(items))
+
+    act(() => {
+      result.current.pagination.handleLastPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(3)
+
+    act(() => {
+      result.current.pagination.handleItemsPerPageChange(10)
+    })
+    expect(result.current.pagination.itemsPerPage).toBe(10)
+    expect(result.current.pagination.totalPages).toBe(2)
+    expect(result.current.pagination.currentPage).toBe(1)
+    expect(result.current.data).toHaveLength(10)
+  })
+
+  test('handleItemsPerPageChange is a no-op when value matches current', () => {
+    const { result } = renderHook(() => useClientPagination(items))
+
+    act(() => {
+      result.current.pagination.handleNextPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(2)
+
+    act(() => {
+      result.current.pagination.handleItemsPerPageChange(5)
+    })
+    expect(result.current.pagination.currentPage).toBe(2)
+  })
+
+  test('searchPredicate filters allItems and resets currentPage to 1', () => {
+    const { result } = renderHook(() =>
+      useClientPagination(items, { searchPredicate: matchesName }),
+    )
+
+    act(() => {
+      result.current.pagination.handleLastPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(3)
+
+    act(() => {
+      result.current.actions.onSearchChange('First0 Last0')
+    })
+
+    expect(result.current.searchValue).toBe('First0 Last0')
+    expect(result.current.pagination.totalCount).toBe(1)
+    expect(result.current.pagination.totalPages).toBe(1)
+    expect(result.current.pagination.currentPage).toBe(1)
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data[0]?.uuid).toBe('uuid-0')
+  })
+
+  test('onSearchClear restores the unfiltered list and resets to page 1', () => {
+    const { result } = renderHook(() =>
+      useClientPagination(items, { searchPredicate: matchesName }),
+    )
+
+    act(() => {
+      result.current.actions.onSearchChange('First9 Last9')
+    })
+    expect(result.current.pagination.totalCount).toBe(1)
+
+    act(() => {
+      result.current.actions.onSearchClear()
+    })
+    expect(result.current.searchValue).toBe('')
+    expect(result.current.pagination.totalCount).toBe(12)
+    expect(result.current.pagination.currentPage).toBe(1)
+  })
+
+  test('safeCurrentPage clamps when allItems shrinks below the current page', () => {
+    const { result, rerender } = renderHook(
+      ({ data }: { data: FakeItem[] }) => useClientPagination(data),
+      { initialProps: { data: items } },
+    )
+
+    act(() => {
+      result.current.pagination.handleLastPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(3)
+
+    rerender({ data: items.slice(0, 1) })
+
+    expect(result.current.pagination.totalPages).toBe(1)
+    expect(result.current.pagination.currentPage).toBe(1)
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data[0]?.uuid).toBe('uuid-0')
+  })
+
+  test('handles an empty array without dividing by zero', () => {
+    const { result } = renderHook(() => useClientPagination<FakeItem>([]))
+
+    expect(result.current.pagination.totalCount).toBe(0)
+    expect(result.current.pagination.totalPages).toBe(1)
+    expect(result.current.pagination.currentPage).toBe(1)
+    expect(result.current.data).toHaveLength(0)
+  })
+})
+
+describe('useClientPagination — boundary math', () => {
+  test('exact-page totals: 10 items at 5/page is exactly 2 pages, not 3', () => {
+    const exact = Array.from({ length: 10 }, (_, i) => makeItem(i))
+    const { result } = renderHook(() => useClientPagination(exact))
+
+    expect(result.current.pagination.totalPages).toBe(2)
+
+    act(() => {
+      result.current.pagination.handleLastPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(2)
+    expect(result.current.data).toHaveLength(5)
+    expect(result.current.data[4]?.uuid).toBe('uuid-9')
+  })
+
+  test('supports itemsPerPage = 50', () => {
+    const big = Array.from({ length: 125 }, (_, i) => makeItem(i))
+    const { result } = renderHook(() => useClientPagination(big, { defaultItemsPerPage: 50 }))
+
+    expect(result.current.pagination.itemsPerPage).toBe(50)
+    expect(result.current.pagination.totalPages).toBe(3)
+    expect(result.current.data).toHaveLength(50)
+    expect(result.current.data[0]?.uuid).toBe('uuid-0')
+    expect(result.current.data[49]?.uuid).toBe('uuid-49')
+
+    act(() => {
+      result.current.pagination.handleLastPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(3)
+    expect(result.current.data).toHaveLength(25)
+    expect(result.current.data[0]?.uuid).toBe('uuid-100')
+    expect(result.current.data[24]?.uuid).toBe('uuid-124')
+  })
+
+  test('handleItemsPerPageChange returns the correct slice of items', () => {
+    const { result } = renderHook(() => useClientPagination(items))
+
+    act(() => {
+      result.current.pagination.handleLastPage()
+    })
+
+    act(() => {
+      result.current.pagination.handleItemsPerPageChange(10)
+    })
+
+    expect(result.current.data).toHaveLength(10)
+    expect(result.current.data[0]?.uuid).toBe('uuid-0')
+    expect(result.current.data[9]?.uuid).toBe('uuid-9')
+  })
+
+  test('switching itemsPerPage larger than totalCount lands on a single-page result', () => {
+    const small = Array.from({ length: 3 }, (_, i) => makeItem(i))
+    const { result } = renderHook(() => useClientPagination(small))
+
+    act(() => {
+      result.current.pagination.handleItemsPerPageChange(50)
+    })
+
+    expect(result.current.pagination.itemsPerPage).toBe(50)
+    expect(result.current.pagination.totalPages).toBe(1)
+    expect(result.current.pagination.currentPage).toBe(1)
+    expect(result.current.data).toHaveLength(3)
+  })
+
+  test('page handlers are safe no-ops on a single-page non-empty list', () => {
+    const small = Array.from({ length: 2 }, (_, i) => makeItem(i))
+    const { result } = renderHook(() => useClientPagination(small))
+
+    expect(result.current.pagination.totalPages).toBe(1)
+
+    act(() => {
+      result.current.pagination.handleNextPage()
+      result.current.pagination.handleLastPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(1)
+    expect(result.current.data).toHaveLength(2)
+  })
+})
+
+describe('useClientPagination — large dataset', () => {
+  test('handles 10,000 items: counts, last-page slice, middle-page slice', () => {
+    const huge = Array.from({ length: 10_000 }, (_, i) => makeItem(i))
+    const { result } = renderHook(() => useClientPagination(huge, { defaultItemsPerPage: 50 }))
+
+    expect(result.current.pagination.totalCount).toBe(10_000)
+    expect(result.current.pagination.totalPages).toBe(200)
+    expect(result.current.data).toHaveLength(50)
+    expect(result.current.data[0]?.uuid).toBe('uuid-0')
+
+    act(() => {
+      result.current.pagination.handleLastPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(200)
+    expect(result.current.data).toHaveLength(50)
+    expect(result.current.data[0]?.uuid).toBe('uuid-9950')
+    expect(result.current.data[49]?.uuid).toBe('uuid-9999')
+
+    act(() => {
+      result.current.pagination.handleFirstPage()
+      result.current.pagination.handleNextPage()
+      result.current.pagination.handleNextPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(3)
+    expect(result.current.data[0]?.uuid).toBe('uuid-100')
+    expect(result.current.data[49]?.uuid).toBe('uuid-149')
+  })
+})
+
+describe('useClientPagination — search', () => {
+  test('zero matches: totalCount 0, totalPages 1, data empty, currentPage 1', () => {
+    const { result } = renderHook(() =>
+      useClientPagination(items, { searchPredicate: matchesName }),
+    )
+
+    act(() => {
+      result.current.actions.onSearchChange('nope-not-a-real-name')
+    })
+
+    expect(result.current.pagination.totalCount).toBe(0)
+    expect(result.current.pagination.totalPages).toBe(1)
+    expect(result.current.pagination.currentPage).toBe(1)
+    expect(result.current.data).toHaveLength(0)
+  })
+
+  test('refining a query mid-pagination clamps currentPage via safeCurrentPage', () => {
+    const big = Array.from({ length: 30 }, (_, i) => makeItem(i))
+    const { result } = renderHook(() => useClientPagination(big, { searchPredicate: matchesName }))
+
+    act(() => {
+      result.current.pagination.handleNextPage()
+      result.current.pagination.handleNextPage()
+      result.current.pagination.handleNextPage()
+    })
+    expect(result.current.pagination.currentPage).toBe(4)
+
+    act(() => {
+      result.current.actions.onSearchChange('First1')
+    })
+
+    expect(result.current.pagination.currentPage).toBe(1)
+    expect(result.current.pagination.totalCount).toBe(11)
+    expect(result.current.pagination.totalPages).toBe(3)
+  })
+
+  test('predicate receives the trimmed deferred value and the item', () => {
+    const predicate = vi.fn<(item: FakeItem, query: string) => boolean>(() => true)
+    const { result } = renderHook(() => useClientPagination(items, { searchPredicate: predicate }))
+
+    expect(predicate).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.actions.onSearchChange('  Smith  ')
+    })
+
+    expect(predicate).toHaveBeenCalled()
+    for (const call of predicate.mock.calls) {
+      expect(call[1]).toBe('Smith')
+    }
+    expect(predicate.mock.calls[0]?.[0]).toMatchObject({ uuid: 'uuid-0' })
+  })
+
+  test('whitespace-only search is treated as no search (predicate not called)', () => {
+    const predicate = vi.fn<(item: FakeItem, query: string) => boolean>(() => false)
+    const { result } = renderHook(() => useClientPagination(items, { searchPredicate: predicate }))
+
+    act(() => {
+      result.current.actions.onSearchChange('   ')
+    })
+
+    expect(predicate).not.toHaveBeenCalled()
+    expect(result.current.pagination.totalCount).toBe(12)
+    expect(result.current.data).toHaveLength(5)
+    expect(result.current.searchValue).toBe('   ')
+  })
+
+  test('successive queries re-filter against each new deferred value', () => {
+    const { result } = renderHook(() =>
+      useClientPagination(items, { searchPredicate: matchesName }),
+    )
+
+    act(() => {
+      result.current.actions.onSearchChange('First1')
+    })
+    expect(result.current.pagination.totalCount).toBe(3)
+
+    act(() => {
+      result.current.actions.onSearchChange('First11')
+    })
+    expect(result.current.pagination.totalCount).toBe(1)
+    expect(result.current.data[0]?.uuid).toBe('uuid-11')
+
+    act(() => {
+      result.current.actions.onSearchChange('zzz-no-match')
+    })
+    expect(result.current.pagination.totalCount).toBe(0)
+
+    act(() => {
+      result.current.actions.onSearchChange('First2')
+    })
+    expect(result.current.pagination.totalCount).toBe(1)
+    expect(result.current.data[0]?.uuid).toBe('uuid-2')
+  })
+
+  test('search + itemsPerPage change cooperate', () => {
+    const big = Array.from({ length: 30 }, (_, i) => makeItem(i))
+    const { result } = renderHook(() => useClientPagination(big, { searchPredicate: matchesName }))
+
+    act(() => {
+      result.current.actions.onSearchChange('First1')
+    })
+    expect(result.current.pagination.totalCount).toBe(11)
+    expect(result.current.pagination.totalPages).toBe(3)
+
+    act(() => {
+      result.current.pagination.handleItemsPerPageChange(50)
+    })
+
+    expect(result.current.pagination.itemsPerPage).toBe(50)
+    expect(result.current.pagination.totalPages).toBe(1)
+    expect(result.current.data).toHaveLength(11)
+  })
+
+  test('updating only the predicate identity re-filters with the same query', () => {
+    const big = Array.from({ length: 20 }, (_, i) => makeItem(i))
+    type Hookprops = { predicate: (item: FakeItem, query: string) => boolean }
+    const { result, rerender } = renderHook(
+      ({ predicate }: Hookprops) => useClientPagination(big, { searchPredicate: predicate }),
+      { initialProps: { predicate: matchesName } satisfies Hookprops },
+    )
+
+    act(() => {
+      result.current.actions.onSearchChange('First1')
+    })
+    expect(result.current.pagination.totalCount).toBe(11)
+
+    rerender({ predicate: () => false })
+
+    expect(result.current.pagination.totalCount).toBe(0)
+    expect(result.current.data).toHaveLength(0)
+  })
+})
+
+describe('useClientPagination — referential stability', () => {
+  test('data and pagination identity are stable across no-op rerenders', () => {
+    const stable = Array.from({ length: 8 }, (_, i) => makeItem(i))
+    const { result, rerender } = renderHook(
+      ({ data }: { data: FakeItem[] }) => useClientPagination(data),
+      { initialProps: { data: stable } },
+    )
+
+    const firstData = result.current.data
+    const firstPagination = result.current.pagination
+
+    rerender({ data: stable })
+
+    expect(result.current.data).toBe(firstData)
+    expect(result.current.pagination).toBe(firstPagination)
+  })
+
+  test('a new allItems reference re-derives data and pagination', () => {
+    const stable = Array.from({ length: 8 }, (_, i) => makeItem(i))
+    const { result, rerender } = renderHook(
+      ({ data }: { data: FakeItem[] }) => useClientPagination(data),
+      { initialProps: { data: stable } },
+    )
+
+    const firstData = result.current.data
+
+    rerender({ data: [...stable] })
+
+    expect(result.current.data).not.toBe(firstData)
+    expect(result.current.data).toHaveLength(5)
+    expect(result.current.data[0]?.uuid).toBe('uuid-0')
+  })
+})

--- a/src/hooks/useClientPagination/useClientPagination.test.ts
+++ b/src/hooks/useClientPagination/useClientPagination.test.ts
@@ -443,7 +443,7 @@ describe('useClientPagination — search', () => {
 })
 
 describe('useClientPagination — referential stability', () => {
-  test('data and pagination identity are stable across no-op rerenders', () => {
+  test('data, pagination, and actions identity are stable across no-op rerenders', () => {
     const stable = Array.from({ length: 8 }, (_, i) => makeItem(i))
     const { result, rerender } = renderHook(
       ({ data }: { data: FakeItem[] }) => useClientPagination(data),
@@ -452,11 +452,29 @@ describe('useClientPagination — referential stability', () => {
 
     const firstData = result.current.data
     const firstPagination = result.current.pagination
+    const firstActions = result.current.actions
 
     rerender({ data: stable })
 
     expect(result.current.data).toBe(firstData)
     expect(result.current.pagination).toBe(firstPagination)
+    expect(result.current.actions).toBe(firstActions)
+  })
+
+  test('actions identity is stable even when pagination state changes', () => {
+    const { result } = renderHook(() => useClientPagination(items))
+
+    const firstActions = result.current.actions
+
+    act(() => {
+      result.current.pagination.handleNextPage()
+    })
+    expect(result.current.actions).toBe(firstActions)
+
+    act(() => {
+      result.current.pagination.handleItemsPerPageChange(10)
+    })
+    expect(result.current.actions).toBe(firstActions)
   })
 
   test('a new allItems reference re-derives data and pagination', () => {

--- a/src/hooks/useClientPagination/useClientPagination.ts
+++ b/src/hooks/useClientPagination/useClientPagination.ts
@@ -1,0 +1,114 @@
+import { useCallback, useDeferredValue, useMemo, useState } from 'react'
+import type {
+  PaginationControlProps,
+  PaginationItemsPerPage,
+} from '@/components/Common/PaginationControl/PaginationControlTypes'
+
+interface UseClientPaginationOptions<TItem> {
+  /**
+   * Optional substring/fuzzy/etc. predicate run against the deferred,
+   * trimmed search value. The hook owns search state and resets to page 1
+   * whenever the value changes. A trimmed-empty value is treated as "no
+   * search" and the predicate is not called. Omit to skip search entirely.
+   */
+  searchPredicate?: (item: TItem, query: string) => boolean
+  /** Display rows-per-page. Default 5. */
+  defaultItemsPerPage?: PaginationItemsPerPage
+}
+
+export interface UseClientPaginationResult<TItem> {
+  /** Current-page slice. */
+  data: TItem[]
+  /** Drop-in `PaginationControlProps` for `useDataView` / `PaginationControl`. */
+  pagination: PaginationControlProps
+  /** Current search value (controlled). */
+  searchValue: string
+  actions: {
+    onSearchChange: (value: string) => void
+    onSearchClear: () => void
+  }
+}
+
+/**
+ * Client-side pagination + optional search over an in-memory array.
+ *
+ * Returns a `PaginationControlProps`-shaped pagination object that drops
+ * straight into `useDataView` / `PaginationControl`. Use this when the
+ * caller already has the full list of items and wants to paginate/search
+ * it locally. Pair with `usePagination` if you want to page through an
+ * API endpoint instead.
+ */
+export function useClientPagination<TItem>(
+  allItems: TItem[],
+  options: UseClientPaginationOptions<TItem> = {},
+): UseClientPaginationResult<TItem> {
+  const { searchPredicate, defaultItemsPerPage = 5 } = options
+
+  const [searchValue, setSearchValue] = useState('')
+  const deferredSearchValue = useDeferredValue(searchValue)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [itemsPerPage, setItemsPerPage] = useState<PaginationItemsPerPage>(defaultItemsPerPage)
+
+  const searchFilteredItems = useMemo<TItem[]>(() => {
+    if (!searchPredicate) return allItems
+    const trimmed = deferredSearchValue.trim()
+    if (!trimmed) return allItems
+    return allItems.filter(item => searchPredicate(item, trimmed))
+  }, [allItems, deferredSearchValue, searchPredicate])
+
+  const totalCount = searchFilteredItems.length
+  const totalPages = Math.max(1, Math.ceil(totalCount / itemsPerPage))
+  // Clamp `currentPage` against the latest `totalPages` so a shrinking list
+  // (e.g. after a search filter) doesn't leave the table on an empty page.
+  const safeCurrentPage = Math.min(currentPage, totalPages)
+
+  const data = useMemo<TItem[]>(() => {
+    const start = (safeCurrentPage - 1) * itemsPerPage
+    return searchFilteredItems.slice(start, start + itemsPerPage)
+  }, [searchFilteredItems, safeCurrentPage, itemsPerPage])
+
+  const pagination = useMemo<PaginationControlProps>(
+    () => ({
+      currentPage: safeCurrentPage,
+      totalPages,
+      totalCount,
+      itemsPerPage,
+      handleFirstPage: () => {
+        setCurrentPage(1)
+      },
+      handleLastPage: () => {
+        setCurrentPage(totalPages)
+      },
+      handleNextPage: () => {
+        setCurrentPage(prev => Math.min(prev + 1, totalPages))
+      },
+      handlePreviousPage: () => {
+        setCurrentPage(prev => Math.max(prev - 1, 1))
+      },
+      handleItemsPerPageChange: (value: PaginationItemsPerPage) => {
+        if (value !== itemsPerPage) {
+          setItemsPerPage(value)
+          setCurrentPage(1)
+        }
+      },
+    }),
+    [safeCurrentPage, totalPages, totalCount, itemsPerPage],
+  )
+
+  const onSearchChange = useCallback((value: string) => {
+    setSearchValue(value)
+    setCurrentPage(1)
+  }, [])
+
+  const onSearchClear = useCallback(() => {
+    setSearchValue('')
+    setCurrentPage(1)
+  }, [])
+
+  return {
+    data,
+    pagination,
+    searchValue,
+    actions: { onSearchChange, onSearchClear },
+  }
+}

--- a/src/hooks/useClientPagination/useClientPagination.ts
+++ b/src/hooks/useClientPagination/useClientPagination.ts
@@ -1,19 +1,30 @@
-import { useCallback, useDeferredValue, useMemo, useState } from 'react'
+import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react'
 import type {
   PaginationControlProps,
   PaginationItemsPerPage,
 } from '@/components/Common/PaginationControl/PaginationControlTypes'
 
+const DEFAULT_SEARCH_DEBOUNCE_MS = 120
+
 interface UseClientPaginationOptions<TItem> {
   /**
-   * Optional substring/fuzzy/etc. predicate run against the deferred,
-   * trimmed search value. The hook owns search state and resets to page 1
-   * whenever the value changes. A trimmed-empty value is treated as "no
-   * search" and the predicate is not called. Omit to skip search entirely.
+   * Optional substring/fuzzy/etc. predicate run against the debounced,
+   * deferred, trimmed search value. The hook owns search state and
+   * resets to page 1 once the debounce settles. A trimmed-empty value is
+   * treated as "no search" and the predicate is not called. Omit to skip
+   * search entirely.
    */
   searchPredicate?: (item: TItem, query: string) => boolean
   /** Display rows-per-page. Default 5. */
   defaultItemsPerPage?: PaginationItemsPerPage
+  /**
+   * Debounce window (ms) applied to the search value before it reaches
+   * the predicate and page reset. Keeps the controlled input responsive
+   * while preventing the filter from running on every keystroke for
+   * large lists or expensive predicates. Defaults to 120ms. Pass 0 to
+   * disable debouncing entirely (useful for tests).
+   */
+  searchDebounceMs?: number
 }
 
 export interface UseClientPaginationResult<TItem> {
@@ -42,12 +53,32 @@ export function useClientPagination<TItem>(
   allItems: TItem[],
   options: UseClientPaginationOptions<TItem> = {},
 ): UseClientPaginationResult<TItem> {
-  const { searchPredicate, defaultItemsPerPage = 5 } = options
+  const {
+    searchPredicate,
+    defaultItemsPerPage = 5,
+    searchDebounceMs = DEFAULT_SEARCH_DEBOUNCE_MS,
+  } = options
 
   const [searchValue, setSearchValue] = useState('')
-  const deferredSearchValue = useDeferredValue(searchValue)
+  const [debouncedSearchValue, setDebouncedSearchValue] = useState('')
+  const deferredSearchValue = useDeferredValue(debouncedSearchValue)
   const [currentPage, setCurrentPage] = useState(1)
   const [itemsPerPage, setItemsPerPage] = useState<PaginationItemsPerPage>(defaultItemsPerPage)
+
+  useEffect(() => {
+    if (searchDebounceMs <= 0) {
+      setDebouncedSearchValue(prev => (prev === searchValue ? prev : searchValue))
+      setCurrentPage(prev => (prev === 1 ? prev : 1))
+      return
+    }
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearchValue(prev => (prev === searchValue ? prev : searchValue))
+      setCurrentPage(prev => (prev === 1 ? prev : 1))
+    }, searchDebounceMs)
+    return () => {
+      clearTimeout(timeoutId)
+    }
+  }, [searchValue, searchDebounceMs])
 
   const searchFilteredItems = useMemo<TItem[]>(() => {
     if (!searchPredicate) return allItems
@@ -97,12 +128,10 @@ export function useClientPagination<TItem>(
 
   const onSearchChange = useCallback((value: string) => {
     setSearchValue(value)
-    setCurrentPage(1)
   }, [])
 
   const onSearchClear = useCallback(() => {
     setSearchValue('')
-    setCurrentPage(1)
   }, [])
 
   const actions = useMemo(

--- a/src/hooks/useClientPagination/useClientPagination.ts
+++ b/src/hooks/useClientPagination/useClientPagination.ts
@@ -105,10 +105,15 @@ export function useClientPagination<TItem>(
     setCurrentPage(1)
   }, [])
 
+  const actions = useMemo(
+    () => ({ onSearchChange, onSearchClear }),
+    [onSearchChange, onSearchClear],
+  )
+
   return {
     data,
     pagination,
     searchValue,
-    actions: { onSearchChange, onSearchClear },
+    actions,
   }
 }


### PR DESCRIPTION
## Summary

Adds a reusable `useClientPagination(items, options)` hook that owns in-memory pagination plus an optional search predicate over a `T[]`, returning a `PaginationControlProps`-shaped object that drops straight into `useDataView` and `PaginationControl`.

Pairs with the existing server-side `usePagination`:

| Driver | Source | Use when |
|---|---|---|
| `usePagination` | `x-total-pages` / `x-total-count` headers | Paging through an API endpoint |
| `useClientPagination` | In-memory `T[]` | Caller already has the full list |

Both return the same shape, so swapping a list from server-paginated to client-paginated (or vice versa) is a one-line change at the call site.

### First adopter: `HolidayPolicyDetail`

Today this component hand-rolls a `searchValue` + `useMemo` filter over the policy's enrolled employees, **with no pagination at all**. This PR swaps it for `useClientPagination` at 10 per page, so rosters with more than 5 enrolled employees now render a pager.

Net code change in that file: drops the local `searchValue` state and the filter `useMemo`, adds one `useClientPagination(...)` call, wires `pagination` into the existing `employees` prop that `PolicyDetailLayout` already exposed.

### Behavior

- Whitespace-only queries (`'   '`) are treated as no-search; the predicate is never called.
- The predicate is invoked with the **trimmed, deferred** value, so partner predicates do not need to defensively trim.
- `searchValue` from the hook is the **raw** input the user typed (controlled-input semantics), even when the trimmed version is empty.
- Identity of `data` / `pagination` is stable across no-op rerenders so downstream `useMemo`s in `useDataView` are not invalidated.

## Test plan

- [x] 26 unit tests on the hook: initial state, page nav and clamps, items-per-page reset, items-per-page no-op when unchanged, exact-page totals (10 items / 5 per page == 2 pages, not 3), all three `PaginationItemsPerPage` values, large dataset (10k items: count, last-page slice 9950-9999, middle-page slice), zero matches, query-refine clamp via `safeCurrentPage`, successive queries, whitespace-only no-op, predicate receives trimmed deferred value, search + items-per-page interaction, predicate identity change re-filters, referential stability across no-op rerenders, new `allItems` reference re-derives.
- [x] 3 integration tests on `HolidayPolicyDetail`: pager hidden when roster <= 5, paginates at 10 per page and navigates between pages with 12 enrolled employees, search resets to page 1 (asserts page-2 content disappears).
- [x] Pre-existing `HolidayPolicyDetail` search test still passes against the new hook-backed implementation.
- [x] `npm run test -- --run src/components/TimeOff src/hooks` -> 433/433 pass.
- [x] `npm run lint:check` -> 0 errors (25 pre-existing warnings, none in touched files).
- [x] `npm run format:check` clean.

## Follow-ups (not in this PR)

- `useSelectEmployeesData` ([#1843](https://github.com/Gusto/embedded-react-sdk/pull/1843)) hand-rolls the same state machine. Once that PR merges main, it can adopt the hook in a small follow-up.
- `TimeOffPolicyDetail` has the same client-side-search-without-pagination pattern as `HolidayPolicyDetail` did; left for a follow-up PR to keep this diff scoped.


Made with [Cursor](https://cursor.com)