### PR TITLE
fix(Dashboard): nested anchor in document viewer + tab state loss

### DIFF
--- a/src/components/Employee/Dashboard/Dashboard.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.tsx
@@ -17,18 +17,25 @@ type EmployeeFederalTax = NonNullable<
   GetV1EmployeesEmployeeIdFederalTaxesResponse['employeeFederalTax']
 >
 
-type DashboardTab = 'basicDetails' | 'jobAndPay' | 'taxes' | 'documents'
+export type DashboardTab = 'basicDetails' | 'jobAndPay' | 'taxes' | 'documents'
 
 export interface DashboardProps extends BaseComponentInterface<'Employee.Dashboard'> {
   employeeId: string
+  selectedTab?: DashboardTab
 }
 
-function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
+function DashboardRoot({
+  employeeId,
+  dictionary,
+  onEvent,
+  selectedTab: controlledTab,
+}: DashboardProps) {
   useI18n('Employee.Dashboard')
   useComponentDictionary('Employee.Dashboard', dictionary)
   const { t } = useTranslation('Employee.Dashboard')
   const Components = useComponentContext()
-  const [selectedTab, setSelectedTab] = useState<DashboardTab>('basicDetails')
+  const [internalTab, setInternalTab] = useState<DashboardTab>('basicDetails')
+  const selectedTab = controlledTab ?? internalTab
 
   const handleEditBasicDetails = useCallback(() => {
     onEvent(componentEvents.EMPLOYEE_UPDATE, { employeeId })
@@ -115,7 +122,9 @@ function DashboardRoot({ employeeId, dictionary, onEvent }: DashboardProps) {
         tabs={tabs}
         selectedId={selectedTab}
         onSelectionChange={id => {
-          setSelectedTab(id as DashboardTab)
+          const next = id as DashboardTab
+          setInternalTab(next)
+          onEvent(componentEvents.EMPLOYEE_DASHBOARD_TAB_CHANGE, { tab: next })
         }}
         aria-label={t('tabsLabel')}
       />

--- a/src/components/Employee/Dashboard/DashboardComponents.tsx
+++ b/src/components/Employee/Dashboard/DashboardComponents.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import type { Job } from '@gusto/embedded-api/models/components/job'
-import { Dashboard } from './Dashboard'
+import { Dashboard, type DashboardTab } from './Dashboard'
 import { HomeAddress } from '@/components/Employee/HomeAddress/management/HomeAddress'
 import { WorkAddress } from '@/components/Employee/WorkAddress/management/WorkAddress'
 import { FederalTaxes } from '@/components/Employee/FederalTaxes/management/FederalTaxes'
@@ -34,12 +34,15 @@ export interface DashboardContextInterface extends FlowContextInterface {
   /** Set by the EMPLOYEE_DEDUCTION_EDIT transition; consumed by
    *  DeductionFormContextual to pre-populate the form. */
   editingDeductionId?: string
+  /** Persists the active Dashboard tab across sub-flows so Cancel/Back
+   *  returns to the originating tab instead of resetting to basic details. */
+  selectedTab?: DashboardTab
 }
 
 export function DashboardViewContextual() {
   useI18n('Employee.Dashboard')
   const { t } = useTranslation('Employee.Dashboard')
-  const { employeeId, onEvent, successAlert } = useFlow<DashboardContextInterface>()
+  const { employeeId, onEvent, successAlert, selectedTab } = useFlow<DashboardContextInterface>()
   const Components = useComponentContext()
 
   const alertLabels: Record<DashboardSuccessAlert, string> = {
@@ -63,7 +66,11 @@ export function DashboardViewContextual() {
           disableScrollIntoView
         />
       )}
-      <Dashboard employeeId={ensureRequired(employeeId)} onEvent={onEvent} />
+      <Dashboard
+        employeeId={ensureRequired(employeeId)}
+        onEvent={onEvent}
+        selectedTab={selectedTab}
+      />
     </>
   )
 }

--- a/src/components/Employee/Dashboard/dashboardStateMachine.ts
+++ b/src/components/Employee/Dashboard/dashboardStateMachine.ts
@@ -1,6 +1,7 @@
 import { transition, reduce, state } from 'robot3'
 import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
 import type { Job } from '@gusto/embedded-api/models/components/job'
+import type { DashboardTab } from './Dashboard'
 import {
   DashboardViewContextual,
   HomeAddressContextual,
@@ -24,6 +25,7 @@ type EventPayloads = {
   [componentEvents.EMPLOYEE_VIEW_FORM_TO_SIGN]: { employeeId: string; formId: string }
   [componentEvents.EMPLOYEE_DEDUCTION_EDIT]: Garnishment
   [componentEvents.EMPLOYEE_COMPENSATION_CREATE]: { employeeId: string; job: Job }
+  [componentEvents.EMPLOYEE_DASHBOARD_TAB_CHANGE]: { tab: DashboardTab }
 }
 
 const returnToIndex = reduce(
@@ -247,6 +249,19 @@ export const dashboardStateMachine = {
         (ctx: DashboardContextInterface): DashboardContextInterface => ({
           ...ctx,
           successAlert: null,
+        }),
+      ),
+    ),
+    transition(
+      componentEvents.EMPLOYEE_DASHBOARD_TAB_CHANGE,
+      'index',
+      reduce(
+        (
+          ctx: DashboardContextInterface,
+          ev: MachineEventType<EventPayloads, typeof componentEvents.EMPLOYEE_DASHBOARD_TAB_CHANGE>,
+        ): DashboardContextInterface => ({
+          ...ctx,
+          selectedTab: ev.payload.tab,
         }),
       ),
     ),

--- a/src/components/Employee/Documents/management/DocumentManager.test.tsx
+++ b/src/components/Employee/Documents/management/DocumentManager.test.tsx
@@ -76,6 +76,25 @@ describe('DocumentManager', () => {
 
       expect(screen.queryByLabelText('Signature')).not.toBeInTheDocument()
     })
+
+    it('does not nest an anchor inside the download CTA anchor', async () => {
+      const pdfHref = 'https://example.com/form-w4.pdf'
+      server.use(
+        handleGetEmployeeFormPdf(() => HttpResponse.json({ ...formPdf, document_url: pdfHref })),
+      )
+
+      const { container } = renderWithProviders(<DocumentManager {...defaultProps} />)
+
+      await waitFor(() => {
+        expect(container.querySelector(`a[href="${pdfHref}"][download]`)).not.toBeNull()
+      })
+
+      // Every anchor must not contain another anchor — nested <a> elements
+      // are invalid HTML and trigger a React hydration error.
+      Array.from(container.querySelectorAll('a')).forEach(anchor => {
+        expect(anchor.querySelector('a')).toBeNull()
+      })
+    })
   })
 
   describe('signing mode (requiresSigning = true)', () => {

--- a/src/i18n/en/Employee.DocumentManager.json
+++ b/src/i18n/en/Employee.DocumentManager.json
@@ -1,5 +1,5 @@
 {
   "viewDocumentCta": "View document",
-  "downloadDocumentCta": "You can also <downloadLink>download this document<downloadLink>.",
+  "downloadDocumentCta": "You can also <downloadLink>download this document</downloadLink>.",
   "backCta": "Back"
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -71,6 +71,7 @@ export const employeeEvents = {
   EMPLOYEE_ONBOARDING_DOCUMENTS_CONFIG_UPDATED: 'employee/onboardingDocumentsConfig/updated',
   EMPLOYEE_DOCUMENTS_DONE: 'employee/documents/done',
   EMPLOYEE_REHIRE: 'employee/rehire',
+  EMPLOYEE_DASHBOARD_TAB_CHANGE: 'employee/dashboard/tabChange',
 } as const
 
 export const companyEvents = {


### PR DESCRIPTION
## Summary

Two blocking bugs surfaced during the Dashboard OCP test fest:

- **🔴 Nested `<a>` in document viewer hydration error** — `downloadDocumentCta` had a malformed closing tag (`<downloadLink>` instead of `</downloadLink>`). The Trans component rendered the trailing period inside a second nested `<a>` with the same S3 href, producing invalid HTML and a React hydration warning every time an employee opened a signed form (W-4, Direct Deposit Authorization).
- **🔴 Tab state lost across sub-flows** — selected tab lived in local React state, and `Dashboard` remounts on every state-machine transition back to `index`, so Cancel/Back from Add bank account, Add deduction, Edit Federal/State taxes, View document, etc. dropped the user on Basic details instead of the originating tab.

## Changes

**`fix(Documents)`**
- `src/i18n/en/Employee.DocumentManager.json` — close the `<downloadLink>` tag.
- `src/components/Employee/Documents/management/DocumentManager.test.tsx` — regression test asserting no anchor contains another anchor.

**`fix(Dashboard)`**
- `src/shared/constants.ts` — new `EMPLOYEE_DASHBOARD_TAB_CHANGE` event.
- `src/components/Employee/Dashboard/Dashboard.tsx` — export `DashboardTab`; optional `selectedTab` controlled prop; tab change emits the new event via existing `onEvent` (no new prop). Uncontrolled local state still backs Storybook/test usage.
- `src/components/Employee/Dashboard/DashboardComponents.tsx` — `DashboardContextInterface.selectedTab`; `DashboardViewContextual` forwards it from flow context to `Dashboard`.
- `src/components/Employee/Dashboard/dashboardStateMachine.ts` — typed payload + self-transition on `index` that reduces the new tab into context. `returnToIndex` spread already preserves it.

## Out of scope

Yellow issues from the same test fest still need PM/design input:
- Bank account row actions menu only offers Delete (no Edit / Set primary).
- State taxes "File a New Hire Report?" appears in the view but not in the edit form.
- Modal vs full-page inconsistency across cards.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test -- --run src/components/Employee` → 582 / 582 (was 581; +1 regression)
- [ ] Manual: open a signed form in `Employee/DashboardFlow` — no console hydration warning
- [ ] Manual: from Job and pay tab, click Add bank account → Cancel — land back on Job and pay
- [ ] Manual: from Taxes tab, click Edit Federal taxes → Cancel — land back on Taxes
- [ ] Manual: from Documents tab, click View → Back — land back on Documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)