### PR TITLE
fix: provide descriptive error when balance update exceeds policy max

### DIFF
--- a/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.tsx
+++ b/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetail.tsx
@@ -5,6 +5,7 @@ import { useTimeOffPoliciesRemoveEmployeesMutation } from '@gusto/embedded-api/r
 import { useTimeOffPoliciesUpdateBalanceMutation } from '@gusto/embedded-api/react-query/timeOffPoliciesUpdateBalance'
 import { useEmployeesListSuspense } from '@gusto/embedded-api/react-query/employeesList'
 import type { TimeOffPolicy } from '@gusto/embedded-api/models/components/timeoffpolicy'
+import { UnprocessableEntityError } from '@gusto/embedded-api/models/errors/unprocessableentityerror'
 import { useQueryClient } from '@tanstack/react-query'
 import { TimeOffPolicyDetailPresentation } from './TimeOffPolicyDetailPresentation'
 import { EditEmployeeBalanceModal } from './EditEmployeeBalanceModal'
@@ -18,6 +19,7 @@ import type {
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import { BaseComponent, type BaseComponentInterface } from '@/components/Base'
 import { useBase } from '@/components/Base/useBase'
+import { SDKInternalError } from '@/types/sdkError'
 import { componentEvents } from '@/shared/constants'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
@@ -209,20 +211,51 @@ function Root({ policyId }: TimeOffPolicyDetailProps) {
     async (newBalance: number) => {
       if (!editBalanceState) return
       await baseSubmitHandler({}, async () => {
-        await updateBalance({
-          request: {
-            timeOffPolicyUuid: policyId,
-            requestBody: {
-              employees: [{ uuid: editBalanceState.employeeUuid, balance: String(newBalance) }],
+        try {
+          await updateBalance({
+            request: {
+              timeOffPolicyUuid: policyId,
+              requestBody: {
+                employees: [{ uuid: editBalanceState.employeeUuid, balance: String(newBalance) }],
+              },
             },
-          },
-        })
+          })
+        } catch (err) {
+          if (err instanceof UnprocessableEntityError) {
+            const maxHours = policy.maxHours != null ? Number(policy.maxHours) : null
+            const hasLimitViolation = err.errors.some(
+              e =>
+                e.message === 'LIMIT_VIOLATION_MAX_HOURS' ||
+                e.category === 'invalid_attribute_value',
+            )
+            if (hasLimitViolation && maxHours != null) {
+              throw new SDKInternalError(
+                t('editBalanceModal.errors.balanceExceedsMax', { max: maxHours }),
+                'api_error',
+              )
+            }
+            const messages = err.errors.map(e => e.message).filter(Boolean)
+            throw new SDKInternalError(
+              messages.join('. ') || t('editBalanceModal.errors.updateFailed'),
+              'api_error',
+            )
+          }
+          throw err
+        }
         invalidatePolicy()
         setEditBalanceState(null)
         setSuccessAlert(t('flash.balanceUpdated', { name: editBalanceState.employeeName }))
       })
     },
-    [baseSubmitHandler, updateBalance, policyId, editBalanceState, invalidatePolicy, t],
+    [
+      baseSubmitHandler,
+      updateBalance,
+      policyId,
+      editBalanceState,
+      invalidatePolicy,
+      t,
+      policy.maxHours,
+    ],
   )
 
   const handleAddEmployees = useCallback(() => {

--- a/src/i18n/en/Company.TimeOff.TimeOffPolicyDetails.json
+++ b/src/i18n/en/Company.TimeOff.TimeOffPolicyDetails.json
@@ -93,7 +93,11 @@
     "currentBalance": "Current balance",
     "hoursUnit": "hours",
     "cancelCta": "Cancel",
-    "updateCta": "Update balance"
+    "updateCta": "Update balance",
+    "errors": {
+      "balanceExceedsMax": "Balance cannot exceed the policy maximum of {{max}} hours. Reduce the balance or increase the policy's balance maximum.",
+      "updateFailed": "Unable to update balance. Please try again."
+    }
   },
   "removeEmployeeModal": {
     "title": "Remove {{name}} from policy?",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -748,6 +748,10 @@ export interface CompanyTimeOffTimeOffPolicyDetails{
 "hoursUnit":string;
 "cancelCta":string;
 "updateCta":string;
+"errors":{
+"balanceExceedsMax":string;
+"updateFailed":string;
+};
 };
 "removeEmployeeModal":{
 "title":string;


### PR DESCRIPTION
## Summary
- Catches 422 errors during balance update and provides a clear error message indicating the policy maximum and recommended action.
- Adds i18n keys for balance-specific error messages in the edit-balance modal.

Fixes bug: updating balance to an invalid value (balance > max) shows generic "one field has issues" without guidance.

## Test plan
- [x] Existing `TimeOffPolicyDetail.test.tsx` passes (10/10)
- Manually verify: set balance above max → error says "Balance cannot exceed the policy maximum of X hours"