### PR TITLE
fix: remove Text wrapper from time off balance cell

### DIFF
--- a/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
+++ b/src/components/TimeOff/TimeOffPolicyDetail/TimeOffPolicyDetailPresentation.tsx
@@ -32,7 +32,6 @@ export function TimeOffPolicyDetailPresentation({
 }: TimeOffPolicyDetailPresentationProps) {
   useI18n('Company.TimeOff.TimeOffPolicyDetails')
   const { t } = useTranslation('Company.TimeOff.TimeOffPolicyDetails')
-  const { Text } = useComponentContext()
 
   const isUnlimited = policyDetails.accrualMethod === 'unlimited'
 
@@ -44,12 +43,10 @@ export function TimeOffPolicyDetailPresentation({
             {
               key: 'balance' as keyof TimeOffPolicyDetailEmployee,
               title: t('employeeTable.balance'),
-              render: (item: TimeOffPolicyDetailEmployee) => (
-                <Text as="span">{item.balance ?? '-'}</Text>
-              ),
+              render: (item: TimeOffPolicyDetailEmployee) => item.balance ?? '-',
             },
           ],
-    [t, isUnlimited, Text],
+    [t, isUnlimited],
   )
 
   const detailsTabContent = (


### PR DESCRIPTION
## Summary

The balance cell in the time off policy detail employee table wrapped its value in `<Text as="span">`, which applied default Text styles inside a table cell where the DataView already controls typography.

## Changes

- Render the raw `balance` value (or `'-'`) directly in the cell instead of wrapping it in `<Text as="span">`
- Drop the now-unused `Text` from `useComponentContext()` and from the `useMemo` deps

## Demo

<!-- Screenshot/recording of the time off policy detail employee table -->

## Related

<!-- Jira: SDK-XXX -->

## Testing

- Open Storybook: `npm run storybook` → Company/TimeOff/TimeOffPolicyDetail
- Confirm the Balance column renders values (and `-` for empty) with the table's default text styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)