### PR TITLE
feat(dashboard): show Pending badge for future-dated compensations on job card and table

### DIFF
--- a/src/components/Employee/Dashboard/Dashboard.test.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.test.tsx
@@ -645,52 +645,52 @@ describe('Dashboard', () => {
     })
   })
 
+  type Compensation = {
+    uuid: string
+    version: string
+    payment_unit: string
+    flsa_status: string
+    job_uuid: string
+    effective_date: string
+    rate: string
+    title?: string
+    adjust_for_minimum_wage?: boolean
+    minimum_wages?: Array<{ uuid: string; wage: string }>
+  }
+
+  type JobFixture = {
+    uuid: string
+    version: string
+    employee_uuid: string
+    current_compensation_uuid: string
+    payment_unit: string
+    primary: boolean
+    title: string
+    compensations: Compensation[]
+    rate: string
+    hire_date: string
+  }
+
+  const buildEmployeeWithJobs = async (jobs: JobFixture[]): Promise<Record<string, unknown>> => {
+    const base = (await getFixture('get-v1-employees')) as Record<string, unknown>
+    return { ...base, jobs }
+  }
+
+  const overrideEmployee = (employee: Record<string, unknown>) => {
+    server.use(handleGetEmployee(() => HttpResponse.json(employee)))
+  }
+
+  const goToJobAndPayTab = async (user: ReturnType<typeof userEvent.setup>) => {
+    await waitFor(() => {
+      expect(screen.getByText('Legal name')).toBeTruthy()
+    })
+    await user.click(screen.getByRole('tab', { name: 'Job and pay' }))
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Compensation' })).toBeInTheDocument()
+    })
+  }
+
   describe('Compensation pending changes', () => {
-    type Compensation = {
-      uuid: string
-      version: string
-      payment_unit: string
-      flsa_status: string
-      job_uuid: string
-      effective_date: string
-      rate: string
-      title?: string
-      adjust_for_minimum_wage?: boolean
-      minimum_wages?: Array<{ uuid: string; wage: string }>
-    }
-
-    type JobFixture = {
-      uuid: string
-      version: string
-      employee_uuid: string
-      current_compensation_uuid: string
-      payment_unit: string
-      primary: boolean
-      title: string
-      compensations: Compensation[]
-      rate: string
-      hire_date: string
-    }
-
-    const buildEmployeeWithJobs = async (jobs: JobFixture[]): Promise<Record<string, unknown>> => {
-      const base = (await getFixture('get-v1-employees')) as Record<string, unknown>
-      return { ...base, jobs }
-    }
-
-    const overrideEmployee = (employee: Record<string, unknown>) => {
-      server.use(handleGetEmployee(() => HttpResponse.json(employee)))
-    }
-
-    const goToJobAndPayTab = async (user: ReturnType<typeof userEvent.setup>) => {
-      await waitFor(() => {
-        expect(screen.getByText('Legal name')).toBeTruthy()
-      })
-      await user.click(screen.getByRole('tab', { name: 'Job and pay' }))
-      await waitFor(() => {
-        expect(screen.getByRole('heading', { name: 'Compensation' })).toBeInTheDocument()
-      })
-    }
-
     const baseJob = (
       overrides: Partial<JobFixture> = {},
       compensations: Compensation[] = [],
@@ -1187,51 +1187,6 @@ describe('Dashboard', () => {
   })
 
   describe('Compensation pending badge (future-dated new job)', () => {
-    type Compensation = {
-      uuid: string
-      version: string
-      payment_unit: string
-      flsa_status: string
-      job_uuid: string
-      effective_date: string
-      rate: string
-      title?: string
-      adjust_for_minimum_wage?: boolean
-      minimum_wages?: Array<{ uuid: string; wage: string }>
-    }
-
-    type JobFixture = {
-      uuid: string
-      version: string
-      employee_uuid: string
-      current_compensation_uuid: string
-      payment_unit: string
-      primary: boolean
-      title: string
-      compensations: Compensation[]
-      rate: string
-      hire_date: string
-    }
-
-    const buildEmployeeWithJobs = async (jobs: JobFixture[]): Promise<Record<string, unknown>> => {
-      const base = (await getFixture('get-v1-employees')) as Record<string, unknown>
-      return { ...base, jobs }
-    }
-
-    const overrideEmployee = (employee: Record<string, unknown>) => {
-      server.use(handleGetEmployee(() => HttpResponse.json(employee)))
-    }
-
-    const goToJobAndPayTab = async (user: ReturnType<typeof userEvent.setup>) => {
-      await waitFor(() => {
-        expect(screen.getByText('Legal name')).toBeTruthy()
-      })
-      await user.click(screen.getByRole('tab', { name: 'Job and pay' }))
-      await waitFor(() => {
-        expect(screen.getByRole('heading', { name: 'Compensation' })).toBeInTheDocument()
-      })
-    }
-
     const pendingJob = (overrides: Partial<JobFixture> = {}): JobFixture => ({
       uuid: 'job-pending',
       version: 'v1',

--- a/src/components/Employee/Dashboard/Dashboard.test.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.test.tsx
@@ -1186,6 +1186,354 @@ describe('Dashboard', () => {
     })
   })
 
+  describe('Compensation pending badge (future-dated new job)', () => {
+    type Compensation = {
+      uuid: string
+      version: string
+      payment_unit: string
+      flsa_status: string
+      job_uuid: string
+      effective_date: string
+      rate: string
+      title?: string
+      adjust_for_minimum_wage?: boolean
+      minimum_wages?: Array<{ uuid: string; wage: string }>
+    }
+
+    type JobFixture = {
+      uuid: string
+      version: string
+      employee_uuid: string
+      current_compensation_uuid: string
+      payment_unit: string
+      primary: boolean
+      title: string
+      compensations: Compensation[]
+      rate: string
+      hire_date: string
+    }
+
+    const buildEmployeeWithJobs = async (jobs: JobFixture[]): Promise<Record<string, unknown>> => {
+      const base = (await getFixture('get-v1-employees')) as Record<string, unknown>
+      return { ...base, jobs }
+    }
+
+    const overrideEmployee = (employee: Record<string, unknown>) => {
+      server.use(handleGetEmployee(() => HttpResponse.json(employee)))
+    }
+
+    const goToJobAndPayTab = async (user: ReturnType<typeof userEvent.setup>) => {
+      await waitFor(() => {
+        expect(screen.getByText('Legal name')).toBeTruthy()
+      })
+      await user.click(screen.getByRole('tab', { name: 'Job and pay' }))
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'Compensation' })).toBeInTheDocument()
+      })
+    }
+
+    const pendingJob = (overrides: Partial<JobFixture> = {}): JobFixture => ({
+      uuid: 'job-pending',
+      version: 'v1',
+      employee_uuid: 'employee-123',
+      current_compensation_uuid: 'comp-pending',
+      payment_unit: 'Year',
+      primary: true,
+      title: 'Marketing Director',
+      rate: '120000.00',
+      hire_date: ONE_YEAR_AHEAD,
+      compensations: [
+        {
+          uuid: 'comp-pending',
+          version: 'comp-v1',
+          payment_unit: 'Year',
+          flsa_status: 'Exempt',
+          job_uuid: 'job-pending',
+          effective_date: ONE_YEAR_AHEAD,
+          rate: '120000.00',
+          adjust_for_minimum_wage: false,
+          minimum_wages: [],
+        },
+      ],
+      ...overrides,
+    })
+
+    it('shows a Pending badge row on the single-job card when the job has no current comp (exempt/salary)', async () => {
+      const user = userEvent.setup()
+      const employee = await buildEmployeeWithJobs([pendingJob()])
+      overrideEmployee(employee)
+
+      renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+      await goToJobAndPayTab(user)
+
+      const compensationCard = screen
+        .getByRole('heading', { name: 'Compensation' })
+        .closest('[data-testid="data-box"]')! as HTMLElement
+
+      expect(within(compensationCard).getByText('Status')).toBeInTheDocument()
+      expect(within(compensationCard).getByText('Pending')).toBeInTheDocument()
+      expect(within(compensationCard).queryByRole('alert')).toBeNull()
+    })
+
+    it('shows a Pending badge row on the single nonexempt job card when the job has no current comp', async () => {
+      const user = userEvent.setup()
+      const employee = await buildEmployeeWithJobs([
+        pendingJob({
+          payment_unit: 'Hour',
+          compensations: [
+            {
+              uuid: 'comp-pending',
+              version: 'comp-v1',
+              payment_unit: 'Hour',
+              flsa_status: 'Nonexempt',
+              job_uuid: 'job-pending',
+              effective_date: ONE_YEAR_AHEAD,
+              rate: '28.00',
+              adjust_for_minimum_wage: false,
+              minimum_wages: [],
+            },
+          ],
+        }),
+      ])
+      overrideEmployee(employee)
+
+      renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+      await goToJobAndPayTab(user)
+
+      const compensationCard = screen
+        .getByRole('heading', { name: 'Compensation' })
+        .closest('[data-testid="data-box"]')! as HTMLElement
+
+      expect(within(compensationCard).getByText('Status')).toBeInTheDocument()
+      expect(within(compensationCard).getByText('Pending')).toBeInTheDocument()
+      expect(within(compensationCard).queryByRole('alert')).toBeNull()
+    })
+
+    it('still shows the alert (not badge) when the single job has a current comp and a future update', async () => {
+      const user = userEvent.setup()
+      const employee = await buildEmployeeWithJobs([
+        {
+          uuid: 'job-1',
+          version: 'v1',
+          employee_uuid: 'employee-123',
+          current_compensation_uuid: 'comp-current',
+          payment_unit: 'Year',
+          primary: true,
+          title: 'Marketing Director',
+          rate: '100000.00',
+          hire_date: '2024-01-01',
+          compensations: [
+            {
+              uuid: 'comp-current',
+              version: 'v1',
+              payment_unit: 'Year',
+              flsa_status: 'Exempt',
+              job_uuid: 'job-1',
+              effective_date: '2024-01-01',
+              rate: '100000.00',
+              adjust_for_minimum_wage: false,
+              minimum_wages: [],
+            },
+            {
+              uuid: 'comp-future',
+              version: 'v2',
+              payment_unit: 'Year',
+              flsa_status: 'Exempt',
+              job_uuid: 'job-1',
+              effective_date: ONE_YEAR_AHEAD,
+              rate: '120000.00',
+              adjust_for_minimum_wage: false,
+              minimum_wages: [],
+            },
+          ],
+        },
+      ])
+      overrideEmployee(employee)
+
+      renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+      await goToJobAndPayTab(user)
+
+      const compensationCard = screen
+        .getByRole('heading', { name: 'Compensation' })
+        .closest('[data-testid="data-box"]')! as HTMLElement
+
+      expect(within(compensationCard).queryByText('Pending')).toBeNull()
+      expect(within(compensationCard).queryByText('Status')).toBeNull()
+
+      const alert = await screen.findByRole('alert')
+      expect(within(alert).getByText(/Compensation will change on/)).toBeInTheDocument()
+    })
+
+    it('shows a Pending Status column in the multi-job table when a secondary job is pending-new', async () => {
+      const user = userEvent.setup()
+      const employee = await buildEmployeeWithJobs([
+        {
+          uuid: PRIMARY_JOB_UUID,
+          version: 'primary-version',
+          employee_uuid: 'employee-123',
+          current_compensation_uuid: 'primary-comp-uuid',
+          payment_unit: 'Hour',
+          primary: true,
+          title: 'Cashier',
+          rate: '30.00',
+          hire_date: '2024-01-01',
+          compensations: [
+            {
+              uuid: 'primary-comp-uuid',
+              version: 'v1',
+              payment_unit: 'Hour',
+              flsa_status: 'Nonexempt',
+              job_uuid: PRIMARY_JOB_UUID,
+              effective_date: '2024-01-01',
+              rate: '30.00',
+              adjust_for_minimum_wage: false,
+              minimum_wages: [],
+            },
+          ],
+        },
+        {
+          uuid: SECONDARY_JOB_UUID,
+          version: 'secondary-version',
+          employee_uuid: 'employee-123',
+          current_compensation_uuid: 'secondary-comp-pending',
+          payment_unit: 'Hour',
+          primary: false,
+          title: 'Stock Associate',
+          rate: '22.00',
+          hire_date: ONE_YEAR_AHEAD,
+          compensations: [
+            {
+              uuid: 'secondary-comp-pending',
+              version: 'v1',
+              payment_unit: 'Hour',
+              flsa_status: 'Nonexempt',
+              job_uuid: SECONDARY_JOB_UUID,
+              effective_date: ONE_YEAR_AHEAD,
+              rate: '22.00',
+              adjust_for_minimum_wage: false,
+              minimum_wages: [],
+            },
+          ],
+        },
+      ])
+      overrideEmployee(employee)
+
+      renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+      await goToJobAndPayTab(user)
+
+      const compensationCard = screen
+        .getByRole('heading', { name: 'Compensation' })
+        .closest('[data-testid="data-box"]')! as HTMLElement
+
+      expect(within(compensationCard).getByText('Status')).toBeInTheDocument()
+
+      const pendingRow = screen.getByText('Stock Associate').closest('[role="row"]')! as HTMLElement
+      expect(within(pendingRow).getByText('Pending')).toBeInTheDocument()
+
+      const currentRow = screen.getByText('Cashier').closest('[role="row"]')! as HTMLElement
+      expect(within(currentRow).queryByText('Pending')).toBeNull()
+
+      expect(within(compensationCard).queryByRole('alert')).toBeNull()
+    })
+
+    it('shows no Status column when all multi-job table rows have current compensations', async () => {
+      const user = userEvent.setup()
+
+      const multiJobFixture = await getMultiJobFixture()
+      server.use(handleGetEmployee(() => HttpResponse.json(multiJobFixture)))
+
+      renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+      await goToJobAndPayTab(user)
+
+      const compensationCard = screen
+        .getByRole('heading', { name: 'Compensation' })
+        .closest('[data-testid="data-box"]')! as HTMLElement
+
+      expect(within(compensationCard).queryByText('Status')).toBeNull()
+      expect(within(compensationCard).queryByText('Pending')).toBeNull()
+    })
+
+    it('shows both a Pending badge in the table and an alert when one job is pending-new and another has a comp update', async () => {
+      const user = userEvent.setup()
+      const employee = await buildEmployeeWithJobs([
+        {
+          uuid: PRIMARY_JOB_UUID,
+          version: 'primary-version',
+          employee_uuid: 'employee-123',
+          current_compensation_uuid: 'primary-comp-uuid',
+          payment_unit: 'Hour',
+          primary: true,
+          title: 'Cashier',
+          rate: '30.00',
+          hire_date: '2024-01-01',
+          compensations: [
+            {
+              uuid: 'primary-comp-uuid',
+              version: 'v1',
+              payment_unit: 'Hour',
+              flsa_status: 'Nonexempt',
+              job_uuid: PRIMARY_JOB_UUID,
+              effective_date: '2024-01-01',
+              rate: '30.00',
+              adjust_for_minimum_wage: false,
+              minimum_wages: [],
+            },
+            {
+              uuid: 'primary-comp-future',
+              version: 'v2',
+              payment_unit: 'Hour',
+              flsa_status: 'Nonexempt',
+              job_uuid: PRIMARY_JOB_UUID,
+              effective_date: ONE_YEAR_AHEAD,
+              rate: '35.00',
+              adjust_for_minimum_wage: false,
+              minimum_wages: [],
+            },
+          ],
+        },
+        {
+          uuid: SECONDARY_JOB_UUID,
+          version: 'secondary-version',
+          employee_uuid: 'employee-123',
+          current_compensation_uuid: 'secondary-comp-pending',
+          payment_unit: 'Hour',
+          primary: false,
+          title: 'Stock Associate',
+          rate: '22.00',
+          hire_date: TWO_YEARS_AHEAD,
+          compensations: [
+            {
+              uuid: 'secondary-comp-pending',
+              version: 'v1',
+              payment_unit: 'Hour',
+              flsa_status: 'Nonexempt',
+              job_uuid: SECONDARY_JOB_UUID,
+              effective_date: TWO_YEARS_AHEAD,
+              rate: '22.00',
+              adjust_for_minimum_wage: false,
+              minimum_wages: [],
+            },
+          ],
+        },
+      ])
+      overrideEmployee(employee)
+
+      renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+      await goToJobAndPayTab(user)
+
+      const compensationCard = screen
+        .getByRole('heading', { name: 'Compensation' })
+        .closest('[data-testid="data-box"]')! as HTMLElement
+
+      expect(within(compensationCard).getByText('Status')).toBeInTheDocument()
+      const pendingRow = screen.getByText('Stock Associate').closest('[role="row"]')! as HTMLElement
+      expect(within(pendingRow).getByText('Pending')).toBeInTheDocument()
+
+      const alert = await screen.findByRole('alert')
+      expect(within(alert).getByText(/Compensation for Cashier will change on/)).toBeInTheDocument()
+    })
+  })
+
   it('emits EMPLOYEE_STATE_TAXES_EDIT with only employeeId when clicking state taxes edit', async () => {
     const user = userEvent.setup()
 

--- a/src/components/Employee/Dashboard/Dashboard.test.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.test.tsx
@@ -12,15 +12,10 @@ import { setupApiTestMocks } from '@/test/mocks/apiServer'
 import { server } from '@/test/mocks/server'
 import { API_BASE_URL } from '@/test/constants'
 import { handleGetEmployeeForms, i9Form } from '@/test/mocks/apis/employee_forms'
-import {
-  handleGetEmployee,
-  handleGetEmployeeJobs,
-  handleDeleteEmployeeJob,
-} from '@/test/mocks/apis/employees'
+import { handleGetEmployeeJobs, handleDeleteEmployeeJob } from '@/test/mocks/apis/employees'
 import { handleDeleteCompensation } from '@/test/mocks/apis/compensations'
 import { componentEvents } from '@/shared/constants'
 import { assertDefined } from '@/test-utils/assertions'
-import { getFixture } from '@/test/mocks/fixtures/getFixture'
 
 type GarnishmentFixture = {
   uuid: string
@@ -663,13 +658,8 @@ describe('Dashboard', () => {
     hire_date: string
   }
 
-  const buildEmployeeWithJobs = async (jobs: JobFixture[]): Promise<Record<string, unknown>> => {
-    const base = (await getFixture('get-v1-employees')) as Record<string, unknown>
-    return { ...base, jobs }
-  }
-
-  const overrideEmployee = (employee: Record<string, unknown>) => {
-    server.use(handleGetEmployee(() => HttpResponse.json(employee)))
+  const overrideEmployeeJobs = (jobs: JobFixture[]) => {
+    server.use(handleGetEmployeeJobs(() => HttpResponse.json(jobs)))
   }
 
   const goToJobAndPayTab = async (user: ReturnType<typeof userEvent.setup>) => {
@@ -683,10 +673,6 @@ describe('Dashboard', () => {
   }
 
   describe('Compensation pending changes', () => {
-    const overrideEmployeeJobs = (jobs: JobFixture[]) => {
-      server.use(handleGetEmployeeJobs(() => HttpResponse.json(jobs)))
-    }
-
     const baseJob = (
       overrides: Partial<JobFixture> = {},
       compensations: Compensation[] = [],
@@ -1196,8 +1182,7 @@ describe('Dashboard', () => {
 
     it('shows a Pending badge row on the single-job card when the job has no current comp (exempt/salary)', async () => {
       const user = userEvent.setup()
-      const employee = await buildEmployeeWithJobs([pendingJob()])
-      overrideEmployee(employee)
+      overrideEmployeeJobs([pendingJob()])
 
       renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
       await goToJobAndPayTab(user)
@@ -1213,7 +1198,7 @@ describe('Dashboard', () => {
 
     it('shows a Pending badge row on the single nonexempt job card when the job has no current comp', async () => {
       const user = userEvent.setup()
-      const employee = await buildEmployeeWithJobs([
+      overrideEmployeeJobs([
         pendingJob({
           payment_unit: 'Hour',
           compensations: [
@@ -1231,7 +1216,6 @@ describe('Dashboard', () => {
           ],
         }),
       ])
-      overrideEmployee(employee)
 
       renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
       await goToJobAndPayTab(user)
@@ -1247,7 +1231,7 @@ describe('Dashboard', () => {
 
     it('still shows the alert (not badge) when the single job has a current comp and a future update', async () => {
       const user = userEvent.setup()
-      const employee = await buildEmployeeWithJobs([
+      overrideEmployeeJobs([
         {
           uuid: 'job-1',
           version: 'v1',
@@ -1284,7 +1268,6 @@ describe('Dashboard', () => {
           ],
         },
       ])
-      overrideEmployee(employee)
 
       renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
       await goToJobAndPayTab(user)
@@ -1302,7 +1285,7 @@ describe('Dashboard', () => {
 
     it('shows a Pending Status column in the multi-job table when a secondary job is pending-new', async () => {
       const user = userEvent.setup()
-      const employee = await buildEmployeeWithJobs([
+      overrideEmployeeJobs([
         {
           uuid: PRIMARY_JOB_UUID,
           version: 'primary-version',
@@ -1352,7 +1335,6 @@ describe('Dashboard', () => {
           ],
         },
       ])
-      overrideEmployee(employee)
 
       renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
       await goToJobAndPayTab(user)
@@ -1375,8 +1357,7 @@ describe('Dashboard', () => {
     it('shows no Status column when all multi-job table rows have current compensations', async () => {
       const user = userEvent.setup()
 
-      const multiJobFixture = getMultiJobFixture()
-      server.use(handleGetEmployee(() => HttpResponse.json(multiJobFixture)))
+      overrideEmployeeJobs(getMultiJobFixture())
 
       renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
       await goToJobAndPayTab(user)
@@ -1391,7 +1372,7 @@ describe('Dashboard', () => {
 
     it('shows both a Pending badge in the table and an alert when one job is pending-new and another has a comp update', async () => {
       const user = userEvent.setup()
-      const employee = await buildEmployeeWithJobs([
+      overrideEmployeeJobs([
         {
           uuid: PRIMARY_JOB_UUID,
           version: 'primary-version',
@@ -1452,7 +1433,6 @@ describe('Dashboard', () => {
           ],
         },
       ])
-      overrideEmployee(employee)
 
       renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
       await goToJobAndPayTab(user)

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -15,7 +15,7 @@ import { PendingChangesReviewModal } from './PendingChangesReviewModal'
 import styles from './JobAndPayView.module.scss'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
-import { DataView, useDataView, EmptyData, Loading } from '@/components/Common'
+import { DataView, useDataView, EmptyData, Loading, VisuallyHidden } from '@/components/Common'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import { BaseLayout } from '@/components/Base/Base'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
@@ -229,10 +229,21 @@ export function JobAndPayView({
   const [isReviewOpen, setIsReviewOpen] = useState(false)
   const renderDetail = usePendingChangeDetailRenderer(employeeFirstName)
 
-  const hasPendingChanges = pendingChanges.length > 0
-  const showSummaryAlert = hasMultipleJobs && pendingChanges.length > 1
-  const showInlineAlert = hasPendingChanges && !showSummaryAlert
-  const nextChange = pendingChanges[0]
+  // Split pending changes: "new job" (job hasn't started yet, no current comp)
+  // vs "update" (existing comp with a scheduled future change).
+  // New-job changes get a Pending badge on the card/table row.
+  // Update changes get the existing warning alert treatment.
+  const newJobPendingChanges = pendingChanges.filter(c => c.isNewJob)
+  const updatePendingChanges = pendingChanges.filter(c => !c.isNewJob)
+
+  const pendingNewJobUuids = new Set(newJobPendingChanges.map(c => c.jobUuid))
+  const singleJobIsPendingNew = singleJob ? pendingNewJobUuids.has(singleJob.uuid) : false
+  const hasAnyPendingNewJobs = pendingNewJobUuids.size > 0
+
+  const hasPendingUpdates = updatePendingChanges.length > 0
+  const showSummaryAlert = hasMultipleJobs && updatePendingChanges.length > 1
+  const showInlineAlert = hasPendingUpdates && !showSummaryAlert
+  const nextChange = updatePendingChanges[0]
 
   const paymentMethodList = usePaymentMethodList({ employeeId })
   const paymentMethod = paymentMethodList.isLoading
@@ -311,6 +322,20 @@ export function JobAndPayView({
         return currentComp?.effectiveDate ? formatDateLongWithYear(currentComp.effectiveDate) : '-'
       },
     },
+    ...(hasAnyPendingNewJobs
+      ? [
+          {
+            key: 'status',
+            title: <VisuallyHidden>{t('jobAndPay.compensation.columns.status')}</VisuallyHidden>,
+            render: (job: Job) =>
+              pendingNewJobUuids.has(job.uuid) ? (
+                <Components.Badge status="warning">
+                  {t('jobAndPay.compensation.pendingStatus')}
+                </Components.Badge>
+              ) : null,
+          },
+        ]
+      : []),
   ]
 
   const jobsDataView = useDataView({
@@ -565,7 +590,7 @@ export function JobAndPayView({
             <Loading />
           ) : (
             <Flex flexDirection="column" gap={16}>
-              {hasPendingChanges && (
+              {hasPendingUpdates && (
                 <div className={hasMultipleJobs ? styles.alertWrapper : undefined}>
                   <Flex flexDirection="column" gap={16}>
                     {showInlineAlert && nextChange && (
@@ -667,6 +692,19 @@ export function JobAndPayView({
                   )}
 
                   {singleJobEffectiveDateRow}
+
+                  {singleJobIsPendingNew && (
+                    <Flex flexDirection="column" gap={0}>
+                      <Components.Text variant="supporting">
+                        {t('jobAndPay.compensation.columns.status')}
+                      </Components.Text>
+                      <div>
+                        <Components.Badge status="warning">
+                          {t('jobAndPay.compensation.pendingStatus')}
+                        </Components.Badge>
+                      </div>
+                    </Flex>
+                  )}
                 </Flex>
               ) : (
                 <EmptyData
@@ -771,7 +809,7 @@ export function JobAndPayView({
 
         <PendingChangesReviewModal
           isOpen={isReviewOpen}
-          pendingChanges={pendingChanges}
+          pendingChanges={updatePendingChanges}
           employeeFirstName={employeeFirstName}
           cancellingCompensationUuid={cancellingCompensationUuid}
           onClose={() => {

--- a/src/components/Employee/Dashboard/getPendingCompensationChanges.test.ts
+++ b/src/components/Employee/Dashboard/getPendingCompensationChanges.test.ts
@@ -278,6 +278,49 @@ describe('getPendingCompensationChanges', () => {
     expect(result[0]).toMatchObject({ details: [{ kind: 'newJob' }] })
   })
 
+  describe('isNewJob flag', () => {
+    it('sets isNewJob=false when there is a current comp and a future update', () => {
+      const current = buildComp()
+      const future = buildComp({ uuid: 'comp-future', rate: '35.00', effectiveDate: '2026-06-01' })
+      const job = buildJob({}, [current, future])
+
+      const result = getPendingCompensationChanges([job], { today: TODAY })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({ isNewJob: false })
+    })
+
+    it('sets isNewJob=true when the job has only a future-dated compensation (job not yet started)', () => {
+      const future = buildComp({ uuid: 'comp-future', rate: '22.00', effectiveDate: '2026-06-01' })
+      const job = buildJob({ currentCompensationUuid: 'comp-future' }, [future])
+
+      const result = getPendingCompensationChanges([job], { today: TODAY })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({ isNewJob: true })
+    })
+
+    it('sets isNewJob=true on only the first stacked comp when a new job has stacked future comps', () => {
+      const futureA = buildComp({
+        uuid: 'comp-future-a',
+        rate: '22.00',
+        effectiveDate: '2026-06-01',
+      })
+      const futureB = buildComp({
+        uuid: 'comp-future-b',
+        rate: '25.00',
+        effectiveDate: '2026-09-01',
+      })
+      const job = buildJob({ currentCompensationUuid: 'comp-future-a' }, [futureA, futureB])
+
+      const result = getPendingCompensationChanges([job], { today: TODAY })
+
+      expect(result).toHaveLength(2)
+      expect(result[0]).toMatchObject({ compensationUuid: 'comp-future-a', isNewJob: true })
+      expect(result[1]).toMatchObject({ compensationUuid: 'comp-future-b', isNewJob: false })
+    })
+  })
+
   it('returns stacked future comps in ascending effectiveDate order with diff baselined to the previous comp', () => {
     const current = buildComp({ rate: '30.00' })
     const futureA = buildComp({

--- a/src/components/Employee/Dashboard/getPendingCompensationChanges.ts
+++ b/src/components/Employee/Dashboard/getPendingCompensationChanges.ts
@@ -23,6 +23,12 @@ export interface PendingCompensationChange {
   effectiveDate: string
   jobTitle: string | null
   details: PendingChangeDetail[]
+  /**
+   * True when the job has no current (on-or-before-today) compensation —
+   * i.e., the job itself hasn't started yet. The UI renders a "Pending"
+   * badge rather than a change alert in this case.
+   */
+  isNewJob: boolean
 }
 
 const startOfLocalDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate())
@@ -160,6 +166,7 @@ export function getPendingCompensationChanges(
         effectiveDate: future.effectiveDate!,
         jobTitle: job.title,
         details,
+        isNewJob: baseline === null,
       })
     }
   }

--- a/src/i18n/en/Employee.Dashboard.json
+++ b/src/i18n/en/Employee.Dashboard.json
@@ -49,8 +49,10 @@
       "columns": {
         "jobTitle": "Job title",
         "payType": "Pay type",
-        "effectiveDate": "Effective date"
+        "effectiveDate": "Effective date",
+        "status": "Status"
       },
+      "pendingStatus": "Pending",
       "deleteJobDialog": {
         "title": "Delete job?",
         "description": "{{jobTitle}} will be permanently removed.",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1478,7 +1478,9 @@ export interface EmployeeDashboard{
 "jobTitle":string;
 "payType":string;
 "effectiveDate":string;
+"status":string;
 };
+"pendingStatus":string;
 "deleteJobDialog":{
 "title":string;
 "description":string;


### PR DESCRIPTION
## Summary

- When a job has no current (on-or-before-today) compensation — i.e., it was created with a future effective date and hasn't started yet — display a **Pending** status badge instead of the existing change alert
- **Single-job card view** (exempt or nonexempt with one job): adds a Status / Pending badge row below the effective date field
- **Multi-job table view**: conditionally adds a visually-hidden-labeled Status column with a Pending badge for future-dated job rows; column is omitted entirely when all jobs have current compensations
- Existing warning alert behavior is unchanged for jobs that already have an active compensation with a scheduled future update

## How it works

\`getPendingCompensationChanges\` now carries an \`isNewJob: boolean\` field on each \`PendingCompensationChange\`. It is \`true\` when \`baseline === null\` (no current comp exists for the job), which maps to the existing \`buildNewJobDetails\` path. The view splits pending changes into two buckets — \`newJobPendingChanges\` (badge) and \`updatePendingChanges\` (alert) — and drives each UI surface independently.

## Test plan

- [x] Unit tests for \`isNewJob\` flag in \`getPendingCompensationChanges.test.ts\` (update-only → false, new-job-only → true, stacked future comps → true on first / false on subsequent)
- [x] Integration tests in \`Dashboard.test.tsx\`:
  - Single exempt (salary) job with only future comp → Pending badge, no alert
  - Single nonexempt job with only future comp → Pending badge, no alert
  - Single job with current comp + future update → alert still shown, no badge
  - Multi-job table with a pending-new secondary job → Status column with Pending badge on that row only
  - Multi-job table with all current jobs → no Status column
  - Mixed: one job with comp update + one pending-new job → badge in table + inline alert for the update

<img width="1271" height="379" alt="Screenshot 2026-05-21 at 2 51 16 PM" src="https://github.com/user-attachments/assets/f583329e-ff50-43a6-8ca9-1a8a1ef0b374" />

<img width="1234" height="535" alt="Screenshot 2026-05-21 at 2 43 57 PM" src="https://github.com/user-attachments/assets/78cfa88c-408d-464f-af57-b6dc5ddee22e" />

Made with [Cursor](https://cursor.com)