### PR TITLE
fix(SDK-942): handle no-income-tax states in State taxes card and edit form

### DIFF
--- a/src/components/Employee/Dashboard/Dashboard.test.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.test.tsx
@@ -13,6 +13,7 @@ import { server } from '@/test/mocks/server'
 import { API_BASE_URL } from '@/test/constants'
 import { handleGetEmployeeForms, i9Form } from '@/test/mocks/apis/employee_forms'
 import { handleGetEmployeeJobs, handleDeleteEmployeeJob } from '@/test/mocks/apis/employees'
+import { handleGetEmployeeStateTaxes } from '@/test/mocks/apis/employee_state_taxes'
 import { handleDeleteCompensation } from '@/test/mocks/apis/compensations'
 import { componentEvents } from '@/shared/constants'
 import { assertDefined } from '@/test-utils/assertions'
@@ -1602,6 +1603,45 @@ describe('Dashboard', () => {
     expect(onEvent).toHaveBeenCalledWith(componentEvents.EMPLOYEE_STATE_TAXES_EDIT, {
       employeeId: 'employee-123',
     })
+  })
+
+  it('renders no-withholding messaging and hides Edit when the state has no income tax', async () => {
+    server.use(
+      handleGetEmployeeStateTaxes(() =>
+        HttpResponse.json([
+          {
+            employee_uuid: 'employee-123',
+            state: 'WA',
+            file_new_hire_report: false,
+            is_work_state: true,
+            questions: [],
+          },
+        ]),
+      ),
+    )
+    const user = userEvent.setup()
+
+    renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+
+    await waitFor(() => expect(screen.getByText('Legal name')).toBeInTheDocument())
+    await user.click(screen.getByRole('tab', { name: 'Taxes' }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'State taxes' })).toBeInTheDocument(),
+    )
+
+    const stateTaxesBox = screen
+      .getByRole('heading', { name: 'State taxes' })
+      .closest<HTMLElement>('[data-testid="data-box"]')
+    assertDefined(stateTaxesBox)
+
+    expect(
+      await within(stateTaxesBox).findByRole('heading', { name: 'Washington' }),
+    ).toBeInTheDocument()
+    expect(
+      within(stateTaxesBox).getByText('No state income tax withholding required.'),
+    ).toBeInTheDocument()
+    expect(within(stateTaxesBox).queryByRole('button', { name: 'Edit' })).toBeNull()
   })
 
   it('shows employee forms on the Documents tab', async () => {

--- a/src/components/Employee/Dashboard/TaxesView.tsx
+++ b/src/components/Employee/Dashboard/TaxesView.tsx
@@ -74,8 +74,11 @@ export function TaxesView({
   onEditStateTaxes,
 }: TaxesViewProps) {
   const { t } = useTranslation('Employee.Dashboard')
+  const { t: tCommon } = useTranslation('common')
   const Components = useComponentContext()
   const formatCurrency = useNumberFormatter('currency')
+
+  const stateTaxesHaveAnyQuestions = !!stateTaxes?.some(s => (s.questions?.length ?? 0) > 0)
 
   // Helper function to format state tax answer values
   const formatStateTaxAnswer = (
@@ -218,13 +221,15 @@ export function TaxesView({
           <Components.BoxHeader
             title={t('taxes.state.title')}
             action={
-              <Components.Button
-                variant="secondary"
-                onClick={onEditStateTaxes}
-                isDisabled={isStateTaxesLoading}
-              >
-                {t('taxes.state.editCta')}
-              </Components.Button>
+              isStateTaxesLoading || stateTaxesHaveAnyQuestions ? (
+                <Components.Button
+                  variant="secondary"
+                  onClick={onEditStateTaxes}
+                  isDisabled={isStateTaxesLoading}
+                >
+                  {t('taxes.state.editCta')}
+                </Components.Button>
+              ) : undefined
             }
           />
         }
@@ -234,29 +239,43 @@ export function TaxesView({
             <Loading />
           ) : stateTaxes && stateTaxes.length > 0 ? (
             <Flex flexDirection="column" gap={24}>
-              {stateTaxes.map((stateTax, index) => (
-                <Flex key={stateTax.state || index} flexDirection="column" gap={16}>
-                  <Components.Heading as="h4">{stateTax.state}</Components.Heading>
+              {stateTaxes.map((stateTax, index) => {
+                const stateName = stateTax.state
+                  ? tCommon(`statesHash.${stateTax.state}`, stateTax.state)
+                  : ''
+                const hasQuestions = (stateTax.questions?.length ?? 0) > 0
+                return (
+                  <Flex key={stateTax.state || index} flexDirection="column" gap={16}>
+                    {stateName ? (
+                      <Components.Heading as="h4">{stateName}</Components.Heading>
+                    ) : null}
 
-                  {stateTax.questions && stateTax.questions.length > 0 && (
-                    <Flex flexDirection="column" gap={12}>
-                      {stateTax.questions.map((question, qIndex) => {
-                        const answer = question.answers[0]?.value
-                        if (answer === null || answer === undefined) return null
+                    {hasQuestions ? (
+                      <Flex flexDirection="column" gap={12}>
+                        {stateTax.questions!.map((question, qIndex) => {
+                          const answer = question.answers[0]?.value
+                          if (answer === null || answer === undefined) return null
 
-                        return (
-                          <Flex key={question.key || qIndex} flexDirection="column" gap={0}>
-                            <Components.Text variant="supporting">{question.label}</Components.Text>
-                            <Components.Text>
-                              {formatStateTaxAnswer(question, answer)}
-                            </Components.Text>
-                          </Flex>
-                        )
-                      })}
-                    </Flex>
-                  )}
-                </Flex>
-              ))}
+                          return (
+                            <Flex key={question.key || qIndex} flexDirection="column" gap={0}>
+                              <Components.Text variant="supporting">
+                                {question.label}
+                              </Components.Text>
+                              <Components.Text>
+                                {formatStateTaxAnswer(question, answer)}
+                              </Components.Text>
+                            </Flex>
+                          )
+                        })}
+                      </Flex>
+                    ) : (
+                      <Components.Text variant="supporting">
+                        {t('taxes.state.noWithholdingForState')}
+                      </Components.Text>
+                    )}
+                  </Flex>
+                )
+              })}
             </Flex>
           ) : (
             <Components.Text>{t('taxes.state.noStateTaxes')}</Components.Text>

--- a/src/components/Employee/StateTaxes/shared/EmployeeStateTaxesView.tsx
+++ b/src/components/Employee/StateTaxes/shared/EmployeeStateTaxesView.tsx
@@ -40,20 +40,24 @@ export function EmployeeStateTaxesView({
           <Form onSubmit={onSubmit}>
             {alert}
 
-            {groups.map(group => {
-              const stateName = tCommon(`statesHash.${group.state}`, group.state)
-              return (
-                <Fragment key={group.state}>
-                  <Components.Heading as="h2">
-                    {t('stateTaxesTitle', { state: stateName })}
-                  </Components.Heading>
+            {groups.length === 0 ? (
+              <Components.Text>{t('noWithholding')}</Components.Text>
+            ) : (
+              groups.map(group => {
+                const stateName = tCommon(`statesHash.${group.state}`, group.state)
+                return (
+                  <Fragment key={group.state}>
+                    <Components.Heading as="h2">
+                      {t('stateTaxesTitle', { state: stateName })}
+                    </Components.Heading>
 
-                  {group.questions.map(({ questionId, Field }) => {
-                    return <Field key={questionId} />
-                  })}
-                </Fragment>
-              )
-            })}
+                    {group.questions.map(({ questionId, Field }) => {
+                      return <Field key={questionId} />
+                    })}
+                  </Fragment>
+                )
+              })
+            )}
 
             {actions}
           </Form>

--- a/src/i18n/en/Employee.Dashboard.json
+++ b/src/i18n/en/Employee.Dashboard.json
@@ -150,7 +150,8 @@
     "state": {
       "title": "State taxes",
       "editCta": "Edit",
-      "noStateTaxes": "No state taxes on file"
+      "noStateTaxes": "No state taxes on file",
+      "noWithholdingForState": "No state income tax withholding required."
     }
   },
   "documents": {

--- a/src/i18n/en/Employee.StateTaxes.json
+++ b/src/i18n/en/Employee.StateTaxes.json
@@ -1,5 +1,6 @@
 {
   "stateTaxesTitle": "{{state}} Tax Requirements",
+  "noWithholding": "No state income tax withholding is required for this employee's work state.",
   "submitCta": "Continue",
   "saveCta": "Save",
   "cancelCta": "Cancel",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1585,6 +1585,7 @@ export interface EmployeeDashboard{
 "title":string;
 "editCta":string;
 "noStateTaxes":string;
+"noWithholdingForState":string;
 };
 };
 "documents":{
@@ -2245,6 +2246,7 @@ export interface EmployeeSplitPaycheck{
 };
 export interface EmployeeStateTaxes{
 "stateTaxesTitle":string;
+"noWithholding":string;
 "submitCta":string;
 "saveCta":string;
 "cancelCta":string;


### PR DESCRIPTION
## Summary

When an employee's work address is in a state without personal income tax (WA, TX, etc.), the API returns a state-tax record with \`questions: []\`. The Employee Dashboard:

- Rendered just the 2-letter state code with no fields under it on the **Taxes tab** card.
- Left the Edit button clickable, which opened the State Taxes edit form with only Back / Save / Cancel chrome (no fields).

Three small changes give a coherent UI:

1. **\`TaxesView\`** (Dashboard summary): render the full state name via \`common:statesHash.*\` (so "Washington" instead of "WA"), surface an explicit "No state income tax withholding required." message for states with no visible questions, and hide the Edit button when no state has any. Kept the Edit button visible during loading so it doesn't pop in late.
2. **\`EmployeeStateTaxesView\`** (edit form): when all state groups filter out to zero visible questions, render the same explicit empty-state message instead of bare actions chrome.
3. **i18n**: new \`taxes.state.noWithholdingForState\` and \`Employee.StateTaxes.noWithholding\` strings.

## Changes

- \`src/components/Employee/Dashboard/TaxesView.tsx\` — state-name lookup, no-withholding line, conditional Edit.
- \`src/components/Employee/StateTaxes/shared/EmployeeStateTaxesView.tsx\` — empty-groups fallback.
- \`src/i18n/en/Employee.Dashboard.json\`, \`src/i18n/en/Employee.StateTaxes.json\` — two new strings.
- \`src/types/i18next.d.ts\` — regenerated via \`npm run i18n:generate\`.
- \`src/components/Employee/Dashboard/Dashboard.test.tsx\` — new regression test stubbing WA \`questions: []\` and asserting the messaging + hidden Edit.

## Out of scope

- The ticket bonus ("Save appears to still 'work' even though the form is empty") — with this fix the user lands on the empty-state message and the only meaningful action is Cancel. Save can still be clicked but has nothing to submit; suppressing Save in the empty case is a follow-up.

## Related

- Jira: [SDK-942](https://gustohq.atlassian.net/browse/SDK-942)
- Epic: [SDK-517](https://gustohq.atlassian.net/browse/SDK-517) — Test Fest, Employee Dashboard

## Testing

- \`npm run test -- --run src/components/Employee/Dashboard src/components/Employee/StateTaxes\` → 135 passed
- Stashed only the source/i18n changes and re-ran the new test → fails on \`main\`, confirming the test guards the regression.
- \`npx tsc --noEmit\` → clean
- \`npm run i18n:generate\` → clean

Manual: \`npm run sdk-app\` → set work address to a WA or TX location → open the Taxes tab → confirm the State taxes card shows "Washington" + "No state income tax withholding required." and the Edit button is hidden.

[SDK-942]: https://gustohq.atlassian.net/browse/SDK-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ