### PR TITLE
chore(SDK-970): install eslint-plugin-tsdoc to lint comment syntax

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ import jsxA11y from 'eslint-plugin-jsx-a11y'
 import pluginReactHooks from 'eslint-plugin-react-hooks'
 import importPlugin from 'eslint-plugin-import'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import tsdoc from 'eslint-plugin-tsdoc'
 
 export default [
   { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },
@@ -142,5 +143,15 @@ export default [
       '@typescript-eslint/no-unnecessary-type-arguments': 'off',
     },
   },
+  // TSDoc syntax validation on any comment that already exists.
+  // Validates tag names, param format, brace escaping, etc.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    plugins: { tsdoc },
+    rules: {
+      'tsdoc/syntax': 'error',
+    },
+  },
+
   ...storybook.configs['flat/recommended'],
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "eslint-plugin-storybook": "^10.4.1",
+        "eslint-plugin-tsdoc": "^0.5.2",
         "fuse.js": "^7.3.0",
         "globals": "^17.6.0",
         "husky": "^9.1.7",
@@ -9974,9 +9975,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -13054,6 +13055,211 @@
         "storybook": "^10.4.1"
       }
     },
+    "node_modules/eslint-plugin-tsdoc": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.5.2.tgz",
+      "integrity": "sha512-BlvqjWZdBJDIPO/YU3zcPCF23CvjYT3gyu63yo6b609NNV3D1b6zceAREy2xnweuBoDpZcLNuPyAUq9cvx6bbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@microsoft/tsdoc-config": "0.18.1",
+        "@typescript-eslint/utils": "~8.56.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -13282,9 +13488,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "eslint-plugin-storybook": "^10.4.1",
+    "eslint-plugin-tsdoc": "^0.5.2",
     "fuse.js": "^7.3.0",
     "globals": "^17.6.0",
     "husky": "^9.1.7",

--- a/src/components/Common/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/Common/VisuallyHidden/VisuallyHidden.tsx
@@ -6,7 +6,7 @@ import styles from './VisuallyHidden.module.scss'
 export interface VisuallyHiddenProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * The element to render the visually hidden content as.
-   * @default 'div'
+   * @defaultValue 'div'
    */
   as?: React.ElementType
   /**

--- a/src/components/Employee/Deductions/shared/useDeductionForm/useDeductionForm.tsx
+++ b/src/components/Employee/Deductions/shared/useDeductionForm/useDeductionForm.tsx
@@ -65,9 +65,9 @@ export interface UseDeductionFormProps {
    */
   garnishmentId?: string
   /**
-   * Court-ordered deductions are stored as garnishments with `courtOrdered:
-   * true` and require a `garnishmentType` (Federal Tax Lien, Student Loan,
-   * etc.). When `false`, the form is for a "custom" post-tax deduction —
+   * Court-ordered deductions are stored as garnishments with `courtOrdered: true`
+   * and require a `garnishmentType` (Federal Tax Lien, Student Loan, etc.).
+   * When `false`, the form is for a "custom" post-tax deduction —
    * `garnishmentType` is excluded from the schema and submit payload.
    *
    * Note: this hook does NOT handle `garnishmentType: 'child_support'`. Use

--- a/src/components/Employee/PaymentMethod/shared/useSplitPaymentsForm/splitFieldFactory.tsx
+++ b/src/components/Employee/PaymentMethod/shared/useSplitPaymentsForm/splitFieldFactory.tsx
@@ -12,7 +12,7 @@ import { SPLIT_BY } from '@/shared/constants'
 /**
  * Validation codes a bound split-amount Field can emit at submit time:
  * `REQUIRED` (every non-remainder split must have a value), `INVALID_AMOUNT`
- * (Amount mode, value < 0), `INVALID_PERCENTAGE` (Percentage mode, non-integer
+ * (Amount mode, `value < 0`), `INVALID_PERCENTAGE` (Percentage mode, non-integer
  * or out of `0..100`). Supply translations for all three via `validationMessages`.
  * The sum-to-100 invariant is surfaced separately via `status.hasPercentageImbalance`.
  */

--- a/src/helpers/breadcrumbHelpers.ts
+++ b/src/helpers/breadcrumbHelpers.ts
@@ -50,7 +50,7 @@ export const buildBreadcrumbs = (nodes: BreadcrumbNodes): BreadcrumbTrail => {
 /**
  * Resolves template variables in breadcrumb labels using values from a context object.
  *
- * Supports Handlebars-style template syntax ({{variableName}}) for dynamic breadcrumb labels.
+ * Supports Handlebars-style template syntax (`{{variableName}}`) for dynamic breadcrumb labels.
  * Variables enclosed in double braces are replaced with their corresponding values from the context.
  * Non-template strings are returned as-is.
  */

--- a/src/helpers/mask.ts
+++ b/src/helpers/mask.ts
@@ -4,18 +4,21 @@ import type { Transform } from '@/components/Common/Fields/hooks/useField'
  * Formats a string according to a specified mask pattern.
  * @param value - The input string to format
  * @param mask - The mask pattern where:
- *   # represents a digit (\d)
- *   @ represents a letter ([a-zA-Z])
- *   ^ represents an uppercase letter ([A-Z])
- *   % represents a digit or uppercase letter ([0-9A-Z])
+ *   `#` represents a digit (`\d`)
+ *   `@` represents a letter (`[a-zA-Z]`)
+ *   `^` represents an uppercase letter (`[A-Z]`)
+ *   `%` represents a digit or uppercase letter (`[0-9A-Z]`)
  *   any other character represents the literal character
  * @returns The formatted string according to the mask
+ *
  * @example
+ * ```ts
  * formatWithMask('123456789', '###-##-####') // returns '123-45-6789'
  * formatWithMask('ABC123', '@@@-###') // returns 'ABC-123'
  * formatWithMask('123456', '(###) ###-####') // returns '(123) 456'
  * formatWithMask('ABC123', '^^^-###') // returns 'ABC-123'
  * formatWithMask('A1B2C3', '%%%-%%%') // returns 'A1B-2C3'
+ * ```
  */
 export const formatWithMask = (value: string, mask: string | null): string => {
   if (!value || !mask) return value

--- a/src/helpers/rem.ts
+++ b/src/helpers/rem.ts
@@ -3,7 +3,7 @@ let cachedRootFontSize: string | null = null
 /**
  * Detects font-size on the document root element with fallback to 16px which is the default browser setting.
  * The value is cached after the first call to avoid repeated expensive getComputedStyle() calls.
- * @param options.forceRefresh - Force a fresh detection instead of using the cached value
+ * @param options - Set `forceRefresh` to force a fresh detection instead of using the cached value
  * @returns The root font size in pixels as a string
  */
 export function getRootFontSize(options?: { forceRefresh?: boolean }) {

--- a/src/i18n/I18n.ts
+++ b/src/i18n/I18n.ts
@@ -23,9 +23,9 @@ function resolveTranslationLoader(lng: string | undefined, ns: string) {
 const resourceCache = new LRUCache(50)
 /**
  * Dynamic loading of translation resources - works with Suspence to prevent early access to loadable strings
- * @param lng(string): resource language
- * @param ns(string): Namespace/name of the component/resource
- * @returns Promise<Translation resource>
+ * @param lng - resource language
+ * @param ns - Namespace/name of the component/resource
+ * @returns translation resource
  */
 const loadResource = ({ lng = 'en', ns }: { ns: string; lng?: string }) => {
   let isLoading = true
@@ -62,7 +62,8 @@ const loadResource = ({ lng = 'en', ns }: { ns: string; lng?: string }) => {
 
 /**
  * Hook that allows component to load custom dictionary
- * @param @private {string} ns - Namespace - should match component name exactly - not exposed to consumers
+ * @param ns - Namespace - should match component name exactly - not exposed to consumers
+ * @internal
  */
 export const useI18n = (
   namespaces:

--- a/src/test/factories/jobsAndCompensations.ts
+++ b/src/test/factories/jobsAndCompensations.ts
@@ -6,7 +6,7 @@
  * The Speakeasy SDK transforms these into camelCase for the React Query layer.
  *
  * Each builder validates its output against the SDK's public `*FromJSON`
- * parser so any drift between our fixtures and the @gusto/embedded-api wire
+ * parser so any drift between our fixtures and the `@gusto/embedded-api` wire
  * schema fails loudly at the call site instead of producing silently-wrong
  * camelCase data inside hooks under test.
  */

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -28,7 +28,7 @@ export type {
  * SDK hooks interface for consumers
  *
  * This interface defines the supported hook types that can be passed to the GustoProvider.
- * Each hook type must implement the corresponding interface from @gusto/embedded-api/hooks/types.
+ * Each hook type must implement the corresponding interface from `@gusto/embedded-api/hooks/types`.
  *
  * Only the following hook types are supported:
  * - beforeCreateRequest: Hooks executed before creating a Request object

--- a/src/types/observability.ts
+++ b/src/types/observability.ts
@@ -125,7 +125,7 @@ export interface ObservabilityHook {
 
   /**
    * Configuration for sanitizing data before sending to observability tools.
-   * Default: { enabled: true, includeRawError: false }
+   * Default: `{ enabled: true, includeRawError: false }`
    */
   sanitization?: SanitizationConfig
 }


### PR DESCRIPTION
## Summary

Enforce that `/** */` comments in our `src/` directory contain valid TSDoc syntax, via the [`eslint-plugin-tsdoc`](https://www.npmjs.com/package/eslint-plugin-tsdoc) rules.

First in a series of small PRs to introduce TSDoc linting one rule at a time.

## Related

- Jira ticket: [SDK-970](https://gustohq.atlassian.net/browse/SDK-970)



[SDK-970]: https://gustohq.atlassian.net/browse/SDK-970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ