### PR TITLE
fix(Dashboard): unblock paystub download — drop noopener and defer blob URL revoke

### DIFF
--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -120,7 +120,9 @@ export function JobAndPayView({
 
   const handlePaystubDownload = useCallback(
     async (payrollUuid: string) => {
-      const newWindow = window.open('', '_blank', 'noopener,noreferrer')
+      // Omit `noopener` — it makes window.open return null in modern browsers,
+      // which would leave us unable to navigate the new tab to the blob URL.
+      const newWindow = window.open('', '_blank')
       const loadingMessage = t('jobAndPay.paystubs.downloadLoadingMessage')
       if (newWindow) {
         // Avoid the user staring at about:blank while we fetch the PDF. The
@@ -158,9 +160,15 @@ export function JobAndPayView({
         const pdfBlob = await readableStreamToBlob(response.value.responseStream, 'application/pdf')
         const url = URL.createObjectURL(pdfBlob)
         if (newWindow) {
+          // Revoke after the new tab has loaded the blob; revoking synchronously
+          // would race the navigation and leave the tab blank.
+          newWindow.addEventListener('load', () => {
+            URL.revokeObjectURL(url)
+          })
           newWindow.location.href = url
+        } else {
+          URL.revokeObjectURL(url)
         }
-        URL.revokeObjectURL(url)
       } catch (err) {
         if (newWindow) {
           newWindow.close()


### PR DESCRIPTION
## Summary

The paystub download CTA on the employee Dashboard opened a new tab but never rendered the PDF. Two bugs in `handlePaystubDownload` combined to leave the tab blank — fixed here.

## Changes

- Drop `noopener,noreferrer` from `window.open(...)`. Modern browsers return `null` from `window.open` when `noopener` is set, so `newWindow` was always `null` — the loading-UI setup and the final `newWindow.location.href = url` navigation both skipped, leaving the popup at `about:blank`.
- Defer `URL.revokeObjectURL(url)` until the new tab's `load` event. The original code revoked the blob URL synchronously after assigning `location.href`, racing the (async) navigation and leaving the tab blank even if the popup reference existed. The popup-blocked branch still revokes immediately so we don't leak an unused URL.

## Testing

- Manual: From the employee Dashboard, open the **Pay stubs** section and click the download icon on a row. A new tab should open with a brief loading spinner, then display the paystub PDF.
- Manual: Verify the new tab no longer stays blank.
- `npm run build` passes via lint-staged pre-commit hook.