### PR TITLE
ci: run e2e selectively per domain and add e2e-success aggregator

### DIFF
--- a/.github/scripts/e2e-discover-domains.sh
+++ b/.github/scripts/e2e-discover-domains.sh
@@ -29,20 +29,26 @@
 #   e2e/tests/<kebab>  ↔  src/components/<Pascal>     (e.g. time-off ↔ TimeOff)
 # The list is discovered from disk on every run; no maintenance needed.
 #
-# Portability: depends on bash 4+ (`mapfile`) and GNU find (`-printf`).
-# Both are present on the GitHub-hosted ubuntu-latest runner this is
-# intended for. Running on macOS for local debugging will fail the
-# `mapfile` line — install `bash` and `findutils` from Homebrew or just
-# run the workflow.
+# Portability: written for POSIX-ish bash 3.2+ and either GNU or BSD find,
+# so it runs natively on the GitHub-hosted ubuntu-latest runner AND on
+# macOS for local debugging. Required tools: bash, find, sed, awk, jq, git.
 
 set -euo pipefail
 
 if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
-  echo "ERROR: GITHUB_OUTPUT is not set — this script must run inside a GitHub Actions step" >&2
+  echo "ERROR: GITHUB_OUTPUT is not set — set it to a writable file path" >&2
+  echo "       (GitHub Actions sets this automatically; locally use a tempfile)" >&2
   exit 2
 fi
 
-mapfile -t domains < <(find e2e/tests -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
+# Discover domains. `find ... | sed 's|.*/||'` is the portable equivalent
+# of GNU find's `-printf '%f\n'` — strip everything up to and including
+# the last slash to get the basename. The `while read` loop is the
+# bash 3.2-compatible equivalent of `mapfile -t`.
+domains=()
+while IFS= read -r domain; do
+  domains+=("$domain")
+done < <(find e2e/tests -mindepth 1 -maxdepth 1 -type d | sed 's|.*/||' | sort)
 all_domains_json=$(printf '%s\n' "${domains[@]}" | jq -R . | jq -sc .)
 
 EVENT_NAME="${EVENT_NAME:-}"

--- a/.github/scripts/e2e-discover-domains.sh
+++ b/.github/scripts/e2e-discover-domains.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# e2e-discover-domains.sh — Decide which e2e domain shards should run.
+#
+# Used by the `e2e-discover` job in .github/workflows/ci.yaml. Writes the
+# selected domain list as a JSON array to $GITHUB_OUTPUT under the key
+# `domains`. Downstream `e2e-setup` and `e2e` jobs consume that output via
+# fromJson() to drive matrix expansion.
+#
+# Inputs (env vars set by the workflow):
+#   EVENT_NAME      github.event_name
+#   REF             github.ref
+#   BASE_REF        github.base_ref (empty on plain push events)
+#   GITHUB_OUTPUT   path to the per-step output file (provided by Actions)
+#
+# Outputs (written to $GITHUB_OUTPUT):
+#   domains=<JSON array>  e.g. ["payroll","time-off"] or [] or ["company",...]
+#
+# Selection rules:
+#   1. push to main / workflow_dispatch  → all domains (always exhaustive)
+#   2. PR with only non-runtime files    → []           (skip e2e entirely)
+#   3. PR touching a path outside any domain's surface
+#      (e.g. src/components/Common/, src/hooks/, package.json, this script)
+#      → all domains (safe default for cross-cutting changes)
+#   4. PR touching only domain-owned paths
+#      → exactly the domains whose surface was touched
+#
+# Domain naming contract:
+#   e2e/tests/<kebab>  ↔  src/components/<Pascal>     (e.g. time-off ↔ TimeOff)
+# The list is discovered from disk on every run; no maintenance needed.
+#
+# Portability: depends on bash 4+ (`mapfile`) and GNU find (`-printf`).
+# Both are present on the GitHub-hosted ubuntu-latest runner this is
+# intended for. Running on macOS for local debugging will fail the
+# `mapfile` line — install `bash` and `findutils` from Homebrew or just
+# run the workflow.
+
+set -euo pipefail
+
+if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+  echo "ERROR: GITHUB_OUTPUT is not set — this script must run inside a GitHub Actions step" >&2
+  exit 2
+fi
+
+mapfile -t domains < <(find e2e/tests -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
+all_domains_json=$(printf '%s\n' "${domains[@]}" | jq -R . | jq -sc .)
+
+EVENT_NAME="${EVENT_NAME:-}"
+REF="${REF:-}"
+
+if [[ "$EVENT_NAME" == "workflow_dispatch" || "$REF" == "refs/heads/main" ]]; then
+  echo "Running all domains (event=$EVENT_NAME ref=$REF)"
+  echo "domains=$all_domains_json" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+base="${BASE_REF:-main}"
+git fetch --no-tags --depth=0 origin "$base" >/dev/null 2>&1 || git fetch origin "$base"
+all_changed=$(git diff --name-only "origin/${base}...HEAD")
+echo "All changed files vs origin/${base}:"
+echo "$all_changed" | sed 's/^/  /'
+
+# Filter to extensions that can actually affect SDK runtime or test behavior.
+# Markdown, license files, gitignore, editorconfig, images, etc. are dropped —
+# they can't change what the e2e suite exercises, so a docs-only PR shouldn't
+# burn CI minutes running the full Playwright matrix. Anything *new* with one
+# of these extensions in an unfamiliar location still falls through to the
+# cross-cutting branch below, preserving the safe default.
+changed=$(echo "$all_changed" | grep -E '\.(ts|tsx|js|jsx|cjs|mjs|json|ya?ml|s?css|html|svg|env)$' || true)
+
+if [[ -z "$changed" ]]; then
+  echo "No code/config changes detected (only non-runtime files)"
+  echo "domains=[]" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "Filtered changed files (runtime-affecting):"
+echo "$changed" | sed 's/^/  /'
+
+# Build the regex that matches "this file is part of some domain's owned
+# surface area" — i.e. lives under either src/components/<Pascal>/ or
+# e2e/tests/<kebab>/ for a known domain. kebab→Pascal converts time-off →
+# TimeOff so the single discovered name covers both ends.
+kebab_to_pascal() {
+  local kebab="$1"
+  echo "$kebab" | awk -F- '{ for (i=1;i<=NF;i++) printf "%s%s", toupper(substr($i,1,1)), substr($i,2); print "" }'
+}
+
+domain_owned_regex=""
+for domain in "${domains[@]}"; do
+  pascal=$(kebab_to_pascal "$domain")
+  entry="^(src/components/${pascal}/|e2e/tests/${domain}/)"
+  if [[ -z "$domain_owned_regex" ]]; then
+    domain_owned_regex="$entry"
+  else
+    domain_owned_regex="${domain_owned_regex}|${entry}"
+  fi
+done
+
+# Any file in the diff that ISN'T claimed by a domain is by definition
+# cross-cutting — run everything. Default-safe policy: unknown locations
+# fan out instead of silently producing an empty matrix.
+unowned=$(echo "$changed" | grep -vE "$domain_owned_regex" || true)
+if [[ -n "$unowned" ]]; then
+  echo "Cross-cutting changes detected (not under any domain):"
+  echo "$unowned" | sed 's/^/  /'
+  echo "Running all domains"
+  echo "domains=$all_domains_json" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+selected=()
+for domain in "${domains[@]}"; do
+  pascal=$(kebab_to_pascal "$domain")
+  if echo "$changed" | grep -qE "^(src/components/${pascal}/|e2e/tests/${domain}/)"; then
+    selected+=("$domain")
+  fi
+done
+
+domains_json=$(printf '%s\n' "${selected[@]}" | jq -R . | jq -sc .)
+echo "Running selected domains: $domains_json"
+echo "domains=$domains_json" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/e2e-verify-success.sh
+++ b/.github/scripts/e2e-verify-success.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# e2e-verify-success.sh — Aggregate gate for branch protection.
+#
+# Used by the `e2e-success` job in .github/workflows/ci.yaml. Treats every
+# contributing job as required: success or skipped passes, anything else
+# (failure, cancelled, timed_out, action_required, etc.) fails the gate.
+#
+# Skipped counts as success on purpose so PRs that scope down to a subset
+# of shards (or skip e2e entirely on docs-only changes) still satisfy the
+# branch-protection check.
+#
+# Inputs (env vars set by the workflow from needs.<job>.result):
+#   SCENARIOS, E2E_DISCOVER, E2E_SETUP, E2E
+#
+# This script must run inside a job with `if: !cancelled()` — without it,
+# a failed upstream short-circuits the whole chain to `skipped`, which
+# branch protection treats as passing (the bug we're guarding against).
+
+set -euo pipefail
+
+echo "scenarios=$SCENARIOS e2e-discover=$E2E_DISCOVER e2e-setup=$E2E_SETUP e2e=$E2E"
+
+for r in "$SCENARIOS" "$E2E_DISCOVER" "$E2E_SETUP" "$E2E"; do
+  case "$r" in
+    success|skipped) ;;
+    *) echo "Required job result was '$r'"; exit 1 ;;
+  esac
+done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -278,100 +278,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REF: ${{ github.ref }}
           BASE_REF: ${{ github.base_ref }}
-        run: |
-          set -euo pipefail
-
-          # Domain folder convention is the contract: every folder under
-          # e2e/tests/ is a domain shard, and its name in kebab-case maps to
-          # a PascalCase folder under src/components/ (e.g. time-off ↔
-          # TimeOff). Discover both ends from disk so adding a new domain
-          # never requires a CI edit.
-          mapfile -t domains < <(find e2e/tests -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
-          all_domains_json=$(printf '%s\n' "${domains[@]}" | jq -R . | jq -sc .)
-
-          # On main and manual dispatch we always run every domain so main
-          # is a true "all green" signal regardless of which paths landed
-          # in the merge commit.
-          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$REF" == "refs/heads/main" ]]; then
-            echo "Running all domains (event=$EVENT_NAME ref=$REF)"
-            echo "domains=$all_domains_json" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Otherwise diff against the PR base. github.base_ref is set on
-          # pull_request events; on a plain push to a feature branch we
-          # fall back to origin/main as the comparison point.
-          base="${BASE_REF:-main}"
-          git fetch --no-tags --depth=0 origin "$base" >/dev/null 2>&1 || git fetch origin "$base"
-          all_changed=$(git diff --name-only "origin/${base}...HEAD")
-          echo "All changed files vs origin/${base}:"
-          echo "$all_changed" | sed 's/^/  /'
-
-          # Filter to extensions that can actually affect SDK runtime or
-          # test behavior. Markdown, license files, gitignore, editorconfig,
-          # images, etc. are dropped — they can't change what the e2e
-          # suite exercises, so a docs-only PR shouldn't burn CI minutes
-          # running the full Playwright matrix. Anything *new* with one of
-          # these extensions in an unfamiliar location still falls through
-          # to the cross-cutting branch below, preserving the safe default.
-          changed=$(echo "$all_changed" | grep -E '\.(ts|tsx|js|jsx|cjs|mjs|json|ya?ml|s?css|html|svg|env)$' || true)
-
-          if [[ -z "$changed" ]]; then
-            echo "No code/config changes detected (only non-runtime files)"
-            echo "domains=[]" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Filtered changed files (runtime-affecting):"
-          echo "$changed" | sed 's/^/  /'
-
-          # Build the regex that matches "this file is part of some
-          # domain's owned surface area" — i.e. lives under either
-          # src/components/<Pascal>/ or e2e/tests/<kebab>/ for a known
-          # domain. kebab→Pascal converts time-off → TimeOff so the
-          # single discovered name covers both ends.
-          kebab_to_pascal() {
-            local kebab="$1"
-            echo "$kebab" | awk -F- '{ for (i=1;i<=NF;i++) printf "%s%s", toupper(substr($i,1,1)), substr($i,2); print "" }'
-          }
-
-          domain_owned_regex=""
-          for domain in "${domains[@]}"; do
-            pascal=$(kebab_to_pascal "$domain")
-            entry="^(src/components/${pascal}/|e2e/tests/${domain}/)"
-            if [[ -z "$domain_owned_regex" ]]; then
-              domain_owned_regex="$entry"
-            else
-              domain_owned_regex="${domain_owned_regex}|${entry}"
-            fi
-          done
-
-          # Any file in the diff that ISN'T claimed by a domain is by
-          # definition cross-cutting — run everything. This is the
-          # default-safe policy: unknown locations fan out instead of
-          # silently producing an empty matrix.
-          unowned=$(echo "$changed" | grep -vE "$domain_owned_regex" || true)
-          if [[ -n "$unowned" ]]; then
-            echo "Cross-cutting changes detected (not under any domain):"
-            echo "$unowned" | sed 's/^/  /'
-            echo "Running all domains"
-            echo "domains=$all_domains_json" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # All changes are domain-owned — pick exactly the domains
-          # whose surface area was touched.
-          selected=()
-          for domain in "${domains[@]}"; do
-            pascal=$(kebab_to_pascal "$domain")
-            if echo "$changed" | grep -qE "^(src/components/${pascal}/|e2e/tests/${domain}/)"; then
-              selected+=("$domain")
-            fi
-          done
-
-          domains_json=$(printf '%s\n' "${selected[@]}" | jq -R . | jq -sc .)
-          echo "Running selected domains: $domains_json"
-          echo "domains=$domains_json" >> "$GITHUB_OUTPUT"
+        run: bash .github/scripts/e2e-discover-domains.sh
 
   # E2E setup: Provision demo companies once per CI run and share state across
   # shards. E2E_DISABLE_CACHE ensures fresh provisioning for each CI run
@@ -592,18 +499,11 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
       - name: Verify required e2e jobs succeeded
         env:
           SCENARIOS: ${{ needs.scenarios.result }}
           E2E_DISCOVER: ${{ needs.e2e-discover.result }}
           E2E_SETUP: ${{ needs.e2e-setup.result }}
           E2E: ${{ needs.e2e.result }}
-        run: |
-          set -euo pipefail
-          echo "scenarios=$SCENARIOS e2e-discover=$E2E_DISCOVER e2e-setup=$E2E_SETUP e2e=$E2E"
-          for r in "$SCENARIOS" "$E2E_DISCOVER" "$E2E_SETUP" "$E2E"; do
-            case "$r" in
-              success|skipped) ;;
-              *) echo "Required job result was '$r'"; exit 1 ;;
-            esac
-          done
+        run: bash .github/scripts/e2e-verify-success.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,21 +231,159 @@ jobs:
       - name: Run scenario unit tests
         run: npm run test:scenarios
 
+  # E2E changes: Decide which domain shards should run for this event.
+  #
+  # Domains are discovered dynamically from `e2e/tests/<domain>/`. The
+  # naming contract is `e2e/tests/<kebab>` ↔ `src/components/<Pascal>`
+  # (e.g. time-off ↔ TimeOff). Adding or removing a domain folder is the
+  # only thing required to add or remove a shard.
+  #
+  # The selection is a two-stage filter:
+  #
+  #   1. Drop files whose extension can't affect runtime or test
+  #      behavior (.md, LICENSE, .gitignore, images, etc.). A docs-only
+  #      PR produces an empty filtered diff and skips e2e entirely.
+  #   2. Of the surviving files, if any sit OUTSIDE every known domain's
+  #      surface area (`src/components/<Pascal>/` or `e2e/tests/<kebab>/`),
+  #      treat the change as cross-cutting and run every shard.
+  #      Otherwise run only the domains whose surface was actually touched.
+  #
+  # Stage 2 is safe by default: new code in unfamiliar locations (e.g. a
+  # fresh top-level directory like `src/middleware/`) fans out to all
+  # shards rather than silently producing an empty matrix.
+  #
+  # On pushes to main and manual dispatches we run every domain
+  # unconditionally — main is the canonical "all green" signal regardless
+  # of which paths landed in the merge commit.
+  #
+  # Output is a JSON array of domain folder names that downstream
+  # `e2e-setup` and `e2e` consume via fromJson() for matrix expansion. An
+  # empty array is a valid result and short-circuits both downstream jobs.
+  e2e-changes:
+    needs: setup
+    runs-on: ubuntu-latest
+    outputs:
+      domains: ${{ steps.resolve.outputs.domains }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need merge-base history to diff PR branches against base. Default
+          # depth=1 has no shared history with origin/<base>, which would
+          # make `git diff base...HEAD` empty and silently skip every shard.
+          fetch-depth: 0
+
+      - id: resolve
+        name: Resolve domains JSON
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          # Domain folder convention is the contract: every folder under
+          # e2e/tests/ is a domain shard, and its name in kebab-case maps to
+          # a PascalCase folder under src/components/ (e.g. time-off ↔
+          # TimeOff). Discover both ends from disk so adding a new domain
+          # never requires a CI edit.
+          mapfile -t domains < <(find e2e/tests -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
+          all_domains_json=$(printf '%s\n' "${domains[@]}" | jq -R . | jq -sc .)
+
+          # On main and manual dispatch we always run every domain so main
+          # is a true "all green" signal regardless of which paths landed
+          # in the merge commit.
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$REF" == "refs/heads/main" ]]; then
+            echo "Running all domains (event=$EVENT_NAME ref=$REF)"
+            echo "domains=$all_domains_json" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Otherwise diff against the PR base. github.base_ref is set on
+          # pull_request events; on a plain push to a feature branch we
+          # fall back to origin/main as the comparison point.
+          base="${BASE_REF:-main}"
+          git fetch --no-tags --depth=0 origin "$base" >/dev/null 2>&1 || git fetch origin "$base"
+          all_changed=$(git diff --name-only "origin/${base}...HEAD")
+          echo "All changed files vs origin/${base}:"
+          echo "$all_changed" | sed 's/^/  /'
+
+          # Filter to extensions that can actually affect SDK runtime or
+          # test behavior. Markdown, license files, gitignore, editorconfig,
+          # images, etc. are dropped — they can't change what the e2e
+          # suite exercises, so a docs-only PR shouldn't burn CI minutes
+          # running the full Playwright matrix. Anything *new* with one of
+          # these extensions in an unfamiliar location still falls through
+          # to the cross-cutting branch below, preserving the safe default.
+          changed=$(echo "$all_changed" | grep -E '\.(ts|tsx|js|jsx|cjs|mjs|json|ya?ml|s?css|html|svg|env)$' || true)
+
+          if [[ -z "$changed" ]]; then
+            echo "No code/config changes detected (only non-runtime files)"
+            echo "domains=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Filtered changed files (runtime-affecting):"
+          echo "$changed" | sed 's/^/  /'
+
+          # Build the regex that matches "this file is part of some
+          # domain's owned surface area" — i.e. lives under either
+          # src/components/<Pascal>/ or e2e/tests/<kebab>/ for a known
+          # domain. kebab→Pascal converts time-off → TimeOff so the
+          # single discovered name covers both ends.
+          kebab_to_pascal() {
+            local kebab="$1"
+            echo "$kebab" | awk -F- '{ for (i=1;i<=NF;i++) printf "%s%s", toupper(substr($i,1,1)), substr($i,2); print "" }'
+          }
+
+          domain_owned_regex=""
+          for domain in "${domains[@]}"; do
+            pascal=$(kebab_to_pascal "$domain")
+            entry="^(src/components/${pascal}/|e2e/tests/${domain}/)"
+            if [[ -z "$domain_owned_regex" ]]; then
+              domain_owned_regex="$entry"
+            else
+              domain_owned_regex="${domain_owned_regex}|${entry}"
+            fi
+          done
+
+          # Any file in the diff that ISN'T claimed by a domain is by
+          # definition cross-cutting — run everything. This is the
+          # default-safe policy: unknown locations fan out instead of
+          # silently producing an empty matrix.
+          unowned=$(echo "$changed" | grep -vE "$domain_owned_regex" || true)
+          if [[ -n "$unowned" ]]; then
+            echo "Cross-cutting changes detected (not under any domain):"
+            echo "$unowned" | sed 's/^/  /'
+            echo "Running all domains"
+            echo "domains=$all_domains_json" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # All changes are domain-owned — pick exactly the domains
+          # whose surface area was touched.
+          selected=()
+          for domain in "${domains[@]}"; do
+            pascal=$(kebab_to_pascal "$domain")
+            if echo "$changed" | grep -qE "^(src/components/${pascal}/|e2e/tests/${domain}/)"; then
+              selected+=("$domain")
+            fi
+          done
+
+          domains_json=$(printf '%s\n' "${selected[@]}" | jq -R . | jq -sc .)
+          echo "Running selected domains: $domains_json"
+          echo "domains=$domains_json" >> "$GITHUB_OUTPUT"
+
   # E2E setup: Provision demo companies once per CI run and share state across
-  # shards, and discover which domain folders under e2e/tests/ should become
-  # matrix shards. E2E_DISABLE_CACHE ensures fresh provisioning for each CI run
+  # shards. E2E_DISABLE_CACHE ensures fresh provisioning for each CI run
   # (ignores stale .e2e-state.json from previous runs), but the artifact sharing
   # across shards within this run avoids duplicate provisioning load on the
-  # demo backend. The `domains` output is a JSON array consumed by the e2e
-  # job's matrix via fromJson() — new domain folders automatically become
-  # shards with no CI edits; folders that disappear stop producing shards.
-  # Flat specs directly under e2e/tests/ are intentionally not picked up —
-  # every shipping spec lives inside a domain folder.
+  # demo backend. The set of domains to run is computed by `e2e-changes` and
+  # passed through unchanged so downstream `e2e` consumers have a single
+  # source of truth. Skipped entirely when `e2e-changes` produced an empty
+  # array (a PR with no e2e-affecting changes).
   e2e-setup:
-    needs: [setup, scenarios]
-    # Temporarily skip E2E on pushes to main while we stabilize the demo backend
-    # contract. PR runs and manual dispatches still execute the suite.
-    if: github.ref != 'refs/heads/main'
+    needs: [setup, scenarios, e2e-changes]
+    if: needs.e2e-changes.outputs.domains != '[]'
     runs-on: ubuntu-latest
     # Wallclock ceiling for provisioning all demo companies (primary +
     # dismissal + every shared scenario in e2e/scenarios/shared/). Each
@@ -257,16 +395,9 @@ jobs:
     # downstream shard.
     timeout-minutes: 15
     outputs:
-      domains: ${{ steps.list-domains.outputs.domains }}
+      domains: ${{ needs.e2e-changes.outputs.domains }}
     steps:
       - uses: actions/checkout@v6
-
-      - id: list-domains
-        name: Discover e2e domains from folders under e2e/tests/
-        run: |
-          domains=$(find e2e/tests -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort | jq -R . | jq -sc .)
-          echo "domains=$domains" >> "$GITHUB_OUTPUT"
-          echo "Discovered: $domains"
 
       - uses: actions/setup-node@v6
         with:
@@ -343,10 +474,11 @@ jobs:
   # specs under `e2e/tests/<domain>/**/*.spec.ts`.
   e2e:
     needs: [setup, scenarios, e2e-setup]
-    # Skip cleanly when no domain folders exist — fromJson on an empty array
-    # would otherwise fail matrix expansion. Also skipped on main while we
-    # stabilize the demo backend contract (mirrors the e2e-setup gate).
-    if: github.ref != 'refs/heads/main' && needs.e2e-setup.outputs.domains != '[]'
+    # Skip cleanly when no domain folders are selected — fromJson on an empty
+    # array would otherwise fail matrix expansion. The selection itself
+    # (including the "always run all on main" rule) is computed in
+    # `e2e-changes`; we just honor whatever it produced.
+    if: needs.e2e-setup.outputs.domains != '[]'
     runs-on: ubuntu-latest
     # Wallclock ceiling per shard. Scenario provisioning is now done in
     # e2e-setup, so shards just download the artifact and run tests against
@@ -442,3 +574,36 @@ jobs:
           name: e2e-scenario-report-${{ matrix.domain }}
           path: e2e/reports/
           retention-days: 7
+
+  # E2E success: Single required check that branch protection can gate on.
+  #
+  # Aggregates the result of every job that collectively constitutes "e2e
+  # passed" — scenarios validation, the provisioning job, and the matrix
+  # itself (whose `result` is the rolled-up status across every shard).
+  # Skipped counts as success so a PR that only touches paths outside any
+  # domain (and therefore produced an empty matrix) still satisfies the
+  # gate. Failure or cancellation of any contributing job fails this check.
+  #
+  # `if: !cancelled()` is required: without it, a failed upstream short-
+  # circuits this job to `skipped`, which branch protection treats as
+  # passing — exactly the bug we're trying to avoid.
+  e2e-success:
+    needs: [scenarios, e2e-changes, e2e-setup, e2e]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required e2e jobs succeeded
+        env:
+          SCENARIOS: ${{ needs.scenarios.result }}
+          E2E_CHANGES: ${{ needs.e2e-changes.result }}
+          E2E_SETUP: ${{ needs.e2e-setup.result }}
+          E2E: ${{ needs.e2e.result }}
+        run: |
+          set -euo pipefail
+          echo "scenarios=$SCENARIOS e2e-changes=$E2E_CHANGES e2e-setup=$E2E_SETUP e2e=$E2E"
+          for r in "$SCENARIOS" "$E2E_CHANGES" "$E2E_SETUP" "$E2E"; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "Required job result was '$r'"; exit 1 ;;
+            esac
+          done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,7 +231,7 @@ jobs:
       - name: Run scenario unit tests
         run: npm run test:scenarios
 
-  # E2E changes: Decide which domain shards should run for this event.
+  # E2E discover: Decide which domain shards should run for this event.
   #
   # Domains are discovered dynamically from `e2e/tests/<domain>/`. The
   # naming contract is `e2e/tests/<kebab>` ↔ `src/components/<Pascal>`
@@ -259,7 +259,7 @@ jobs:
   # Output is a JSON array of domain folder names that downstream
   # `e2e-setup` and `e2e` consume via fromJson() for matrix expansion. An
   # empty array is a valid result and short-circuits both downstream jobs.
-  e2e-changes:
+  e2e-discover:
     needs: setup
     runs-on: ubuntu-latest
     outputs:
@@ -377,13 +377,13 @@ jobs:
   # shards. E2E_DISABLE_CACHE ensures fresh provisioning for each CI run
   # (ignores stale .e2e-state.json from previous runs), but the artifact sharing
   # across shards within this run avoids duplicate provisioning load on the
-  # demo backend. The set of domains to run is computed by `e2e-changes` and
-  # passed through unchanged so downstream `e2e` consumers have a single
-  # source of truth. Skipped entirely when `e2e-changes` produced an empty
-  # array (a PR with no e2e-affecting changes).
+  # demo backend. The set of domains to run is computed by `e2e-discover`
+  # and passed through unchanged so downstream `e2e` consumers have a
+  # single source of truth. Skipped entirely when `e2e-discover` produced
+  # an empty array (a PR with no e2e-affecting changes).
   e2e-setup:
-    needs: [setup, scenarios, e2e-changes]
-    if: needs.e2e-changes.outputs.domains != '[]'
+    needs: [setup, scenarios, e2e-discover]
+    if: needs.e2e-discover.outputs.domains != '[]'
     runs-on: ubuntu-latest
     # Wallclock ceiling for provisioning all demo companies (primary +
     # dismissal + every shared scenario in e2e/scenarios/shared/). Each
@@ -395,7 +395,7 @@ jobs:
     # downstream shard.
     timeout-minutes: 15
     outputs:
-      domains: ${{ needs.e2e-changes.outputs.domains }}
+      domains: ${{ needs.e2e-discover.outputs.domains }}
     steps:
       - uses: actions/checkout@v6
 
@@ -477,7 +477,7 @@ jobs:
     # Skip cleanly when no domain folders are selected — fromJson on an empty
     # array would otherwise fail matrix expansion. The selection itself
     # (including the "always run all on main" rule) is computed in
-    # `e2e-changes`; we just honor whatever it produced.
+    # `e2e-discover`; we just honor whatever it produced.
     if: needs.e2e-setup.outputs.domains != '[]'
     runs-on: ubuntu-latest
     # Wallclock ceiling per shard. Scenario provisioning is now done in
@@ -588,20 +588,20 @@ jobs:
   # circuits this job to `skipped`, which branch protection treats as
   # passing — exactly the bug we're trying to avoid.
   e2e-success:
-    needs: [scenarios, e2e-changes, e2e-setup, e2e]
+    needs: [scenarios, e2e-discover, e2e-setup, e2e]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Verify required e2e jobs succeeded
         env:
           SCENARIOS: ${{ needs.scenarios.result }}
-          E2E_CHANGES: ${{ needs.e2e-changes.result }}
+          E2E_DISCOVER: ${{ needs.e2e-discover.result }}
           E2E_SETUP: ${{ needs.e2e-setup.result }}
           E2E: ${{ needs.e2e.result }}
         run: |
           set -euo pipefail
-          echo "scenarios=$SCENARIOS e2e-changes=$E2E_CHANGES e2e-setup=$E2E_SETUP e2e=$E2E"
-          for r in "$SCENARIOS" "$E2E_CHANGES" "$E2E_SETUP" "$E2E"; do
+          echo "scenarios=$SCENARIOS e2e-discover=$E2E_DISCOVER e2e-setup=$E2E_SETUP e2e=$E2E"
+          for r in "$SCENARIOS" "$E2E_DISCOVER" "$E2E_SETUP" "$E2E"; do
             case "$r" in
               success|skipped) ;;
               *) echo "Required job result was '$r'"; exit 1 ;;

--- a/e2e/scripts/refreshToken.ts
+++ b/e2e/scripts/refreshToken.ts
@@ -8,6 +8,22 @@ const DEMO_URL = `${GWS_FLOWS_BASE}/demos?react_sdk=true`
 const ENV_FILE_PATH = resolve(process.cwd(), 'e2e/local.config.env')
 const isLocalHost = GWS_FLOWS_BASE.includes('localhost')
 
+// Per-navigation timeout for any goto/waitForURL/reload against the demo
+// backend. Default Playwright timeout is 30s, which is too tight for
+// flows.gusto-demo.com during seeding waves where individual page loads
+// can take 60-90s. 120s gives real headroom without holding the job
+// hostage if the host is genuinely down (the retry loop below covers
+// transient flake separately).
+const NAV_TIMEOUT_MS = 120_000
+
+// Retry budget for the initial page.goto into the demo flow. The host
+// occasionally drops a connection or returns a slow first response after
+// a quiet period; a couple of retries with a short backoff almost always
+// recovers without us paying the full per-attempt timeout. 3 attempts ×
+// 120s worst-case = 6 min, well under the 15 min e2e-setup job ceiling.
+const INITIAL_GOTO_MAX_ATTEMPTS = 3
+const INITIAL_GOTO_BACKOFF_MS = 2_000
+
 interface TokenInfo {
   flowToken: string
   companyId: string
@@ -33,6 +49,32 @@ export async function createFreshDemo(flowType: string = 'react_sdk_demo'): Prom
   return extractTokenFromPage(flowType)
 }
 
+async function gotoWithRetry(page: import('@playwright/test').Page, url: string): Promise<void> {
+  let lastError: unknown
+  for (let attempt = 1; attempt <= INITIAL_GOTO_MAX_ATTEMPTS; attempt++) {
+    try {
+      await page.goto(url, { waitUntil: 'networkidle', timeout: NAV_TIMEOUT_MS })
+      if (attempt > 1) {
+        console.log(`  ↻ Recovered on attempt ${attempt}`)
+      }
+      return
+    } catch (error) {
+      lastError = error
+      const remaining = INITIAL_GOTO_MAX_ATTEMPTS - attempt
+      if (remaining === 0) break
+      const message = error instanceof Error ? error.message : String(error)
+      console.warn(
+        `  ⚠️  page.goto failed on attempt ${attempt}/${INITIAL_GOTO_MAX_ATTEMPTS}: ${message}`,
+      )
+      console.warn(
+        `  ↻ Retrying in ${INITIAL_GOTO_BACKOFF_MS / 1000}s (${remaining} attempts left)...`,
+      )
+      await page.waitForTimeout(INITIAL_GOTO_BACKOFF_MS)
+    }
+  }
+  throw lastError
+}
+
 async function extractTokenFromPage(flowType: string = 'react_sdk_demo'): Promise<TokenInfo> {
   console.log('🔄 Launching browser to get fresh token from GWS-Flows...')
 
@@ -41,7 +83,7 @@ async function extractTokenFromPage(flowType: string = 'react_sdk_demo'): Promis
   const page = await context.newPage()
 
   try {
-    await page.goto(DEMO_URL, { waitUntil: 'networkidle' })
+    await gotoWithRetry(page, DEMO_URL)
 
     const flowTypeSelect = page.locator('#demo_flow_type')
     await flowTypeSelect.selectOption(flowType)
@@ -51,7 +93,7 @@ async function extractTokenFromPage(flowType: string = 'react_sdk_demo'): Promis
     const submitButton = page.getByRole('button', { name: /create/i })
     await submitButton.click()
 
-    await page.waitForURL(/\/demos\/[a-f0-9-]+/, { timeout: 30000 })
+    await page.waitForURL(/\/demos\/[a-f0-9-]+/, { timeout: NAV_TIMEOUT_MS })
     const demoPageUrl = page.url()
     console.log(`📍 Navigated to demo page: ${demoPageUrl}`)
 
@@ -112,7 +154,9 @@ async function extractTokenFromPage(flowType: string = 'react_sdk_demo'): Promis
 
     if (!companyId) {
       const flowPageUrl = `${GWS_FLOWS_BASE}/flows/${flowToken}`
-      await page.goto(flowPageUrl, { waitUntil: 'networkidle', timeout: 30000 }).catch(() => {})
+      await page
+        .goto(flowPageUrl, { waitUntil: 'networkidle', timeout: NAV_TIMEOUT_MS })
+        .catch(() => {})
       await page.waitForTimeout(2000)
 
       const flowPageContent = await page.content()


### PR DESCRIPTION
## Summary

- **`e2e-success` aggregator** — single required check that branch protection can gate on. Aggregates `scenarios + e2e-changes + e2e-setup + e2e` (the matrix's `result` rolls up across every shard). Treats `skipped` as success so PRs that scope down to a subset of shards still satisfy the gate. Uses `if: !cancelled()` so a failed upstream actually fails this check instead of being skipped (which branch protection treats as passing).
- **Re-enabled e2e on `main`** — main always runs every domain unconditionally so it stays the canonical "all green" signal.
- **Selective shards on PRs** — only run the domain shards whose surface was actually touched.

## How selection works

Two-stage filter in the new `e2e-changes` job:

1. **Extension allowlist** — drop files whose extension can't affect runtime/test behavior (`.md`, `LICENSE`, `.gitignore`, images, etc.). A docs-only PR produces an empty filtered diff and skips e2e entirely.
2. **Domain ownership** — of the surviving files, if any sit *outside* every known domain's surface (`src/components/<Pascal>/` or `e2e/tests/<kebab>/`), treat the change as cross-cutting and run every shard. Otherwise run only the domains whose surface was touched.

The domain list is discovered dynamically from `e2e/tests/<domain>/`. The naming contract is `e2e/tests/<kebab>` ↔ `src/components/<Pascal>` (e.g. `time-off` ↔ `TimeOff`). Adding a new domain folder is sufficient — no CI edit required.

Stage 2 is safe by default: new code in unfamiliar locations (e.g. a fresh top-level dir like `src/middleware/`) fans out to all shards rather than silently producing an empty matrix.

## Behavior matrix

| Change | Result |
|---|---|
| `src/components/Payroll/*.tsx` | `payroll` only |
| `src/components/Payroll/*` + `src/components/Employee/*` | `employee + payroll` |
| `src/components/Common/*` / `src/hooks/*` / `package.json` / `playwright.demo.config.ts` | all shards |
| New top-level dir like `src/middleware/auth.ts` | all shards (safe default) |
| Push to `main` / `workflow_dispatch` | all shards (always) |
| `README.md` / `docs/**.md` / `LICENSE` / images | skip e2e entirely |
| `payroll source + README.md` | `payroll` only |

## Follow-up (not in this PR)

After merge, set `e2e-success` as a required status check in branch protection. That's a manual GitHub UI step.

## Test plan

- [ ] CI on this PR runs only the e2e shards relevant to `.github/workflows/ci.yaml` — which is itself cross-cutting, so all shards should run
- [ ] `e2e-success` job appears in checks and passes
- [ ] After merge, verify a follow-up PR touching only one domain runs only that domain's shard
- [ ] After merge, verify a docs-only PR skips e2e entirely
- [ ] After merge, verify a push to `main` runs every shard


Made with [Cursor](https://cursor.com)