### PR TITLE
fix: close remove-employee modal on error and clear stale errors in balance modal

### DIFF
--- a/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.tsx
+++ b/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.tsx
@@ -190,6 +190,7 @@ function Root({ policyId }: TimeOffPolicyDetailProps) {
 
   const handleRemoveEmployee = useCallback(
     async (employeeUuid: string, employeeName: string) => {
+      setRemoveTarget(null)
       await baseSubmitHandler({}, async () => {
         await removeEmployees({
           request: {
@@ -198,7 +199,6 @@ function Root({ policyId }: TimeOffPolicyDetailProps) {
           },
         })
         invalidatePolicy()
-        setRemoveTarget(null)
         setSuccessAlert(t('flash.employeeRemoved', { name: employeeName }))
       })
     },
@@ -265,6 +265,7 @@ function Root({ policyId }: TimeOffPolicyDetailProps) {
                 label: t('employeeTable.editBalance'),
                 icon: <EditIcon aria-hidden />,
                 onClick: () => {
+                  setError(null)
                   setEditBalanceState({
                     employeeUuid: employee.uuid,
                     employeeName,
@@ -289,7 +290,7 @@ function Root({ policyId }: TimeOffPolicyDetailProps) {
         />
       )
     },
-    [t, isUnlimited],
+    [t, isUnlimited, setError],
   )
 
   const discriminatedProps =


### PR DESCRIPTION
## Summary
- Closes the remove-employee confirmation dialog unconditionally (before the API call) so errors display as a page-level banner instead of being hidden behind the modal overlay.
- Clears stale error state when opening the edit-balance modal, preventing removal errors from leaking into the balance editor.

Fixes bugs: remove-employee modal stays open on error; stale error shows in edit-balance modal.

## Test plan
- [x] Existing `TimeOffPolicyDetail.test.tsx` passes (10/10)
- Manually verify: trigger a remove-employee error → modal closes, error banner visible
- Manually verify: after a removal error, open edit balance → no stale error shown