### PR TITLE
fix(SDK-934): stop double-encoding interpolated values in work address banner

### DIFF
--- a/src/components/Employee/WorkAddress/management/WorkAddressView.tsx
+++ b/src/components/Employee/WorkAddress/management/WorkAddressView.tsx
@@ -360,6 +360,10 @@ export function WorkAddressView({
                   effectiveDate: pendingFutureAddress.effectiveDate
                     ? formatDateLongWithYear(pendingFutureAddress.effectiveDate)
                     : '—',
+                  // Values are inserted into JSX text, so the browser already
+                  // escapes them. Telling i18next to escape too produces
+                  // double-encoded entities like `&#39;` showing as text.
+                  interpolation: { escapeValue: false },
                 })}
               </Components.Text>
             </Components.Alert>


### PR DESCRIPTION
## Summary

The "Change pending" banner on the work address management screen rendered HTML-encoded characters (\`&#39;\` instead of \`'\`) as literal text — affecting both the employee possessive ("\`{name}&#39;s\` work address will change to…") and the formatted address.

Root cause: the \`t('changePendingDescription', { ... })\` call was missing \`interpolation: { escapeValue: false }\`. i18next escaped the placeholder values before React inserted them into JSX (where the browser already escapes), producing double-encoded entities.

The home address equivalent (\`HomeAddressView.tsx:380–386\`) already opts out of i18next escaping for the same string. Apply the same fix.

## Changes

In \`Employee/WorkAddress/management/WorkAddressView.tsx\` (line 357), pass \`interpolation: { escapeValue: false }\` to \`t('changePendingDescription', ...)\` with a short comment explaining why.

No i18n string changes; no schema changes; no test file additions (the change mirrors a known-good pattern in HomeAddress).

## Related

- Jira: [SDK-934](https://gustohq.atlassian.net/browse/SDK-934)
- Epic: [SDK-517](https://gustohq.atlassian.net/browse/SDK-517) — Test Fest, Employee Dashboard

## Testing

- \`npx tsc --noEmit\` → clean
- No existing component tests for WorkAddressView; the fix surface is a single i18next option.

Manual: \`npm run sdk-app\` → WorkAddress → create a future-dated work-address change → confirm the "Change pending" banner shows \`{name}'s work address…\` rather than \`{name}&#39;s work address…\`.

[SDK-934]: https://gustohq.atlassian.net/browse/SDK-934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ