### PR TITLE
fix: preserve date picker state when switching back from unlimited

### DIFF
--- a/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx
+++ b/src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx
@@ -78,6 +78,9 @@ export function PolicyConfigurationFormPresentation({
   }, [resetMonth, getValues, setValue])
 
   useEffect(() => {
+    if (accrualMethod === 'unlimited') {
+      return
+    }
     if (accrualMethod !== 'per_hour_paid') {
       setValue('accrualRateUnit', undefined)
       setValue('includeOvertime', undefined)
@@ -85,12 +88,6 @@ export function PolicyConfigurationFormPresentation({
     }
     if (accrualMethod !== 'per_calendar_year') {
       setValue('accrualMethodFixed', undefined)
-    }
-    if (accrualMethod !== 'per_hour_paid' && accrualMethod !== 'per_calendar_year') {
-      setValue('resetDateType', undefined)
-      setValue('resetMonth', 1)
-      setValue('resetDay', 1)
-      setValue('accrualRate', undefined)
     }
   }, [accrualMethod, setValue])
 


### PR DESCRIPTION
## Summary
- The useEffect that clears form fields on accrual method change now returns early for unlimited, preserving resetDateType, resetMonth, and resetDay in hidden form state.
- Switching from an accrual method to unlimited and back now restores the custom date picker and its previously-selected values.

Fixes bug: selecting unlimited then switching back to accrual hides the date picker and auto-fills Jan 1.

## Test plan
- [x] Existing `PolicyConfigurationForm.test.tsx` passes (41/41)
- Manually verify: set per-year accrual with custom date → switch to unlimited → switch back → date picker shows with previous values