### PR TITLE
fix(SDK-940): make Documents tab forms table flush with its container

### DIFF
--- a/src/components/Employee/Dashboard/DocumentsView.tsx
+++ b/src/components/Employee/Dashboard/DocumentsView.tsx
@@ -101,14 +101,15 @@ export function DocumentsView({ forms = [], isLoading = false, onViewForm }: Doc
 
   return (
     <Flex flexDirection="column" gap={24}>
-      <Components.Box header={<Components.BoxHeader title={t('documents.title')} />}>
-        <Flex flexDirection="column" gap={16}>
-          {isLoading ? (
-            <Loading />
-          ) : (
-            <DataView label={t('documents.listLabel')} {...formsDataView} />
-          )}
-        </Flex>
+      <Components.Box
+        withPadding={false}
+        header={<Components.BoxHeader title={t('documents.title')} />}
+      >
+        {isLoading ? (
+          <Loading />
+        ) : (
+          <DataView label={t('documents.listLabel')} isWithinBox {...formsDataView} />
+        )}
       </Components.Box>
     </Flex>
   )


### PR DESCRIPTION
## Summary

The Forms table on the Documents tab on the Employee Dashboard had inconsistent inset/padding versus the other dashboard tables (pay stubs, payment methods, deductions). It should sit edge-to-edge inside its container.

The Box wrapping the table inherited the default \`withPadding\` and the DataView wasn't told it was inside a box, so the table picked up an extra inset.

## Changes

In \`Employee/Dashboard/DocumentsView.tsx\`:
- \`<Components.Box ...>\` → \`<Components.Box withPadding={false} ...>\`
- \`<DataView ... />\` → \`<DataView isWithinBox ... />\`
- Removed the redundant inner \`<Flex flexDirection="column" gap={16}>\` wrapper (only one child, gap has no effect).

This matches the canonical pattern already used in \`JobAndPayView.tsx\` (lines 770–826) for pay stubs / payment methods / deductions.

## Related

- Jira: [SDK-940](https://gustohq.atlassian.net/browse/SDK-940)
- Epic: [SDK-517](https://gustohq.atlassian.net/browse/SDK-517) — Test Fest, Employee Dashboard

## Testing

- \`npm run test -- --run src/components/Employee/Dashboard\` → 89/89 passed (no test relied on the old inset)
- \`npx tsc --noEmit\` → clean

Manual: \`npm run storybook\` → Dashboard story → Documents tab → confirm the Forms table is flush with the Box edges, matching pay stubs / deductions tables on the Job & Pay tab.

[SDK-940]: https://gustohq.atlassian.net/browse/SDK-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-517]: https://gustohq.atlassian.net/browse/SDK-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ