### PR TITLE
perf(Dashboard): non-Suspense queries + per-section skeletons

### DIFF
--- a/src/components/Employee/Dashboard/BasicDetailsView.tsx
+++ b/src/components/Employee/Dashboard/BasicDetailsView.tsx
@@ -92,7 +92,11 @@ export function BasicDetailsView({
           <Components.BoxHeader
             title={t('basicDetails.title')}
             action={
-              <Components.Button variant="secondary" onClick={onEditBasicDetails}>
+              <Components.Button
+                variant="secondary"
+                onClick={onEditBasicDetails}
+                isDisabled={isEmployeeLoading}
+              >
                 {t('basicDetails.editCta')}
               </Components.Button>
             }
@@ -100,9 +104,9 @@ export function BasicDetailsView({
         }
       >
         <Flex flexDirection="column" gap={16}>
-          {isEmployeeLoading || !employee ? (
+          {isEmployeeLoading ? (
             <Loading />
-          ) : (
+          ) : employee ? (
             <Flex flexDirection="column" gap={12}>
               {legalName && (
                 <Flex flexDirection="column" gap={0}>
@@ -149,7 +153,7 @@ export function BasicDetailsView({
                 </Flex>
               )}
             </Flex>
-          )}
+          ) : null}
         </Flex>
       </Components.Box>
 
@@ -158,7 +162,11 @@ export function BasicDetailsView({
           <Components.BoxHeader
             title={t('homeAddress.title')}
             action={
-              <Components.Button variant="secondary" onClick={onManageHomeAddress}>
+              <Components.Button
+                variant="secondary"
+                onClick={onManageHomeAddress}
+                isDisabled={isHomeAddressLoading}
+              >
                 {t('homeAddress.manageCta')}
               </Components.Button>
             }
@@ -187,7 +195,11 @@ export function BasicDetailsView({
           <Components.BoxHeader
             title={t('workAddress.title')}
             action={
-              <Components.Button variant="secondary" onClick={onManageWorkAddress}>
+              <Components.Button
+                variant="secondary"
+                onClick={onManageWorkAddress}
+                isDisabled={isWorkAddressLoading}
+              >
                 {t('workAddress.manageCta')}
               </Components.Button>
             }

--- a/src/components/Employee/Dashboard/BasicDetailsView.tsx
+++ b/src/components/Employee/Dashboard/BasicDetailsView.tsx
@@ -14,7 +14,12 @@ export interface BasicDetailsViewProps {
   employee?: Employee
   currentHomeAddress?: EmployeeAddress
   currentWorkAddress?: EmployeeWorkAddress
+  /** Loads all three cards. Per-section flags below take precedence
+   *  when each query resolves independently. */
   isLoading?: boolean
+  isEmployeeLoading?: boolean
+  isHomeAddressLoading?: boolean
+  isWorkAddressLoading?: boolean
   onEditBasicDetails?: () => void
   onManageHomeAddress?: () => void
   onManageWorkAddress?: () => void
@@ -30,8 +35,8 @@ export interface BasicDetailsViewWithDataProps {
 /**
  * Tab-mounted container for the Basic details tab. Owns the
  * `useEmployeeBasicDetails` fetch (employee + home address + work address)
- * so the requests only fire when the tab is mounted. The presentational
- * `BasicDetailsView` stays pure for testing/stories.
+ * so the requests only fire when the tab is mounted. Each card paints
+ * its own skeleton + content as the underlying query resolves.
  */
 export function BasicDetailsViewWithData({
   employeeId,
@@ -41,16 +46,15 @@ export function BasicDetailsViewWithData({
 }: BasicDetailsViewWithDataProps) {
   const basicDetails = useEmployeeBasicDetails({ employeeId })
 
-  if (basicDetails.isLoading) {
-    return <BaseLayout isLoading error={basicDetails.errorHandling.errors} />
-  }
-
   return (
     <BaseLayout error={basicDetails.errorHandling.errors}>
       <BasicDetailsView
         employee={basicDetails.data.employee}
         currentHomeAddress={basicDetails.data.currentHomeAddress}
         currentWorkAddress={basicDetails.data.currentWorkAddress}
+        isEmployeeLoading={basicDetails.status.isEmployeeLoading}
+        isHomeAddressLoading={basicDetails.status.isHomeAddressLoading}
+        isWorkAddressLoading={basicDetails.status.isWorkAddressLoading}
         onEditBasicDetails={onEditBasicDetails}
         onManageHomeAddress={onManageHomeAddress}
         onManageWorkAddress={onManageWorkAddress}
@@ -64,6 +68,9 @@ export function BasicDetailsView({
   currentHomeAddress,
   currentWorkAddress,
   isLoading = false,
+  isEmployeeLoading = isLoading,
+  isHomeAddressLoading = isLoading,
+  isWorkAddressLoading = isLoading,
   onEditBasicDetails,
   onManageHomeAddress,
   onManageWorkAddress,
@@ -71,17 +78,12 @@ export function BasicDetailsView({
   const { t } = useTranslation('Employee.Dashboard')
   const Components = useComponentContext()
 
-  if (isLoading || !employee) {
-    return <Loading />
-  }
-
-  const legalName = firstLastName({
-    first_name: employee.firstName,
-    last_name: employee.lastName,
-  })
-  const startDate = formatDateLongWithYear(employee.jobs?.[0]?.hireDate)
-  const dateOfBirth = formatDateLongWithYear(employee.dateOfBirth)
-  const maskedSsn = employee.hasSsn ? 'XXX-XX-XXXX' : undefined
+  const legalName = employee
+    ? firstLastName({ first_name: employee.firstName, last_name: employee.lastName })
+    : undefined
+  const startDate = employee ? formatDateLongWithYear(employee.jobs?.[0]?.hireDate) : undefined
+  const dateOfBirth = employee ? formatDateLongWithYear(employee.dateOfBirth) : undefined
+  const maskedSsn = employee?.hasSsn ? 'XXX-XX-XXXX' : undefined
 
   return (
     <Flex flexDirection="column" gap={24}>
@@ -98,52 +100,56 @@ export function BasicDetailsView({
         }
       >
         <Flex flexDirection="column" gap={16}>
-          <Flex flexDirection="column" gap={12}>
-            {legalName && (
-              <Flex flexDirection="column" gap={0}>
-                <Components.Text variant="supporting">
-                  {t('basicDetails.legalName')}
-                </Components.Text>
-                <Components.Text>{legalName}</Components.Text>
-              </Flex>
-            )}
+          {isEmployeeLoading || !employee ? (
+            <Loading />
+          ) : (
+            <Flex flexDirection="column" gap={12}>
+              {legalName && (
+                <Flex flexDirection="column" gap={0}>
+                  <Components.Text variant="supporting">
+                    {t('basicDetails.legalName')}
+                  </Components.Text>
+                  <Components.Text>{legalName}</Components.Text>
+                </Flex>
+              )}
 
-            {startDate && (
-              <Flex flexDirection="column" gap={0}>
-                <Components.Text variant="supporting">
-                  {t('basicDetails.startDate')}
-                </Components.Text>
-                <Components.Text>{startDate}</Components.Text>
-              </Flex>
-            )}
+              {startDate && (
+                <Flex flexDirection="column" gap={0}>
+                  <Components.Text variant="supporting">
+                    {t('basicDetails.startDate')}
+                  </Components.Text>
+                  <Components.Text>{startDate}</Components.Text>
+                </Flex>
+              )}
 
-            {maskedSsn && (
-              <Flex flexDirection="column" gap={0}>
-                <Components.Text variant="supporting">
-                  {t('basicDetails.socialSecurityNumber')}
-                </Components.Text>
-                <Components.Text>{maskedSsn}</Components.Text>
-              </Flex>
-            )}
+              {maskedSsn && (
+                <Flex flexDirection="column" gap={0}>
+                  <Components.Text variant="supporting">
+                    {t('basicDetails.socialSecurityNumber')}
+                  </Components.Text>
+                  <Components.Text>{maskedSsn}</Components.Text>
+                </Flex>
+              )}
 
-            {dateOfBirth && (
-              <Flex flexDirection="column" gap={0}>
-                <Components.Text variant="supporting">
-                  {t('basicDetails.dateOfBirth')}
-                </Components.Text>
-                <Components.Text>{dateOfBirth}</Components.Text>
-              </Flex>
-            )}
+              {dateOfBirth && (
+                <Flex flexDirection="column" gap={0}>
+                  <Components.Text variant="supporting">
+                    {t('basicDetails.dateOfBirth')}
+                  </Components.Text>
+                  <Components.Text>{dateOfBirth}</Components.Text>
+                </Flex>
+              )}
 
-            {employee.email && (
-              <Flex flexDirection="column" gap={0}>
-                <Components.Text variant="supporting">
-                  {t('basicDetails.personalEmail')}
-                </Components.Text>
-                <Components.Text>{employee.email}</Components.Text>
-              </Flex>
-            )}
-          </Flex>
+              {employee.email && (
+                <Flex flexDirection="column" gap={0}>
+                  <Components.Text variant="supporting">
+                    {t('basicDetails.personalEmail')}
+                  </Components.Text>
+                  <Components.Text>{employee.email}</Components.Text>
+                </Flex>
+              )}
+            </Flex>
+          )}
         </Flex>
       </Components.Box>
 
@@ -160,7 +166,9 @@ export function BasicDetailsView({
         }
       >
         <Flex flexDirection="column" gap={16}>
-          {currentHomeAddress ? (
+          {isHomeAddressLoading ? (
+            <Loading />
+          ) : currentHomeAddress ? (
             <Flex flexDirection="column" gap={0}>
               <Components.Text variant="supporting">
                 {t('homeAddress.currentAddress')}
@@ -187,7 +195,9 @@ export function BasicDetailsView({
         }
       >
         <Flex flexDirection="column" gap={16}>
-          {currentWorkAddress ? (
+          {isWorkAddressLoading ? (
+            <Loading />
+          ) : currentWorkAddress ? (
             <Flex flexDirection="column" gap={0}>
               <Components.Text variant="supporting">
                 {t('workAddress.currentAddress')}

--- a/src/components/Employee/Dashboard/Dashboard.test.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.test.tsx
@@ -270,11 +270,10 @@ describe('Dashboard', () => {
 
     await user.click(screen.getByRole('tab', { name: 'Job and pay' }))
 
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Compensation' })).toBeInTheDocument()
-    })
-
-    expect(screen.getByText('No compensation')).toBeInTheDocument()
+    // BasicDetails and Compensation use different employeesGet query
+    // keys now (the include differs), so Compensation does its own
+    // fetch — wait for the empty-state copy rather than just the header.
+    expect(await screen.findByText('No compensation')).toBeInTheDocument()
     expect(screen.getByText('Compensation will appear here once added')).toBeInTheDocument()
 
     const addJobButton = screen.getByRole('button', { name: 'Add job' })
@@ -786,8 +785,10 @@ describe('Dashboard', () => {
     it('cancel-change: fires DELETE with the right path, refetches, emits the event', async () => {
       const user = userEvent.setup()
       let deletePath: string | null = null
+      let wasDeleteCalled = false
       const deleteResolver = vi.fn<HttpResponseResolver>(({ request }) => {
         deletePath = new URL(request.url).pathname
+        wasDeleteCalled = true
         return new HttpResponse(null, { status: 204 })
       })
 
@@ -801,12 +802,15 @@ describe('Dashboard', () => {
       ])
       const employeeAfter = await buildEmployeeWithJobs([baseJob({}, [baseComp()])])
 
-      let getCallCount = 0
+      // Return employeeBefore until the DELETE fires, then employeeAfter.
+      // BasicDetails and Compensation now use different employeesGet
+      // query keys (the include differs), so each tab fetches the
+      // employee independently — a count-based handler would diverge
+      // between tabs.
       server.use(
-        handleGetEmployee(() => {
-          getCallCount += 1
-          return HttpResponse.json(getCallCount === 1 ? employeeBefore : employeeAfter)
-        }),
+        handleGetEmployee(() =>
+          HttpResponse.json(wasDeleteCalled ? employeeAfter : employeeBefore),
+        ),
       )
       server.use(handleDeleteCompensation(deleteResolver))
 
@@ -968,9 +972,11 @@ describe('Dashboard', () => {
 
     it('confirms cancel from inside the review modal and only removes the cancelled change', async () => {
       const user = userEvent.setup()
-      const deleteResolver = vi.fn<HttpResponseResolver>(
-        () => new HttpResponse(null, { status: 204 }),
-      )
+      let wasDeleteCalled = false
+      const deleteResolver = vi.fn<HttpResponseResolver>(() => {
+        wasDeleteCalled = true
+        return new HttpResponse(null, { status: 204 })
+      })
 
       const futurePrimary = baseComp({
         uuid: 'comp-primary-future',
@@ -1032,12 +1038,14 @@ describe('Dashboard', () => {
         ),
       ])
 
-      let getCallCount = 0
+      // Return employeeBefore until the DELETE fires, then employeeAfter.
+      // BasicDetails and Compensation use different employeesGet query
+      // keys (the include differs), so a count-based handler would
+      // diverge between tabs.
       server.use(
-        handleGetEmployee(() => {
-          getCallCount += 1
-          return HttpResponse.json(getCallCount === 1 ? employeeBefore : employeeAfter)
-        }),
+        handleGetEmployee(() =>
+          HttpResponse.json(wasDeleteCalled ? employeeAfter : employeeBefore),
+        ),
       )
       server.use(handleDeleteCompensation(deleteResolver))
 

--- a/src/components/Employee/Dashboard/DocumentsView.tsx
+++ b/src/components/Employee/Dashboard/DocumentsView.tsx
@@ -26,13 +26,13 @@ export interface DocumentsViewWithDataProps {
 export function DocumentsViewWithData({ employeeId, onViewForm }: DocumentsViewWithDataProps) {
   const forms = useEmployeeForms({ employeeId })
 
-  if (forms.isLoading) {
-    return <BaseLayout isLoading error={forms.errorHandling.errors} />
-  }
-
   return (
     <BaseLayout error={forms.errorHandling.errors}>
-      <DocumentsView forms={forms.data.formList} onViewForm={onViewForm} />
+      <DocumentsView
+        forms={forms.data.formList}
+        isLoading={forms.status.isFormsLoading}
+        onViewForm={onViewForm}
+      />
     </BaseLayout>
   )
 }
@@ -99,15 +99,15 @@ export function DocumentsView({ forms = [], isLoading = false, onViewForm }: Doc
     ),
   })
 
-  if (isLoading) {
-    return <Loading />
-  }
-
   return (
     <Flex flexDirection="column" gap={24}>
       <Components.Box header={<Components.BoxHeader title={t('documents.title')} />}>
         <Flex flexDirection="column" gap={16}>
-          <DataView label={t('documents.listLabel')} {...formsDataView} />
+          {isLoading ? (
+            <Loading />
+          ) : (
+            <DataView label={t('documents.listLabel')} {...formsDataView} />
+          )}
         </Flex>
       </Components.Box>
     </Flex>

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -472,8 +472,15 @@ export function JobAndPayView({
     ),
   })
 
-  const isPaymentMethodLoading = paymentMethodList.isLoading
-  const isDeductionsLoading = deductionsList.isLoading
+  // `usePaymentMethodList` and `useDeductionsList` still use the older
+  // `HookLoadingResult | Ready` shape, which returns `isLoading: true`
+  // when the query has errored AND data is missing. Treat those rows
+  // as "not loading" so the section doesn't show a perpetual skeleton
+  // while BaseLayout already renders the error alert above.
+  const isPaymentMethodLoading =
+    paymentMethodList.isLoading && paymentMethodList.errorHandling.errors.length === 0
+  const isDeductionsLoading =
+    deductionsList.isLoading && deductionsList.errorHandling.errors.length === 0
   const isDirectDeposit = paymentMethod?.type === PAYMENT_METHODS.directDeposit
 
   return (
@@ -485,7 +492,11 @@ export function JobAndPayView({
             <Components.BoxHeader
               title={t('jobAndPay.compensation.title')}
               action={
-                hasMultipleJobs ? null : singleJob ? (
+                // While the compensation card is loading we don't yet
+                // know if the employee has jobs — suppress the action
+                // so we don't surface an "Add job" CTA against an
+                // employee who already has one.
+                isCompensationCardLoading ? null : hasMultipleJobs ? null : singleJob ? (
                   <Components.Button
                     variant="secondary"
                     onClick={() => {
@@ -507,7 +518,7 @@ export function JobAndPayView({
             />
           }
           footer={
-            canAddAnotherJob ? (
+            !isCompensationCardLoading && canAddAnotherJob ? (
               <Components.Button
                 variant="secondary"
                 onClick={onAddAnotherJob}

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -14,7 +14,7 @@ import { usePendingChangeDetailRenderer } from './usePendingChangeDetailRenderer
 import { PendingChangesReviewModal } from './PendingChangesReviewModal'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
-import { DataView, useDataView, EmptyData } from '@/components/Common'
+import { DataView, useDataView, EmptyData, Loading } from '@/components/Common'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import { BaseLayout } from '@/components/Base/Base'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
@@ -86,23 +86,22 @@ export function JobAndPayView({
   const { showBoundary } = useErrorBoundary()
 
   const compensation = useEmployeeCompensation({ employeeId })
-  const jobs = compensation.isLoading ? [] : compensation.data.jobs
-  const primaryFlsaStatus = compensation.isLoading ? undefined : compensation.data.primaryFlsaStatus
-  const pendingChanges = compensation.isLoading ? [] : compensation.data.pendingChanges
-  const hasMultipleJobsFromHook = compensation.isLoading ? false : compensation.data.hasMultipleJobs
-  const payStubs = compensation.isLoading ? [] : compensation.data.payStubs
-  const payStubsPagination = compensation.isLoading ? undefined : compensation.pagination.payStubs
-  const cancellingCompensationUuid = compensation.isLoading
-    ? null
-    : compensation.status.cancellingCompensationUuid
-  const cancelPendingChange = compensation.isLoading
-    ? undefined
-    : compensation.actions.cancelPendingChange
-  const employeeFirstName = compensation.isLoading ? undefined : compensation.data.employeeFirstName
+  const {
+    jobs,
+    primaryFlsaStatus,
+    pendingChanges,
+    hasMultipleJobs: hasMultipleJobsFromHook,
+    payStubs,
+    employeeFirstName,
+  } = compensation.data
+  const payStubsPagination = compensation.pagination.payStubs
+  const cancellingCompensationUuid = compensation.status.cancellingCompensationUuid
+  const { cancelPendingChange } = compensation.actions
+  const isCompensationCardLoading = compensation.status.isEmployeeLoading
+  const isPayStubsLoading = compensation.status.isPayStubsLoading
 
   const handleCancelChange = useCallback(
     async (pendingChange: PendingCompensationChange) => {
-      if (!cancelPendingChange) return
       const result = await cancelPendingChange(pendingChange)
       if (result) {
         onEvent(componentEvents.EMPLOYEE_COMPENSATION_CHANGE_CANCELLED, {
@@ -473,10 +472,8 @@ export function JobAndPayView({
     ),
   })
 
-  if (compensation.isLoading || paymentMethodList.isLoading || deductionsList.isLoading) {
-    return <BaseLayout isLoading error={errorHandling.errors} />
-  }
-
+  const isPaymentMethodLoading = paymentMethodList.isLoading
+  const isDeductionsLoading = deductionsList.isLoading
   const isDirectDeposit = paymentMethod?.type === PAYMENT_METHODS.directDeposit
 
   return (
@@ -521,118 +518,124 @@ export function JobAndPayView({
             ) : undefined
           }
         >
-          <Flex flexDirection="column" gap={16}>
-            {showInlineAlert && nextChange && (
-              <Components.Alert
-                status="warning"
-                disableScrollIntoView
-                label={
-                  hasMultipleJobs
-                    ? t('jobAndPay.compensation.pendingChange.alertLabelWithJob', {
-                        jobTitle: nextChange.jobTitle,
-                        date: formatDateLongWithYear(nextChange.effectiveDate),
-                      })
-                    : t('jobAndPay.compensation.pendingChange.alertLabel', {
-                        date: formatDateLongWithYear(nextChange.effectiveDate),
-                      })
-                }
-              >
-                <Flex flexDirection="column" gap={12}>
-                  <Components.UnorderedList
-                    items={nextChange.details.map(detail => renderDetail(detail))}
-                  />
-                  <div>
+          {isCompensationCardLoading ? (
+            <Loading />
+          ) : (
+            <Flex flexDirection="column" gap={16}>
+              {showInlineAlert && nextChange && (
+                <Components.Alert
+                  status="warning"
+                  disableScrollIntoView
+                  label={
+                    hasMultipleJobs
+                      ? t('jobAndPay.compensation.pendingChange.alertLabelWithJob', {
+                          jobTitle: nextChange.jobTitle,
+                          date: formatDateLongWithYear(nextChange.effectiveDate),
+                        })
+                      : t('jobAndPay.compensation.pendingChange.alertLabel', {
+                          date: formatDateLongWithYear(nextChange.effectiveDate),
+                        })
+                  }
+                >
+                  <Flex flexDirection="column" gap={12}>
+                    <Components.UnorderedList
+                      items={nextChange.details.map(detail => renderDetail(detail))}
+                    />
+                    <div>
+                      <Components.Button
+                        variant="secondary"
+                        isLoading={cancellingCompensationUuid === nextChange.compensationUuid}
+                        onClick={() => {
+                          void handleCancelChange(nextChange)
+                        }}
+                      >
+                        {t('jobAndPay.compensation.pendingChange.cancelCta')}
+                      </Components.Button>
+                    </div>
+                  </Flex>
+                </Components.Alert>
+              )}
+              {showSummaryAlert && (
+                <Components.Alert
+                  status="warning"
+                  disableScrollIntoView
+                  label={t('jobAndPay.compensation.pendingChange.summaryLabel', {
+                    name: employeeFirstName ?? '',
+                  })}
+                  action={
                     <Components.Button
                       variant="secondary"
-                      isLoading={cancellingCompensationUuid === nextChange.compensationUuid}
                       onClick={() => {
-                        void handleCancelChange(nextChange)
+                        setIsReviewOpen(true)
                       }}
                     >
-                      {t('jobAndPay.compensation.pendingChange.cancelCta')}
+                      {t('jobAndPay.compensation.pendingChange.reviewCta')}
                     </Components.Button>
-                  </div>
+                  }
+                />
+              )}
+              {hasMultipleJobs ? (
+                <DataView
+                  label={t('jobAndPay.compensation.tableLabel')}
+                  isWithinBox
+                  {...jobsDataView}
+                />
+              ) : singleJob ? (
+                <Flex flexDirection="column" gap={12}>
+                  {singleJob.title && (
+                    <Flex flexDirection="column" gap={0}>
+                      <Components.Text variant="supporting">
+                        {t('jobAndPay.compensation.jobTitle')}
+                      </Components.Text>
+                      <Components.Text>{singleJob.title}</Components.Text>
+                    </Flex>
+                  )}
+
+                  {singleJob.paymentUnit && (
+                    <Flex flexDirection="column" gap={0}>
+                      <Components.Text variant="supporting">
+                        {t('jobAndPay.compensation.type')}
+                      </Components.Text>
+                      <Components.Text>
+                        {singleJob.paymentUnit === 'Hour'
+                          ? t('jobAndPay.compensation.types.hourly')
+                          : singleJob.paymentUnit === 'Salary' || singleJob.paymentUnit === 'Year'
+                            ? t('jobAndPay.compensation.types.salary')
+                            : singleJob.paymentUnit}
+                      </Components.Text>
+                    </Flex>
+                  )}
+
+                  {singleJobNumericRate !== null && singleJob.paymentUnit && (
+                    <Flex flexDirection="column" gap={0}>
+                      <Components.Text variant="supporting">
+                        {t('jobAndPay.compensation.wage')}
+                      </Components.Text>
+                      <Components.Text>
+                        {formatCompensationRate(singleJobNumericRate, singleJob.paymentUnit)}
+                      </Components.Text>
+                    </Flex>
+                  )}
+
+                  {singleJob.hireDate && (
+                    <Flex flexDirection="column" gap={0}>
+                      <Components.Text variant="supporting">
+                        {t('jobAndPay.compensation.startDate')}
+                      </Components.Text>
+                      <Components.Text>
+                        {formatDateLongWithYear(singleJob.hireDate)}
+                      </Components.Text>
+                    </Flex>
+                  )}
                 </Flex>
-              </Components.Alert>
-            )}
-            {showSummaryAlert && (
-              <Components.Alert
-                status="warning"
-                disableScrollIntoView
-                label={t('jobAndPay.compensation.pendingChange.summaryLabel', {
-                  name: employeeFirstName ?? '',
-                })}
-                action={
-                  <Components.Button
-                    variant="secondary"
-                    onClick={() => {
-                      setIsReviewOpen(true)
-                    }}
-                  >
-                    {t('jobAndPay.compensation.pendingChange.reviewCta')}
-                  </Components.Button>
-                }
-              />
-            )}
-            {hasMultipleJobs ? (
-              <DataView
-                label={t('jobAndPay.compensation.tableLabel')}
-                isWithinBox
-                {...jobsDataView}
-              />
-            ) : singleJob ? (
-              <Flex flexDirection="column" gap={12}>
-                {singleJob.title && (
-                  <Flex flexDirection="column" gap={0}>
-                    <Components.Text variant="supporting">
-                      {t('jobAndPay.compensation.jobTitle')}
-                    </Components.Text>
-                    <Components.Text>{singleJob.title}</Components.Text>
-                  </Flex>
-                )}
-
-                {singleJob.paymentUnit && (
-                  <Flex flexDirection="column" gap={0}>
-                    <Components.Text variant="supporting">
-                      {t('jobAndPay.compensation.type')}
-                    </Components.Text>
-                    <Components.Text>
-                      {singleJob.paymentUnit === 'Hour'
-                        ? t('jobAndPay.compensation.types.hourly')
-                        : singleJob.paymentUnit === 'Salary' || singleJob.paymentUnit === 'Year'
-                          ? t('jobAndPay.compensation.types.salary')
-                          : singleJob.paymentUnit}
-                    </Components.Text>
-                  </Flex>
-                )}
-
-                {singleJobNumericRate !== null && singleJob.paymentUnit && (
-                  <Flex flexDirection="column" gap={0}>
-                    <Components.Text variant="supporting">
-                      {t('jobAndPay.compensation.wage')}
-                    </Components.Text>
-                    <Components.Text>
-                      {formatCompensationRate(singleJobNumericRate, singleJob.paymentUnit)}
-                    </Components.Text>
-                  </Flex>
-                )}
-
-                {singleJob.hireDate && (
-                  <Flex flexDirection="column" gap={0}>
-                    <Components.Text variant="supporting">
-                      {t('jobAndPay.compensation.startDate')}
-                    </Components.Text>
-                    <Components.Text>{formatDateLongWithYear(singleJob.hireDate)}</Components.Text>
-                  </Flex>
-                )}
-              </Flex>
-            ) : (
-              <EmptyData
-                title={t('jobAndPay.compensation.emptyState.title')}
-                description={t('jobAndPay.compensation.emptyState.description')}
-              />
-            )}
-          </Flex>
+              ) : (
+                <EmptyData
+                  title={t('jobAndPay.compensation.emptyState.title')}
+                  description={t('jobAndPay.compensation.emptyState.description')}
+                />
+              )}
+            </Flex>
+          )}
         </Components.Box>
 
         <Components.Box
@@ -667,7 +670,9 @@ export function JobAndPayView({
             />
           }
         >
-          {bankAccounts.length === 0 ? (
+          {isPaymentMethodLoading ? (
+            <Loading />
+          ) : bankAccounts.length === 0 ? (
             <Flex flexDirection="column" gap={0}>
               <Components.Text variant="supporting">
                 {tPayment('paymentMethodLabel')}
@@ -702,18 +707,26 @@ export function JobAndPayView({
             />
           }
         >
-          <DataView
-            label={t('jobAndPay.deductions.listLabel')}
-            isWithinBox
-            {...garnishmentsDataView}
-          />
+          {isDeductionsLoading ? (
+            <Loading />
+          ) : (
+            <DataView
+              label={t('jobAndPay.deductions.listLabel')}
+              isWithinBox
+              {...garnishmentsDataView}
+            />
+          )}
         </Components.Box>
 
         <Components.Box
           withPadding={false}
           header={<Components.BoxHeader title={t('jobAndPay.paystubs.title')} />}
         >
-          <DataView label={t('jobAndPay.paystubs.listLabel')} isWithinBox {...payStubsDataView} />
+          {isPayStubsLoading ? (
+            <Loading />
+          ) : (
+            <DataView label={t('jobAndPay.paystubs.listLabel')} isWithinBox {...payStubsDataView} />
+          )}
         </Components.Box>
 
         <PendingChangesReviewModal

--- a/src/components/Employee/Dashboard/TaxesView.tsx
+++ b/src/components/Employee/Dashboard/TaxesView.tsx
@@ -129,7 +129,11 @@ export function TaxesView({
           <Components.BoxHeader
             title={t('taxes.federal.title')}
             action={
-              <Components.Button variant="secondary" onClick={onEditFederalTaxes}>
+              <Components.Button
+                variant="secondary"
+                onClick={onEditFederalTaxes}
+                isDisabled={isFederalTaxesLoading}
+              >
                 {t('taxes.federal.editCta')}
               </Components.Button>
             }
@@ -214,7 +218,11 @@ export function TaxesView({
           <Components.BoxHeader
             title={t('taxes.state.title')}
             action={
-              <Components.Button variant="secondary" onClick={onEditStateTaxes}>
+              <Components.Button
+                variant="secondary"
+                onClick={onEditStateTaxes}
+                isDisabled={isStateTaxesLoading}
+              >
                 {t('taxes.state.editCta')}
               </Components.Button>
             }

--- a/src/components/Employee/Dashboard/TaxesView.tsx
+++ b/src/components/Employee/Dashboard/TaxesView.tsx
@@ -19,7 +19,11 @@ type EmployeeStateTax = NonNullable<
 export interface TaxesViewProps {
   federalTaxes?: EmployeeFederalTax
   stateTaxes?: EmployeeStateTax[]
+  /** Loads both cards. Override per-card via `isFederalTaxesLoading` /
+   *  `isStateTaxesLoading` when the queries resolve independently. */
   isLoading?: boolean
+  isFederalTaxesLoading?: boolean
+  isStateTaxesLoading?: boolean
   onEditFederalTaxes?: () => void
   onEditStateTaxes?: () => void
 }
@@ -35,7 +39,8 @@ export interface TaxesViewWithDataProps {
 /**
  * Tab-mounted container for the Taxes tab. Owns the `useEmployeeTaxes`
  * fetch so federal/state tax requests only fire when the tab is mounted.
- * The presentational `TaxesView` stays pure for testing/stories.
+ * Federal and state queries run independently — each card paints its
+ * own skeleton + content as data arrives.
  */
 export function TaxesViewWithData({
   employeeId,
@@ -44,16 +49,14 @@ export function TaxesViewWithData({
 }: TaxesViewWithDataProps) {
   const taxes = useEmployeeTaxes({ employeeId })
 
-  if (taxes.isLoading) {
-    return <BaseLayout isLoading error={taxes.errorHandling.errors} />
-  }
-
   const federalTaxes = taxes.data.employeeFederalTax
   return (
     <BaseLayout error={taxes.errorHandling.errors}>
       <TaxesView
         federalTaxes={federalTaxes}
         stateTaxes={taxes.data.employeeStateTaxesList}
+        isFederalTaxesLoading={taxes.status.isFederalTaxesLoading}
+        isStateTaxesLoading={taxes.status.isStateTaxesLoading}
         onEditFederalTaxes={() => onEditFederalTaxes?.(federalTaxes)}
         onEditStateTaxes={onEditStateTaxes}
       />
@@ -65,16 +68,14 @@ export function TaxesView({
   federalTaxes,
   stateTaxes,
   isLoading = false,
+  isFederalTaxesLoading = isLoading,
+  isStateTaxesLoading = isLoading,
   onEditFederalTaxes,
   onEditStateTaxes,
 }: TaxesViewProps) {
   const { t } = useTranslation('Employee.Dashboard')
   const Components = useComponentContext()
   const formatCurrency = useNumberFormatter('currency')
-
-  if (isLoading) {
-    return <Loading />
-  }
 
   // Helper function to format state tax answer values
   const formatStateTaxAnswer = (
@@ -136,7 +137,9 @@ export function TaxesView({
         }
       >
         <Flex flexDirection="column" gap={16}>
-          {federalTaxes && (
+          {isFederalTaxesLoading ? (
+            <Loading />
+          ) : federalTaxes ? (
             <Flex flexDirection="column" gap={12}>
               {federalTaxes.filingStatus && (
                 <Flex flexDirection="column" gap={0}>
@@ -202,7 +205,7 @@ export function TaxesView({
                 </Flex>
               )}
             </Flex>
-          )}
+          ) : null}
         </Flex>
       </Components.Box>
 
@@ -219,7 +222,9 @@ export function TaxesView({
         }
       >
         <Flex flexDirection="column" gap={16}>
-          {stateTaxes && stateTaxes.length > 0 ? (
+          {isStateTaxesLoading ? (
+            <Loading />
+          ) : stateTaxes && stateTaxes.length > 0 ? (
             <Flex flexDirection="column" gap={24}>
               {stateTaxes.map((stateTax, index) => (
                 <Flex key={stateTax.state || index} flexDirection="column" gap={16}>

--- a/src/components/Employee/Dashboard/hooks/useEmployeeBasicDetails.test.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeBasicDetails.test.tsx
@@ -1,0 +1,197 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { useEmployeeBasicDetails } from './useEmployeeBasicDetails'
+import { GustoTestProvider } from '@/test/GustoTestApiProvider'
+import { server } from '@/test/mocks/server'
+import { handleGetEmployee } from '@/test/mocks/apis/employees'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { API_BASE_URL } from '@/test/constants'
+
+describe('useEmployeeBasicDetails', () => {
+  beforeEach(() => {
+    setupApiTestMocks()
+  })
+
+  it('starts loading with all three per-query flags true and resolves to populated data', async () => {
+    const { result } = renderHook(() => useEmployeeBasicDetails({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    expect(result.current.status.isEmployeeLoading).toBe(true)
+    expect(result.current.status.isHomeAddressLoading).toBe(true)
+    expect(result.current.status.isWorkAddressLoading).toBe(true)
+    expect(result.current.data.employee).toBeUndefined()
+    expect(result.current.data.currentHomeAddress).toBeUndefined()
+    expect(result.current.data.currentWorkAddress).toBeUndefined()
+
+    await waitFor(() => {
+      expect(result.current.status.isEmployeeLoading).toBe(false)
+      expect(result.current.status.isHomeAddressLoading).toBe(false)
+      expect(result.current.status.isWorkAddressLoading).toBe(false)
+    })
+
+    expect(result.current.data.employee).toMatchObject({
+      firstName: 'Isom',
+      lastName: 'Jaskolski',
+    })
+    expect(result.current.data.currentHomeAddress).toBeDefined()
+    expect(result.current.data.currentWorkAddress).toBeDefined()
+  })
+
+  it('picks the active home address out of the returned list', async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/v1/employees/:employee_id/home_addresses`, () =>
+        HttpResponse.json([
+          {
+            uuid: 'home-inactive',
+            version: '1',
+            street_1: '1 Old St',
+            city: 'Oldtown',
+            state: 'CA',
+            zip: '90001',
+            country: 'USA',
+            active: false,
+          },
+          {
+            uuid: 'home-active',
+            version: '1',
+            street_1: '2 Current Ave',
+            city: 'Newtown',
+            state: 'CA',
+            zip: '90002',
+            country: 'USA',
+            active: true,
+          },
+        ]),
+      ),
+    )
+
+    const { result } = renderHook(() => useEmployeeBasicDetails({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    await waitFor(() => {
+      expect(result.current.status.isHomeAddressLoading).toBe(false)
+    })
+
+    expect(result.current.data.currentHomeAddress).toMatchObject({
+      uuid: 'home-active',
+      active: true,
+    })
+  })
+
+  it('picks the active work address out of the returned list', async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/v1/employees/:employee_id/work_addresses`, () =>
+        HttpResponse.json([
+          {
+            uuid: 'work-inactive',
+            version: '1',
+            street_1: '1 Old Way',
+            city: 'Oldville',
+            state: 'CA',
+            zip: '90100',
+            active: false,
+          },
+          {
+            uuid: 'work-active',
+            version: '1',
+            street_1: '500 New Ln',
+            city: 'Newville',
+            state: 'CA',
+            zip: '90200',
+            active: true,
+          },
+        ]),
+      ),
+    )
+
+    const { result } = renderHook(() => useEmployeeBasicDetails({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    await waitFor(() => {
+      expect(result.current.status.isWorkAddressLoading).toBe(false)
+    })
+
+    expect(result.current.data.currentWorkAddress).toMatchObject({
+      uuid: 'work-active',
+      active: true,
+    })
+  })
+
+  it('returns undefined active addresses when none in the list are active', async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/v1/employees/:employee_id/home_addresses`, () =>
+        HttpResponse.json([]),
+      ),
+      http.get(`${API_BASE_URL}/v1/employees/:employee_id/work_addresses`, () =>
+        HttpResponse.json([]),
+      ),
+    )
+
+    const { result } = renderHook(() => useEmployeeBasicDetails({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    await waitFor(() => {
+      expect(result.current.status.isHomeAddressLoading).toBe(false)
+      expect(result.current.status.isWorkAddressLoading).toBe(false)
+    })
+
+    expect(result.current.data.currentHomeAddress).toBeUndefined()
+    expect(result.current.data.currentWorkAddress).toBeUndefined()
+  })
+
+  it('surfaces a query failure through errorHandling.errors', async () => {
+    server.use(
+      handleGetEmployee(() =>
+        HttpResponse.json(
+          { errors: [{ category: 'server_error', message: 'Boom' }] },
+          { status: 500 },
+        ),
+      ),
+    )
+
+    const { result } = renderHook(() => useEmployeeBasicDetails({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    await waitFor(() => {
+      expect(result.current.errorHandling.errors.length).toBeGreaterThan(0)
+    })
+
+    // Employee query has settled with an error; the per-section flag
+    // is no longer "loading", so the consuming view will fall through
+    // its skeleton branch instead of showing one forever.
+    expect(result.current.status.isEmployeeLoading).toBe(false)
+    expect(result.current.data.employee).toBeUndefined()
+  })
+
+  it('does not include `?include=all_compensations` in the employee fetch', async () => {
+    let employeeRequestUrl: string | null = null
+    server.use(
+      handleGetEmployee(({ request }) => {
+        employeeRequestUrl = request.url
+        return HttpResponse.json({
+          uuid: 'employee-123',
+          first_name: 'Isom',
+          last_name: 'Jaskolski',
+          jobs: [],
+        })
+      }),
+    )
+
+    const { result } = renderHook(() => useEmployeeBasicDetails({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    await waitFor(() => {
+      expect(result.current.status.isEmployeeLoading).toBe(false)
+    })
+
+    expect(employeeRequestUrl).not.toBeNull()
+    expect(employeeRequestUrl).not.toContain('all_compensations')
+  })
+})

--- a/src/components/Employee/Dashboard/hooks/useEmployeeBasicDetails.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeBasicDetails.tsx
@@ -6,26 +6,25 @@ import type { Employee } from '@gusto/embedded-api/models/components/employee'
 import type { EmployeeAddress } from '@gusto/embedded-api/models/components/employeeaddress'
 import type { EmployeeWorkAddress } from '@gusto/embedded-api/models/components/employeeworkaddress'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
-import type { HookErrorHandling } from '@/partner-hook-utils/types'
+import type { BaseHookReady } from '@/partner-hook-utils/types'
 
 export interface UseEmployeeBasicDetailsProps {
   employeeId: string
 }
 
-export interface UseEmployeeBasicDetailsResult {
-  data: {
+export type UseEmployeeBasicDetailsResult = BaseHookReady<
+  {
     employee?: Employee
     currentHomeAddress?: EmployeeAddress
     currentWorkAddress?: EmployeeWorkAddress
-  }
-  status: {
+  },
+  {
     isPending: boolean
     isEmployeeLoading: boolean
     isHomeAddressLoading: boolean
     isWorkAddressLoading: boolean
   }
-  errorHandling: HookErrorHandling
-}
+>
 
 /**
  * Phase B: each query runs non-Suspense so the three cards (employee
@@ -61,6 +60,7 @@ export function useEmployeeBasicDetails({
   }, [employeeWorkAddressesList])
 
   return {
+    isLoading: false,
     data: {
       employee,
       currentHomeAddress,

--- a/src/components/Employee/Dashboard/hooks/useEmployeeBasicDetails.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeBasicDetails.tsx
@@ -37,10 +37,14 @@ export function useEmployeeBasicDetails({
 }: UseEmployeeBasicDetailsProps): UseEmployeeBasicDetailsResult {
   // staleTime: Infinity — see useEmployeeCompensation for rationale (SDK
   // QueryClient invalidates on any mutation success).
-  const employeeQuery = useEmployeesGet(
-    { employeeId, include: ['all_compensations'] },
-    { staleTime: Infinity },
-  )
+  //
+  // No `include: ['all_compensations']` here: BasicDetails only reads
+  // `firstName/lastName/dateOfBirth/email/hasSsn` and the first job's
+  // `hireDate` — the historical compensations are dead weight in this
+  // payload. `useEmployeeCompensation` keeps the include since the
+  // JobAndPay tab actually consumes it. The two hooks intentionally use
+  // different query keys; mount-time payload shrinks on the active tab.
+  const employeeQuery = useEmployeesGet({ employeeId }, { staleTime: Infinity })
   const addressesQuery = useEmployeeAddressesGet({ employeeId }, { staleTime: Infinity })
   const workAddressesQuery = useEmployeeAddressesGetWorkAddresses(
     { employeeId },

--- a/src/components/Employee/Dashboard/hooks/useEmployeeBasicDetails.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeBasicDetails.tsx
@@ -1,43 +1,57 @@
 import { useMemo } from 'react'
-import { useEmployeesGetSuspense } from '@gusto/embedded-api/react-query/employeesGet'
-import { useEmployeeAddressesGetSuspense } from '@gusto/embedded-api/react-query/employeeAddressesGet'
-import { useEmployeeAddressesGetWorkAddressesSuspense } from '@gusto/embedded-api/react-query/employeeAddressesGetWorkAddresses'
+import { useEmployeesGet } from '@gusto/embedded-api/react-query/employeesGet'
+import { useEmployeeAddressesGet } from '@gusto/embedded-api/react-query/employeeAddressesGet'
+import { useEmployeeAddressesGetWorkAddresses } from '@gusto/embedded-api/react-query/employeeAddressesGetWorkAddresses'
 import type { Employee } from '@gusto/embedded-api/models/components/employee'
 import type { EmployeeAddress } from '@gusto/embedded-api/models/components/employeeaddress'
 import type { EmployeeWorkAddress } from '@gusto/embedded-api/models/components/employeeworkaddress'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
-import type { HookLoadingResult, BaseHookReady } from '@/partner-hook-utils/types'
+import type { HookErrorHandling } from '@/partner-hook-utils/types'
 
 export interface UseEmployeeBasicDetailsProps {
   employeeId: string
 }
 
-type UseEmployeeBasicDetailsReady = BaseHookReady<
-  {
-    employee: Employee
+export interface UseEmployeeBasicDetailsResult {
+  data: {
+    employee?: Employee
     currentHomeAddress?: EmployeeAddress
     currentWorkAddress?: EmployeeWorkAddress
-  },
-  { isPending: boolean }
->
+  }
+  status: {
+    isPending: boolean
+    isEmployeeLoading: boolean
+    isHomeAddressLoading: boolean
+    isWorkAddressLoading: boolean
+  }
+  errorHandling: HookErrorHandling
+}
 
-export type UseEmployeeBasicDetailsResult = HookLoadingResult | UseEmployeeBasicDetailsReady
-
+/**
+ * Phase B: each query runs non-Suspense so the three cards (employee
+ * info, home address, work address) can paint independently. The
+ * consuming view branches on the per-query loading flags to render
+ * skeletons inside the box bodies.
+ */
 export function useEmployeeBasicDetails({
   employeeId,
 }: UseEmployeeBasicDetailsProps): UseEmployeeBasicDetailsResult {
-  const employeeQuery = useEmployeesGetSuspense({
-    employeeId,
-    include: ['all_compensations'],
-  })
-  const addressesQuery = useEmployeeAddressesGetSuspense({ employeeId })
-  const workAddressesQuery = useEmployeeAddressesGetWorkAddressesSuspense({ employeeId })
+  // staleTime: Infinity — see useEmployeeCompensation for rationale (SDK
+  // QueryClient invalidates on any mutation success).
+  const employeeQuery = useEmployeesGet(
+    { employeeId, include: ['all_compensations'] },
+    { staleTime: Infinity },
+  )
+  const addressesQuery = useEmployeeAddressesGet({ employeeId }, { staleTime: Infinity })
+  const workAddressesQuery = useEmployeeAddressesGetWorkAddresses(
+    { employeeId },
+    { staleTime: Infinity },
+  )
 
-  const employee = employeeQuery.data.employee
-  const employeeAddressList = addressesQuery.data.employeeAddressList
-  const employeeWorkAddressesList = workAddressesQuery.data.employeeWorkAddressesList
+  const employee = employeeQuery.data?.employee
+  const employeeAddressList = addressesQuery.data?.employeeAddressList
+  const employeeWorkAddressesList = workAddressesQuery.data?.employeeWorkAddressesList
 
-  // Derive current addresses
   const currentHomeAddress = useMemo(() => {
     return employeeAddressList?.find(address => address.active)
   }, [employeeAddressList])
@@ -46,29 +60,19 @@ export function useEmployeeBasicDetails({
     return employeeWorkAddressesList?.find(address => address.active)
   }, [employeeWorkAddressesList])
 
-  const isPending =
-    employeeQuery.isFetching || addressesQuery.isFetching || workAddressesQuery.isFetching
-  const isLoading = !employee && isPending
-
-  const errorHandling = composeErrorHandler([employeeQuery, addressesQuery, workAddressesQuery])
-
-  if (isLoading) {
-    return {
-      isLoading: true,
-      errorHandling,
-    }
-  }
-
   return {
-    isLoading: false,
     data: {
-      employee: employee!,
+      employee,
       currentHomeAddress,
       currentWorkAddress,
     },
     status: {
-      isPending,
+      isPending:
+        employeeQuery.isFetching || addressesQuery.isFetching || workAddressesQuery.isFetching,
+      isEmployeeLoading: employeeQuery.isLoading,
+      isHomeAddressLoading: addressesQuery.isLoading,
+      isWorkAddressLoading: workAddressesQuery.isLoading,
     },
-    errorHandling,
+    errorHandling: composeErrorHandler([employeeQuery, addressesQuery, workAddressesQuery]),
   }
 }

--- a/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.test.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.test.tsx
@@ -1,0 +1,306 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { http, HttpResponse, type HttpResponseResolver } from 'msw'
+import { useEmployeeCompensation } from './useEmployeeCompensation'
+import { GustoTestProvider } from '@/test/GustoTestApiProvider'
+import { server } from '@/test/mocks/server'
+import { handleGetEmployee } from '@/test/mocks/apis/employees'
+import { handleDeleteCompensation } from '@/test/mocks/apis/compensations'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { API_BASE_URL } from '@/test/constants'
+import { FlsaStatus } from '@/shared/constants'
+
+// Test fixtures — these match the default `get-v1-employees.json` shape
+// but are inlined here so the test pins behaviour to specific values
+// rather than a moving fixture file.
+type JobFixture = Record<string, unknown>
+
+const ONE_YEAR_AHEAD = (() => {
+  const d = new Date()
+  d.setFullYear(d.getFullYear() + 1)
+  return d.toISOString().split('T')[0]!
+})()
+const TWO_YEARS_AHEAD = (() => {
+  const d = new Date()
+  d.setFullYear(d.getFullYear() + 2)
+  return d.toISOString().split('T')[0]!
+})()
+
+const buildEmployee = (jobs: JobFixture[]) => ({
+  uuid: 'employee-123',
+  first_name: 'Isom',
+  last_name: 'Jaskolski',
+  email: 'isom@example.com',
+  date_of_birth: '1986-06-25',
+  has_ssn: true,
+  jobs,
+})
+
+const baseJob = (
+  overrides: Partial<JobFixture> = {},
+  compensations: Record<string, unknown>[] = [],
+): JobFixture => ({
+  uuid: 'job-1',
+  version: 'job-v1',
+  employee_uuid: 'employee-123',
+  current_compensation_uuid: 'comp-current',
+  payment_unit: 'Hour',
+  primary: true,
+  title: 'Cashier',
+  rate: '30.00',
+  hire_date: '2024-01-01',
+  compensations,
+  ...overrides,
+})
+
+const baseComp = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  uuid: 'comp-current',
+  version: 'comp-v1',
+  payment_unit: 'Hour',
+  flsa_status: 'Nonexempt',
+  job_uuid: 'job-1',
+  effective_date: '2024-01-01',
+  rate: '30.00',
+  adjust_for_minimum_wage: false,
+  minimum_wages: [],
+  ...overrides,
+})
+
+describe('useEmployeeCompensation', () => {
+  beforeEach(() => {
+    setupApiTestMocks()
+  })
+
+  it('starts loading with both per-query flags true and resolves to populated data', async () => {
+    const { result } = renderHook(() => useEmployeeCompensation({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    expect(result.current.status.isEmployeeLoading).toBe(true)
+    expect(result.current.status.isPayStubsLoading).toBe(true)
+    expect(result.current.data.jobs).toEqual([])
+    expect(result.current.data.payStubs).toEqual([])
+
+    await waitFor(() => {
+      expect(result.current.status.isEmployeeLoading).toBe(false)
+      expect(result.current.status.isPayStubsLoading).toBe(false)
+    })
+
+    expect(result.current.data.jobs.length).toBeGreaterThan(0)
+  })
+
+  it('derives primaryJob, primaryFlsaStatus, hasMultipleJobs, and employeeFirstName from the employee fetch', async () => {
+    server.use(
+      handleGetEmployee(() =>
+        HttpResponse.json(
+          buildEmployee([baseJob({ primary: true }, [baseComp({ flsa_status: 'Nonexempt' })])]),
+        ),
+      ),
+    )
+
+    const { result } = renderHook(() => useEmployeeCompensation({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    await waitFor(() => {
+      expect(result.current.status.isEmployeeLoading).toBe(false)
+    })
+
+    expect(result.current.data.primaryJob).toMatchObject({ uuid: 'job-1', primary: true })
+    expect(result.current.data.primaryFlsaStatus).toBe(FlsaStatus.NONEXEMPT)
+    expect(result.current.data.hasMultipleJobs).toBe(false)
+    expect(result.current.data.employeeFirstName).toBe('Isom')
+  })
+
+  it('reports hasMultipleJobs=true and surfaces all jobs when the employee has more than one', async () => {
+    server.use(
+      handleGetEmployee(() =>
+        HttpResponse.json(
+          buildEmployee([
+            baseJob({ uuid: 'job-primary', primary: true, title: 'Manager' }, [
+              baseComp({ uuid: 'comp-primary', job_uuid: 'job-primary' }),
+            ]),
+            baseJob({ uuid: 'job-secondary', primary: false, title: 'Cashier' }, [
+              baseComp({ uuid: 'comp-secondary', job_uuid: 'job-secondary' }),
+            ]),
+          ]),
+        ),
+      ),
+    )
+
+    const { result } = renderHook(() => useEmployeeCompensation({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    await waitFor(() => {
+      expect(result.current.status.isEmployeeLoading).toBe(false)
+    })
+
+    expect(result.current.data.hasMultipleJobs).toBe(true)
+    expect(result.current.data.jobs).toHaveLength(2)
+    expect(result.current.data.primaryJob?.uuid).toBe('job-primary')
+  })
+
+  it('derives pendingChanges from future-effective compensations on each job', async () => {
+    server.use(
+      handleGetEmployee(() =>
+        HttpResponse.json(
+          buildEmployee([
+            baseJob({ uuid: 'job-primary', current_compensation_uuid: 'comp-primary-current' }, [
+              baseComp({ uuid: 'comp-primary-current', job_uuid: 'job-primary' }),
+              baseComp({
+                uuid: 'comp-primary-future',
+                job_uuid: 'job-primary',
+                rate: '35.00',
+                effective_date: ONE_YEAR_AHEAD,
+              }),
+            ]),
+          ]),
+        ),
+      ),
+    )
+
+    const { result } = renderHook(() => useEmployeeCompensation({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    await waitFor(() => {
+      expect(result.current.status.isEmployeeLoading).toBe(false)
+    })
+
+    expect(result.current.data.pendingChanges).toHaveLength(1)
+    expect(result.current.data.pendingChanges[0]).toMatchObject({
+      compensationUuid: 'comp-primary-future',
+      effectiveDate: ONE_YEAR_AHEAD,
+    })
+  })
+
+  it('actions.cancelPendingChange fires DELETE /v1/compensations/:id and returns a HookSubmitResult', async () => {
+    server.use(
+      handleGetEmployee(() =>
+        HttpResponse.json(
+          buildEmployee([
+            baseJob({}, [
+              baseComp(),
+              baseComp({
+                uuid: 'comp-future',
+                rate: '35.00',
+                effective_date: ONE_YEAR_AHEAD,
+              }),
+            ]),
+          ]),
+        ),
+      ),
+    )
+
+    let deletePath: string | null = null
+    const deleteResolver = vi.fn<HttpResponseResolver>(({ request }) => {
+      deletePath = new URL(request.url).pathname
+      return new HttpResponse(null, { status: 204 })
+    })
+    server.use(handleDeleteCompensation(deleteResolver))
+
+    const { result } = renderHook(() => useEmployeeCompensation({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    await waitFor(() => {
+      expect(result.current.data.pendingChanges).toHaveLength(1)
+    })
+    const change = result.current.data.pendingChanges[0]!
+
+    let submitResult: unknown
+    await act(async () => {
+      submitResult = await result.current.actions.cancelPendingChange(change)
+    })
+
+    expect(deleteResolver).toHaveBeenCalledTimes(1)
+    expect(deletePath).toBe('/v1/compensations/comp-future')
+    expect(submitResult).toMatchObject({ mode: 'update' })
+  })
+
+  it('surfaces a failing cancel mutation through errorHandling.errors and leaves submitResult undefined', async () => {
+    server.use(
+      handleGetEmployee(() =>
+        HttpResponse.json(
+          buildEmployee([
+            baseJob({}, [
+              baseComp(),
+              baseComp({
+                uuid: 'comp-future',
+                rate: '35.00',
+                effective_date: TWO_YEARS_AHEAD,
+              }),
+            ]),
+          ]),
+        ),
+      ),
+    )
+    server.use(
+      handleDeleteCompensation(() =>
+        HttpResponse.json(
+          { errors: [{ category: 'invalid_attribute_value', message: 'Cannot cancel' }] },
+          { status: 422 },
+        ),
+      ),
+    )
+
+    const { result } = renderHook(() => useEmployeeCompensation({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    await waitFor(() => {
+      expect(result.current.data.pendingChanges).toHaveLength(1)
+    })
+    const change = result.current.data.pendingChanges[0]!
+
+    let submitResult: unknown = 'unset'
+    await act(async () => {
+      submitResult = await result.current.actions.cancelPendingChange(change)
+    })
+
+    expect(submitResult).toBeUndefined()
+    expect(result.current.errorHandling.errors.length).toBeGreaterThan(0)
+  })
+
+  it('requests the employee with `include=all_compensations` so JobAndPay sees compensation history', async () => {
+    let employeeRequestUrl: string | null = null
+    server.use(
+      handleGetEmployee(({ request }) => {
+        employeeRequestUrl = request.url
+        return HttpResponse.json(buildEmployee([baseJob({}, [baseComp()])]))
+      }),
+    )
+
+    const { result } = renderHook(() => useEmployeeCompensation({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    await waitFor(() => {
+      expect(result.current.status.isEmployeeLoading).toBe(false)
+    })
+
+    expect(employeeRequestUrl).not.toBeNull()
+    expect(employeeRequestUrl).toContain('all_compensations')
+  })
+
+  it('surfaces paystub pagination control props once the paystubs query resolves', async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/v1/employees/:employee_uuid/pay_stubs`, () =>
+        HttpResponse.json([], {
+          headers: { 'x-total-count': '0', 'x-total-pages': '1', 'x-page': '1' },
+        }),
+      ),
+    )
+
+    const { result } = renderHook(() => useEmployeeCompensation({ employeeId: 'employee-123' }), {
+      wrapper: GustoTestProvider,
+    })
+
+    await waitFor(() => {
+      expect(result.current.status.isPayStubsLoading).toBe(false)
+    })
+
+    expect(result.current.pagination.payStubs).toBeDefined()
+  })
+})

--- a/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
@@ -12,7 +12,7 @@ import { derivePrimaryFlsaStatus } from '@/components/Employee/Compensation/shar
 import { useBaseSubmit } from '@/components/Base/useBaseSubmit'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
 import { usePagination } from '@/hooks/usePagination/usePagination'
-import type { HookErrorHandling, HookSubmitResult } from '@/partner-hook-utils/types'
+import type { BaseHookReady, HookSubmitResult } from '@/partner-hook-utils/types'
 import type { PaginationControlProps } from '@/components/Common/PaginationControl/PaginationControlTypes'
 
 type EmployeePayStub = NonNullable<
@@ -23,8 +23,8 @@ export interface UseEmployeeCompensationProps {
   employeeId: string
 }
 
-export interface UseEmployeeCompensationResult {
-  data: {
+export interface UseEmployeeCompensationResult extends BaseHookReady<
+  {
     jobs: Job[]
     primaryJob?: Job
     primaryFlsaStatus?: string
@@ -35,8 +35,8 @@ export interface UseEmployeeCompensationResult {
      *  in alerts (e.g. "Heads up, Jane has pending changes"). Optional
      *  because the employee record can omit it. */
     employeeFirstName?: string
-  }
-  status: {
+  },
+  {
     isPending: boolean
     cancellingCompensationUuid: string | null
     /** Compensation card depends on the employee fetch (jobs, pending
@@ -45,6 +45,7 @@ export interface UseEmployeeCompensationResult {
     /** Paystubs card depends on a separate paginated endpoint. */
     isPayStubsLoading: boolean
   }
+> {
   pagination: {
     payStubs?: PaginationControlProps
   }
@@ -53,7 +54,6 @@ export interface UseEmployeeCompensationResult {
       pendingChange: PendingCompensationChange,
     ) => Promise<HookSubmitResult<unknown> | undefined>
   }
-  errorHandling: HookErrorHandling
 }
 
 /**
@@ -137,6 +137,7 @@ export function useEmployeeCompensation({
   })
 
   return {
+    isLoading: false,
     data: {
       jobs,
       primaryJob,

--- a/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react'
-import { useEmployeesGetSuspense } from '@gusto/embedded-api/react-query/employeesGet'
+import { useEmployeesGet } from '@gusto/embedded-api/react-query/employeesGet'
 import { useJobsAndCompensationsDeleteCompensationMutation } from '@gusto/embedded-api/react-query/jobsAndCompensationsDeleteCompensation'
-import { usePayrollsGetPayStubsSuspense } from '@gusto/embedded-api/react-query/payrollsGetPayStubs'
+import { usePayrollsGetPayStubs } from '@gusto/embedded-api/react-query/payrollsGetPayStubs'
 import type { Job } from '@gusto/embedded-api/models/components/job'
 import type { GetV1EmployeesEmployeeUuidPayStubsResponse } from '@gusto/embedded-api/models/operations/getv1employeesemployeeuuidpaystubs'
 import {
@@ -12,7 +12,7 @@ import { derivePrimaryFlsaStatus } from '@/components/Employee/Compensation/shar
 import { useBaseSubmit } from '@/components/Base/useBaseSubmit'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
 import { usePagination } from '@/hooks/usePagination/usePagination'
-import type { BaseHookReady, HookLoadingResult, HookSubmitResult } from '@/partner-hook-utils/types'
+import type { HookErrorHandling, HookSubmitResult } from '@/partner-hook-utils/types'
 import type { PaginationControlProps } from '@/components/Common/PaginationControl/PaginationControlTypes'
 
 type EmployeePayStub = NonNullable<
@@ -23,8 +23,8 @@ export interface UseEmployeeCompensationProps {
   employeeId: string
 }
 
-interface UseEmployeeCompensationReady extends BaseHookReady<
-  {
+export interface UseEmployeeCompensationResult {
+  data: {
     jobs: Job[]
     primaryJob?: Job
     primaryFlsaStatus?: string
@@ -35,9 +35,16 @@ interface UseEmployeeCompensationReady extends BaseHookReady<
      *  in alerts (e.g. "Heads up, Jane has pending changes"). Optional
      *  because the employee record can omit it. */
     employeeFirstName?: string
-  },
-  { isPending: boolean; cancellingCompensationUuid: string | null }
-> {
+  }
+  status: {
+    isPending: boolean
+    cancellingCompensationUuid: string | null
+    /** Compensation card depends on the employee fetch (jobs, pending
+     *  changes, FLSA status). */
+    isEmployeeLoading: boolean
+    /** Paystubs card depends on a separate paginated endpoint. */
+    isPayStubsLoading: boolean
+  }
   pagination: {
     payStubs?: PaginationControlProps
   }
@@ -46,10 +53,15 @@ interface UseEmployeeCompensationReady extends BaseHookReady<
       pendingChange: PendingCompensationChange,
     ) => Promise<HookSubmitResult<unknown> | undefined>
   }
+  errorHandling: HookErrorHandling
 }
 
-export type UseEmployeeCompensationResult = HookLoadingResult | UseEmployeeCompensationReady
-
+/**
+ * Phase B: non-Suspense queries so the Compensation and Paystubs cards
+ * can paint independently within the Job and pay tab. JobAndPayView
+ * already gets the Payment and Deductions cards as separate non-Suspense
+ * hooks, so this completes the four-section incremental render.
+ */
 export function useEmployeeCompensation({
   employeeId,
 }: UseEmployeeCompensationProps): UseEmployeeCompensationResult {
@@ -57,15 +69,18 @@ export function useEmployeeCompensation({
     defaultItemsPerPage: 10,
   })
 
-  const employeeQuery = useEmployeesGetSuspense({
-    employeeId,
-    include: ['all_compensations'],
-  })
-  const payStubsQuery = usePayrollsGetPayStubsSuspense({
-    employeeId,
-    page: currentPage,
-    per: itemsPerPage,
-  })
+  // staleTime: Infinity on dashboard reads — the SDK QueryClient already
+  // invalidates all queries on any mutation success, so post-write
+  // freshness is preserved. Without this, every subscriber re-mount
+  // (e.g. tab navigation) would fire a redundant background refetch.
+  const employeeQuery = useEmployeesGet(
+    { employeeId, include: ['all_compensations'] },
+    { staleTime: Infinity },
+  )
+  const payStubsQuery = usePayrollsGetPayStubs(
+    { employeeId, page: currentPage, per: itemsPerPage },
+    { staleTime: Infinity },
+  )
   const cancelCompensationMutation = useJobsAndCompensationsDeleteCompensationMutation()
   const {
     baseSubmitHandler,
@@ -73,8 +88,7 @@ export function useEmployeeCompensation({
     setError: setSubmitError,
   } = useBaseSubmit('Employee.Dashboard.JobAndPay.Compensation')
 
-  const employee = employeeQuery.data.employee
-  const payStubsData = payStubsQuery.data
+  const employee = employeeQuery.data?.employee
 
   const jobs = useMemo(() => employee?.jobs ?? [], [employee?.jobs])
   const primaryJob = useMemo(() => jobs.find(job => job.primary === true), [jobs])
@@ -86,12 +100,13 @@ export function useEmployeeCompensation({
     [employee?.jobs],
   )
 
-  const payStubs = payStubsData.employeePayStubsList || []
+  const payStubs = payStubsQuery.data?.employeePayStubsList ?? []
 
   const payStubsPagination = useMemo(() => {
-    const headers = payStubsData.httpMeta.response.headers
+    const headers = payStubsQuery.data?.httpMeta.response.headers
+    if (!headers) return undefined
     return getPaginationProps(headers, payStubsQuery.isFetching)
-  }, [payStubsData.httpMeta.response.headers, payStubsQuery.isFetching, getPaginationProps])
+  }, [payStubsQuery.data?.httpMeta.response.headers, payStubsQuery.isFetching, getPaginationProps])
 
   const cancellingCompensationUuid = cancelCompensationMutation.isPending
     ? cancelCompensationMutation.variables.request.compensationId
@@ -116,22 +131,12 @@ export function useEmployeeCompensation({
   const isPending =
     employeeQuery.isFetching || payStubsQuery.isFetching || cancelCompensationMutation.isPending
 
-  const isLoading = !employee && isPending
-
   const errorHandling = composeErrorHandler([employeeQuery, payStubsQuery], {
     submitError,
     setSubmitError,
   })
 
-  if (isLoading) {
-    return {
-      isLoading: true,
-      errorHandling,
-    }
-  }
-
   return {
-    isLoading: false,
     data: {
       jobs,
       primaryJob,
@@ -144,6 +149,8 @@ export function useEmployeeCompensation({
     status: {
       isPending,
       cancellingCompensationUuid,
+      isEmployeeLoading: employeeQuery.isLoading,
+      isPayStubsLoading: payStubsQuery.isLoading,
     },
     pagination: {
       payStubs: payStubsPagination,

--- a/src/components/Employee/Dashboard/hooks/useEmployeeForms.test.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeForms.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { renderHook, waitFor } from '@testing-library/react'
 import { describe, it, expect, beforeEach } from 'vitest'
 import { HttpResponse } from 'msw'
@@ -7,40 +6,40 @@ import { GustoTestProvider } from '@/test/GustoTestApiProvider'
 import { server } from '@/test/mocks/server'
 import { handleGetEmployeeForms, i9Form } from '@/test/mocks/apis/employee_forms'
 import { setupApiTestMocks } from '@/test/mocks/apiServer'
-import { requireNotLoading } from '@/test-utils/assertions'
-
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <GustoTestProvider>
-    <React.Suspense fallback={null}>{children}</React.Suspense>
-  </GustoTestProvider>
-)
 
 describe('useEmployeeForms', () => {
   beforeEach(() => {
     setupApiTestMocks()
   })
 
-  it('returns the list of forms from the API', async () => {
+  it('starts loading with an empty list and resolves to the API response', async () => {
     server.use(handleGetEmployeeForms(() => HttpResponse.json([i9Form])))
 
     const { result } = renderHook(() => useEmployeeForms({ employeeId: 'employee-123' }), {
-      wrapper,
+      wrapper: GustoTestProvider,
     })
 
-    const loadedResult = await waitFor(() => requireNotLoading(result.current))
+    expect(result.current.status.isFormsLoading).toBe(true)
+    expect(result.current.data.formList).toEqual([])
 
-    expect(loadedResult.data.formList).toMatchObject([
+    await waitFor(() => {
+      expect(result.current.status.isFormsLoading).toBe(false)
+    })
+
+    expect(result.current.data.formList).toMatchObject([
       { uuid: 'i9-form-123', title: 'Form I-9', requiresSigning: true },
     ])
   })
 
   it('returns an empty list when the employee has no forms', async () => {
     const { result } = renderHook(() => useEmployeeForms({ employeeId: 'employee-123' }), {
-      wrapper,
+      wrapper: GustoTestProvider,
     })
 
-    const loadedResult = await waitFor(() => requireNotLoading(result.current))
+    await waitFor(() => {
+      expect(result.current.status.isFormsLoading).toBe(false)
+    })
 
-    expect(loadedResult.data.formList).toEqual([])
+    expect(result.current.data.formList).toEqual([])
   })
 })

--- a/src/components/Employee/Dashboard/hooks/useEmployeeForms.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeForms.tsx
@@ -1,22 +1,16 @@
 import { useEmployeeFormsList } from '@gusto/embedded-api/react-query/employeeFormsList'
 import type { Form } from '@gusto/embedded-api/models/components/form'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
-import type { HookErrorHandling } from '@/partner-hook-utils/types'
+import type { BaseHookReady } from '@/partner-hook-utils/types'
 
 export interface UseEmployeeFormsProps {
   employeeId: string
 }
 
-export interface UseEmployeeFormsResult {
-  data: {
-    formList: Form[]
-  }
-  status: {
-    isPending: boolean
-    isFormsLoading: boolean
-  }
-  errorHandling: HookErrorHandling
-}
+export type UseEmployeeFormsResult = BaseHookReady<
+  { formList: Form[] },
+  { isPending: boolean; isFormsLoading: boolean }
+>
 
 /**
  * Phase B: non-Suspense query so the consuming view can paint its frame
@@ -31,6 +25,7 @@ export function useEmployeeForms({ employeeId }: UseEmployeeFormsProps): UseEmpl
   const formsQuery = useEmployeeFormsList({ employeeId }, { staleTime: Infinity })
 
   return {
+    isLoading: false,
     data: {
       formList: formsQuery.data?.forms ?? [],
     },

--- a/src/components/Employee/Dashboard/hooks/useEmployeeForms.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeForms.tsx
@@ -1,41 +1,43 @@
-import { useEmployeeFormsListSuspense } from '@gusto/embedded-api/react-query/employeeFormsList'
+import { useEmployeeFormsList } from '@gusto/embedded-api/react-query/employeeFormsList'
 import type { Form } from '@gusto/embedded-api/models/components/form'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
-import type { HookLoadingResult, BaseHookReady } from '@/partner-hook-utils/types'
+import type { HookErrorHandling } from '@/partner-hook-utils/types'
 
 export interface UseEmployeeFormsProps {
   employeeId: string
 }
 
-type UseEmployeeFormsReady = BaseHookReady<{ formList: Form[] }, { isPending: boolean }>
-
-export type UseEmployeeFormsResult = HookLoadingResult | UseEmployeeFormsReady
-
-export function useEmployeeForms({ employeeId }: UseEmployeeFormsProps): UseEmployeeFormsResult {
-  const formsQuery = useEmployeeFormsListSuspense({ employeeId })
-
-  const formList = formsQuery.data.forms
-
-  const isPending = formsQuery.isFetching
-  const isLoading = !formList && isPending
-
-  const errorHandling = composeErrorHandler([formsQuery])
-
-  if (isLoading) {
-    return {
-      isLoading: true,
-      errorHandling,
-    }
+export interface UseEmployeeFormsResult {
+  data: {
+    formList: Form[]
   }
+  status: {
+    isPending: boolean
+    isFormsLoading: boolean
+  }
+  errorHandling: HookErrorHandling
+}
+
+/**
+ * Phase B: non-Suspense query so the consuming view can paint its frame
+ * (box header, tab structure) before the data arrives. The `formList`
+ * defaults to `[]` while the query is loading — consumers branch on
+ * `status.isFormsLoading` to distinguish "still loading" from "loaded
+ * empty" and render a skeleton accordingly.
+ */
+export function useEmployeeForms({ employeeId }: UseEmployeeFormsProps): UseEmployeeFormsResult {
+  // staleTime: Infinity — see useEmployeeCompensation for rationale (SDK
+  // QueryClient invalidates on any mutation success).
+  const formsQuery = useEmployeeFormsList({ employeeId }, { staleTime: Infinity })
 
   return {
-    isLoading: false,
     data: {
-      formList: formList || [],
+      formList: formsQuery.data?.forms ?? [],
     },
     status: {
-      isPending,
+      isPending: formsQuery.isFetching,
+      isFormsLoading: formsQuery.isLoading,
     },
-    errorHandling,
+    errorHandling: composeErrorHandler([formsQuery]),
   }
 }

--- a/src/components/Employee/Dashboard/hooks/useEmployeeTaxes.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeTaxes.tsx
@@ -1,11 +1,10 @@
-import { useEmployeeTaxSetupGetFederalTaxesSuspense } from '@gusto/embedded-api/react-query/employeeTaxSetupGetFederalTaxes'
-import { useEmployeeTaxSetupGetStateTaxesSuspense } from '@gusto/embedded-api/react-query/employeeTaxSetupGetStateTaxes'
+import { useEmployeeTaxSetupGetFederalTaxes } from '@gusto/embedded-api/react-query/employeeTaxSetupGetFederalTaxes'
+import { useEmployeeTaxSetupGetStateTaxes } from '@gusto/embedded-api/react-query/employeeTaxSetupGetStateTaxes'
 import type { GetV1EmployeesEmployeeIdFederalTaxesResponse } from '@gusto/embedded-api/models/operations/getv1employeesemployeeidfederaltaxes'
 import type { GetV1EmployeesEmployeeIdStateTaxesResponse } from '@gusto/embedded-api/models/operations/getv1employeesemployeeidstatetaxes'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
-import type { HookLoadingResult, BaseHookReady } from '@/partner-hook-utils/types'
+import type { HookErrorHandling } from '@/partner-hook-utils/types'
 
-// Derive types from operations responses
 type EmployeeFederalTax = NonNullable<
   GetV1EmployeesEmployeeIdFederalTaxesResponse['employeeFederalTax']
 >
@@ -17,44 +16,47 @@ export interface UseEmployeeTaxesProps {
   employeeId: string
 }
 
-type UseEmployeeTaxesReady = BaseHookReady<
-  {
+export interface UseEmployeeTaxesResult {
+  data: {
     employeeFederalTax?: EmployeeFederalTax
     employeeStateTaxesList: EmployeeStateTax[]
-  },
-  { isPending: boolean }
->
-
-export type UseEmployeeTaxesResult = HookLoadingResult | UseEmployeeTaxesReady
-
-export function useEmployeeTaxes({ employeeId }: UseEmployeeTaxesProps): UseEmployeeTaxesResult {
-  const federalTaxesQuery = useEmployeeTaxSetupGetFederalTaxesSuspense({ employeeUuid: employeeId })
-  const stateTaxesQuery = useEmployeeTaxSetupGetStateTaxesSuspense({ employeeUuid: employeeId })
-
-  const employeeFederalTax = federalTaxesQuery.data.employeeFederalTax
-  const employeeStateTaxesList = stateTaxesQuery.data.employeeStateTaxesList
-
-  const isPending = federalTaxesQuery.isFetching || stateTaxesQuery.isFetching
-  const isLoading = !employeeFederalTax && isPending
-
-  const errorHandling = composeErrorHandler([federalTaxesQuery, stateTaxesQuery])
-
-  if (isLoading) {
-    return {
-      isLoading: true,
-      errorHandling,
-    }
   }
+  status: {
+    isPending: boolean
+    isFederalTaxesLoading: boolean
+    isStateTaxesLoading: boolean
+  }
+  errorHandling: HookErrorHandling
+}
+
+/**
+ * Phase B: non-Suspense queries so the federal and state tax cards
+ * paint independently. `isFederalTaxesLoading` and `isStateTaxesLoading`
+ * let TaxesView render a per-card skeleton while the box header stays
+ * visible.
+ */
+export function useEmployeeTaxes({ employeeId }: UseEmployeeTaxesProps): UseEmployeeTaxesResult {
+  // staleTime: Infinity — see useEmployeeCompensation for rationale (SDK
+  // QueryClient invalidates on any mutation success).
+  const federalTaxesQuery = useEmployeeTaxSetupGetFederalTaxes(
+    { employeeUuid: employeeId },
+    { staleTime: Infinity },
+  )
+  const stateTaxesQuery = useEmployeeTaxSetupGetStateTaxes(
+    { employeeUuid: employeeId },
+    { staleTime: Infinity },
+  )
 
   return {
-    isLoading: false,
     data: {
-      employeeFederalTax,
-      employeeStateTaxesList: employeeStateTaxesList || [],
+      employeeFederalTax: federalTaxesQuery.data?.employeeFederalTax,
+      employeeStateTaxesList: stateTaxesQuery.data?.employeeStateTaxesList ?? [],
     },
     status: {
-      isPending,
+      isPending: federalTaxesQuery.isFetching || stateTaxesQuery.isFetching,
+      isFederalTaxesLoading: federalTaxesQuery.isLoading,
+      isStateTaxesLoading: stateTaxesQuery.isLoading,
     },
-    errorHandling,
+    errorHandling: composeErrorHandler([federalTaxesQuery, stateTaxesQuery]),
   }
 }

--- a/src/components/Employee/Dashboard/hooks/useEmployeeTaxes.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeTaxes.tsx
@@ -3,7 +3,7 @@ import { useEmployeeTaxSetupGetStateTaxes } from '@gusto/embedded-api/react-quer
 import type { GetV1EmployeesEmployeeIdFederalTaxesResponse } from '@gusto/embedded-api/models/operations/getv1employeesemployeeidfederaltaxes'
 import type { GetV1EmployeesEmployeeIdStateTaxesResponse } from '@gusto/embedded-api/models/operations/getv1employeesemployeeidstatetaxes'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
-import type { HookErrorHandling } from '@/partner-hook-utils/types'
+import type { BaseHookReady } from '@/partner-hook-utils/types'
 
 type EmployeeFederalTax = NonNullable<
   GetV1EmployeesEmployeeIdFederalTaxesResponse['employeeFederalTax']
@@ -16,18 +16,17 @@ export interface UseEmployeeTaxesProps {
   employeeId: string
 }
 
-export interface UseEmployeeTaxesResult {
-  data: {
+export type UseEmployeeTaxesResult = BaseHookReady<
+  {
     employeeFederalTax?: EmployeeFederalTax
     employeeStateTaxesList: EmployeeStateTax[]
-  }
-  status: {
+  },
+  {
     isPending: boolean
     isFederalTaxesLoading: boolean
     isStateTaxesLoading: boolean
   }
-  errorHandling: HookErrorHandling
-}
+>
 
 /**
  * Phase B: non-Suspense queries so the federal and state tax cards
@@ -48,6 +47,7 @@ export function useEmployeeTaxes({ employeeId }: UseEmployeeTaxesProps): UseEmpl
   )
 
   return {
+    isLoading: false,
     data: {
       employeeFederalTax: federalTaxesQuery.data?.employeeFederalTax,
       employeeStateTaxesList: stateTaxesQuery.data?.employeeStateTaxesList ?? [],


### PR DESCRIPTION
## Summary

Phase B of the Dashboard performance work, building on #1890. The previous PR cut first-paint requests from 7+ to 3 by mounting each tab's data hook lazily. That made tabs *load* faster, but within a tab everything still painted at once — the slowest of the tab's queries gated the whole tab.

This makes data fetching incremental within a tab. Box headers paint immediately and each card body fills in as its specific query resolves. Hooks switch from `*Suspense` to non-Suspense React Query variants and expose per-query loading flags; views render a section-level `<Loading>` skeleton inside each `<Components.Box>` body until that query lands.

Also includes a small follow-up (`87a52644`): BasicDetails no longer requests `?include=all_compensations`. That payload is dead weight for that tab — only `useEmployeeCompensation` needs the compensation history. BasicDetails and Compensation now have separate `employeesGet` query keys; the first-paint employee fetch is smaller.

## Changes

- Each composite hook keeps the `BaseHookReady` envelope used across the SDK (`isLoading: false` + `data` + `status` + `errorHandling`), but `status` now exposes per-query loading flags. Affects `useEmployeeForms`, `useEmployeeTaxes`, `useEmployeeBasicDetails`, `useEmployeeCompensation`. None of these are exported from the SDK root, so the change is internal.
- Each tab view (`BasicDetailsView`, `TaxesView`, `DocumentsView`) gains per-section `is…Loading` props that default off `isLoading`, preserving existing story/test ergonomics while letting the `…WithData` containers thread per-query flags. `JobAndPayView` gates each `<Components.Box>` body on its respective flag (`isCompensationCardLoading`, `isPaymentMethodLoading`, `isDeductionsLoading`, `isPayStubsLoading`).
- All dashboard hooks set `staleTime: Infinity` on their underlying queries. Without that, a second observer mounting under the same query key would fire a redundant background refetch on every tab navigation. The SDK QueryClient already invalidates all `@gusto/embedded-api` queries on every mutation success (`createSdkQueryClient.ts`), so post-write freshness is preserved without it.
- BasicDetails drops `?include=all_compensations` from its employee fetch. Two cancel-change tests that relied on a `getCallCount` mock were rewritten to flip a `wasDeleteCalled` flag set by the delete resolver — expresses the test intent more directly and tolerates the new per-tab query key.

The presentational view types stay backward-compatible — `isLoading` still works as a single "all sections loading" toggle for stories.

## Testing

Verified per-section paint via Playwright on `/employee/DashboardFlow`: within the Basic Details tab the home/work address boxes finished loading ("No home address on file") while the employee card still showed the shimmer skeleton — independent paint timing confirmed.

Commands run, all green:
- \`npx tsc --noEmit\`
- \`npm run lint\` — 0 errors (25 pre-existing warnings in unrelated files)
- \`npm run test -- --run src/components/Employee/Dashboard src/components/Employee/Deductions src/components/Employee/PaymentMethod\` — **170/170 pass**

## Related

Builds on #1890 (lazy-load tab data, merged).