### PR TITLE
fix(SDK-938): show a format-specific message for invalid account numbers

### DIFF
--- a/src/components/Employee/PaymentMethod/onboarding/BankForm.tsx
+++ b/src/components/Employee/PaymentMethod/onboarding/BankForm.tsx
@@ -55,7 +55,7 @@ export function BankForm({ employeeId, onEvent, ...hookProps }: BankFormProps) {
             label={t('accountNumberLabel')}
             validationMessages={{
               REQUIRED: t('validations.accountNumber'),
-              INVALID_ACCOUNT_NUMBER: t('validations.accountNumber'),
+              INVALID_ACCOUNT_NUMBER: t('validations.accountNumberFormat'),
             }}
           />
           <Fields.AccountType

--- a/src/components/Employee/PaymentMethod/onboarding/ListView.test.tsx
+++ b/src/components/Employee/PaymentMethod/onboarding/ListView.test.tsx
@@ -236,7 +236,9 @@ describe('PaymentMethod onboarding ListView', () => {
       await waitFor(() => {
         expect(screen.getByText('Routing number should be a number (9 digits)')).toBeInTheDocument()
       })
-      expect(screen.getByText('Account number is a required field')).toBeInTheDocument()
+      expect(
+        screen.getByText('Account number should contain only digits (up to 17)'),
+      ).toBeInTheDocument()
     })
 
     it('returns to list view when Cancel is clicked from BankForm', async () => {

--- a/src/i18n/en/Employee.PaymentMethod.json
+++ b/src/i18n/en/Employee.PaymentMethod.json
@@ -60,6 +60,7 @@
     "amountError": "Please enter valid amount",
     "accountName": "Account name is required",
     "routingNumber": "Routing number should be a number (9 digits)",
-    "accountNumber": "Account number is a required field"
+    "accountNumber": "Account number is a required field",
+    "accountNumberFormat": "Account number should contain only digits (up to 17)"
   }
 }

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -2185,6 +2185,7 @@ export interface EmployeePaymentMethod{
 "accountName":string;
 "routingNumber":string;
 "accountNumber":string;
+"accountNumberFormat":string;
 };
 };
 export interface EmployeeProfile{


### PR DESCRIPTION
## Summary

Entering an alphanumeric account number in the Add bank account form surfaced "Account number is a required field" — misleading, because a value WAS entered. The schema correctly returned the \`INVALID_ACCOUNT_NUMBER\` error code; the view just mapped both \`REQUIRED\` and \`INVALID_ACCOUNT_NUMBER\` to the same i18n string.

Add a new \`validations.accountNumberFormat\` string and route \`INVALID_ACCOUNT_NUMBER\` to it. \`REQUIRED\` continues to use the existing "is a required field" copy.

## Changes

- \`Employee.PaymentMethod.json\`: new \`validations.accountNumberFormat\` = "Account number should contain only digits (up to 17)" (matches the schema's \`/^[0-9]{1,17}$/\` rule).
- \`BankForm.tsx\`: \`INVALID_ACCOUNT_NUMBER\` → \`t('validations.accountNumberFormat')\`. \`REQUIRED\` unchanged.
- \`ListView.test.tsx\`: format-error test now asserts the new message.
- Regenerated \`src/types/i18next.d.ts\` via \`npm run i18n:generate\`.

## Related

- Jira: [SDK-938](https://gustohq.atlassian.net/browse/SDK-938)
- Epic: [SDK-517](https://gustohq.atlassian.net/browse/SDK-517) — Test Fest, Employee Dashboard

## Testing

- \`npm run test -- --run src/components/Employee/PaymentMethod\` → 74/74 passed
- \`npx tsc --noEmit\` → clean
- \`npm run i18n:generate\` → updated i18next.d.ts cleanly

Manual: \`npm run storybook\` → PaymentMethod story → Add bank account → enter "abc" in Account number → expect the new format message rather than "required".

[SDK-938]: https://gustohq.atlassian.net/browse/SDK-938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-517]: https://gustohq.atlassian.net/browse/SDK-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ