### PR TITLE
fix: fall back to first job title when no primary job is flagged

### DIFF
--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/useSelectEmployeesData.ts
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/useSelectEmployeesData.ts
@@ -66,13 +66,13 @@ export function useSelectEmployeesData(companyId: string, excludeUuids?: Set<str
       ...restPageResults.flatMap(r => r.data.showEmployees ?? []),
     ]
     return showEmployees
-      .filter(e => isStartedByToday(e.jobs?.find(job => job.primary)?.hireDate))
+      .filter(e => isStartedByToday((e.jobs?.find(job => job.primary) ?? e.jobs?.[0])?.hireDate))
       .filter(e => !excludeUuids?.has(e.uuid))
       .map(e => ({
         uuid: e.uuid,
         firstName: e.firstName,
         lastName: e.lastName,
-        jobTitle: e.jobs?.find(job => job.primary)?.title ?? null,
+        jobTitle: e.jobs?.find(job => job.primary)?.title ?? e.jobs?.[0]?.title ?? null,
         department: e.department ?? null,
         eligiblePaidTimeOff: e.eligiblePaidTimeOff as PaidTimeOff[] | undefined,
       }))

--- a/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.tsx
+++ b/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.tsx
@@ -118,7 +118,7 @@ function deriveEmployees(
       uuid: policyEmp.uuid ?? '',
       firstName: emp?.firstName ?? null,
       lastName: emp?.lastName ?? null,
-      jobTitle: primaryJob?.title ?? null,
+      jobTitle: primaryJob?.title ?? emp?.jobs?.[0]?.title ?? null,
       balance: policyEmp.balance != null ? Number(policyEmp.balance) : null,
     }
   })


### PR DESCRIPTION
## Summary
- Falls back to the first available job title when no primary job is flagged on an employee.
- Applies the same fallback logic for hire-date eligibility filtering.
- Fixes both the add-employees table and the policy detail employees tab.

Fixes bug: not all job titles displaying on the add-employees-to-policy page.

## Test plan
- [x] All SelectEmployees + TimeOffPolicyDetail tests pass (89/89)
- Manually verify: employees without a primary-flagged job now show their first job's title