### PR TITLE
fix: use fresh compensation version from job PUT response in EditPendingCompensation

### DIFF
--- a/src/components/Employee/Compensation/management/EditPendingCompensation/EditPendingCompensation.tsx
+++ b/src/components/Employee/Compensation/management/EditPendingCompensation/EditPendingCompensation.tsx
@@ -123,9 +123,18 @@ function Root({
 
     onEvent(componentEvents.EMPLOYEE_JOB_UPDATED, jobResult.data)
 
-    const compensationResult = await compensationForm.actions.onSubmit(
-      hireDateOverride ? { effectiveDate: hireDateOverride } : undefined,
-    )
+    // When the hire date moves forward, the API auto-syncs the compensation's
+    // effective_date to the new hire_date as part of the job PUT, which bumps
+    // the compensation's version. Read it from the job response so the
+    // subsequent compensation PUT doesn't send a stale version.
+    const freshCompVersion = jobResult.data.compensations?.find(
+      c => c.uuid === compensationId,
+    )?.version
+
+    const compensationResult = await compensationForm.actions.onSubmit({
+      ...(hireDateOverride ? { effectiveDate: hireDateOverride } : {}),
+      compensationVersion: freshCompVersion,
+    })
     if (!compensationResult) return
 
     onEvent(componentEvents.EMPLOYEE_COMPENSATION_UPDATED, compensationResult.data)


### PR DESCRIPTION
## Summary

- When moving a primary new job's hire date **forward**, the Gusto API auto-syncs the pending compensation's `effective_date` to match the new hire date as a side effect of the job `PUT`. This bumps the compensation's `version` on the server.
- The subsequent compensation `PUT` was sending the stale pre-submit version (captured in `useCompensationForm`'s closure), causing the API to reject it with "You are attempting to update a resource using an out-of-date version."
- Moving the date backward didn't trigger this server-side auto-sync, so it worked fine — explaining the asymmetric behavior.

**Fix:** After the job `PUT` succeeds, read the fresh compensation version from the response (`jobResult.data.compensations`) and pass it via `CompensationSubmitOptions.compensationVersion`, which already exists for exactly this kind of post-chain threading scenario.

## Test plan

- [ ] Edit a pending compensation on a primary new job, move the hire date forward — should save successfully
- [ ] Edit a pending compensation on a primary new job, move the hire date backward — should still save successfully
- [ ] Edit a pending compensation on a secondary new job (no hire date field) — unaffected, should save as before

Made with [Cursor](https://cursor.com)