### PR TITLE
fix(Deductions): await column header render before asserting in DeductionsList test

### DIFF
--- a/src/components/Employee/Deductions/DeductionsList/DeductionsList.test.tsx
+++ b/src/components/Employee/Deductions/DeductionsList/DeductionsList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { Garnishment } from '@gusto/embedded-api/models/components/garnishment'
 import type { UseDeductionsListReady } from '../shared/useDeductionsList'
@@ -60,10 +60,7 @@ describe('DeductionsList', () => {
       />,
     )
 
-    await waitFor(() => {
-      expect(screen.getByTestId('data-table')).toBeInTheDocument()
-    })
-    expect(screen.getByText('Deduction')).toBeInTheDocument()
+    await screen.findByText('Deduction')
     expect(screen.getByText('Frequency')).toBeInTheDocument()
     expect(screen.getByText('Withheld')).toBeInTheDocument()
     expect(screen.getByText('Add another deduction')).toBeInTheDocument()


### PR DESCRIPTION
## Summary

- The `renders the table headers` test in `DeductionsList.test.tsx` was asserting on column headers (`Deduction`, `Frequency`, `Withheld`) synchronously after only waiting for the `data-table` container element, causing intermittent failures on slower CI runners where React Aria Table populates headers asynchronously.
- Replaced the `waitFor` + synchronous `getByText` pattern with `await screen.findByText('Deduction')` so the first column header assertion acts as the async gate, then the remaining synchronous checks run once the table is fully rendered.

## Test plan

- [ ] `npm run test -- --run src/components/Employee/Deductions/DeductionsList/DeductionsList.test.tsx` — 3 tests pass

Made with [Cursor](https://cursor.com)