### PR TITLE
fix: always show Create Policy button in page header

### DIFF
--- a/src/components/TimeOff/PolicyList/PolicyList.test.tsx
+++ b/src/components/TimeOff/PolicyList/PolicyList.test.tsx
@@ -269,7 +269,8 @@ describe('PolicyList', () => {
       renderWithProviders(<PolicyList {...defaultProps} />)
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Create policy' })).toBeInTheDocument()
+        const buttons = screen.getAllByRole('button', { name: 'Create policy' })
+        expect(buttons.length).toBeGreaterThanOrEqual(1)
       })
     })
   })

--- a/src/components/TimeOff/PolicyList/PolicyListPresentation.tsx
+++ b/src/components/TimeOff/PolicyList/PolicyListPresentation.tsx
@@ -137,11 +137,9 @@ export function PolicyListPresentation({
         gap={{ base: 12, medium: 24 }}
       >
         <Heading as="h2">{t('pageTitle')}</Heading>
-        {policies.length > 0 && (
-          <Button variant="primary" onClick={onCreatePolicy}>
-            {t('createPolicyCta')}
-          </Button>
-        )}
+        <Button variant="primary" onClick={onCreatePolicy}>
+          {t('createPolicyCta')}
+        </Button>
       </Flex>
 
       <DataView label={t('tableLabel')} {...dataViewProps} />


### PR DESCRIPTION
## Summary
- Removes the `policies.length > 0` condition that hid the Create Policy button when the list was empty.
- The empty-state illustration retains its own Create Policy button for visual emphasis.

Fixes bug: Create button disappears when there are no policies.

## Test plan
- [x] Existing `PolicyList.test.tsx` passes (26/26)
- Manually verify: with zero policies, both the header Create button and the empty-state button are visible