### PR TITLE
feat: allow searching by department in add-employee tables (SDK-892)

### DIFF
--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.test.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesHoliday.test.tsx
@@ -152,6 +152,23 @@ describe('SelectEmployeesHoliday', () => {
     expect(screen.getByText('Bob Jones')).toBeInTheDocument()
   })
 
+  it('filters employees by department', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    })
+
+    const input = screen.getByPlaceholderText('searchPlaceholder')
+    await user.type(input, 'Design')
+
+    await waitFor(() => {
+      expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument()
+  })
+
   it('fires CANCEL when Back is clicked', async () => {
     const user = userEvent.setup()
     renderComponent()

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesTimeOff.test.tsx
@@ -250,6 +250,24 @@ describe('SelectEmployeesTimeOff', () => {
     expect(screen.getByText('Alice Smith')).toBeInTheDocument()
   })
 
+  it('filters employees by department', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    })
+
+    const input = screen.getByPlaceholderText('searchPlaceholder')
+    await user.type(input, 'Engineering')
+
+    await waitFor(() => {
+      expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    expect(screen.queryByText('Carol Davis')).not.toBeInTheDocument()
+  })
+
   it('fires TIME_OFF_ADD_EMPLOYEES_BACK when Back is clicked', async () => {
     const user = userEvent.setup()
     renderComponent()

--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/useSelectEmployeesData.ts
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/useSelectEmployeesData.ts
@@ -25,7 +25,7 @@ export function isStartedByToday(hireDate: string | undefined): boolean {
 // Single source of truth for the search predicate so the client-pagination
 // hook and the select-all handler agree on what's "in scope" for a query.
 export function matchesEmployeeSearch(employee: EmployeeItem, query: string): boolean {
-  return `${employee.firstName ?? ''} ${employee.lastName ?? ''}`
+  return `${employee.firstName ?? ''} ${employee.lastName ?? ''} ${employee.department ?? ''}`
     .toLowerCase()
     .includes(query.toLowerCase())
 }

--- a/src/i18n/en/Company.TimeOff.EmployeeTable.json
+++ b/src/i18n/en/Company.TimeOff.EmployeeTable.json
@@ -7,8 +7,8 @@
   "selectAll": "Select all",
   "clearAriaLabel": "Clear selected employees",
   "clear": "Clear",
-  "searchPlaceholder": "Search employees",
-  "searchLabel": "Search employees",
+  "searchPlaceholder": "Search by name or department",
+  "searchLabel": "Search by name or department",
   "tableLabel": "Employees",
   "noSearchResults": "No employees found",
   "clearSearch": "Clear search"


### PR DESCRIPTION
## Summary
- Widen the shared `matchesEmployeeSearch` predicate so the search input in the time off and holiday pay "Add employees" tables matches against the employee's `department` in addition to `firstName lastName`. Single source of truth, so client-side filtering and select-all scope stay in sync automatically.
- Update the search placeholder/label copy from "Search employees" to "Search by name or department" so the broader scope is discoverable.
- Add a "filters employees by department" test to both `SelectEmployeesTimeOff.test.tsx` and `SelectEmployeesHoliday.test.tsx`.

## Test plan
- [ ] `npm run test -- --run src/components/TimeOff/TimeOffManagement/SelectEmployees` — all SelectEmployees tests pass, including the new department-search cases.
- [ ] In Storybook (`npm run storybook`), open `Components/TimeOff/SelectEmployeesPresentation`, type a department name, confirm the table filters correctly and that "Select all" + selection count reflect the filtered subset (off-page selection invariant).
- [ ] Verify the search input shows the new "Search by name or department" placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)