### PR TITLE
fix(Dashboard): show pending compensation changes including title

### DIFF
--- a/docs/reference/endpoint-inventory.json
+++ b/docs/reference/endpoint-inventory.json
@@ -839,6 +839,10 @@
         },
         {
           "method": "GET",
+          "path": "/v1/employees/:employeeId/jobs"
+        },
+        {
+          "method": "GET",
           "path": "/v1/employees/:employeeId/pay_stubs"
         },
         {
@@ -1981,6 +1985,10 @@
         {
           "method": "GET",
           "path": "/v1/employees/:employeeId/home_addresses"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/employees/:employeeId/jobs"
         },
         {
           "method": "GET",

--- a/docs/reference/endpoint-reference.md
+++ b/docs/reference/endpoint-reference.md
@@ -163,6 +163,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/forms` |
 |  | GET | `/v1/employees/:employeeId/home_addresses` |
+|  | GET | `/v1/employees/:employeeId/jobs` |
 |  | GET | `/v1/employees/:employeeId/pay_stubs` |
 |  | GET | `/v1/employees/:employeeId/work_addresses` |
 |  | GET | `/v1/employees/:employeeUuid/federal_taxes` |
@@ -374,6 +375,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | `/v1/employees/:employeeId` |
 |  | GET | `/v1/employees/:employeeId/forms` |
 |  | GET | `/v1/employees/:employeeId/home_addresses` |
+|  | GET | `/v1/employees/:employeeId/jobs` |
 |  | GET | `/v1/employees/:employeeId/pay_stubs` |
 |  | GET | `/v1/employees/:employeeId/work_addresses` |
 |  | GET | `/v1/employees/:employeeUuid/federal_taxes` |

--- a/src/components/Employee/Dashboard/Dashboard.test.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.test.tsx
@@ -12,11 +12,10 @@ import { setupApiTestMocks } from '@/test/mocks/apiServer'
 import { server } from '@/test/mocks/server'
 import { API_BASE_URL } from '@/test/constants'
 import { handleGetEmployeeForms, i9Form } from '@/test/mocks/apis/employee_forms'
-import { handleGetEmployee, handleDeleteEmployeeJob } from '@/test/mocks/apis/employees'
+import { handleGetEmployeeJobs, handleDeleteEmployeeJob } from '@/test/mocks/apis/employees'
 import { handleDeleteCompensation } from '@/test/mocks/apis/compensations'
 import { componentEvents } from '@/shared/constants'
 import { assertDefined } from '@/test-utils/assertions'
-import { getFixture } from '@/test/mocks/fixtures/getFixture'
 
 type GarnishmentFixture = {
   uuid: string
@@ -71,94 +70,89 @@ const openJobAndPayTab = async (user: ReturnType<typeof userEvent.setup>) => {
 const PRIMARY_JOB_UUID = '428a653a-0745-4db4-9c80-558288d416fa'
 const SECONDARY_JOB_UUID = 'secondary-job-uuid'
 
-async function getSingleNonexemptJobFixture() {
-  const employeeFixture = (await getFixture('get-v1-employees')) as Record<string, unknown>
-  return {
-    ...employeeFixture,
-    jobs: [
-      {
-        uuid: PRIMARY_JOB_UUID,
-        version: 'primary-version',
-        employee_uuid: 'employee-123',
-        current_compensation_uuid: 'primary-comp-uuid',
-        payment_unit: 'Hour',
-        primary: true,
-        title: 'Office Admin',
-        compensations: [
-          {
-            uuid: 'primary-comp-uuid',
-            version: 'primary-comp-version',
-            payment_unit: 'Hour',
-            flsa_status: 'Nonexempt',
-            job_uuid: PRIMARY_JOB_UUID,
-            effective_date: '2019-06-06',
-            rate: '32.00',
-            adjust_for_minimum_wage: false,
-            minimum_wages: [],
-          },
-        ],
-        rate: '32.00',
-        hire_date: '2019-06-06',
-      },
-    ],
-  }
+function getSingleNonexemptJobFixture() {
+  return [
+    {
+      uuid: PRIMARY_JOB_UUID,
+      version: 'primary-version',
+      employee_uuid: 'employee-123',
+      current_compensation_uuid: 'primary-comp-uuid',
+      payment_unit: 'Hour',
+      primary: true,
+      title: 'Office Admin',
+      compensations: [
+        {
+          uuid: 'primary-comp-uuid',
+          version: 'primary-comp-version',
+          payment_unit: 'Hour',
+          flsa_status: 'Nonexempt',
+          job_uuid: PRIMARY_JOB_UUID,
+          effective_date: '2019-06-06',
+          rate: '32.00',
+          title: 'Office Admin',
+          adjust_for_minimum_wage: false,
+          minimum_wages: [],
+        },
+      ],
+      rate: '32.00',
+      hire_date: '2019-06-06',
+    },
+  ]
 }
 
-async function getMultiJobFixture() {
-  const employeeFixture = (await getFixture('get-v1-employees')) as Record<string, unknown>
-  return {
-    ...employeeFixture,
-    jobs: [
-      {
-        uuid: PRIMARY_JOB_UUID,
-        version: 'primary-version',
-        employee_uuid: 'employee-123',
-        current_compensation_uuid: 'primary-comp-uuid',
-        payment_unit: 'Hour',
-        primary: true,
-        title: 'Administrator',
-        compensations: [
-          {
-            uuid: 'primary-comp-uuid',
-            version: 'primary-comp-version',
-            payment_unit: 'Hour',
-            flsa_status: 'Nonexempt',
-            job_uuid: PRIMARY_JOB_UUID,
-            effective_date: '2019-04-05',
-            rate: '35.00',
-            adjust_for_minimum_wage: false,
-            minimum_wages: [],
-          },
-        ],
-        rate: '35.00',
-        hire_date: '2019-04-05',
-      },
-      {
-        uuid: SECONDARY_JOB_UUID,
-        version: 'secondary-version',
-        employee_uuid: 'employee-123',
-        current_compensation_uuid: 'secondary-comp-uuid',
-        payment_unit: 'Hour',
-        primary: false,
-        title: 'Administrative Supervisor',
-        compensations: [
-          {
-            uuid: 'secondary-comp-uuid',
-            version: 'secondary-comp-version',
-            payment_unit: 'Hour',
-            flsa_status: 'Nonexempt',
-            job_uuid: SECONDARY_JOB_UUID,
-            effective_date: '2026-05-01',
-            rate: '35.00',
-            adjust_for_minimum_wage: false,
-            minimum_wages: [],
-          },
-        ],
-        rate: '35.00',
-        hire_date: '2026-05-01',
-      },
-    ],
-  }
+function getMultiJobFixture() {
+  return [
+    {
+      uuid: PRIMARY_JOB_UUID,
+      version: 'primary-version',
+      employee_uuid: 'employee-123',
+      current_compensation_uuid: 'primary-comp-uuid',
+      payment_unit: 'Hour',
+      primary: true,
+      title: 'Administrator',
+      compensations: [
+        {
+          uuid: 'primary-comp-uuid',
+          version: 'primary-comp-version',
+          payment_unit: 'Hour',
+          flsa_status: 'Nonexempt',
+          job_uuid: PRIMARY_JOB_UUID,
+          effective_date: '2019-04-05',
+          rate: '35.00',
+          title: 'Administrator',
+          adjust_for_minimum_wage: false,
+          minimum_wages: [],
+        },
+      ],
+      rate: '35.00',
+      hire_date: '2019-04-05',
+    },
+    {
+      uuid: SECONDARY_JOB_UUID,
+      version: 'secondary-version',
+      employee_uuid: 'employee-123',
+      current_compensation_uuid: 'secondary-comp-uuid',
+      payment_unit: 'Hour',
+      primary: false,
+      title: 'Administrative Supervisor',
+      compensations: [
+        {
+          uuid: 'secondary-comp-uuid',
+          version: 'secondary-comp-version',
+          payment_unit: 'Hour',
+          flsa_status: 'Nonexempt',
+          job_uuid: SECONDARY_JOB_UUID,
+          effective_date: '2026-05-01',
+          rate: '35.00',
+          title: 'Administrative Supervisor',
+          adjust_for_minimum_wage: false,
+          minimum_wages: [],
+        },
+      ],
+      rate: '35.00',
+      hire_date: '2026-05-01',
+    },
+  ]
 }
 
 const ONE_YEAR_AHEAD = (() => {
@@ -259,8 +253,7 @@ describe('Dashboard', () => {
   it('shows an empty Compensation card with Add job CTA when the employee has no jobs', async () => {
     const user = userEvent.setup()
 
-    const employeeFixture = (await getFixture('get-v1-employees')) as Record<string, unknown>
-    server.use(handleGetEmployee(() => HttpResponse.json({ ...employeeFixture, jobs: [] })))
+    server.use(handleGetEmployeeJobs(() => HttpResponse.json([])))
 
     renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
 
@@ -270,9 +263,8 @@ describe('Dashboard', () => {
 
     await user.click(screen.getByRole('tab', { name: 'Job and pay' }))
 
-    // BasicDetails and Compensation use different employeesGet query
-    // keys now (the include differs), so Compensation does its own
-    // fetch — wait for the empty-state copy rather than just the header.
+    // BasicDetails uses the employee endpoint; Compensation uses the jobs
+    // endpoint — wait for the empty-state copy rather than just the header.
     expect(await screen.findByText('No compensation')).toBeInTheDocument()
     expect(screen.getByText('Compensation will appear here once added')).toBeInTheDocument()
 
@@ -384,6 +376,7 @@ describe('Dashboard', () => {
   it('emits EMPLOYEE_COMPENSATION_CREATE with the primary job when clicking the single-job Edit CTA', async () => {
     const user = userEvent.setup()
 
+    server.use(handleGetEmployeeJobs(() => HttpResponse.json(getSingleNonexemptJobFixture())))
     renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
 
     await waitFor(() => {
@@ -437,8 +430,7 @@ describe('Dashboard', () => {
   it('shows the single-job detail view with both Edit and Add another job when the primary job is nonexempt', async () => {
     const user = userEvent.setup()
 
-    const fixture = await getSingleNonexemptJobFixture()
-    server.use(handleGetEmployee(() => HttpResponse.json(fixture)))
+    server.use(handleGetEmployeeJobs(() => HttpResponse.json(getSingleNonexemptJobFixture())))
 
     renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
 
@@ -472,8 +464,7 @@ describe('Dashboard', () => {
   it('renders a jobs table with no header Edit CTA when the employee has multiple nonexempt jobs', async () => {
     const user = userEvent.setup()
 
-    const multiJobFixture = await getMultiJobFixture()
-    server.use(handleGetEmployee(() => HttpResponse.json(multiJobFixture)))
+    server.use(handleGetEmployeeJobs(() => HttpResponse.json(getMultiJobFixture())))
 
     renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
 
@@ -503,8 +494,7 @@ describe('Dashboard', () => {
   it('hides Delete on the primary job and shows Edit + Delete on the non-primary job', async () => {
     const user = userEvent.setup()
 
-    const multiJobFixture = await getMultiJobFixture()
-    server.use(handleGetEmployee(() => HttpResponse.json(multiJobFixture)))
+    server.use(handleGetEmployeeJobs(() => HttpResponse.json(getMultiJobFixture())))
 
     renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
 
@@ -539,8 +529,7 @@ describe('Dashboard', () => {
   it('emits EMPLOYEE_COMPENSATION_CREATE with the row job when clicking the per-row Edit menu item', async () => {
     const user = userEvent.setup()
 
-    const multiJobFixture = await getMultiJobFixture()
-    server.use(handleGetEmployee(() => HttpResponse.json(multiJobFixture)))
+    server.use(handleGetEmployeeJobs(() => HttpResponse.json(getMultiJobFixture())))
 
     renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
 
@@ -572,8 +561,7 @@ describe('Dashboard', () => {
   it('opens the delete dialog and calls the delete API when confirming a non-primary job deletion', async () => {
     const user = userEvent.setup()
 
-    const multiJobFixture = await getMultiJobFixture()
-    server.use(handleGetEmployee(() => HttpResponse.json(multiJobFixture)))
+    server.use(handleGetEmployeeJobs(() => HttpResponse.json(getMultiJobFixture())))
 
     let deletePath: string | null = null
     const deleteJobResolver = vi.fn<
@@ -626,8 +614,7 @@ describe('Dashboard', () => {
   it('emits EMPLOYEE_JOB_ADD_ANOTHER when clicking the Add another job CTA in the multi-job view', async () => {
     const user = userEvent.setup()
 
-    const multiJobFixture = await getMultiJobFixture()
-    server.use(handleGetEmployee(() => HttpResponse.json(multiJobFixture)))
+    server.use(handleGetEmployeeJobs(() => HttpResponse.json(getMultiJobFixture())))
 
     renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
 
@@ -672,13 +659,8 @@ describe('Dashboard', () => {
       hire_date: string
     }
 
-    const buildEmployeeWithJobs = async (jobs: JobFixture[]): Promise<Record<string, unknown>> => {
-      const base = (await getFixture('get-v1-employees')) as Record<string, unknown>
-      return { ...base, jobs }
-    }
-
-    const overrideEmployee = (employee: Record<string, unknown>) => {
-      server.use(handleGetEmployee(() => HttpResponse.json(employee)))
+    const overrideEmployeeJobs = (jobs: JobFixture[]) => {
+      server.use(handleGetEmployeeJobs(() => HttpResponse.json(jobs)))
     }
 
     const goToJobAndPayTab = async (user: ReturnType<typeof userEvent.setup>) => {
@@ -732,7 +714,7 @@ describe('Dashboard', () => {
 
     it('renders an inline alert with bullet details and a Cancel button for a single-job pending change', async () => {
       const user = userEvent.setup()
-      const employee = await buildEmployeeWithJobs([
+      overrideEmployeeJobs([
         baseJob({}, [
           baseComp(),
           baseComp({
@@ -743,7 +725,6 @@ describe('Dashboard', () => {
           }),
         ]),
       ])
-      overrideEmployee(employee)
 
       renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
       await goToJobAndPayTab(user)
@@ -757,7 +738,7 @@ describe('Dashboard', () => {
 
     it('shows the nearest upcoming change when a single job has stacked future compensations', async () => {
       const user = userEvent.setup()
-      const employee = await buildEmployeeWithJobs([
+      overrideEmployeeJobs([
         baseJob({}, [
           baseComp(),
           baseComp({
@@ -772,7 +753,6 @@ describe('Dashboard', () => {
           }),
         ]),
       ])
-      overrideEmployee(employee)
 
       renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
       await goToJobAndPayTab(user)
@@ -797,20 +777,15 @@ describe('Dashboard', () => {
         rate: '35.00',
         effective_date: ONE_YEAR_AHEAD,
       })
-      const employeeBefore = await buildEmployeeWithJobs([
-        baseJob({}, [baseComp(), futureCompensation]),
-      ])
-      const employeeAfter = await buildEmployeeWithJobs([baseJob({}, [baseComp()])])
+      const jobsBefore = [baseJob({}, [baseComp(), futureCompensation])]
+      const jobsAfter = [baseJob({}, [baseComp()])]
 
-      // Return employeeBefore until the DELETE fires, then employeeAfter.
-      // BasicDetails and Compensation now use different employeesGet
-      // query keys (the include differs), so each tab fetches the
-      // employee independently — a count-based handler would diverge
-      // between tabs.
+      // Return jobsBefore until the DELETE fires, then jobsAfter.
+      // BasicDetails uses the employee endpoint; Compensation uses the jobs
+      // endpoint — they have different query keys so a count-based handler
+      // would diverge between tabs.
       server.use(
-        handleGetEmployee(() =>
-          HttpResponse.json(wasDeleteCalled ? employeeAfter : employeeBefore),
-        ),
+        handleGetEmployeeJobs(() => HttpResponse.json(wasDeleteCalled ? jobsAfter : jobsBefore)),
       )
       server.use(handleDeleteCompensation(deleteResolver))
 
@@ -849,8 +824,7 @@ describe('Dashboard', () => {
         rate: '35.00',
         effective_date: ONE_YEAR_AHEAD,
       })
-      const employee = await buildEmployeeWithJobs([baseJob({}, [baseComp(), futureCompensation])])
-      overrideEmployee(employee)
+      overrideEmployeeJobs([baseJob({}, [baseComp(), futureCompensation])])
       server.use(handleDeleteCompensation(deleteResolver))
 
       renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
@@ -875,7 +849,7 @@ describe('Dashboard', () => {
 
     it('renders a summary alert with a Review button when the employee has multiple jobs with pending changes', async () => {
       const user = userEvent.setup()
-      const employee = await buildEmployeeWithJobs([
+      overrideEmployeeJobs([
         baseJob({ uuid: 'job-primary', current_compensation_uuid: 'comp-primary-current' }, [
           baseComp({ uuid: 'comp-primary-current', job_uuid: 'job-primary' }),
           baseComp({
@@ -909,7 +883,6 @@ describe('Dashboard', () => {
           ],
         ),
       ])
-      overrideEmployee(employee)
 
       renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
       await goToJobAndPayTab(user)
@@ -921,7 +894,7 @@ describe('Dashboard', () => {
 
     it('opens the review modal listing pending changes chronologically when Review is clicked', async () => {
       const user = userEvent.setup()
-      const employee = await buildEmployeeWithJobs([
+      overrideEmployeeJobs([
         baseJob({ uuid: 'job-primary', current_compensation_uuid: 'comp-primary-current' }, [
           baseComp({ uuid: 'comp-primary-current', job_uuid: 'job-primary' }),
           baseComp({
@@ -955,7 +928,6 @@ describe('Dashboard', () => {
           ],
         ),
       ])
-      overrideEmployee(employee)
 
       renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
       await goToJobAndPayTab(user)
@@ -992,7 +964,7 @@ describe('Dashboard', () => {
         effective_date: ONE_YEAR_AHEAD,
       })
 
-      const employeeBefore = await buildEmployeeWithJobs([
+      const jobsBefore = [
         baseJob({ uuid: 'job-primary', current_compensation_uuid: 'comp-primary-current' }, [
           baseComp({ uuid: 'comp-primary-current', job_uuid: 'job-primary' }),
           futurePrimary,
@@ -1014,8 +986,8 @@ describe('Dashboard', () => {
             futureSecondary,
           ],
         ),
-      ])
-      const employeeAfter = await buildEmployeeWithJobs([
+      ]
+      const jobsAfter = [
         baseJob({ uuid: 'job-primary', current_compensation_uuid: 'comp-primary-current' }, [
           baseComp({ uuid: 'comp-primary-current', job_uuid: 'job-primary' }),
           futurePrimary,
@@ -1036,16 +1008,14 @@ describe('Dashboard', () => {
             }),
           ],
         ),
-      ])
+      ]
 
-      // Return employeeBefore until the DELETE fires, then employeeAfter.
-      // BasicDetails and Compensation use different employeesGet query
-      // keys (the include differs), so a count-based handler would
-      // diverge between tabs.
+      // Return jobsBefore until the DELETE fires, then jobsAfter.
+      // BasicDetails uses the employee endpoint; Compensation uses the jobs
+      // endpoint — they have different query keys so a count-based handler
+      // would diverge between tabs.
       server.use(
-        handleGetEmployee(() =>
-          HttpResponse.json(wasDeleteCalled ? employeeAfter : employeeBefore),
-        ),
+        handleGetEmployeeJobs(() => HttpResponse.json(wasDeleteCalled ? jobsAfter : jobsBefore)),
       )
       server.use(handleDeleteCompensation(deleteResolver))
 
@@ -1071,13 +1041,12 @@ describe('Dashboard', () => {
     describe('multi-job alert variants', () => {
       it('single hourly job with a comp update: shows inline alert with standard copy', async () => {
         const user = userEvent.setup()
-        const employee = await buildEmployeeWithJobs([
+        overrideEmployeeJobs([
           baseJob({}, [
             baseComp(),
             baseComp({ uuid: 'comp-future', rate: '35.00', effective_date: ONE_YEAR_AHEAD }),
           ]),
         ])
-        overrideEmployee(employee)
 
         renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
         await goToJobAndPayTab(user)
@@ -1090,7 +1059,7 @@ describe('Dashboard', () => {
 
       it('multiple hourly jobs with a single comp update: shows inline alert including the job title', async () => {
         const user = userEvent.setup()
-        const employee = await buildEmployeeWithJobs([
+        overrideEmployeeJobs([
           baseJob(
             {
               uuid: 'job-primary',
@@ -1124,7 +1093,6 @@ describe('Dashboard', () => {
             ],
           ),
         ])
-        overrideEmployee(employee)
 
         renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
         await goToJobAndPayTab(user)
@@ -1139,7 +1107,7 @@ describe('Dashboard', () => {
 
       it('multiple hourly jobs with multiple comp updates: shows summary alert with Review CTA', async () => {
         const user = userEvent.setup()
-        const employee = await buildEmployeeWithJobs([
+        overrideEmployeeJobs([
           baseJob({ uuid: 'job-primary', current_compensation_uuid: 'comp-primary-current' }, [
             baseComp({ uuid: 'comp-primary-current', job_uuid: 'job-primary' }),
             baseComp({
@@ -1173,7 +1141,6 @@ describe('Dashboard', () => {
             ],
           ),
         ])
-        overrideEmployee(employee)
 
         renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
         await goToJobAndPayTab(user)

--- a/src/components/Employee/Dashboard/JobAndPayView.module.scss
+++ b/src/components/Employee/Dashboard/JobAndPayView.module.scss
@@ -1,4 +1,7 @@
 .alertWrapper {
-  padding: toRem(20) toRem(20) 0;
   width: 100%;
+}
+
+.alertWrapperPadded {
+  padding: toRem(20) toRem(20) 0;
 }

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -98,7 +98,7 @@ export function JobAndPayView({
   const payStubsPagination = compensation.pagination.payStubs
   const cancellingCompensationUuid = compensation.status.cancellingCompensationUuid
   const { cancelPendingChange } = compensation.actions
-  const isCompensationCardLoading = compensation.status.isEmployeeLoading
+  const isCompensationCardLoading = compensation.status.isCompensationLoading
   const isPayStubsLoading = compensation.status.isPayStubsLoading
 
   const handleCancelChange = useCallback(

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -566,7 +566,11 @@ export function JobAndPayView({
           ) : (
             <Flex flexDirection="column" gap={16}>
               {hasPendingChanges && (
-                <div className={hasMultipleJobs ? styles.alertWrapper : undefined}>
+                <div
+                  className={[styles.alertWrapper, hasMultipleJobs && styles.alertWrapperPadded]
+                    .filter(Boolean)
+                    .join(' ')}
+                >
                   <Flex flexDirection="column" gap={16}>
                     {showInlineAlert && nextChange && (
                       <Components.Alert

--- a/src/components/Employee/Dashboard/getPendingCompensationChanges.test.ts
+++ b/src/components/Employee/Dashboard/getPendingCompensationChanges.test.ts
@@ -112,6 +112,27 @@ describe('getPendingCompensationChanges', () => {
     })
   })
 
+  it('detects titleChange when baseline.title is absent and future.title differs from jobTitle', () => {
+    // Real-world scenario: GET /v1/employees/:id/jobs returns compensation.title
+    // only when it was explicitly stored via PUT /v1/compensations/:id.
+    // The current comp may have title=undefined (API omits it) while the future
+    // comp carries the new title. The jobTitle fallback on the baseline must not
+    // mask the difference.
+    const current = buildComp({ title: undefined })
+    const future = buildComp({
+      uuid: 'comp-future',
+      title: 'Senior Cashier',
+      effectiveDate: '2026-06-01',
+    })
+    const job = buildJob({ title: 'Cashier' }, [current, future])
+
+    const result = getPendingCompensationChanges([job], { today: TODAY })
+
+    expect(result[0]).toMatchObject({
+      details: [{ kind: 'titleChange', title: 'Senior Cashier' }],
+    })
+  })
+
   it('emits both titleChange and payChange when both differ', () => {
     const current = buildComp({ title: 'Cashier', rate: '30.00' })
     const future = buildComp({

--- a/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.test.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.test.tsx
@@ -4,15 +4,14 @@ import { http, HttpResponse, type HttpResponseResolver } from 'msw'
 import { useEmployeeCompensation } from './useEmployeeCompensation'
 import { GustoTestProvider } from '@/test/GustoTestApiProvider'
 import { server } from '@/test/mocks/server'
-import { handleGetEmployee } from '@/test/mocks/apis/employees'
+import { handleGetEmployee, handleGetEmployeeJobs } from '@/test/mocks/apis/employees'
 import { handleDeleteCompensation } from '@/test/mocks/apis/compensations'
 import { setupApiTestMocks } from '@/test/mocks/apiServer'
 import { API_BASE_URL } from '@/test/constants'
 import { FlsaStatus } from '@/shared/constants'
 
-// Test fixtures — these match the default `get-v1-employees.json` shape
-// but are inlined here so the test pins behaviour to specific values
-// rather than a moving fixture file.
+// Test fixtures — inlined to pin behaviour to specific values rather than a
+// moving fixture file.
 type JobFixture = Record<string, unknown>
 
 const ONE_YEAR_AHEAD = (() => {
@@ -26,14 +25,14 @@ const TWO_YEARS_AHEAD = (() => {
   return d.toISOString().split('T')[0]!
 })()
 
-const buildEmployee = (jobs: JobFixture[]) => ({
+const buildEmployee = (overrides: Record<string, unknown> = {}) => ({
   uuid: 'employee-123',
   first_name: 'Isom',
   last_name: 'Jaskolski',
   email: 'isom@example.com',
   date_of_birth: '1986-06-25',
   has_ssn: true,
-  jobs,
+  ...overrides,
 })
 
 const baseJob = (
@@ -89,12 +88,11 @@ describe('useEmployeeCompensation', () => {
     expect(result.current.data.jobs.length).toBeGreaterThan(0)
   })
 
-  it('derives primaryJob, primaryFlsaStatus, hasMultipleJobs, and employeeFirstName from the employee fetch', async () => {
+  it('derives primaryJob, primaryFlsaStatus, hasMultipleJobs, and employeeFirstName from the respective fetches', async () => {
     server.use(
-      handleGetEmployee(() =>
-        HttpResponse.json(
-          buildEmployee([baseJob({ primary: true }, [baseComp({ flsa_status: 'Nonexempt' })])]),
-        ),
+      handleGetEmployee(() => HttpResponse.json(buildEmployee())),
+      handleGetEmployeeJobs(() =>
+        HttpResponse.json([baseJob({ primary: true }, [baseComp({ flsa_status: 'Nonexempt' })])]),
       ),
     )
 
@@ -114,17 +112,15 @@ describe('useEmployeeCompensation', () => {
 
   it('reports hasMultipleJobs=true and surfaces all jobs when the employee has more than one', async () => {
     server.use(
-      handleGetEmployee(() =>
-        HttpResponse.json(
-          buildEmployee([
-            baseJob({ uuid: 'job-primary', primary: true, title: 'Manager' }, [
-              baseComp({ uuid: 'comp-primary', job_uuid: 'job-primary' }),
-            ]),
-            baseJob({ uuid: 'job-secondary', primary: false, title: 'Cashier' }, [
-              baseComp({ uuid: 'comp-secondary', job_uuid: 'job-secondary' }),
-            ]),
+      handleGetEmployeeJobs(() =>
+        HttpResponse.json([
+          baseJob({ uuid: 'job-primary', primary: true, title: 'Manager' }, [
+            baseComp({ uuid: 'comp-primary', job_uuid: 'job-primary' }),
           ]),
-        ),
+          baseJob({ uuid: 'job-secondary', primary: false, title: 'Cashier' }, [
+            baseComp({ uuid: 'comp-secondary', job_uuid: 'job-secondary' }),
+          ]),
+        ]),
       ),
     )
 
@@ -143,20 +139,18 @@ describe('useEmployeeCompensation', () => {
 
   it('derives pendingChanges from future-effective compensations on each job', async () => {
     server.use(
-      handleGetEmployee(() =>
-        HttpResponse.json(
-          buildEmployee([
-            baseJob({ uuid: 'job-primary', current_compensation_uuid: 'comp-primary-current' }, [
-              baseComp({ uuid: 'comp-primary-current', job_uuid: 'job-primary' }),
-              baseComp({
-                uuid: 'comp-primary-future',
-                job_uuid: 'job-primary',
-                rate: '35.00',
-                effective_date: ONE_YEAR_AHEAD,
-              }),
-            ]),
+      handleGetEmployeeJobs(() =>
+        HttpResponse.json([
+          baseJob({ uuid: 'job-primary', current_compensation_uuid: 'comp-primary-current' }, [
+            baseComp({ uuid: 'comp-primary-current', job_uuid: 'job-primary' }),
+            baseComp({
+              uuid: 'comp-primary-future',
+              job_uuid: 'job-primary',
+              rate: '35.00',
+              effective_date: ONE_YEAR_AHEAD,
+            }),
           ]),
-        ),
+        ]),
       ),
     )
 
@@ -177,19 +171,17 @@ describe('useEmployeeCompensation', () => {
 
   it('actions.cancelPendingChange fires DELETE /v1/compensations/:id and returns a HookSubmitResult', async () => {
     server.use(
-      handleGetEmployee(() =>
-        HttpResponse.json(
-          buildEmployee([
-            baseJob({}, [
-              baseComp(),
-              baseComp({
-                uuid: 'comp-future',
-                rate: '35.00',
-                effective_date: ONE_YEAR_AHEAD,
-              }),
-            ]),
+      handleGetEmployeeJobs(() =>
+        HttpResponse.json([
+          baseJob({}, [
+            baseComp(),
+            baseComp({
+              uuid: 'comp-future',
+              rate: '35.00',
+              effective_date: ONE_YEAR_AHEAD,
+            }),
           ]),
-        ),
+        ]),
       ),
     )
 
@@ -221,19 +213,17 @@ describe('useEmployeeCompensation', () => {
 
   it('surfaces a failing cancel mutation through errorHandling.errors and leaves submitResult undefined', async () => {
     server.use(
-      handleGetEmployee(() =>
-        HttpResponse.json(
-          buildEmployee([
-            baseJob({}, [
-              baseComp(),
-              baseComp({
-                uuid: 'comp-future',
-                rate: '35.00',
-                effective_date: TWO_YEARS_AHEAD,
-              }),
-            ]),
+      handleGetEmployeeJobs(() =>
+        HttpResponse.json([
+          baseJob({}, [
+            baseComp(),
+            baseComp({
+              uuid: 'comp-future',
+              rate: '35.00',
+              effective_date: TWO_YEARS_AHEAD,
+            }),
           ]),
-        ),
+        ]),
       ),
     )
     server.use(
@@ -263,12 +253,12 @@ describe('useEmployeeCompensation', () => {
     expect(result.current.errorHandling.errors.length).toBeGreaterThan(0)
   })
 
-  it('requests the employee with `include=all_compensations` so JobAndPay sees compensation history', async () => {
-    let employeeRequestUrl: string | null = null
+  it('requests the jobs endpoint so JobAndPay sees compensation history with titles', async () => {
+    let jobsRequestUrl: string | null = null
     server.use(
-      handleGetEmployee(({ request }) => {
-        employeeRequestUrl = request.url
-        return HttpResponse.json(buildEmployee([baseJob({}, [baseComp()])]))
+      handleGetEmployeeJobs(({ request }) => {
+        jobsRequestUrl = request.url
+        return HttpResponse.json([baseJob({}, [baseComp()])])
       }),
     )
 
@@ -280,8 +270,9 @@ describe('useEmployeeCompensation', () => {
       expect(result.current.status.isEmployeeLoading).toBe(false)
     })
 
-    expect(employeeRequestUrl).not.toBeNull()
-    expect(employeeRequestUrl).toContain('all_compensations')
+    expect(jobsRequestUrl).not.toBeNull()
+    expect(jobsRequestUrl).toContain('/v1/employees/employee-123/jobs')
+    expect(jobsRequestUrl).toContain('include=all_compensations')
   })
 
   it('surfaces paystub pagination control props once the paystubs query resolves', async () => {

--- a/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.test.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.test.tsx
@@ -75,13 +75,13 @@ describe('useEmployeeCompensation', () => {
       wrapper: GustoTestProvider,
     })
 
-    expect(result.current.status.isEmployeeLoading).toBe(true)
+    expect(result.current.status.isCompensationLoading).toBe(true)
     expect(result.current.status.isPayStubsLoading).toBe(true)
     expect(result.current.data.jobs).toEqual([])
     expect(result.current.data.payStubs).toEqual([])
 
     await waitFor(() => {
-      expect(result.current.status.isEmployeeLoading).toBe(false)
+      expect(result.current.status.isCompensationLoading).toBe(false)
       expect(result.current.status.isPayStubsLoading).toBe(false)
     })
 
@@ -101,7 +101,7 @@ describe('useEmployeeCompensation', () => {
     })
 
     await waitFor(() => {
-      expect(result.current.status.isEmployeeLoading).toBe(false)
+      expect(result.current.status.isCompensationLoading).toBe(false)
     })
 
     expect(result.current.data.primaryJob).toMatchObject({ uuid: 'job-1', primary: true })
@@ -129,7 +129,7 @@ describe('useEmployeeCompensation', () => {
     })
 
     await waitFor(() => {
-      expect(result.current.status.isEmployeeLoading).toBe(false)
+      expect(result.current.status.isCompensationLoading).toBe(false)
     })
 
     expect(result.current.data.hasMultipleJobs).toBe(true)
@@ -159,7 +159,7 @@ describe('useEmployeeCompensation', () => {
     })
 
     await waitFor(() => {
-      expect(result.current.status.isEmployeeLoading).toBe(false)
+      expect(result.current.status.isCompensationLoading).toBe(false)
     })
 
     expect(result.current.data.pendingChanges).toHaveLength(1)
@@ -267,7 +267,7 @@ describe('useEmployeeCompensation', () => {
     })
 
     await waitFor(() => {
-      expect(result.current.status.isEmployeeLoading).toBe(false)
+      expect(result.current.status.isCompensationLoading).toBe(false)
     })
 
     expect(jobsRequestUrl).not.toBeNull()

--- a/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { useEmployeesGet } from '@gusto/embedded-api/react-query/employeesGet'
+import { useJobsAndCompensationsGetJobs } from '@gusto/embedded-api/react-query/jobsAndCompensationsGetJobs'
+import { GetV1EmployeesEmployeeIdJobsQueryParamInclude } from '@gusto/embedded-api/models/operations/getv1employeesemployeeidjobs'
 import { useJobsAndCompensationsDeleteCompensationMutation } from '@gusto/embedded-api/react-query/jobsAndCompensationsDeleteCompensation'
 import { usePayrollsGetPayStubs } from '@gusto/embedded-api/react-query/payrollsGetPayStubs'
 import type { Job } from '@gusto/embedded-api/models/components/job'
@@ -39,7 +41,7 @@ export interface UseEmployeeCompensationResult extends BaseHookReady<
   {
     isPending: boolean
     cancellingCompensationUuid: string | null
-    /** Compensation card depends on the employee fetch (jobs, pending
+    /** Compensation card depends on the jobs fetch (jobs, pending
      *  changes, FLSA status). */
     isEmployeeLoading: boolean
     /** Paystubs card depends on a separate paginated endpoint. */
@@ -73,10 +75,18 @@ export function useEmployeeCompensation({
   // invalidates all queries on any mutation success, so post-write
   // freshness is preserved. Without this, every subscriber re-mount
   // (e.g. tab navigation) would fire a redundant background refetch.
-  const employeeQuery = useEmployeesGet(
-    { employeeId, include: ['all_compensations'] },
+  //
+  // GET /v1/employees/:id/jobs?include=all_compensations returns all effective-
+  // dated compensations (current + future) with compensation.title on each,
+  // which is required for pending-change detection. Without the include param,
+  // only the current compensation is returned.
+  const jobsQuery = useJobsAndCompensationsGetJobs(
+    { employeeId, include: GetV1EmployeesEmployeeIdJobsQueryParamInclude.AllCompensations },
     { staleTime: Infinity },
   )
+  // Employee query is a lightweight secondary fetch for cosmetic data only
+  // (first name used in alert copy). Jobs / compensation data comes from jobsQuery.
+  const employeeQuery = useEmployeesGet({ employeeId }, { staleTime: Infinity })
   const payStubsQuery = usePayrollsGetPayStubs(
     { employeeId, page: currentPage, per: itemsPerPage },
     { staleTime: Infinity },
@@ -90,15 +100,12 @@ export function useEmployeeCompensation({
 
   const employee = employeeQuery.data?.employee
 
-  const jobs = useMemo(() => employee?.jobs ?? [], [employee?.jobs])
+  const jobs = useMemo(() => jobsQuery.data?.jobs ?? [], [jobsQuery.data?.jobs])
   const primaryJob = useMemo(() => jobs.find(job => job.primary === true), [jobs])
   const primaryFlsaStatus = useMemo(() => derivePrimaryFlsaStatus(jobs), [jobs])
   const hasMultipleJobs = jobs.length > 1
 
-  const pendingChanges = useMemo(
-    () => getPendingCompensationChanges(employee?.jobs),
-    [employee?.jobs],
-  )
+  const pendingChanges = useMemo(() => getPendingCompensationChanges(jobs), [jobs])
 
   const payStubs = payStubsQuery.data?.employeePayStubsList ?? []
 
@@ -129,9 +136,12 @@ export function useEmployeeCompensation({
   )
 
   const isPending =
-    employeeQuery.isFetching || payStubsQuery.isFetching || cancelCompensationMutation.isPending
+    jobsQuery.isFetching ||
+    employeeQuery.isFetching ||
+    payStubsQuery.isFetching ||
+    cancelCompensationMutation.isPending
 
-  const errorHandling = composeErrorHandler([employeeQuery, payStubsQuery], {
+  const errorHandling = composeErrorHandler([jobsQuery, employeeQuery, payStubsQuery], {
     submitError,
     setSubmitError,
   })
@@ -150,7 +160,7 @@ export function useEmployeeCompensation({
     status: {
       isPending,
       cancellingCompensationUuid,
-      isEmployeeLoading: employeeQuery.isLoading,
+      isEmployeeLoading: jobsQuery.isLoading,
       isPayStubsLoading: payStubsQuery.isLoading,
     },
     pagination: {

--- a/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
+++ b/src/components/Employee/Dashboard/hooks/useEmployeeCompensation.tsx
@@ -43,7 +43,7 @@ export interface UseEmployeeCompensationResult extends BaseHookReady<
     cancellingCompensationUuid: string | null
     /** Compensation card depends on the jobs fetch (jobs, pending
      *  changes, FLSA status). */
-    isEmployeeLoading: boolean
+    isCompensationLoading: boolean
     /** Paystubs card depends on a separate paginated endpoint. */
     isPayStubsLoading: boolean
   }
@@ -160,7 +160,7 @@ export function useEmployeeCompensation({
     status: {
       isPending,
       cancellingCompensationUuid,
-      isEmployeeLoading: jobsQuery.isLoading,
+      isCompensationLoading: jobsQuery.isLoading,
       isPayStubsLoading: payStubsQuery.isLoading,
     },
     pagination: {

--- a/src/test/mocks/fixtures/get-v1-employees-employee_id-jobs.json
+++ b/src/test/mocks/fixtures/get-v1-employees-employee_id-jobs.json
@@ -19,6 +19,7 @@
         "job_uuid": "d6d1035e-8a21-4e1d-89d5-fa894f9aff97",
         "effective_date": "2021-01-20",
         "rate": "70000.00",
+        "title": "Client Support Director",
         "adjust_for_minimum_wage": false,
         "minimum_wages": []
       }


### PR DESCRIPTION
## Summary

- **Root cause**: `GET /v1/employees/:id/jobs` (without `include`) only returns the *current* compensation per job — future-dated compensations are omitted, so `getPendingCompensationChanges` had nothing to compare and emitted no alerts.
- **Fix**: Switch `useEmployeeCompensation` to call `GET /v1/employees/:id/jobs?include=all_compensations`, which is the only endpoint that returns all effective-dated compensations *with* `compensation.title` on each — satisfying both requirements in a single call.
- **Alert width fix**: `width: 100%` is now unconditionally applied to the alert wrapper div. Previously the class (and therefore `width: 100%`) was only applied for multi-job employees, leaving the alert unconstrained for the single-job case.

## Changes

- `useEmployeeCompensation.tsx` — pass `include: GetV1EmployeesEmployeeIdJobsQueryParamInclude.AllCompensations` to `useJobsAndCompensationsGetJobs`
- `JobAndPayView.module.scss` / `JobAndPayView.tsx` — split `alertWrapper` into base (width) + `alertWrapperPadded` (padding only for multi-job); always apply base class
- `get-v1-employees-employee_id-jobs.json` — add `title` to the compensation fixture to match real API responses
- Test updates across `useEmployeeCompensation.test.tsx`, `Dashboard.test.tsx`, and `getPendingCompensationChanges.test.ts` to align with the new API call strategy; URL assertion tightened to verify `include=all_compensations` is sent

## Test plan

- [x] Create a future-dated compensation change for a single-job employee and verify the pending change alert appears in the Dashboard compensation card
- [x] Verify the alert text fills the full width of the card
- [x] Create a future-dated compensation change for a multi-job employee and verify the summary alert appears
- [x] Cancel a pending change and verify the alert disappears
- [x] `npm run test -- --run src/components/Employee/Dashboard` passes

<img width="1255" height="621" alt="Screenshot 2026-05-21 at 6 23 25 PM" src="https://github.com/user-attachments/assets/7d496dae-063d-484e-a30a-6cabd515906d" />

Made with [Cursor](https://cursor.com)