### PR TITLE
fix: remove Flex container from job cell in employee dashboard

### DIFF
--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -314,14 +314,14 @@ export function JobAndPayView({
       render: (job: Job) => {
         const numericRate = parseJobRate(job.rate)
         return (
-          <Flex flexDirection="column" gap={0}>
-            <Components.Text>{job.title || '-'}</Components.Text>
+          <>
+            {job.title || '-'}
             {numericRate !== null && job.paymentUnit ? (
-              <Components.Text variant="supporting">
+              <Components.Text variant="supporting" size="sm">
                 {formatCompensationRate(numericRate, job.paymentUnit)}
               </Components.Text>
             ) : null}
-          </Flex>
+          </>
         )
       },
     },


### PR DESCRIPTION
## Summary

Simplifies the job-and-pay table's job cell by removing the wrapping `Flex` column container and dropping down to a smaller supporting text size for the compensation rate.

## Changes

- Replace `Flex` column wrapper with a fragment in [JobAndPayView.tsx](src/components/Employee/Dashboard/JobAndPayView.tsx#L314-L324)
- Render the job title as plain text instead of `Components.Text`
- Use `size="sm"` on the supporting compensation-rate text

## Demo

Before:

<img width="1247" height="411" alt="Screenshot 2026-05-28 at 11 27 22 AM" src="https://github.com/user-attachments/assets/dbc24d6d-2a96-4048-b896-4dbd8fda4b00" />

After:

<img width="1303" height="392" alt="Screenshot 2026-05-28 at 11 27 12 AM" src="https://github.com/user-attachments/assets/a8d1681b-3721-45ae-bf76-ab5629d5b144" />

## Testing

- Storybook: open the Employee Dashboard job and pay view and verify the title + rate render correctly in the table cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)