### PR TITLE
ci: skip E2E jobs on pushes to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,6 +243,9 @@ jobs:
   # every shipping spec lives inside a domain folder.
   e2e-setup:
     needs: [setup, scenarios]
+    # Temporarily skip E2E on pushes to main while we stabilize the demo backend
+    # contract. PR runs and manual dispatches still execute the suite.
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       domains: ${{ steps.list-domains.outputs.domains }}
@@ -325,8 +328,9 @@ jobs:
   e2e:
     needs: [setup, scenarios, e2e-setup]
     # Skip cleanly when no domain folders exist — fromJson on an empty array
-    # would otherwise fail matrix expansion.
-    if: needs.e2e-setup.outputs.domains != '[]'
+    # would otherwise fail matrix expansion. Also skipped on main while we
+    # stabilize the demo backend contract (mirrors the e2e-setup gate).
+    if: github.ref != 'refs/heads/main' && needs.e2e-setup.outputs.domains != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Gate the `e2e-setup` and `e2e` jobs in `.github/workflows/ci.yaml` on `github.ref != 'refs/heads/main'` so post-merge main runs no longer execute Playwright against the demo backend.
- PR runs and manual `workflow_dispatch` runs are unaffected — the suite still gates merges.

## Why

The main-branch E2E run isn't currently providing useful signal (the only meaningful gate happens on the PR), and each main run consumes demo-backend provisioning load and CI minutes. Skip until we want to re-enable it.

## Test plan

- [ ] Confirm this PR's CI run shows `e2e-setup` and `e2e (<domain>)` executing (PR runs unaffected).
- [ ] After merge, confirm the `push` run on `main` shows `e2e-setup` and `e2e` as skipped while all other checks (lint, format, typecheck, test, scenarios, build, storybook-build, sdk-app-build, endpoints) still run.
- [ ] Confirm `workflow_dispatch` still runs E2E if needed.


Made with [Cursor](https://cursor.com)