### PR TITLE
fix: hide compensation Edit while a pending update exists (SDK-975)

### DIFF
--- a/src/components/Employee/Dashboard/Dashboard.test.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.test.tsx
@@ -1281,6 +1281,169 @@ describe('Dashboard', () => {
         expect(within(alert).queryByRole('button', { name: 'Cancel change' })).toBeNull()
       })
     })
+
+    describe('Edit suppression while a comp update is pending', () => {
+      it('hides the single-job card Edit button while a pending comp update exists', async () => {
+        const user = userEvent.setup()
+        overrideEmployeeJobs([
+          baseJob({}, [
+            baseComp(),
+            baseComp({ uuid: 'comp-future', rate: '35.00', effective_date: ONE_YEAR_AHEAD }),
+          ]),
+        ])
+
+        renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+        await goToJobAndPayTab(user)
+
+        const compensationCard = screen
+          .getByRole('heading', { name: 'Compensation' })
+          .closest('[data-testid="data-box"]')! as HTMLElement
+
+        expect(
+          within(compensationCard).queryByRole('button', { name: 'Edit' }),
+        ).not.toBeInTheDocument()
+        expect(
+          within(compensationCard).getByRole('button', { name: 'Cancel change' }),
+        ).toBeInTheDocument()
+      })
+
+      it('restores the single-job card Edit button after the pending update is cancelled', async () => {
+        const user = userEvent.setup()
+        let wasDeleteCalled = false
+        const deleteResolver = vi.fn<HttpResponseResolver>(() => {
+          wasDeleteCalled = true
+          return new HttpResponse(null, { status: 204 })
+        })
+
+        const futureCompensation = baseComp({
+          uuid: 'comp-future',
+          rate: '35.00',
+          effective_date: ONE_YEAR_AHEAD,
+        })
+        const jobsBefore = [baseJob({}, [baseComp(), futureCompensation])]
+        const jobsAfter = [baseJob({}, [baseComp()])]
+
+        server.use(
+          handleGetEmployeeJobs(() => HttpResponse.json(wasDeleteCalled ? jobsAfter : jobsBefore)),
+        )
+        server.use(handleDeleteCompensation(deleteResolver))
+
+        renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+        await goToJobAndPayTab(user)
+
+        const compensationCard = screen
+          .getByRole('heading', { name: 'Compensation' })
+          .closest('[data-testid="data-box"]')! as HTMLElement
+
+        expect(
+          within(compensationCard).queryByRole('button', { name: 'Edit' }),
+        ).not.toBeInTheDocument()
+
+        await user.click(within(compensationCard).getByRole('button', { name: 'Cancel change' }))
+
+        await waitFor(() => {
+          expect(within(compensationCard).getByRole('button', { name: 'Edit' })).toBeInTheDocument()
+        })
+      })
+
+      it('hides the per-row Edit menu item for a multi-job row with a pending comp update, keeping it on rows without one', async () => {
+        const user = userEvent.setup()
+        overrideEmployeeJobs([
+          baseJob({ uuid: 'job-primary', current_compensation_uuid: 'comp-primary-current' }, [
+            baseComp({ uuid: 'comp-primary-current', job_uuid: 'job-primary' }),
+            baseComp({
+              uuid: 'comp-primary-future',
+              job_uuid: 'job-primary',
+              rate: '35.00',
+              effective_date: ONE_YEAR_AHEAD,
+            }),
+          ]),
+          baseJob(
+            {
+              uuid: 'job-secondary',
+              primary: false,
+              title: 'Stock Associate',
+              current_compensation_uuid: 'comp-secondary-current',
+            },
+            [
+              baseComp({
+                uuid: 'comp-secondary-current',
+                job_uuid: 'job-secondary',
+                title: 'Stock Associate',
+                rate: '22.00',
+              }),
+            ],
+          ),
+        ])
+
+        renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+        await goToJobAndPayTab(user)
+
+        // The job title appears both in the table row and in the inline alert
+        // ("Compensation for Cashier will change on..."), so scope row lookups
+        // to the jobs table to disambiguate.
+        const jobsTable = screen.getByRole('grid', { name: 'List of jobs' })
+
+        const primaryRow = within(jobsTable)
+          .getByText('Cashier')
+          .closest('[role="row"]')! as HTMLElement
+        expect(
+          within(primaryRow).queryByRole('button', { name: 'Job actions' }),
+        ).not.toBeInTheDocument()
+
+        const secondaryRow = within(jobsTable)
+          .getByText('Stock Associate')
+          .closest('[role="row"]')! as HTMLElement
+        await user.click(within(secondaryRow).getByRole('button', { name: 'Job actions' }))
+
+        expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument()
+      })
+
+      it('keeps Delete in the per-row menu for a non-primary job whose Edit is suppressed by a pending update', async () => {
+        const user = userEvent.setup()
+        overrideEmployeeJobs([
+          baseJob({ uuid: 'job-primary', current_compensation_uuid: 'comp-primary-current' }, [
+            baseComp({ uuid: 'comp-primary-current', job_uuid: 'job-primary' }),
+          ]),
+          baseJob(
+            {
+              uuid: 'job-secondary',
+              primary: false,
+              title: 'Stock Associate',
+              current_compensation_uuid: 'comp-secondary-current',
+            },
+            [
+              baseComp({
+                uuid: 'comp-secondary-current',
+                job_uuid: 'job-secondary',
+                title: 'Stock Associate',
+                rate: '22.00',
+              }),
+              baseComp({
+                uuid: 'comp-secondary-future',
+                job_uuid: 'job-secondary',
+                title: 'Stock Associate',
+                rate: '24.00',
+                effective_date: ONE_YEAR_AHEAD,
+              }),
+            ],
+          ),
+        ])
+
+        renderWithProviders(<Dashboard employeeId="employee-123" onEvent={onEvent} />)
+        await goToJobAndPayTab(user)
+
+        const jobsTable = screen.getByRole('grid', { name: 'List of jobs' })
+        const secondaryRow = within(jobsTable)
+          .getByText('Stock Associate')
+          .closest('[role="row"]')! as HTMLElement
+        await user.click(within(secondaryRow).getByRole('button', { name: 'Job actions' }))
+
+        expect(screen.queryByRole('menuitem', { name: 'Edit' })).not.toBeInTheDocument()
+        expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument()
+      })
+    })
   })
 
   describe('Compensation pending badge (future-dated new job)', () => {

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -254,6 +254,13 @@ export function JobAndPayView({
   const singleJobIsPendingNew = singleJob ? pendingNewJobUuids.has(singleJob.uuid) : false
   const hasAnyPendingNewJobs = pendingNewJobUuids.size > 0
 
+  // Jobs with a future-dated comp stacked on a current comp ("pending update"
+  // as opposed to "pending new job"). Editing while one is queued would just
+  // stack another future comp on top — confusing UX. Hide Edit until the
+  // existing pending change is cancelled or it goes into effect.
+  const pendingUpdateJobUuids = new Set(updatePendingChanges.map(c => c.jobUuid))
+  const singleJobHasPendingUpdate = singleJob ? pendingUpdateJobUuids.has(singleJob.uuid) : false
+
   const hasPendingUpdates = updatePendingChanges.length > 0
   const showSummaryAlert = hasMultipleJobs && updatePendingChanges.length > 1
   const showInlineAlert = hasPendingUpdates && !showSummaryAlert
@@ -355,32 +362,41 @@ export function JobAndPayView({
   const jobsDataView = useDataView({
     data: jobs,
     columns: jobsColumns,
-    itemMenu: (job: Job) => (
-      <HamburgerMenu
-        triggerLabel={t('jobAndPay.compensation.hamburgerTitle')}
-        isLoading={isDeletingJob}
-        items={[
-          {
-            label: t('jobAndPay.compensation.editJobCta'),
-            icon: <PencilSvg aria-hidden />,
-            onClick: () => {
-              onEditCompensation?.(job)
-            },
-          },
-          ...(!job.primary
-            ? [
-                {
-                  label: t('jobAndPay.compensation.deleteJobCta'),
-                  icon: <TrashCanSvg aria-hidden />,
-                  onClick: () => {
-                    setPendingDeleteJob({ uuid: job.uuid, title: job.title ?? '' })
-                  },
+    itemMenu: (job: Job) => {
+      const jobHasPendingUpdate = pendingUpdateJobUuids.has(job.uuid)
+      const items = [
+        ...(jobHasPendingUpdate
+          ? []
+          : [
+              {
+                label: t('jobAndPay.compensation.editJobCta'),
+                icon: <PencilSvg aria-hidden />,
+                onClick: () => {
+                  onEditCompensation?.(job)
                 },
-              ]
-            : []),
-        ]}
-      />
-    ),
+              },
+            ]),
+        ...(!job.primary
+          ? [
+              {
+                label: t('jobAndPay.compensation.deleteJobCta'),
+                icon: <TrashCanSvg aria-hidden />,
+                onClick: () => {
+                  setPendingDeleteJob({ uuid: job.uuid, title: job.title ?? '' })
+                },
+              },
+            ]
+          : []),
+      ]
+      if (items.length === 0) return null
+      return (
+        <HamburgerMenu
+          triggerLabel={t('jobAndPay.compensation.hamburgerTitle')}
+          isLoading={isDeletingJob}
+          items={items}
+        />
+      )
+    },
   })
 
   const bankAccountsColumns = [
@@ -568,14 +584,16 @@ export function JobAndPayView({
                 // so we don't surface an "Add job" CTA against an
                 // employee who already has one.
                 isCompensationCardLoading ? null : hasMultipleJobs ? null : singleJob ? (
-                  <Components.Button
-                    variant="secondary"
-                    onClick={() => {
-                      onEditCompensation?.(singleJob)
-                    }}
-                  >
-                    {t('jobAndPay.compensation.editCta')}
-                  </Components.Button>
+                  singleJobHasPendingUpdate ? null : (
+                    <Components.Button
+                      variant="secondary"
+                      onClick={() => {
+                        onEditCompensation?.(singleJob)
+                      }}
+                    >
+                      {t('jobAndPay.compensation.editCta')}
+                    </Components.Button>
+                  )
                 ) : (
                   <Components.Button
                     variant="secondary"


### PR DESCRIPTION
## Summary

Closes [SDK-975](https://gusto.atlassian.net/browse/SDK-975). The compensation card was showing the "Compensation will change on [date]" banner alongside an Edit button. Clicking Edit while a pending change is queued just stacks another future compensation on top, which produces a confusing chain the user has to cancel one at a time.

- Hide the single-job card-level Edit button when that job has a pending compensation update.
- Hide the per-row Edit menu item in the multi-job hamburger when that specific job has a pending update.
- When a primary row's menu would otherwise be empty (no Edit because of a pending update, no Delete because primary), suppress the hamburger trigger entirely instead of opening an empty popover.

The "pending new job" badge path (no current comp; future-dated start) is intentionally left alone — it's a separate UX consideration not covered by the ticket.

## Investigate criterion

Per the ticket's investigate bullet: `getPendingCompensationChanges` already iterates each job's future-dated compensations chronologically and emits one entry per stacked future comp, so multiple pending compensations on a single job are surfaced today. The inline alert shows the nearest one and the rest become visible after each cancel. Existing test `shows the nearest upcoming change when a single job has stacked future compensations` covers this path. No additional handling needed.

## Test plan

Unit tests (in `Dashboard.test.tsx`, new `Edit suppression while a comp update is pending` block):

- [x] Hides the single-job card Edit button while a pending comp update exists
- [x] Restores the single-job card Edit button after the pending update is cancelled
- [x] Hides the per-row Edit menu item for the row with a pending update; other rows still show Edit + Delete
- [x] Keeps Delete on a non-primary row whose Edit is suppressed by a pending update
- [x] All 93 Dashboard tests pass

Manual:

- [x] Single hourly job + future-dated comp update → banner shows, no Edit button on the card
- [x] Cancel the pending change → Edit button reappears
- [x] Multi-job table: row with a pending update has no Edit in its hamburger; other rows still show Edit
- [x] Primary multi-job row with a pending update shows no hamburger trigger at all


<img width="1260" height="638" alt="Screenshot 2026-05-27 at 2 04 35 PM" src="https://github.com/user-attachments/assets/80298bdf-9adb-4da9-b142-8b30133be5d0" />

<img width="1230" height="490" alt="Screenshot 2026-05-27 at 2 06 23 PM" src="https://github.com/user-attachments/assets/8fe78514-cb2b-4aba-ad9d-3f27a026a57e" />

Made with [Cursor](https://cursor.com)

[SDK-975]: https://gustohq.atlassian.net/browse/SDK-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ