### PR TITLE
fix(Dashboard): show compensation effective date instead of hire date

### DIFF
--- a/src/components/Employee/Dashboard/CompensationCard.tsx
+++ b/src/components/Employee/Dashboard/CompensationCard.tsx
@@ -39,6 +39,8 @@ export function CompensationCard({
 
   const [isReviewOpen, setIsReviewOpen] = useState(false)
 
+  const currentComp = job?.compensations?.find(c => c.uuid === job.currentCompensationUuid)
+
   const hasPendingChanges = pendingChanges.length > 0
   const showSummaryAlert = hasMultipleJobs && pendingChanges.length > 1
   const showInlineAlert = hasPendingChanges && !showSummaryAlert
@@ -153,12 +155,14 @@ export function CompensationCard({
                 </Flex>
               )}
 
-              {job.hireDate && (
+              {currentComp?.effectiveDate && (
                 <Flex flexDirection="column" gap={0}>
                   <Components.Text variant="supporting">
-                    {t('jobAndPay.compensation.startDate')}
+                    {t('jobAndPay.compensation.effectiveDate')}
                   </Components.Text>
-                  <Components.Text>{formatDateLongWithYear(job.hireDate)}</Components.Text>
+                  <Components.Text>
+                    {formatDateLongWithYear(currentComp.effectiveDate)}
+                  </Components.Text>
                 </Flex>
               )}
             </Flex>

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -212,6 +212,19 @@ export function JobAndPayView({
   const canAddAnotherJob =
     jobs.length >= 1 && primaryFlsaStatus === FlsaStatus.NONEXEMPT && !hasFutureNonNonexemptComp
   const singleJobNumericRate = singleJob ? parseJobRate(singleJob.rate) : null
+  const singleJobCurrentComp = singleJob?.compensations?.find(
+    c => c.uuid === singleJob.currentCompensationUuid,
+  )
+  const singleJobEffectiveDateRow = singleJobCurrentComp?.effectiveDate ? (
+    <Flex flexDirection="column" gap={0}>
+      <Components.Text variant="supporting">
+        {t('jobAndPay.compensation.effectiveDate')}
+      </Components.Text>
+      <Components.Text>
+        {formatDateLongWithYear(singleJobCurrentComp.effectiveDate)}
+      </Components.Text>
+    </Flex>
+  ) : null
 
   const [isReviewOpen, setIsReviewOpen] = useState(false)
   const renderDetail = usePendingChangeDetailRenderer(employeeFirstName)
@@ -291,9 +304,12 @@ export function JobAndPayView({
       },
     },
     {
-      key: 'startDate',
-      title: t('jobAndPay.compensation.columns.startDate'),
-      render: (job: Job) => (job.hireDate ? formatDateLongWithYear(job.hireDate) : '-'),
+      key: 'effectiveDate',
+      title: t('jobAndPay.compensation.columns.effectiveDate'),
+      render: (job: Job) => {
+        const currentComp = job.compensations?.find(c => c.uuid === job.currentCompensationUuid)
+        return currentComp?.effectiveDate ? formatDateLongWithYear(currentComp.effectiveDate) : '-'
+      },
     },
   ]
 
@@ -650,16 +666,7 @@ export function JobAndPayView({
                     </Flex>
                   )}
 
-                  {singleJob.hireDate && (
-                    <Flex flexDirection="column" gap={0}>
-                      <Components.Text variant="supporting">
-                        {t('jobAndPay.compensation.startDate')}
-                      </Components.Text>
-                      <Components.Text>
-                        {formatDateLongWithYear(singleJob.hireDate)}
-                      </Components.Text>
-                    </Flex>
-                  )}
+                  {singleJobEffectiveDateRow}
                 </Flex>
               ) : (
                 <EmptyData

--- a/src/i18n/en/Employee.Dashboard.json
+++ b/src/i18n/en/Employee.Dashboard.json
@@ -39,7 +39,7 @@
         "salary": "Salary/No overtime"
       },
       "wage": "Wage",
-      "startDate": "Start date",
+      "effectiveDate": "Effective date",
       "addJobCta": "Add job",
       "addAnotherJobCta": "Add another job",
       "tableLabel": "List of jobs",
@@ -49,7 +49,7 @@
       "columns": {
         "jobTitle": "Job title",
         "payType": "Pay type",
-        "startDate": "Start date"
+        "effectiveDate": "Effective date"
       },
       "deleteJobDialog": {
         "title": "Delete job?",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1467,7 +1467,7 @@ export interface EmployeeDashboard{
 "salary":string;
 };
 "wage":string;
-"startDate":string;
+"effectiveDate":string;
 "addJobCta":string;
 "addAnotherJobCta":string;
 "tableLabel":string;
@@ -1477,7 +1477,7 @@ export interface EmployeeDashboard{
 "columns":{
 "jobTitle":string;
 "payType":string;
-"startDate":string;
+"effectiveDate":string;
 };
 "deleteJobDialog":{
 "title":string;


### PR DESCRIPTION
## Summary

- Replace the **"Start date"** label and `hireDate` value on compensation cards with **"Effective date"** from the current active compensation (`currentCompensationUuid`)
- Updated in two places: `JobAndPayView` (single-job detail view and multi-job table column) and `CompensationCard`
- Updated translation key in `Employee.Dashboard.json` and regenerated `i18next.d.ts`

## Test plan

- [x] Single-job employee: verify the compensation card shows "Effective date" with the date the current compensation took effect
- [x] Multi-job employee: verify the jobs table column header reads "Effective date" and each row shows the correct effective date
- [x] Employee with no current compensation: verify the field is hidden (not shown as blank)

<img width="1276" height="467" alt="Screenshot 2026-05-21 at 1 48 40 PM" src="https://github.com/user-attachments/assets/95b6582f-073a-4e5b-bfd2-dbc916b18bf1" />

Made with [Cursor](https://cursor.com)