### PR TITLE
test(e2e): shrink dismissal poll budget, fix unlimited-edit assertion

### DIFF
--- a/e2e/tests/time-off/03-policy-edit-and-navigation.spec.ts
+++ b/e2e/tests/time-off/03-policy-edit-and-navigation.spec.ts
@@ -66,7 +66,14 @@ test.describe('TimeOffFlow - edit unlimited + navigation regressions', () => {
 
     const nameField = page.getByLabel(/policy name/i)
     await expect(nameField).toHaveValue(policyName)
-    await expect(page.getByRole('radio', { name: /unlimited/i })).toBeChecked()
+    // The edit form locks the accrual method for unlimited policies and
+    // renders it as a label + plain text (see
+    // PolicyConfigurationFormPresentation.tsx — when accrualMethodOptions
+    // collapses to a single option the radio group is replaced with two
+    // <Text> nodes). Asserting the label and value verifies the unlimited
+    // selection survived the round-trip without re-introducing the radio.
+    await expect(page.getByText(/^accrual method$/i)).toBeVisible()
+    await expect(page.getByText(/^unlimited$/i)).toBeVisible()
 
     await expect(page.getByText(/unexpected error/i)).toHaveCount(0)
     await expect(page.getByText(/cannot read propert/i)).toHaveCount(0)

--- a/e2e/utils/payrollFlowDrivers.ts
+++ b/e2e/utils/payrollFlowDrivers.ts
@@ -452,7 +452,14 @@ export async function terminateAndRunDismissalPayroll(
     // query, so the component always loads with data already available.
     const gwsFlowsHost = process.env.E2E_GWS_FLOWS_HOST ?? DEMO_GWS_FLOWS_HOST
     const apiBase = `${gwsFlowsHost}/fe_sdk/${scenario.flowToken}/v1`
-    const DISMISSAL_POLL_BUDGET_MS = 3 * PAYROLL_CALCULATION_DEADLINE // 270s
+    // The demo backend either produces the termination pay period within the
+    // first one or two 5s poll intervals or it isn't going to inside this
+    // run. Capping the budget at 60s keeps the payroll shard from paying
+    // ~5 minutes of wall time every CI run just to skip this canary when
+    // the demo is in the degraded state it's been in lately. If/when the
+    // backend reliably produces the period again, raise this back up — the
+    // skip path is here so flaky demo seeding doesn't fail the shard.
+    const DISMISSAL_POLL_BUDGET_MS = 60_000
 
     type TerminationPeriod = { employee_uuid?: string; employeeUuid?: string }
     const periodPollStart = Date.now()


### PR DESCRIPTION
## Summary

Two unrelated e2e shard regressions surfaced in this morning's CI runs:

- **payroll** shard wall time was ~8.5 min, longer than every other domain by a factor of ~3. Scenario-reporter timings ([artifact from run 26458814520](https://github.com/Gusto/embedded-react-sdk/actions/runs/26458814520)) showed `90-dismissal-submit.spec.ts` consumed **295.1s** of body time and was marked `skipped`. The driver in [`e2e/utils/payrollFlowDrivers.ts`](e2e/utils/payrollFlowDrivers.ts) was burning the full `3 * PAYROLL_CALCULATION_DEADLINE` (270s) budget polling the demo backend for `unprocessed_termination_pay_periods` that never appeared, then calling `test.skip()`.
- **time-off** shard failed every run sampled (5/5) on [`03-policy-edit-and-navigation.spec.ts:69`](e2e/tests/time-off/03-policy-edit-and-navigation.spec.ts). The spec asserted `getByRole('radio', { name: /unlimited/i }).toBeChecked()`, but [`PolicyConfigurationFormPresentation.tsx:189-203`](src/components/TimeOff/TimeOffManagement/PolicyConfigurationForm/PolicyConfigurationFormPresentation.tsx) intentionally collapses the accrual-method field to a label + plain `<Text>` when only the unlimited option is available — there's no radio to check. Error-context from the failing trace confirmed the form renders \"Accrual method\" / \"Unlimited\" as paragraphs, not a radio group.

## Changes

### 1. Shrink dismissal poll budget — `e2e/utils/payrollFlowDrivers.ts`

\`DISMISSAL_POLL_BUDGET_MS\` dropped from \`3 * PAYROLL_CALCULATION_DEADLINE\` (270s) to a flat \`60_000\`. The 5s poll interval is unchanged, so if the demo backend is going to produce the termination pay period it'll do so in the first 1-2 polls. Comment in the file calls out when to raise this back up.

Expected impact: payroll shard wall time drops from ~8.5 min to ~3.5 min — back in line with the other domain shards.

### 2. Fix the unlimited-edit assertion — \`e2e/tests/time-off/03-policy-edit-and-navigation.spec.ts\`

Replaced the impossible radio assertion with two positive \`toBeVisible\` checks against the locked label \"Accrual method\" and value \"Unlimited\" that the form actually renders. The \"no unexpected error\" / \"cannot read propert\" guards on the trailing lines stay — those are the original \"renders without crashing\" contract the test was authored to enforce.

## Out of scope (follow-ups)

- Investigating *why* the demo backend stopped producing termination pay periods. Tracked separately; this PR makes the symptom cheap (skip fast) rather than expensive (hang 5 min) so the canary can come back online without code changes once demo recovers.
- Broader audit of the rest of \`03-policy-edit-and-navigation.spec.ts\` against the current Edit-form UI.

## Test plan

- [ ] CI: payroll shard wall time drops to ~3-4 min (vs ~8.5 min on recent runs)
- [ ] CI: time-off shard goes green
- [ ] CI: no other shard regresses

Local validation done:
- \`npm run lint:check\` — 0 errors
- \`npm run format:check\` — clean
- \`npx tsc --noEmit\` — clean

Made with [Cursor](https://cursor.com)