### PR TITLE
fix: remove confirmation dialog from add employees view (SDK-977)

### DIFF
--- a/e2e/tests/time-off/04-policy-add-employees-edge-cases.spec.ts
+++ b/e2e/tests/time-off/04-policy-add-employees-edge-cases.spec.ts
@@ -17,10 +17,10 @@ test.describe('TimeOffFlow - add employees edge cases', () => {
     })
   })
 
-  // QA issue reporter: Wil Alvarez
-  // Adding employees to an already-populated policy must surface a
-  // confirmation dialog so the partner can review before committing.
-  test('confirmation dialog appears when adding employees to an existing populated policy', async ({
+  // SDK-977: adding employees from the detail view used to surface a
+  // confirmation dialog after Continue. The dialog was removed; Continue
+  // now saves immediately and returns to the policy detail view.
+  test('adding employees from the detail view saves immediately without a confirmation dialog', async ({
     page,
     scenario,
   }) => {
@@ -38,7 +38,6 @@ test.describe('TimeOffFlow - add employees edge cases', () => {
       test.skip(true, 'Need at least one additional unenrolled employee in the seeded company')
     }
 
-    // Pick the first selectable unenrolled row.
     let selected = false
     for (let i = 1; i < rowCount; i++) {
       const rowCheckbox = dataRows.nth(i).getByRole('checkbox').first()
@@ -52,9 +51,12 @@ test.describe('TimeOffFlow - add employees edge cases', () => {
 
     await page.getByRole('button', { name: /^continue$/i }).click()
 
-    const dialog = page.getByRole('dialog').filter({ hasText: /add.*to this policy/i })
-    await expect(dialog).toBeVisible({ timeout: 10_000 })
-    await expect(dialog.getByRole('button', { name: /add and save/i })).toBeVisible()
+    await expect(page.getByRole('heading', { name: new RegExp(policyName, 'i') })).toBeVisible({
+      timeout: 30_000,
+    })
+    await expect(page.getByRole('dialog').filter({ hasText: /add.*to this policy/i })).toHaveCount(
+      0,
+    )
   })
 
   // QA issue reporter: Aaron Rosen

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
@@ -29,13 +29,12 @@ export function SelectEmployeesPresentation({
   onBalanceChange,
   pagination,
   isFetching,
-  addConfirmDialog,
   isPending = false,
 }: SelectEmployeesPresentationProps) {
   useI18n('Company.TimeOff.SelectEmployees')
   const { t } = useTranslation('Company.TimeOff.SelectEmployees')
   const Components = useComponentContext()
-  const { Heading, Text, Button, Alert, Dialog } = Components
+  const { Heading, Text, Button, Alert } = Components
   const balanceColHeaderId = useId()
 
   return (
@@ -111,20 +110,6 @@ export function SelectEmployeesPresentation({
           {t('continueCta')}
         </Button>
       </ActionsLayout>
-
-      {addConfirmDialog && (
-        <Dialog
-          isOpen={addConfirmDialog.isOpen}
-          onClose={addConfirmDialog.onClose}
-          onPrimaryActionClick={addConfirmDialog.onConfirm}
-          isPrimaryActionLoading={addConfirmDialog.isPending}
-          title={t('addConfirmDialog.title', { count: addConfirmDialog.count })}
-          primaryActionLabel={t('addConfirmDialog.confirmCta')}
-          closeActionLabel={t('addConfirmDialog.cancelCta')}
-        >
-          {t('addConfirmDialog.description', { count: addConfirmDialog.count })}
-        </Dialog>
-      )}
     </Flex>
   )
 }

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentationTypes.ts
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentationTypes.ts
@@ -11,14 +11,6 @@ export interface EmployeeItem {
   eligiblePaidTimeOff?: PaidTimeOff[]
 }
 
-export interface ConfirmDialogState {
-  isOpen: boolean
-  count: number
-  onConfirm: () => void
-  onClose: () => void
-  isPending?: boolean
-}
-
 export interface SelectEmployeesPresentationProps {
   employees: EmployeeItem[]
   selectedUuids: Set<string>
@@ -36,8 +28,6 @@ export interface SelectEmployeesPresentationProps {
   onBalanceChange?: (uuid: string, value: string) => void
   pagination?: PaginationControlProps
   isFetching?: boolean
-  /** Optional confirm dialog shown before submitting an add to the policy. */
-  addConfirmDialog?: ConfirmDialogState
   /** Disables the back button and shows a spinner on the continue button while a submit is in flight. */
   isPending?: boolean
 }

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
@@ -314,7 +314,6 @@ describe('SelectEmployeesTimeOff', () => {
 
       await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
       await user.click(screen.getByRole('button', { name: 'continueCta' }))
-      await user.click(await screen.findByRole('button', { name: 'addConfirmDialog.confirmCta' }))
 
       await waitFor(() => {
         expect(mockAddEmployees).toHaveBeenCalledWith({
@@ -343,7 +342,6 @@ describe('SelectEmployeesTimeOff', () => {
 
       await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
       await user.click(screen.getByRole('button', { name: 'continueCta' }))
-      await user.click(await screen.findByRole('button', { name: 'addConfirmDialog.confirmCta' }))
 
       await waitFor(() => {
         expect(mockAddEmployees).toHaveBeenCalledWith({
@@ -370,7 +368,6 @@ describe('SelectEmployeesTimeOff', () => {
 
       await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
       await user.click(screen.getByRole('button', { name: 'continueCta' }))
-      await user.click(await screen.findByRole('button', { name: 'addConfirmDialog.confirmCta' }))
 
       await waitFor(() => {
         expect(mockAddEmployees).toHaveBeenCalled()
@@ -393,7 +390,6 @@ describe('SelectEmployeesTimeOff', () => {
       // Select Carol (third employee) — she has no PTO history, no user input
       await user.click(screen.getAllByRole('checkbox')[3] as Element)
       await user.click(screen.getByRole('button', { name: 'continueCta' }))
-      await user.click(await screen.findByRole('button', { name: 'addConfirmDialog.confirmCta' }))
 
       await waitFor(() => {
         expect(mockAddEmployees).toHaveBeenCalled()
@@ -418,7 +414,6 @@ describe('SelectEmployeesTimeOff', () => {
       await user.click(checkboxes[FIRST_EMPLOYEE_CHECKBOX] as Element)
       await user.click(checkboxes[SECOND_EMPLOYEE_CHECKBOX] as Element)
       await user.click(screen.getByRole('button', { name: 'continueCta' }))
-      await user.click(await screen.findByRole('button', { name: 'addConfirmDialog.confirmCta' }))
 
       await waitFor(() => {
         expect(mockAddEmployees).toHaveBeenCalledWith({
@@ -455,7 +450,6 @@ describe('SelectEmployeesTimeOff', () => {
       // Submit — Alice's carry-over should still be in the request even though
       // her row is no longer rendered (carry-over is captured at select-time).
       await user.click(screen.getByRole('button', { name: 'continueCta' }))
-      await user.click(await screen.findByRole('button', { name: 'addConfirmDialog.confirmCta' }))
 
       await waitFor(() => {
         expect(mockAddEmployees).toHaveBeenCalled()
@@ -483,7 +477,6 @@ describe('SelectEmployeesTimeOff', () => {
       await user.click(headerCheckbox)
 
       await user.click(screen.getByRole('button', { name: 'continueCta' }))
-      await user.click(await screen.findByRole('button', { name: 'addConfirmDialog.confirmCta' }))
 
       await waitFor(() => {
         expect(mockAddEmployees).toHaveBeenCalled()
@@ -500,45 +493,6 @@ describe('SelectEmployeesTimeOff', () => {
         ]),
       )
       expect(submitted).toHaveLength(3)
-    })
-    it('opens add confirm dialog and gates submission until confirmed', async () => {
-      const user = userEvent.setup()
-      renderComponent({ mode: 'standalone' })
-
-      await waitFor(() => {
-        expect(screen.getAllByRole('checkbox').length).toBeGreaterThan(1)
-      })
-
-      await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
-      await user.click(screen.getByRole('button', { name: 'continueCta' }))
-
-      expect(
-        await screen.findByRole('button', { name: 'addConfirmDialog.confirmCta' }),
-      ).toBeInTheDocument()
-      expect(mockAddEmployees).not.toHaveBeenCalled()
-
-      await user.click(screen.getByRole('button', { name: 'addConfirmDialog.confirmCta' }))
-
-      await waitFor(() => {
-        expect(mockAddEmployees).toHaveBeenCalledTimes(1)
-      })
-    })
-
-    it('cancelling the add confirm dialog does not submit', async () => {
-      const user = userEvent.setup()
-      renderComponent({ mode: 'standalone' })
-
-      await waitFor(() => {
-        expect(screen.getAllByRole('checkbox').length).toBeGreaterThan(1)
-      })
-
-      await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
-      await user.click(screen.getByRole('button', { name: 'continueCta' }))
-
-      const cancelBtn = await screen.findByRole('button', { name: 'addConfirmDialog.cancelCta' })
-      await user.click(cancelBtn)
-
-      expect(mockAddEmployees).not.toHaveBeenCalled()
     })
 
     it('emits DONE without any mutation when nothing is selected', async () => {
@@ -578,7 +532,6 @@ describe('SelectEmployeesTimeOff', () => {
       // Add Bob — he is not yet on the policy
       await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
       await user.click(screen.getByRole('button', { name: 'continueCta' }))
-      await user.click(await screen.findByRole('button', { name: 'addConfirmDialog.confirmCta' }))
       await waitFor(() => {
         expect(mockAddEmployees).toHaveBeenCalledWith({
           request: {
@@ -617,7 +570,6 @@ describe('SelectEmployeesTimeOff', () => {
 
       await user.click(screen.getAllByRole('checkbox')[FIRST_EMPLOYEE_CHECKBOX] as Element)
       await user.click(screen.getByRole('button', { name: 'continueCta' }))
-      await user.click(await screen.findByRole('button', { name: 'addConfirmDialog.confirmCta' }))
 
       await waitFor(() => {
         expect(mockAddEmployees).toHaveBeenCalledWith({

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.tsx
@@ -172,8 +172,6 @@ function SelectEmployeesTimeOffInner({
     useTimeOffPoliciesUpdateMutation()
   const isSubmitPending = isAddPending || isUpdatePending
 
-  const [confirmAddOpen, setConfirmAddOpen] = useState(false)
-
   const handleBalanceChange = useCallback((uuid: string, value: string) => {
     setBalances(prev => ({ ...prev, [uuid]: value }))
   }, [])
@@ -256,19 +254,8 @@ function SelectEmployeesTimeOffInner({
       return
     }
 
-    if (mode === 'standalone' && toAdd.length > 0) {
-      setConfirmAddOpen(true)
-      return
-    }
-
     await submitAdd(toAdd)
   }, [mode, selectedUuids, onEvent, submitAdd])
-
-  const handleConfirmAdd = useCallback(async () => {
-    const toAdd = [...selectedUuids]
-    setConfirmAddOpen(false)
-    await submitAdd(toAdd)
-  }, [selectedUuids, submitAdd])
 
   const showReassignmentWarning = useMemo(() => {
     const targetPtoName = PAID_TIME_OFF_NAME_BY_POLICY_TYPE[policyType]
@@ -303,21 +290,6 @@ function SelectEmployeesTimeOffInner({
       pagination={pagination}
       isFetching={isFetching}
       isPending={isSubmitPending}
-      addConfirmDialog={
-        mode === 'standalone'
-          ? {
-              isOpen: confirmAddOpen,
-              count: selectedUuids.size,
-              onConfirm: () => {
-                void handleConfirmAdd()
-              },
-              onClose: () => {
-                setConfirmAddOpen(false)
-              },
-              isPending: isAddPending,
-            }
-          : undefined
-      }
     />
   )
 }

--- a/src/i18n/en/Company.TimeOff.SelectEmployees.json
+++ b/src/i18n/en/Company.TimeOff.SelectEmployees.json
@@ -12,13 +12,5 @@
   "emptyState": "All eligible employees have already been added to this policy.",
   "errors": {
     "completePolicyFailed": "Unable to complete this policy. {{details}}"
-  },
-  "addConfirmDialog": {
-    "title_one": "Add {{count}} employee to this policy?",
-    "title_other": "Add {{count}} employees to this policy?",
-    "description_one": "This employee will be added to the policy with the specified starting balance.",
-    "description_other": "These employees will be added to the policy with the specified starting balances.",
-    "confirmCta": "Add and save",
-    "cancelCta": "Cancel"
   }
 }

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -586,14 +586,6 @@ export interface CompanyTimeOffSelectEmployees{
 "errors":{
 "completePolicyFailed":string;
 };
-"addConfirmDialog":{
-"title_one":string;
-"title_other":string;
-"description_one":string;
-"description_other":string;
-"confirmCta":string;
-"cancelCta":string;
-};
 };
 export interface CompanyTimeOffSelectPolicyType{
 "title":string;


### PR DESCRIPTION
## Summary

The standalone "add employees to time off policy" view used to pop a confirmation dialog after clicking Continue ("This employee will be added to the policy with the specified starting balance.") before actually saving. The dialog no longer serves a purpose, so this PR removes it: clicking Continue now saves immediately. Holiday policy add-employees is unaffected — it never had the dialog.

## Changes

- Drop the confirmation `Dialog` (state, handler, presentation prop) from `SelectEmployeesTimeOff` / `SelectEmployeesPresentation` and remove the `addConfirmDialog` translations.
- Update `SelectEmployeesTimeOff` tests: the two-click pattern (Continue → dialog confirm) collapses to a single Continue click; the dialog-specific open/cancel tests are removed.

## Demo

_N/A — UI flow simplification; no visual changes beyond the dialog no longer appearing._

## Related

- Jira ticket: [SDK-977](https://gustohq.atlassian.net/browse/SDK-977)

## Testing

- \`npm run test -- --run src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx\` — all 23 cases pass.
- Manual: open the time-off policy detail → Add employees → select one or more → click Continue. Confirm the row(s) save immediately with no intermediate dialog. Repeat for a holiday policy and confirm behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-977]: https://gustohq.atlassian.net/browse/SDK-977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ