### PR TITLE
fix: show employee names in ineligible-employee add errors

### DIFF
--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
@@ -190,13 +190,38 @@ function SelectEmployeesTimeOffInner({
       await baseSubmitHandler({}, async () => {
         let policyResult: unknown
         if (toAdd.length > 0) {
-          const response = await addEmployees({
-            request: {
-              timeOffPolicyUuid: policyId,
-              requestBody: { employees: buildAddPayload(toAdd) },
-            },
-          })
-          policyResult = response.timeOffPolicy
+          try {
+            const response = await addEmployees({
+              request: {
+                timeOffPolicyUuid: policyId,
+                requestBody: { employees: buildAddPayload(toAdd) },
+              },
+            })
+            policyResult = response.timeOffPolicy
+          } catch (err) {
+            if (err instanceof UnprocessableEntityError) {
+              const messages = err.errors
+                .map(e => {
+                  const uuid = e.errorKey
+                  const employee = selectedEmployeesRef.current.get(uuid)
+                  const name = employee
+                    ? `${employee.firstName ?? ''} ${employee.lastName ?? ''}`.trim()
+                    : null
+                  const reason = e.message ?? t('errors.ineligibleUnknownReason')
+                  return name ? `${name}: ${reason}` : reason
+                })
+                .filter(Boolean)
+              throw new SDKInternalError(
+                messages.length > 0
+                  ? t('errors.ineligibleEmployees', {
+                      details: messages.join('; '),
+                    })
+                  : (err.errors[0]?.message ?? 'Unable to add employees'),
+                'api_error',
+              )
+            }
+            throw err
+          }
         }
         if (mode === 'wizard' && policyResult) {
           const version =

--- a/src/i18n/en/Company.TimeOff.SelectEmployees.json
+++ b/src/i18n/en/Company.TimeOff.SelectEmployees.json
@@ -11,7 +11,9 @@
   "continueCta": "Continue",
   "emptyState": "All eligible employees have already been added to this policy.",
   "errors": {
-    "completePolicyFailed": "Unable to complete this policy. {{details}}"
+    "completePolicyFailed": "Unable to complete this policy. {{details}}",
+    "ineligibleEmployees": "Some employees could not be added to this policy: {{details}}",
+    "ineligibleUnknownReason": "not eligible for this policy"
   },
   "addConfirmDialog": {
     "title_one": "Add {{count}} employee to this policy?",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -585,6 +585,8 @@ export interface CompanyTimeOffSelectEmployees{
 "emptyState":string;
 "errors":{
 "completePolicyFailed":string;
+"ineligibleEmployees":string;
+"ineligibleUnknownReason":string;
 };
 "addConfirmDialog":{
 "title_one":string;


### PR DESCRIPTION
## Summary
- Catches 422 errors from the add-employees API and resolves error UUIDs to human-readable employee names.
- Includes the API-provided reason for each ineligible employee in the error message.
- Adds i18n keys for the formatted error messages.

Fixes bug: adding an ineligible employee to a policy shows UUID only, no reason.

## Test plan
- [x] Existing `SelectEmployeesTimeOff.test.tsx` passes (25/25)
- Manually verify: attempt to add an ineligible employee → error shows their name and reason