### PR TITLE
fix(SDK-933): track agency-required garnishment fields dynamically

### DIFF
--- a/src/components/Employee/Deductions/shared/useChildSupportGarnishmentForm/childSupportGarnishmentFormSchema.ts
+++ b/src/components/Employee/Deductions/shared/useChildSupportGarnishmentForm/childSupportGarnishmentFormSchema.ts
@@ -101,25 +101,47 @@ export type ChildSupportGarnishmentFormOutputs = ChildSupportGarnishmentFormData
 interface ChildSupportGarnishmentFormSchemaOptions {
   mode?: 'create' | 'update'
   /**
-   * The agency record matching the currently selected `state`. The agency's
-   * `requiredAttributes` determine which of `caseNumber` / `orderNumber` /
-   * `remittanceNumber` are required. When omitted (no agency selected yet),
-   * all three are optional.
+   * The agency record matching the currently selected `state`. Used only when
+   * `agencyList` is not provided — `requiredAttributes` are pinned to this
+   * single agency, so the schema must be rebuilt whenever the user picks a
+   * different state. Prefer passing `agencyList` instead so requiredness
+   * tracks the form's `state` value dynamically.
    */
   selectedAgency?: Agencies | null
+  /**
+   * Full list of agencies. When provided, the schema's requiredness for
+   * `caseNumber` / `orderNumber` / `remittanceNumber` is computed at validation
+   * time by looking up the agency whose `state` matches the form's `state`
+   * value — so a single schema instance stays correct as the user changes
+   * states. Takes precedence over `selectedAgency`.
+   */
+  agencyList?: readonly Agencies[]
 }
 
 export function createChildSupportGarnishmentFormSchema({
   mode = 'create',
   selectedAgency,
+  agencyList,
 }: ChildSupportGarnishmentFormSchemaOptions = {}) {
-  const requiredAttrKeys = getRequiredAttrKeys(selectedAgency)
-
-  const requiredFieldsConfig = {
-    caseNumber: requiredAttrKeys.has('case_number') ? 'always' : 'never',
-    orderNumber: requiredAttrKeys.has('order_number') ? 'always' : 'never',
-    remittanceNumber: requiredAttrKeys.has('remittance_number') ? 'always' : 'never',
-  } satisfies RequiredFieldConfig<typeof fieldValidators>
+  const requiredFieldsConfig = agencyList
+    ? ({
+        caseNumber: data =>
+          getRequiredAttrKeys(agencyList.find(a => a.state === data.state)).has('case_number'),
+        orderNumber: data =>
+          getRequiredAttrKeys(agencyList.find(a => a.state === data.state)).has('order_number'),
+        remittanceNumber: data =>
+          getRequiredAttrKeys(agencyList.find(a => a.state === data.state)).has(
+            'remittance_number',
+          ),
+      } satisfies RequiredFieldConfig<typeof fieldValidators>)
+    : (() => {
+        const requiredAttrKeys = getRequiredAttrKeys(selectedAgency)
+        return {
+          caseNumber: requiredAttrKeys.has('case_number') ? 'always' : 'never',
+          orderNumber: requiredAttrKeys.has('order_number') ? 'always' : 'never',
+          remittanceNumber: requiredAttrKeys.has('remittance_number') ? 'always' : 'never',
+        } satisfies RequiredFieldConfig<typeof fieldValidators>
+      })()
 
   return buildFormSchema(fieldValidators, {
     requiredFieldsConfig,

--- a/src/components/Employee/Deductions/shared/useChildSupportGarnishmentForm/childSupportGarnishmentFormSchema.ts
+++ b/src/components/Employee/Deductions/shared/useChildSupportGarnishmentForm/childSupportGarnishmentFormSchema.ts
@@ -123,16 +123,27 @@ export function createChildSupportGarnishmentFormSchema({
   selectedAgency,
   agencyList,
 }: ChildSupportGarnishmentFormSchemaOptions = {}) {
+  // Read `data.state` eagerly (outside the `agencyList.find` callback) so that
+  // `buildFormSchema`'s proxy-based predicate-dep detection always observes
+  // the `state` access — otherwise an empty `agencyList` at schema-build time
+  // would short-circuit the `find` before the proxy sees `data.state` and
+  // `useDeriveFieldsMetadata` would treat the field metadata as static.
   const requiredFieldsConfig = agencyList
     ? ({
-        caseNumber: data =>
-          getRequiredAttrKeys(agencyList.find(a => a.state === data.state)).has('case_number'),
-        orderNumber: data =>
-          getRequiredAttrKeys(agencyList.find(a => a.state === data.state)).has('order_number'),
-        remittanceNumber: data =>
-          getRequiredAttrKeys(agencyList.find(a => a.state === data.state)).has(
+        caseNumber: data => {
+          const state = data.state
+          return getRequiredAttrKeys(agencyList.find(a => a.state === state)).has('case_number')
+        },
+        orderNumber: data => {
+          const state = data.state
+          return getRequiredAttrKeys(agencyList.find(a => a.state === state)).has('order_number')
+        },
+        remittanceNumber: data => {
+          const state = data.state
+          return getRequiredAttrKeys(agencyList.find(a => a.state === state)).has(
             'remittance_number',
-          ),
+          )
+        },
       } satisfies RequiredFieldConfig<typeof fieldValidators>)
     : (() => {
         const requiredAttrKeys = getRequiredAttrKeys(selectedAgency)

--- a/src/components/Employee/Deductions/shared/useChildSupportGarnishmentForm/useChildSupportGarnishmentForm.test.tsx
+++ b/src/components/Employee/Deductions/shared/useChildSupportGarnishmentForm/useChildSupportGarnishmentForm.test.tsx
@@ -205,6 +205,31 @@ describe('useChildSupportGarnishmentForm', () => {
       expect(fm.getValues('orderNumber')).toBe('')
       expect(fm.getValues('remittanceNumber')).toBe('')
     })
+
+    it('marks agency-required attribute fields as required in metadata after selecting that agency', async () => {
+      const { result } = renderHook(
+        () => useChildSupportGarnishmentForm({ employeeId: 'employee-123' }),
+        { wrapper: GustoTestProvider },
+      )
+
+      const ready = await waitForReady(() => result.current)
+
+      act(() => {
+        ready.form.hookFormInternals.formMethods.setValue('state', 'OH')
+      })
+
+      await waitFor(() => {
+        const r = result.current
+        assertReady(r)
+        expect(r.status.selectedAgency?.state).toBe('OH')
+      })
+
+      const updated = result.current
+      assertReady(updated)
+      expect(updated.form.fieldsMetadata.caseNumber?.isRequired).toBe(true)
+      expect(updated.form.fieldsMetadata.orderNumber?.isRequired).toBe(true)
+      expect(updated.form.fieldsMetadata.remittanceNumber?.isRequired).toBe(false)
+    })
   })
 
   describe('create submit', () => {

--- a/src/components/Employee/Deductions/shared/useChildSupportGarnishmentForm/useChildSupportGarnishmentForm.tsx
+++ b/src/components/Employee/Deductions/shared/useChildSupportGarnishmentForm/useChildSupportGarnishmentForm.tsx
@@ -170,16 +170,14 @@ export function useChildSupportGarnishmentForm({
     [fetchedDeduction, partnerDefaults],
   )
 
-  // The schema is built statically here. The agency-attribute fields
-  // (`caseNumber`, `orderNumber`, `remittanceNumber`) are kept optional in the
-  // schema and surfaced as `isRequired` at the metadata level when the
-  // selected agency declares them in `required_attributes`. This matches the
-  // legacy ChildSupportForm, which also used a static schema and relied on the
-  // API to enforce missing-attribute validation. The hook's `requiredAttrKeys`
-  // status flag tells consumers which UI fields to mark required.
+  // Pass the full agency list so requiredness for the agency-attribute fields
+  // (`caseNumber`, `orderNumber`, `remittanceNumber`) is derived dynamically
+  // from the form's `state` value. The schema doesn't need to rebuild when the
+  // user changes states — the predicate runs at validation time and via
+  // `useDeriveFieldsMetadata` for the (optional) label.
   const [schema, metadataConfig] = useMemo(
-    () => createChildSupportGarnishmentFormSchema({ mode: schemaMode }),
-    [schemaMode],
+    () => createChildSupportGarnishmentFormSchema({ mode: schemaMode, agencyList }),
+    [schemaMode, agencyList],
   )
 
   const formMethods = useForm<


### PR DESCRIPTION
## Summary

In the child-support garnishment form (Add deduction → Garnishment → Child Support → pick an agency), fields that the agency requires (e.g. CSE Case Number for South Carolina) were rendered with an "(optional)" label and could be submitted blank — the API would then reject with "Case number is required". The label was wrong AND the form skipped client-side validation, so the user saw a server error instead of inline guidance.

Root cause: \`createChildSupportGarnishmentFormSchema\` was called once at hook init with no agency context. The three agency-attribute fields (\`caseNumber\`, \`orderNumber\`, \`remittanceNumber\`) defaulted to \`'never'\` required, so \`isRequired\` stayed \`false\` for the whole form lifetime. The view rendered them conditionally on \`requiredAttrKeys\`, but their labels still said "(optional)".

Fix: add an \`agencyList\` option to the schema factory. When provided, requiredness for the three fields is computed via predicates that look up the agency by the form's \`state\` value at validation and metadata-derivation time. No schema rebuild is needed when the user switches states — \`useDeriveFieldsMetadata\` already watches predicate dependencies, and \`superRefine\` evaluates the predicates at submit. The hook passes the agency list it already loads, so picking an agency that requires a field immediately flips its \`isRequired\` to \`true\` (dropping the "(optional)" suffix) and an empty submit is rejected client-side before hitting the API.

The legacy \`selectedAgency\` option still produces static rules so external callers of the public factory aren't affected.

## Changes

- \`childSupportGarnishmentFormSchema\`: new \`agencyList\` option. When set, \`requiredFieldsConfig\` is predicate-based against \`data.state\`. Otherwise falls back to the existing static \`selectedAgency\` behavior.
- \`useChildSupportGarnishmentForm\`: pass \`agencyList\` into the factory.
- New test: \`marks agency-required attribute fields as required in metadata after selecting that agency\`. Verified to fail on \`main\` and pass with the fix.

## Out of scope

- The ticket also notes "There was a problem with your submission" rendering below the Deduction type radio instead of at the top. That's a separate concern (the \`BaseLayout\` error banner sits inside the child-support view, so the agency picker renders before it). Tracking as follow-up.

## Related

- Jira: [SDK-933](https://gustohq.atlassian.net/browse/SDK-933)
- Epic: [SDK-517](https://gustohq.atlassian.net/browse/SDK-517) — Test Fest, Employee Dashboard

## Testing

- \`npm run test -- --run src/components/Employee/Deductions\` → 33/33 passed (32 prior + 1 new)
- \`npx tsc --noEmit\` → clean
- Stashed only the schema/hook changes and re-ran the new test → fails on main (\`isRequired\` returns \`false\`), confirming the test guards the regression.

Manual: \`npm run storybook\` → ChildSupportGarnishment story → pick "South Carolina Integrated Child Support Services" → confirm CSE Case Number no longer says "(optional)" and submitting blank surfaces an inline required error rather than an API error.

[SDK-933]: https://gustohq.atlassian.net/browse/SDK-933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ