### PR TITLE
fix: clarify policy deletion error when pending requests exist

### DIFF
--- a/src/components/TimeOff/PolicyList/PolicyList.tsx
+++ b/src/components/TimeOff/PolicyList/PolicyList.tsx
@@ -13,11 +13,13 @@ import {
 } from '@gusto/embedded-api/react-query/holidayPayPoliciesGet'
 import { useHolidayPayPoliciesDeleteMutation } from '@gusto/embedded-api/react-query/holidayPayPoliciesDelete'
 import type { TimeOffPolicy } from '@gusto/embedded-api/models/components/timeoffpolicy'
+import { UnprocessableEntityError } from '@gusto/embedded-api/models/errors/unprocessableentityerror'
 import { PolicyListPresentation } from './PolicyListPresentation'
 import type { PolicyListItem } from './PolicyListTypes'
 import { isListedTimeOffPolicyType } from '@/components/TimeOff/TimeOffFlow/timeOffPolicyTypes'
 import { BaseBoundaries, BaseLayout, type BaseComponentInterface } from '@/components/Base'
 import { useBaseSubmit } from '@/components/Base/useBaseSubmit'
+import { SDKInternalError } from '@/types/sdkError'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
 import { componentEvents } from '@/shared/constants'
 import { useI18n } from '@/i18n'
@@ -140,9 +142,28 @@ function Root({ companyId, onEvent }: PolicyListProps) {
         await invalidateAllHolidayPayPoliciesGet(queryClient)
         setDeleteSuccessAlert(t('flash.holidayDeleted'))
       } else {
-        await deactivatePolicyMutation.mutateAsync({
-          request: { timeOffPolicyUuid: policy.uuid },
-        })
+        try {
+          await deactivatePolicyMutation.mutateAsync({
+            request: { timeOffPolicyUuid: policy.uuid },
+          })
+        } catch (err) {
+          if (err instanceof UnprocessableEntityError) {
+            const hasPendingRequests = err.errors.some(
+              e =>
+                e.message?.toLowerCase().includes('pending') ||
+                e.message?.toLowerCase().includes('approved'),
+            )
+            if (hasPendingRequests) {
+              throw new SDKInternalError(
+                t('errors.pendingRequestsBlockDeletion', { name: policy.name }),
+                'api_error',
+              )
+            }
+            const messages = err.errors.map(e => e.message).filter(Boolean)
+            throw new SDKInternalError(messages.join('. ') || t('errors.deleteFailed'), 'api_error')
+          }
+          throw err
+        }
         await invalidateAllTimeOffPoliciesGetAll(queryClient)
         setDeleteSuccessAlert(t('flash.policyDeleted', { name: policy.name }))
       }

--- a/src/i18n/en/Company.TimeOff.TimeOffPolicies.json
+++ b/src/i18n/en/Company.TimeOff.TimeOffPolicies.json
@@ -37,5 +37,9 @@
     "policyDeleted": "Policy \"{{name}}\" deleted successfully",
     "holidayDeleted": "Holiday pay policy deleted successfully",
     "invalidPolicyType": "Please select a valid policy type."
+  },
+  "errors": {
+    "pendingRequestsBlockDeletion": "\"{{name}}\" has pending or approved time off requests. Please decline or cancel those requests before deleting this policy.",
+    "deleteFailed": "Unable to delete this policy. Please try again."
   }
 }

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -651,6 +651,10 @@ export interface CompanyTimeOffTimeOffPolicies{
 "holidayDeleted":string;
 "invalidPolicyType":string;
 };
+"errors":{
+"pendingRequestsBlockDeletion":string;
+"deleteFailed":string;
+};
 };
 export interface CompanyTimeOffTimeOffPolicyDetails{
 "breadcrumb":string;


### PR DESCRIPTION
## Summary
- Catches the 422 error from the deactivate-policy endpoint and checks for pending/approved request mentions.
- Replaces the raw API text with a clear, actionable message explaining that requests must be declined/cancelled before deletion.
- Adds i18n keys for deletion-related error messages.

Fixes bug: unclear "there are pending or approved time off requests" error on policy deletion.

## Test plan
- [x] Existing `PolicyList.test.tsx` passes (26/26)
- Manually verify: attempt to delete a policy with pending requests → clear message about what action to take