### PR TITLE
fix(SDK-946): remount DocumentViewer embed when the PDF url changes

### DIFF
--- a/src/components/Common/DocumentViewer/DocumentViewer.test.tsx
+++ b/src/components/Common/DocumentViewer/DocumentViewer.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { DocumentViewer } from './DocumentViewer'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+
+const getEmbed = (container: HTMLElement) => container.querySelector('embed')
+
+describe('DocumentViewer', () => {
+  it('remounts the embed when the document URL changes so the browser PDF plugin reloads', () => {
+    const { container, rerender } = renderWithProviders(
+      <DocumentViewer
+        url="https://example.com/unsigned.pdf"
+        title="W-4"
+        viewDocumentLabel="Download"
+      />,
+    )
+
+    const firstEmbed = getEmbed(container)
+    expect(firstEmbed).not.toBeNull()
+    expect(firstEmbed?.getAttribute('src')).toContain('unsigned.pdf')
+
+    rerender(
+      <DocumentViewer
+        url="https://example.com/signed.pdf"
+        title="W-4"
+        viewDocumentLabel="Download"
+      />,
+    )
+
+    const secondEmbed = getEmbed(container)
+    expect(secondEmbed).not.toBeNull()
+    expect(secondEmbed?.getAttribute('src')).toContain('signed.pdf')
+    // A new DOM node — the `key={url}` on <embed> forces React to unmount the
+    // previous element so the browser's PDF plugin picks up the new src.
+    expect(secondEmbed).not.toBe(firstEmbed)
+  })
+
+  it('renders nothing when url is falsy', () => {
+    const { container } = renderWithProviders(
+      <DocumentViewer url={null} title="W-4" viewDocumentLabel="Download" />,
+    )
+    expect(getEmbed(container)).toBeNull()
+  })
+})

--- a/src/components/Common/DocumentViewer/DocumentViewer.tsx
+++ b/src/components/Common/DocumentViewer/DocumentViewer.tsx
@@ -34,14 +34,19 @@ export function DocumentViewer({
     type: 'application/pdf',
   }
 
+  // Keying the `<embed>` on the URL forces React to remount the element when
+  // the URL changes (e.g. after signing replaces an unsigned PDF). Without
+  // this, React reuses the existing DOM node, the browser's PDF plugin
+  // doesn't reload the new src, and the viewer renders blank until a manual
+  // reload.
   return (
     <div className={styles.container} ref={containerRef}>
       {isContainerWidthSmallOrGreater ? (
-        <embed {...commonEmbeddedPdfProps} className={styles.embedPdf} />
+        <embed key={url} {...commonEmbeddedPdfProps} className={styles.embedPdf} />
       ) : (
         <div className={styles.smallEmbedPdfContainer}>
           <Flex gap={20}>
-            <embed {...commonEmbeddedPdfProps} className={styles.smallEmbedPdf} />
+            <embed key={url} {...commonEmbeddedPdfProps} className={styles.smallEmbedPdf} />
             <Flex flexDirection="column" gap={8}>
               <div>
                 {title && (


### PR DESCRIPTION
## Summary

After completing an e-signature, the embedded PDF viewer transitioned to read-only but the PDF itself didn't render. Manually reloading the tab or switching tabs back made the embed appear. The "download this document" link worked the whole time — proving the URL itself updated; the iframe just didn't reload.

Root cause: the global \`@gusto/embedded-api\` mutation auto-invalidation refetches the signed PDF URL after \`signForm\` succeeds, and \`DocumentViewer\` rerenders with a new \`src\`. React was reusing the existing \`<embed>\` DOM node across that rerender, so the browser's PDF plugin never reloaded — the viewer stayed on the previous (unsigned) PDF or went blank.

Fix: add \`key={url}\` to both \`<embed>\` elements in \`DocumentViewer\`. A URL change now forces the DOM node to unmount and remount, which the plugin treats as a fresh document load.

## Changes

- \`src/components/Common/DocumentViewer/DocumentViewer.tsx\` — \`key={url}\` on the two \`<embed>\` render paths (wide + narrow container), plus a short comment explaining the why.
- \`src/components/Common/DocumentViewer/DocumentViewer.test.tsx\` — new test renders DocumentViewer with one URL, rerenders with another, asserts the \`<embed>\` reference changed (verified to fail on \`main\`).

## Related

- Jira: [SDK-946](https://gustohq.atlassian.net/browse/SDK-946)
- Epic: [SDK-517](https://gustohq.atlassian.net/browse/SDK-517) — Test Fest, Employee Dashboard

## Testing

- \`npm run test -- --run src/components/Common/DocumentViewer src/components/Employee/Documents\` → 94/94 passed (new + sibling)
- Stashed the source change and re-ran → new test fails on \`main\`, confirming it guards the regression.
- \`npx tsc --noEmit\` → clean

Manual: \`npm run sdk-app\` → onboarded employee with unsigned W-4 → Documents tab → View → sign → confirm the embedded PDF renders immediately instead of going blank.

[SDK-946]: https://gustohq.atlassian.net/browse/SDK-946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ