### PR TITLE
perf(Dashboard): lazy-load tab data, cut first-paint requests

### DIFF
--- a/src/components/Employee/Dashboard/BasicDetailsView.tsx
+++ b/src/components/Employee/Dashboard/BasicDetailsView.tsx
@@ -2,11 +2,13 @@ import { useTranslation } from 'react-i18next'
 import type { Employee } from '@gusto/embedded-api/models/components/employee'
 import type { EmployeeAddress } from '@gusto/embedded-api/models/components/employeeaddress'
 import type { EmployeeWorkAddress } from '@gusto/embedded-api/models/components/employeeworkaddress'
+import { useEmployeeBasicDetails } from './hooks'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { formatDateLongWithYear } from '@/helpers/dateFormatting'
 import { firstLastName, getStreet, getCityStateZip } from '@/helpers/formattedStrings'
 import { Loading } from '@/components/Common'
+import { BaseLayout } from '@/components/Base/Base'
 
 export interface BasicDetailsViewProps {
   employee?: Employee
@@ -16,6 +18,45 @@ export interface BasicDetailsViewProps {
   onEditBasicDetails?: () => void
   onManageHomeAddress?: () => void
   onManageWorkAddress?: () => void
+}
+
+export interface BasicDetailsViewWithDataProps {
+  employeeId: string
+  onEditBasicDetails?: () => void
+  onManageHomeAddress?: () => void
+  onManageWorkAddress?: () => void
+}
+
+/**
+ * Tab-mounted container for the Basic details tab. Owns the
+ * `useEmployeeBasicDetails` fetch (employee + home address + work address)
+ * so the requests only fire when the tab is mounted. The presentational
+ * `BasicDetailsView` stays pure for testing/stories.
+ */
+export function BasicDetailsViewWithData({
+  employeeId,
+  onEditBasicDetails,
+  onManageHomeAddress,
+  onManageWorkAddress,
+}: BasicDetailsViewWithDataProps) {
+  const basicDetails = useEmployeeBasicDetails({ employeeId })
+
+  if (basicDetails.isLoading) {
+    return <BaseLayout isLoading error={basicDetails.errorHandling.errors} />
+  }
+
+  return (
+    <BaseLayout error={basicDetails.errorHandling.errors}>
+      <BasicDetailsView
+        employee={basicDetails.data.employee}
+        currentHomeAddress={basicDetails.data.currentHomeAddress}
+        currentWorkAddress={basicDetails.data.currentWorkAddress}
+        onEditBasicDetails={onEditBasicDetails}
+        onManageHomeAddress={onManageHomeAddress}
+        onManageWorkAddress={onManageWorkAddress}
+      />
+    </BaseLayout>
+  )
 }
 
 export function BasicDetailsView({

--- a/src/components/Employee/Dashboard/Dashboard.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.tsx
@@ -1,27 +1,21 @@
-import { useState, useCallback } from 'react'
+import { Suspense, useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useGustoEmbeddedContext } from '@gusto/embedded-api/react-query/_context'
-import { payrollsGetPayStub } from '@gusto/embedded-api/funcs/payrollsGetPayStub'
-import { useErrorBoundary } from 'react-error-boundary'
 import type { Job } from '@gusto/embedded-api/models/components/job'
 import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
-import {
-  useEmployeeBasicDetails,
-  useEmployeeCompensation,
-  useEmployeeTaxes,
-  useEmployeeForms,
-} from './hooks'
-import { BasicDetailsView } from './BasicDetailsView'
+import type { GetV1EmployeesEmployeeIdFederalTaxesResponse } from '@gusto/embedded-api/models/operations/getv1employeesemployeeidfederaltaxes'
+import { BasicDetailsViewWithData } from './BasicDetailsView'
 import { JobAndPayView } from './JobAndPayView'
-import { TaxesView } from './TaxesView'
-import { DocumentsView } from './DocumentsView'
-import type { PendingCompensationChange } from './getPendingCompensationChanges'
+import { TaxesViewWithData } from './TaxesView'
+import { DocumentsViewWithData } from './DocumentsView'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { BaseBoundaries, BaseLayout, type BaseComponentInterface } from '@/components/Base/Base'
-import { readableStreamToBlob } from '@/helpers/readableStreamToBlob'
 import { useComponentDictionary, useI18n } from '@/i18n'
 import { componentEvents } from '@/shared/constants'
+
+type EmployeeFederalTax = NonNullable<
+  GetV1EmployeesEmployeeIdFederalTaxesResponse['employeeFederalTax']
+>
 
 type DashboardTab = 'basicDetails' | 'jobAndPay' | 'taxes' | 'documents'
 
@@ -34,31 +28,7 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
   useComponentDictionary('Employee.Dashboard', dictionary)
   const { t } = useTranslation('Employee.Dashboard')
   const Components = useComponentContext()
-  const gustoEmbedded = useGustoEmbeddedContext()
-  const { showBoundary } = useErrorBoundary()
   const [selectedTab, setSelectedTab] = useState<DashboardTab>('basicDetails')
-  const [downloadingPayrollUuids, setDownloadingPayrollUuids] = useState<ReadonlySet<string>>(
-    () => new Set(),
-  )
-
-  const basicDetails = useEmployeeBasicDetails({ employeeId })
-  const compensation = useEmployeeCompensation({ employeeId })
-  const taxes = useEmployeeTaxes({ employeeId })
-  const forms = useEmployeeForms({ employeeId })
-
-  // Derive the inputs these callbacks depend on up here so all hooks are
-  // declared before the early-return below (rules-of-hooks). The data fields
-  // are only present on the non-loading variants of each hook result.
-  const pendingChanges = !compensation.isLoading ? compensation.data.pendingChanges : []
-  const hasMultipleJobs = !compensation.isLoading ? compensation.data.hasMultipleJobs : false
-  const cancellingCompensationUuid = !compensation.isLoading
-    ? compensation.status.cancellingCompensationUuid
-    : null
-  const cancelPendingChange = !compensation.isLoading
-    ? compensation.actions.cancelPendingChange
-    : undefined
-  const employeeFirstName = !basicDetails.isLoading ? basicDetails.data.employee.firstName : null
-  const employeeFederalTax = !taxes.isLoading ? taxes.data.employeeFederalTax : undefined
 
   const handleEditBasicDetails = useCallback(() => {
     onEvent(componentEvents.EMPLOYEE_UPDATE, { employeeId })
@@ -77,20 +47,6 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
       onEvent(componentEvents.EMPLOYEE_COMPENSATION_CREATE, { employeeId, job })
     },
     [onEvent, employeeId],
-  )
-
-  const handleCancelCompensationChange = useCallback(
-    async (pendingChange: PendingCompensationChange) => {
-      if (!cancelPendingChange) return
-      const result = await cancelPendingChange(pendingChange)
-      if (result) {
-        onEvent(componentEvents.EMPLOYEE_COMPENSATION_CHANGE_CANCELLED, {
-          employeeId,
-          compensationId: pendingChange.compensationUuid,
-        })
-      }
-    },
-    [cancelPendingChange, onEvent, employeeId],
   )
 
   const handleAddJob = useCallback(() => {
@@ -112,71 +68,12 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
     [onEvent],
   )
 
-  const handlePaystubDownload = useCallback(
-    async (payrollUuid: string) => {
-      const newWindow = window.open('', '_blank')
-      const loadingMessage = t('jobAndPay.paystubs.downloadLoadingMessage')
-      if (newWindow) {
-        // Avoid the user staring at about:blank while we fetch the PDF. The
-        // navigation to the Blob URL below replaces this document.
-        const doc = newWindow.document
-        doc.title = loadingMessage
-        const style = doc.createElement('style')
-        style.textContent =
-          'body{font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;' +
-          'justify-content:center;height:100vh;margin:0;color:#444;gap:12px}' +
-          '.spinner{width:20px;height:20px;border:2px solid #ccc;border-top-color:#444;' +
-          'border-radius:50%;animation:spin .8s linear infinite}' +
-          '@keyframes spin{to{transform:rotate(360deg)}}'
-        doc.head.appendChild(style)
-        const spinner = doc.createElement('div')
-        spinner.className = 'spinner'
-        spinner.setAttribute('aria-hidden', 'true')
-        const label = doc.createElement('span')
-        label.textContent = loadingMessage
-        doc.body.replaceChildren(spinner, label)
-      }
-      setDownloadingPayrollUuids(prev => {
-        const next = new Set(prev)
-        next.add(payrollUuid)
-        return next
-      })
-      try {
-        const response = await payrollsGetPayStub(gustoEmbedded, {
-          payrollId: payrollUuid,
-          employeeId,
-        })
-        if (!response.value?.responseStream) {
-          throw new Error(t('jobAndPay.paystubs.downloadError'))
-        }
-        const pdfBlob = await readableStreamToBlob(response.value.responseStream, 'application/pdf')
-        const url = URL.createObjectURL(pdfBlob)
-        if (newWindow) {
-          newWindow.location.href = url
-        }
-        URL.revokeObjectURL(url)
-      } catch (err) {
-        if (newWindow) {
-          newWindow.close()
-        }
-        showBoundary(err instanceof Error ? err : new Error(String(err)))
-      } finally {
-        setDownloadingPayrollUuids(prev => {
-          const next = new Set(prev)
-          next.delete(payrollUuid)
-          return next
-        })
-      }
+  const handleEditFederalTaxes = useCallback(
+    (federalTaxes: EmployeeFederalTax | undefined) => {
+      onEvent(componentEvents.EMPLOYEE_FEDERAL_TAXES_EDIT, { employeeId, federalTaxes })
     },
-    [gustoEmbedded, employeeId, t, showBoundary],
+    [onEvent, employeeId],
   )
-
-  const handleEditFederalTaxes = useCallback(() => {
-    onEvent(componentEvents.EMPLOYEE_FEDERAL_TAXES_EDIT, {
-      employeeId,
-      federalTaxes: employeeFederalTax,
-    })
-  }, [onEvent, employeeId, employeeFederalTax])
 
   const handleEditStateTaxes = useCallback(() => {
     onEvent(componentEvents.EMPLOYEE_STATE_TAXES_EDIT, { employeeId })
@@ -188,33 +85,6 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
     },
     [onEvent, employeeId],
   )
-
-  // Collect all errors from hooks
-  const allErrors = [
-    ...basicDetails.errorHandling.errors,
-    ...compensation.errorHandling.errors,
-    ...taxes.errorHandling.errors,
-    ...forms.errorHandling.errors,
-  ]
-
-  // Show loading for initial data fetch
-  if (basicDetails.isLoading || compensation.isLoading || taxes.isLoading || forms.isLoading) {
-    return <BaseLayout isLoading error={allErrors} />
-  }
-
-  const { employee, currentHomeAddress, currentWorkAddress } = basicDetails.data
-  const { jobs, primaryFlsaStatus, payStubs } = compensation.data
-  const { employeeStateTaxesList } = taxes.data
-  const { formList } = forms.data
-
-  // Pagination props
-  const payStubsPagination = compensation.pagination.payStubs
-
-  // Tab-specific loading states based on isPending
-  const isLoadingBasicDetails = basicDetails.status.isPending
-  const isLoadingJobAndPay = compensation.status.isPending
-  const isLoadingTaxes = taxes.status.isPending
-  const isLoadingDocuments = forms.status.isPending
 
   const tabs = [
     {
@@ -240,74 +110,59 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
   ]
 
   return (
-    <BaseLayout error={allErrors}>
-      <Flex flexDirection="column" gap={32}>
-        <Components.Tabs
-          tabs={tabs}
-          selectedId={selectedTab}
-          onSelectionChange={id => {
-            setSelectedTab(id as DashboardTab)
-          }}
-          aria-label={t('tabsLabel')}
-        />
+    <Flex flexDirection="column" gap={32}>
+      <Components.Tabs
+        tabs={tabs}
+        selectedId={selectedTab}
+        onSelectionChange={id => {
+          setSelectedTab(id as DashboardTab)
+        }}
+        aria-label={t('tabsLabel')}
+      />
 
-        <Flex flexDirection="column" gap={24}>
-          {selectedTab === 'basicDetails' && (
-            <BasicDetailsView
-              employee={employee}
-              currentHomeAddress={currentHomeAddress}
-              currentWorkAddress={currentWorkAddress}
-              isLoading={isLoadingBasicDetails}
+      <Flex flexDirection="column" gap={24}>
+        {selectedTab === 'basicDetails' && (
+          <Suspense fallback={<BaseLayout isLoading />}>
+            <BasicDetailsViewWithData
+              employeeId={employeeId}
               onEditBasicDetails={handleEditBasicDetails}
               onManageHomeAddress={handleManageHomeAddress}
               onManageWorkAddress={handleManageWorkAddress}
             />
-          )}
+          </Suspense>
+        )}
 
-          {selectedTab === 'jobAndPay' && (
+        {selectedTab === 'jobAndPay' && (
+          <Suspense fallback={<BaseLayout isLoading />}>
             <JobAndPayView
               employeeId={employeeId}
-              jobs={jobs}
-              primaryFlsaStatus={primaryFlsaStatus}
-              pendingChanges={pendingChanges}
-              hasMultipleJobs={hasMultipleJobs}
-              employeeFirstName={employeeFirstName}
-              cancellingCompensationUuid={cancellingCompensationUuid}
-              payStubs={payStubs}
-              payStubsPagination={payStubsPagination}
-              isLoading={isLoadingJobAndPay}
               onEvent={onEvent}
               onEditCompensation={handleEditCompensation}
               onAddJob={handleAddJob}
               onAddAnotherJob={handleAddAnotherJob}
-              onCancelChange={handleCancelCompensationChange}
               onAddDeduction={handleAddDeduction}
               onEditDeduction={handleEditDeduction}
-              onPaystubDownload={handlePaystubDownload}
-              downloadingPayrollUuids={downloadingPayrollUuids}
             />
-          )}
+          </Suspense>
+        )}
 
-          {selectedTab === 'taxes' && (
-            <TaxesView
-              federalTaxes={employeeFederalTax}
-              stateTaxes={employeeStateTaxesList}
-              isLoading={isLoadingTaxes}
+        {selectedTab === 'taxes' && (
+          <Suspense fallback={<BaseLayout isLoading />}>
+            <TaxesViewWithData
+              employeeId={employeeId}
               onEditFederalTaxes={handleEditFederalTaxes}
               onEditStateTaxes={handleEditStateTaxes}
             />
-          )}
+          </Suspense>
+        )}
 
-          {selectedTab === 'documents' && (
-            <DocumentsView
-              forms={formList}
-              isLoading={isLoadingDocuments}
-              onViewForm={handleViewForm}
-            />
-          )}
-        </Flex>
+        {selectedTab === 'documents' && (
+          <Suspense fallback={<BaseLayout isLoading />}>
+            <DocumentsViewWithData employeeId={employeeId} onViewForm={handleViewForm} />
+          </Suspense>
+        )}
       </Flex>
-    </BaseLayout>
+    </Flex>
   )
 }
 

--- a/src/components/Employee/Dashboard/DocumentsView.tsx
+++ b/src/components/Employee/Dashboard/DocumentsView.tsx
@@ -1,13 +1,40 @@
 import { useTranslation } from 'react-i18next'
 import type { Form } from '@gusto/embedded-api/models/components/form'
+import { useEmployeeForms } from './hooks'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { DataView, useDataView, EmptyData, Loading } from '@/components/Common'
+import { BaseLayout } from '@/components/Base/Base'
 
 export interface DocumentsViewProps {
   forms?: Form[]
   isLoading?: boolean
   onViewForm?: (formUuid: string) => void
+}
+
+export interface DocumentsViewWithDataProps {
+  employeeId: string
+  onViewForm?: (formUuid: string) => void
+}
+
+/**
+ * Tab-mounted container for the Documents tab. Owns the
+ * `useEmployeeForms` fetch so the request only fires when the user
+ * actually opens this tab (or whatever the parent chooses to mount).
+ * The presentational `DocumentsView` stays pure for testing/stories.
+ */
+export function DocumentsViewWithData({ employeeId, onViewForm }: DocumentsViewWithDataProps) {
+  const forms = useEmployeeForms({ employeeId })
+
+  if (forms.isLoading) {
+    return <BaseLayout isLoading error={forms.errorHandling.errors} />
+  }
+
+  return (
+    <BaseLayout error={forms.errorHandling.errors}>
+      <DocumentsView forms={forms.data.formList} onViewForm={onViewForm} />
+    </BaseLayout>
+  )
 }
 
 export function DocumentsView({ forms = [], isLoading = false, onViewForm }: DocumentsViewProps) {

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -1,20 +1,24 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useGustoEmbeddedContext } from '@gusto/embedded-api/react-query/_context'
+import { payrollsGetPayStub } from '@gusto/embedded-api/funcs/payrollsGetPayStub'
+import { useErrorBoundary } from 'react-error-boundary'
 import { useJobsAndCompensationsDeleteMutation } from '@gusto/embedded-api/react-query/jobsAndCompensationsDelete'
 import type { Job } from '@gusto/embedded-api/models/components/job'
 import type { EmployeeBankAccount } from '@gusto/embedded-api/models/components/employeebankaccount'
 import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
 import type { GetV1EmployeesEmployeeUuidPayStubsResponse } from '@gusto/embedded-api/models/operations/getv1employeesemployeeuuidpaystubs'
+import { useEmployeeCompensation } from './hooks'
 import type { PendingCompensationChange } from './getPendingCompensationChanges'
 import { usePendingChangeDetailRenderer } from './usePendingChangeDetailRenderer'
 import { PendingChangesReviewModal } from './PendingChangesReviewModal'
-import type { PaginationControlProps } from '@/components/Common/PaginationControl/PaginationControlTypes'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { DataView, useDataView, EmptyData } from '@/components/Common'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import { BaseLayout } from '@/components/Base/Base'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
+import { readableStreamToBlob } from '@/helpers/readableStreamToBlob'
 import { formatDateLongWithYear } from '@/helpers/dateFormatting'
 import { useFormatCompensationRate } from '@/helpers/formattedStrings'
 import useNumberFormatter from '@/hooks/useNumberFormatter'
@@ -50,46 +54,22 @@ function parseJobRate(rate: Job['rate']): number | null {
 
 export interface JobAndPayViewProps {
   employeeId: string
-  jobs?: Job[]
-  primaryFlsaStatus?: string
-  pendingChanges?: PendingCompensationChange[]
-  hasMultipleJobs?: boolean
-  employeeFirstName?: string | null
-  cancellingCompensationUuid?: string | null
-  payStubs?: EmployeePayStub[]
-  payStubsPagination?: PaginationControlProps
-  isLoading?: boolean
   onEvent: OnEventType<EventType, unknown>
   onEditCompensation?: (job: Job) => void
   onAddJob?: () => void
   onAddAnotherJob?: () => void
-  onCancelChange?: (pendingChange: PendingCompensationChange) => void
   onAddDeduction?: () => void
   onEditDeduction?: (deduction: Garnishment) => void
-  onPaystubDownload?: (payrollUuid: string) => void
-  downloadingPayrollUuids?: ReadonlySet<string>
 }
 
 export function JobAndPayView({
   employeeId,
-  jobs = [],
-  primaryFlsaStatus,
-  pendingChanges = [],
-  hasMultipleJobs: hasMultipleJobsProp,
-  employeeFirstName,
-  cancellingCompensationUuid = null,
-  payStubs = [],
-  payStubsPagination,
-  isLoading = false,
   onEvent,
   onEditCompensation,
   onAddJob,
   onAddAnotherJob,
-  onCancelChange,
   onAddDeduction,
   onEditDeduction,
-  onPaystubDownload,
-  downloadingPayrollUuids,
 }: JobAndPayViewProps) {
   useI18n('Employee.PaymentMethod')
   useI18n('Employee.Compensation')
@@ -102,6 +82,100 @@ export function JobAndPayView({
   const formatCompensationRate = useFormatCompensationRate()
   const formatCurrency = useNumberFormatter('currency')
   const formatPercent = useNumberFormatter('percent')
+  const gustoEmbedded = useGustoEmbeddedContext()
+  const { showBoundary } = useErrorBoundary()
+
+  const compensation = useEmployeeCompensation({ employeeId })
+  const jobs = compensation.isLoading ? [] : compensation.data.jobs
+  const primaryFlsaStatus = compensation.isLoading ? undefined : compensation.data.primaryFlsaStatus
+  const pendingChanges = compensation.isLoading ? [] : compensation.data.pendingChanges
+  const hasMultipleJobsFromHook = compensation.isLoading ? false : compensation.data.hasMultipleJobs
+  const payStubs = compensation.isLoading ? [] : compensation.data.payStubs
+  const payStubsPagination = compensation.isLoading ? undefined : compensation.pagination.payStubs
+  const cancellingCompensationUuid = compensation.isLoading
+    ? null
+    : compensation.status.cancellingCompensationUuid
+  const cancelPendingChange = compensation.isLoading
+    ? undefined
+    : compensation.actions.cancelPendingChange
+  const employeeFirstName = compensation.isLoading ? undefined : compensation.data.employeeFirstName
+
+  const handleCancelChange = useCallback(
+    async (pendingChange: PendingCompensationChange) => {
+      if (!cancelPendingChange) return
+      const result = await cancelPendingChange(pendingChange)
+      if (result) {
+        onEvent(componentEvents.EMPLOYEE_COMPENSATION_CHANGE_CANCELLED, {
+          employeeId,
+          compensationId: pendingChange.compensationUuid,
+        })
+      }
+    },
+    [cancelPendingChange, onEvent, employeeId],
+  )
+
+  const [downloadingPayrollUuids, setDownloadingPayrollUuids] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  )
+
+  const handlePaystubDownload = useCallback(
+    async (payrollUuid: string) => {
+      const newWindow = window.open('', '_blank')
+      const loadingMessage = t('jobAndPay.paystubs.downloadLoadingMessage')
+      if (newWindow) {
+        // Avoid the user staring at about:blank while we fetch the PDF. The
+        // navigation to the Blob URL below replaces this document.
+        const doc = newWindow.document
+        doc.title = loadingMessage
+        const style = doc.createElement('style')
+        style.textContent =
+          'body{font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;' +
+          'justify-content:center;height:100vh;margin:0;color:#444;gap:12px}' +
+          '.spinner{width:20px;height:20px;border:2px solid #ccc;border-top-color:#444;' +
+          'border-radius:50%;animation:spin .8s linear infinite}' +
+          '@keyframes spin{to{transform:rotate(360deg)}}'
+        doc.head.appendChild(style)
+        const spinner = doc.createElement('div')
+        spinner.className = 'spinner'
+        spinner.setAttribute('aria-hidden', 'true')
+        const label = doc.createElement('span')
+        label.textContent = loadingMessage
+        doc.body.replaceChildren(spinner, label)
+      }
+      setDownloadingPayrollUuids(prev => {
+        const next = new Set(prev)
+        next.add(payrollUuid)
+        return next
+      })
+      try {
+        const response = await payrollsGetPayStub(gustoEmbedded, {
+          payrollId: payrollUuid,
+          employeeId,
+        })
+        if (!response.value?.responseStream) {
+          throw new Error(t('jobAndPay.paystubs.downloadError'))
+        }
+        const pdfBlob = await readableStreamToBlob(response.value.responseStream, 'application/pdf')
+        const url = URL.createObjectURL(pdfBlob)
+        if (newWindow) {
+          newWindow.location.href = url
+        }
+        URL.revokeObjectURL(url)
+      } catch (err) {
+        if (newWindow) {
+          newWindow.close()
+        }
+        showBoundary(err instanceof Error ? err : new Error(String(err)))
+      } finally {
+        setDownloadingPayrollUuids(prev => {
+          const next = new Set(prev)
+          next.delete(payrollUuid)
+          return next
+        })
+      }
+    },
+    [gustoEmbedded, employeeId, t, showBoundary],
+  )
 
   const [pendingDeleteJob, setPendingDeleteJob] = useState<{
     uuid: string
@@ -120,7 +194,7 @@ export function JobAndPayView({
   }
 
   const singleJob = jobs.length === 1 ? jobs[0]! : undefined
-  const hasMultipleJobs = hasMultipleJobsProp ?? jobs.length > 1
+  const hasMultipleJobs = hasMultipleJobsFromHook
   const canAddAnotherJob = jobs.length >= 1 && primaryFlsaStatus === FlsaStatus.NONEXEMPT
   const singleJobNumericRate = singleJob ? parseJobRate(singleJob.rate) : null
 
@@ -168,9 +242,10 @@ export function JobAndPayView({
     }
   })
 
-  // Both hooks own a submit error state; merge into one error surface so
-  // the BaseLayout below shows whatever failed.
-  const errorHandling = composeErrorHandler([paymentMethodList, deductionsList])
+  // All three hooks own their own error state; merge into one error
+  // surface so the BaseLayout below shows whatever failed (read errors
+  // from the queries, submit errors from delete/cancel actions).
+  const errorHandling = composeErrorHandler([compensation, paymentMethodList, deductionsList])
 
   const jobsColumns = [
     {
@@ -373,7 +448,7 @@ export function JobAndPayView({
     pagination: payStubsPagination,
     itemMenu: payStub => {
       const isDownloading =
-        !!payStub.payrollUuid && !!downloadingPayrollUuids?.has(payStub.payrollUuid)
+        !!payStub.payrollUuid && downloadingPayrollUuids.has(payStub.payrollUuid)
       return (
         <Components.ButtonIcon
           variant="tertiary"
@@ -382,7 +457,7 @@ export function JobAndPayView({
           isLoading={isDownloading}
           onClick={() => {
             if (payStub.payrollUuid) {
-              onPaystubDownload?.(payStub.payrollUuid)
+              void handlePaystubDownload(payStub.payrollUuid)
             }
           }}
         >
@@ -398,7 +473,7 @@ export function JobAndPayView({
     ),
   })
 
-  if (isLoading || paymentMethodList.isLoading || deductionsList.isLoading) {
+  if (compensation.isLoading || paymentMethodList.isLoading || deductionsList.isLoading) {
     return <BaseLayout isLoading error={errorHandling.errors} />
   }
 
@@ -471,7 +546,7 @@ export function JobAndPayView({
                       variant="secondary"
                       isLoading={cancellingCompensationUuid === nextChange.compensationUuid}
                       onClick={() => {
-                        onCancelChange?.(nextChange)
+                        void handleCancelChange(nextChange)
                       }}
                     >
                       {t('jobAndPay.compensation.pendingChange.cancelCta')}
@@ -650,7 +725,7 @@ export function JobAndPayView({
             setIsReviewOpen(false)
           }}
           onCancelChange={change => {
-            onCancelChange?.(change)
+            void handleCancelChange(change)
           }}
         />
 

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -120,7 +120,7 @@ export function JobAndPayView({
 
   const handlePaystubDownload = useCallback(
     async (payrollUuid: string) => {
-      const newWindow = window.open('', '_blank')
+      const newWindow = window.open('', '_blank', 'noopener,noreferrer')
       const loadingMessage = t('jobAndPay.paystubs.downloadLoadingMessage')
       if (newWindow) {
         // Avoid the user staring at about:blank while we fetch the PDF. The

--- a/src/components/Employee/Dashboard/TaxesView.tsx
+++ b/src/components/Employee/Dashboard/TaxesView.tsx
@@ -2,9 +2,11 @@ import { useTranslation } from 'react-i18next'
 import type { GetV1EmployeesEmployeeIdFederalTaxesResponse } from '@gusto/embedded-api/models/operations/getv1employeesemployeeidfederaltaxes'
 import type { GetV1EmployeesEmployeeIdStateTaxesResponse } from '@gusto/embedded-api/models/operations/getv1employeesemployeeidstatetaxes'
 import type { EmployeeStateTaxQuestion } from '@gusto/embedded-api/models/components/employeestatetaxquestion'
+import { useEmployeeTaxes } from './hooks'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { Loading } from '@/components/Common'
+import { BaseLayout } from '@/components/Base/Base'
 import useNumberFormatter from '@/hooks/useNumberFormatter'
 
 type EmployeeFederalTax = NonNullable<
@@ -20,6 +22,43 @@ export interface TaxesViewProps {
   isLoading?: boolean
   onEditFederalTaxes?: () => void
   onEditStateTaxes?: () => void
+}
+
+export interface TaxesViewWithDataProps {
+  employeeId: string
+  /** Receives the federal-tax record so the parent can preserve the
+   *  existing event payload (`{ employeeId, federalTaxes }`). */
+  onEditFederalTaxes?: (federalTaxes: EmployeeFederalTax | undefined) => void
+  onEditStateTaxes?: () => void
+}
+
+/**
+ * Tab-mounted container for the Taxes tab. Owns the `useEmployeeTaxes`
+ * fetch so federal/state tax requests only fire when the tab is mounted.
+ * The presentational `TaxesView` stays pure for testing/stories.
+ */
+export function TaxesViewWithData({
+  employeeId,
+  onEditFederalTaxes,
+  onEditStateTaxes,
+}: TaxesViewWithDataProps) {
+  const taxes = useEmployeeTaxes({ employeeId })
+
+  if (taxes.isLoading) {
+    return <BaseLayout isLoading error={taxes.errorHandling.errors} />
+  }
+
+  const federalTaxes = taxes.data.employeeFederalTax
+  return (
+    <BaseLayout error={taxes.errorHandling.errors}>
+      <TaxesView
+        federalTaxes={federalTaxes}
+        stateTaxes={taxes.data.employeeStateTaxesList}
+        onEditFederalTaxes={() => onEditFederalTaxes?.(federalTaxes)}
+        onEditStateTaxes={onEditStateTaxes}
+      />
+    </BaseLayout>
+  )
 }
 
 export function TaxesView({

--- a/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
@@ -31,6 +31,10 @@ interface UseEmployeeCompensationReady extends BaseHookReady<
     hasMultipleJobs: boolean
     pendingChanges: PendingCompensationChange[]
     payStubs: EmployeePayStub[]
+    /** First name from the shared employee fetch; useful for cosmetic copy
+     *  in alerts (e.g. "Heads up, Jane has pending changes"). Optional
+     *  because the employee record can omit it. */
+    employeeFirstName?: string
   },
   { isPending: boolean; cancellingCompensationUuid: string | null }
 > {
@@ -135,6 +139,7 @@ export function useEmployeeCompensation({
       hasMultipleJobs,
       pendingChanges,
       payStubs,
+      employeeFirstName: employee?.firstName ?? undefined,
     },
     status: {
       isPending,


### PR DESCRIPTION
## Summary

Employee Dashboard fired every tab's data fetches on mount (Suspense), blocking render until the slowest of 7+ requests resolved. A user who only opened Basic Details still paid for taxes, forms, paystubs, and garnishments bandwidth.

This makes data fetching lazy per tab — each tab's data hook only mounts when its tab is selected, wrapped in its own `<Suspense>` boundary so tabs paint independently.

## Changes

- Each tab now owns its data. `BasicDetailsView`, `TaxesView`, and `DocumentsView` get a co-located `…WithData` container that calls the corresponding hook; presentational views stay pure so existing tests/stories keep passing props.
- `JobAndPayView` (already monolithic) absorbs `useEmployeeCompensation`, the paystub download, and the cancel-pending-change handler that used to live in `Dashboard.tsx`. Compensation errors join the local `composeErrorHandler`.
- `Dashboard.tsx` drops the four data hooks and the all-or-nothing loading gate; each tab mounts inside its own `<Suspense fallback={<BaseLayout isLoading />}>` (323 → 178 lines).
- `useEmployeeCompensation` exposes `employeeFirstName` (free off the shared employee query) so JobAndPayView no longer needs it threaded as a prop.

The `EMPLOYEE_FEDERAL_TAXES_EDIT` event payload (`{ employeeId, federalTaxes }`) is preserved — the federal-tax record is threaded through the `onEditFederalTaxes` callback so the public event contract is unchanged.

## Testing

Verified via Playwright against `/employee/DashboardFlow` (gws-flows local):

| Tab                   | Fires when           |
|-----------------------|----------------------|
| Basic details (mount) | `employee?include=all_compensations`, `home_addresses`, `work_addresses` |
| Job and pay (click)   | `pay_stubs`, `payment_method`, `bank_accounts`, `garnishments` |
| Taxes (click)         | `federal_taxes`, `state_taxes` |
| Documents (click)     | `forms` |

**3 requests on first paint instead of 7+.**

Commands run, all green:
- \`npx tsc --noEmit\`
- \`npm run lint\` — 0 errors (25 pre-existing warnings in unrelated files)
- \`npm run test -- --run src/components/Employee/Dashboard src/components/Employee/Deductions src/components/Employee/PaymentMethod\` — **170/170 pass**