### PR TITLE
fix: render employee steady-state details with DescriptionList

### DIFF
--- a/src/components/Common/UI/DescriptionList/DescriptionList.module.scss
+++ b/src/components/Common/UI/DescriptionList/DescriptionList.module.scss
@@ -6,11 +6,13 @@
   }
 
   dt {
+    font-size: toRem(16);
     font-weight: var(--g-fontWeightMedium);
     color: var(--g-colorBodyContent);
   }
 
   dd {
+    font-size: toRem(16);
     font-weight: var(--g-fontWeightRegular);
     color: var(--g-colorBodySubContent);
     margin-inline-start: 0;

--- a/src/components/Common/UI/DescriptionList/DescriptionList.module.scss
+++ b/src/components/Common/UI/DescriptionList/DescriptionList.module.scss
@@ -5,16 +5,7 @@
     margin-bottom: toRem(16);
   }
 
-  dt {
-    font-size: toRem(16);
-    font-weight: var(--g-fontWeightMedium);
-    color: var(--g-colorBodyContent);
-  }
-
   dd {
-    font-size: toRem(16);
-    font-weight: var(--g-fontWeightRegular);
-    color: var(--g-colorBodySubContent);
     margin-inline-start: 0;
   }
 

--- a/src/components/Common/UI/DescriptionList/DescriptionList.test.tsx
+++ b/src/components/Common/UI/DescriptionList/DescriptionList.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { DescriptionList } from './DescriptionList'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
 
 describe('DescriptionList', () => {
   it('renders a description list with items', () => {
-    render(
+    renderWithProviders(
       <DescriptionList
         items={[
           { term: 'Term 1', description: 'Description 1' },
@@ -20,7 +21,7 @@ describe('DescriptionList', () => {
   })
 
   it('applies custom className', () => {
-    const { container } = render(
+    const { container } = renderWithProviders(
       <DescriptionList className="custom-class" items={[{ term: 'Term', description: 'Desc' }]} />,
     )
 
@@ -29,7 +30,7 @@ describe('DescriptionList', () => {
   })
 
   it('renders with ReactNode items', () => {
-    render(
+    renderWithProviders(
       <DescriptionList
         items={[
           {
@@ -45,7 +46,7 @@ describe('DescriptionList', () => {
   })
 
   it('renders empty list when items array is empty', () => {
-    const { container } = render(<DescriptionList items={[]} />)
+    const { container } = renderWithProviders(<DescriptionList items={[]} />)
 
     const dl = container.querySelector('dl')
     expect(dl).toBeInTheDocument()
@@ -53,7 +54,7 @@ describe('DescriptionList', () => {
   })
 
   it('renders multiple terms for one description', () => {
-    const { container } = render(
+    const { container } = renderWithProviders(
       <DescriptionList
         items={[
           {
@@ -76,7 +77,7 @@ describe('DescriptionList', () => {
   })
 
   it('renders one term with multiple descriptions', () => {
-    const { container } = render(
+    const { container } = renderWithProviders(
       <DescriptionList
         items={[
           {
@@ -98,7 +99,7 @@ describe('DescriptionList', () => {
   })
 
   it('renders mixed patterns of terms and descriptions', () => {
-    const { container } = render(
+    const { container } = renderWithProviders(
       <DescriptionList
         items={[
           { term: 'Single', description: 'Single' },

--- a/src/components/Common/UI/DescriptionList/DescriptionList.tsx
+++ b/src/components/Common/UI/DescriptionList/DescriptionList.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { type DescriptionListProps, DescriptionListDefaults } from './DescriptionListTypes'
 import styles from './DescriptionList.module.scss'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
 export function DescriptionList(rawProps: DescriptionListProps) {
   const resolvedProps = applyMissingDefaults(rawProps, DescriptionListDefaults)
@@ -18,6 +19,8 @@ export function DescriptionList(rawProps: DescriptionListProps) {
     return descriptions.map((d, i) => <dd key={i}>{d}</dd>)
   }
 
+  const Components = useComponentContext()
+
   return (
     <dl
       className={classNames(styles.root, showSeparators && styles.withSeparators, className)}
@@ -25,8 +28,10 @@ export function DescriptionList(rawProps: DescriptionListProps) {
     >
       {items.map((item, index) => (
         <div key={index} className={styles.item}>
-          {renderTerms(item.term)}
-          {renderDescriptions(item.description)}
+          <Components.Text weight="medium">{renderTerms(item.term)}</Components.Text>
+          <Components.Text variant="supporting">
+            {renderDescriptions(item.description)}
+          </Components.Text>
         </div>
       ))}
     </dl>

--- a/src/components/Common/UI/DescriptionList/DescriptionList.tsx
+++ b/src/components/Common/UI/DescriptionList/DescriptionList.tsx
@@ -9,17 +9,29 @@ export function DescriptionList(rawProps: DescriptionListProps) {
   const resolvedProps = applyMissingDefaults(rawProps, DescriptionListDefaults)
   const { items, layout, showSeparators, className } = resolvedProps
 
+  const Components = useComponentContext()
+
   const renderTerms = (term: ReactNode | ReactNode[]) => {
     const terms = Array.isArray(term) ? term : [term]
-    return terms.map((t, i) => <dt key={i}>{t}</dt>)
+    return terms.map((t, i) => (
+      <dt key={i}>
+        <Components.Text as="span" weight="medium">
+          {t}
+        </Components.Text>
+      </dt>
+    ))
   }
 
   const renderDescriptions = (description: ReactNode | ReactNode[]) => {
     const descriptions = Array.isArray(description) ? description : [description]
-    return descriptions.map((d, i) => <dd key={i}>{d}</dd>)
+    return descriptions.map((d, i) => (
+      <dd key={i}>
+        <Components.Text as="span" variant="supporting">
+          {d}
+        </Components.Text>
+      </dd>
+    ))
   }
-
-  const Components = useComponentContext()
 
   return (
     <dl
@@ -28,10 +40,8 @@ export function DescriptionList(rawProps: DescriptionListProps) {
     >
       {items.map((item, index) => (
         <div key={index} className={styles.item}>
-          <Components.Text weight="medium">{renderTerms(item.term)}</Components.Text>
-          <Components.Text variant="supporting">
-            {renderDescriptions(item.description)}
-          </Components.Text>
+          {renderTerms(item.term)}
+          {renderDescriptions(item.description)}
         </div>
       ))}
     </dl>

--- a/src/components/Employee/Dashboard/BasicDetailsView.tsx
+++ b/src/components/Employee/Dashboard/BasicDetailsView.tsx
@@ -85,6 +85,16 @@ export function BasicDetailsView({
   const dateOfBirth = employee ? formatDateLongWithYear(employee.dateOfBirth) : undefined
   const maskedSsn = employee?.hasSsn ? 'XXX-XX-XXXX' : undefined
 
+  const basicDetailsItems = employee
+    ? [
+        { term: t('basicDetails.legalName'), description: legalName || '–' },
+        { term: t('basicDetails.startDate'), description: startDate || '–' },
+        { term: t('basicDetails.socialSecurityNumber'), description: maskedSsn || '–' },
+        { term: t('basicDetails.dateOfBirth'), description: dateOfBirth || '–' },
+        { term: t('basicDetails.personalEmail'), description: employee.email || '–' },
+      ]
+    : []
+
   return (
     <Flex flexDirection="column" gap={24}>
       <Components.Box
@@ -103,58 +113,11 @@ export function BasicDetailsView({
           />
         }
       >
-        <Flex flexDirection="column" gap={16}>
-          {isEmployeeLoading ? (
-            <Loading />
-          ) : employee ? (
-            <Flex flexDirection="column" gap={12}>
-              {legalName && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('basicDetails.legalName')}
-                  </Components.Text>
-                  <Components.Text>{legalName}</Components.Text>
-                </Flex>
-              )}
-
-              {startDate && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('basicDetails.startDate')}
-                  </Components.Text>
-                  <Components.Text>{startDate}</Components.Text>
-                </Flex>
-              )}
-
-              {maskedSsn && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('basicDetails.socialSecurityNumber')}
-                  </Components.Text>
-                  <Components.Text>{maskedSsn}</Components.Text>
-                </Flex>
-              )}
-
-              {dateOfBirth && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('basicDetails.dateOfBirth')}
-                  </Components.Text>
-                  <Components.Text>{dateOfBirth}</Components.Text>
-                </Flex>
-              )}
-
-              {employee.email && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('basicDetails.personalEmail')}
-                  </Components.Text>
-                  <Components.Text>{employee.email}</Components.Text>
-                </Flex>
-              )}
-            </Flex>
-          ) : null}
-        </Flex>
+        {isEmployeeLoading ? (
+          <Loading />
+        ) : employee ? (
+          <Components.DescriptionList items={basicDetailsItems} />
+        ) : null}
       </Components.Box>
 
       <Components.Box

--- a/src/components/Employee/Dashboard/BasicDetailsView.tsx
+++ b/src/components/Employee/Dashboard/BasicDetailsView.tsx
@@ -141,11 +141,12 @@ export function BasicDetailsView({
             <Loading />
           ) : currentHomeAddress ? (
             <Flex flexDirection="column" gap={0}>
-              <Components.Text variant="supporting">
-                {t('homeAddress.currentAddress')}
+              <Components.Text weight="medium">
+                {getStreet(currentHomeAddress).replace(',', '')}
               </Components.Text>
-              <Components.Text>{getStreet(currentHomeAddress).replace(',', '')}</Components.Text>
-              <Components.Text>{getCityStateZip(currentHomeAddress)}</Components.Text>
+              <Components.Text variant="supporting">
+                {getCityStateZip(currentHomeAddress)}
+              </Components.Text>
             </Flex>
           ) : (
             <Components.Text>{t('homeAddress.noAddress')}</Components.Text>
@@ -174,14 +175,11 @@ export function BasicDetailsView({
             <Loading />
           ) : currentWorkAddress ? (
             <Flex flexDirection="column" gap={0}>
-              <Components.Text variant="supporting">
-                {t('workAddress.currentAddress')}
-              </Components.Text>
-              <Components.Text>
+              <Components.Text weight="medium">
                 {currentWorkAddress.street1}
                 {currentWorkAddress.street2 ? `, ${currentWorkAddress.street2}` : ''}
               </Components.Text>
-              <Components.Text>
+              <Components.Text variant="supporting">
                 {currentWorkAddress.city}, {currentWorkAddress.state} {currentWorkAddress.zip}
               </Components.Text>
             </Flex>

--- a/src/components/Employee/Dashboard/BasicDetailsView.tsx
+++ b/src/components/Employee/Dashboard/BasicDetailsView.tsx
@@ -85,13 +85,17 @@ export function BasicDetailsView({
   const dateOfBirth = employee ? formatDateLongWithYear(employee.dateOfBirth) : undefined
   const maskedSsn = employee?.hasSsn ? 'XXX-XX-XXXX' : undefined
 
+  const emptyPlaceholder = <span aria-label={t('listEmptyPlaceholder')}>–</span>
   const basicDetailsItems = employee
     ? [
-        { term: t('basicDetails.legalName'), description: legalName || '–' },
-        { term: t('basicDetails.startDate'), description: startDate || '–' },
-        { term: t('basicDetails.socialSecurityNumber'), description: maskedSsn || '–' },
-        { term: t('basicDetails.dateOfBirth'), description: dateOfBirth || '–' },
-        { term: t('basicDetails.personalEmail'), description: employee.email || '–' },
+        { term: t('basicDetails.legalName'), description: legalName || emptyPlaceholder },
+        { term: t('basicDetails.startDate'), description: startDate || emptyPlaceholder },
+        {
+          term: t('basicDetails.socialSecurityNumber'),
+          description: maskedSsn || emptyPlaceholder,
+        },
+        { term: t('basicDetails.dateOfBirth'), description: dateOfBirth || emptyPlaceholder },
+        { term: t('basicDetails.personalEmail'), description: employee.email || emptyPlaceholder },
       ]
     : []
 

--- a/src/components/Employee/Dashboard/Dashboard.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.tsx
@@ -123,58 +123,61 @@ function DashboardRoot({
       <Suspense fallback={null}>
         <DashboardHeader employeeId={employeeId} />
       </Suspense>
-      <Components.Tabs
-        tabs={tabs}
-        selectedId={selectedTab}
-        onSelectionChange={id => {
-          const next = id as DashboardTab
-          setInternalTab(next)
-          onEvent(componentEvents.EMPLOYEE_DASHBOARD_TAB_CHANGE, { tab: next })
-        }}
-        aria-label={t('tabsLabel')}
-      />
 
-      <Flex flexDirection="column" gap={24}>
-        {selectedTab === 'basicDetails' && (
-          <Suspense fallback={<BaseLayout isLoading />}>
-            <BasicDetailsViewWithData
-              employeeId={employeeId}
-              onEditBasicDetails={handleEditBasicDetails}
-              onManageHomeAddress={handleManageHomeAddress}
-              onManageWorkAddress={handleManageWorkAddress}
-            />
-          </Suspense>
-        )}
+      <Flex flexDirection="column" gap={8}>
+        <Components.Tabs
+          tabs={tabs}
+          selectedId={selectedTab}
+          onSelectionChange={id => {
+            const next = id as DashboardTab
+            setInternalTab(next)
+            onEvent(componentEvents.EMPLOYEE_DASHBOARD_TAB_CHANGE, { tab: next })
+          }}
+          aria-label={t('tabsLabel')}
+        />
 
-        {selectedTab === 'jobAndPay' && (
-          <Suspense fallback={<BaseLayout isLoading />}>
-            <JobAndPayView
-              employeeId={employeeId}
-              onEvent={onEvent}
-              onEditCompensation={handleEditCompensation}
-              onAddJob={handleAddJob}
-              onAddAnotherJob={handleAddAnotherJob}
-              onAddDeduction={handleAddDeduction}
-              onEditDeduction={handleEditDeduction}
-            />
-          </Suspense>
-        )}
+        <Flex flexDirection="column" gap={24}>
+          {selectedTab === 'basicDetails' && (
+            <Suspense fallback={<BaseLayout isLoading />}>
+              <BasicDetailsViewWithData
+                employeeId={employeeId}
+                onEditBasicDetails={handleEditBasicDetails}
+                onManageHomeAddress={handleManageHomeAddress}
+                onManageWorkAddress={handleManageWorkAddress}
+              />
+            </Suspense>
+          )}
 
-        {selectedTab === 'taxes' && (
-          <Suspense fallback={<BaseLayout isLoading />}>
-            <TaxesViewWithData
-              employeeId={employeeId}
-              onEditFederalTaxes={handleEditFederalTaxes}
-              onEditStateTaxes={handleEditStateTaxes}
-            />
-          </Suspense>
-        )}
+          {selectedTab === 'jobAndPay' && (
+            <Suspense fallback={<BaseLayout isLoading />}>
+              <JobAndPayView
+                employeeId={employeeId}
+                onEvent={onEvent}
+                onEditCompensation={handleEditCompensation}
+                onAddJob={handleAddJob}
+                onAddAnotherJob={handleAddAnotherJob}
+                onAddDeduction={handleAddDeduction}
+                onEditDeduction={handleEditDeduction}
+              />
+            </Suspense>
+          )}
 
-        {selectedTab === 'documents' && (
-          <Suspense fallback={<BaseLayout isLoading />}>
-            <DocumentsViewWithData employeeId={employeeId} onViewForm={handleViewForm} />
-          </Suspense>
-        )}
+          {selectedTab === 'taxes' && (
+            <Suspense fallback={<BaseLayout isLoading />}>
+              <TaxesViewWithData
+                employeeId={employeeId}
+                onEditFederalTaxes={handleEditFederalTaxes}
+                onEditStateTaxes={handleEditStateTaxes}
+              />
+            </Suspense>
+          )}
+
+          {selectedTab === 'documents' && (
+            <Suspense fallback={<BaseLayout isLoading />}>
+              <DocumentsViewWithData employeeId={employeeId} onViewForm={handleViewForm} />
+            </Suspense>
+          )}
+        </Flex>
       </Flex>
     </Flex>
   )
@@ -192,7 +195,7 @@ function DashboardHeader({ employeeId }: { employeeId: string }) {
       <Components.Heading as="h2">
         {firstLastName({ first_name: employee?.firstName, last_name: employee?.lastName })}
       </Components.Heading>
-      <Components.Text>{t('employeeRoleLabel')}</Components.Text>
+      <Components.Text variant="supporting">{t('employeeRoleLabel')}</Components.Text>
     </Flex>
   )
 }

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -223,16 +223,6 @@ export function JobAndPayView({
   const singleJobCurrentComp = singleJob?.compensations?.find(
     c => c.uuid === singleJob.currentCompensationUuid,
   )
-  const singleJobEffectiveDateRow = singleJobCurrentComp?.effectiveDate ? (
-    <Flex flexDirection="column" gap={0}>
-      <Components.Text variant="supporting">
-        {t('jobAndPay.compensation.effectiveDate')}
-      </Components.Text>
-      <Components.Text>
-        {formatDateLongWithYear(singleJobCurrentComp.effectiveDate)}
-      </Components.Text>
-    </Flex>
-  ) : null
 
   const [isReviewOpen, setIsReviewOpen] = useState(false)
   const renderDetail = usePendingChangeDetailRenderer(employeeFirstName)
@@ -691,57 +681,63 @@ export function JobAndPayView({
                   {...jobsDataView}
                 />
               ) : singleJob ? (
-                <Flex flexDirection="column" gap={12}>
-                  {singleJob.title && (
-                    <Flex flexDirection="column" gap={0}>
-                      <Components.Text variant="supporting">
-                        {t('jobAndPay.compensation.jobTitle')}
-                      </Components.Text>
-                      <Components.Text>{singleJob.title}</Components.Text>
-                    </Flex>
-                  )}
-
-                  {singleJob.paymentUnit && (
-                    <Flex flexDirection="column" gap={0}>
-                      <Components.Text variant="supporting">
-                        {t('jobAndPay.compensation.type')}
-                      </Components.Text>
-                      <Components.Text>
-                        {singleJob.paymentUnit === 'Hour'
-                          ? t('jobAndPay.compensation.types.hourly')
-                          : singleJob.paymentUnit === 'Salary' || singleJob.paymentUnit === 'Year'
-                            ? t('jobAndPay.compensation.types.salary')
-                            : singleJob.paymentUnit}
-                      </Components.Text>
-                    </Flex>
-                  )}
-
-                  {singleJobNumericRate !== null && singleJob.paymentUnit && (
-                    <Flex flexDirection="column" gap={0}>
-                      <Components.Text variant="supporting">
-                        {t('jobAndPay.compensation.wage')}
-                      </Components.Text>
-                      <Components.Text>
-                        {formatCompensationRate(singleJobNumericRate, singleJob.paymentUnit)}
-                      </Components.Text>
-                    </Flex>
-                  )}
-
-                  {singleJobEffectiveDateRow}
-
-                  {singleJobIsPendingNew && (
-                    <Flex flexDirection="column" gap={0}>
-                      <Components.Text variant="supporting">
-                        {t('jobAndPay.compensation.columns.status')}
-                      </Components.Text>
-                      <div>
-                        <Components.Badge status="warning">
-                          {t('jobAndPay.compensation.pendingStatus')}
-                        </Components.Badge>
-                      </div>
-                    </Flex>
-                  )}
-                </Flex>
+                <Components.DescriptionList
+                  items={[
+                    ...(singleJob.title
+                      ? [
+                          {
+                            term: t('jobAndPay.compensation.jobTitle'),
+                            description: singleJob.title,
+                          },
+                        ]
+                      : []),
+                    ...(singleJob.paymentUnit
+                      ? [
+                          {
+                            term: t('jobAndPay.compensation.type'),
+                            description:
+                              singleJob.paymentUnit === 'Hour'
+                                ? t('jobAndPay.compensation.types.hourly')
+                                : singleJob.paymentUnit === 'Salary' ||
+                                    singleJob.paymentUnit === 'Year'
+                                  ? t('jobAndPay.compensation.types.salary')
+                                  : singleJob.paymentUnit,
+                          },
+                        ]
+                      : []),
+                    ...(singleJobNumericRate !== null && singleJob.paymentUnit
+                      ? [
+                          {
+                            term: t('jobAndPay.compensation.wage'),
+                            description: formatCompensationRate(
+                              singleJobNumericRate,
+                              singleJob.paymentUnit,
+                            ),
+                          },
+                        ]
+                      : []),
+                    ...(singleJobCurrentComp?.effectiveDate
+                      ? [
+                          {
+                            term: t('jobAndPay.compensation.effectiveDate'),
+                            description: formatDateLongWithYear(singleJobCurrentComp.effectiveDate),
+                          },
+                        ]
+                      : []),
+                    ...(singleJobIsPendingNew
+                      ? [
+                          {
+                            term: t('jobAndPay.compensation.columns.status'),
+                            description: (
+                              <Components.Badge status="warning">
+                                {t('jobAndPay.compensation.pendingStatus')}
+                              </Components.Badge>
+                            ),
+                          },
+                        ]
+                      : []),
+                  ]}
+                />
               ) : (
                 <EmptyData
                   title={t('jobAndPay.compensation.emptyState.title')}
@@ -787,14 +783,16 @@ export function JobAndPayView({
           {isPaymentMethodLoading ? (
             <Loading />
           ) : bankAccounts.length === 0 ? (
-            <Flex flexDirection="column" gap={0}>
-              <Components.Text variant="supporting">
-                {tPayment('paymentMethodLabel')}
-              </Components.Text>
-              <Components.Text>
-                {isDirectDeposit ? tPayment('directDepositLabel') : tPayment('checkLabel')}
-              </Components.Text>
-            </Flex>
+            <Components.DescriptionList
+              items={[
+                {
+                  term: tPayment('paymentMethodLabel'),
+                  description: isDirectDeposit
+                    ? tPayment('directDepositLabel')
+                    : tPayment('checkLabel'),
+                },
+              ]}
+            />
           ) : (
             <DataView
               label={t('jobAndPay.payment.listLabel')}

--- a/src/components/Employee/Dashboard/JobAndPayView.tsx
+++ b/src/components/Employee/Dashboard/JobAndPayView.tsx
@@ -223,6 +223,14 @@ export function JobAndPayView({
   const singleJobCurrentComp = singleJob?.compensations?.find(
     c => c.uuid === singleJob.currentCompensationUuid,
   )
+  const emptyPlaceholder = <span aria-label={t('listEmptyPlaceholder')}>–</span>
+  const singleJobPaymentTypeLabel = singleJob?.paymentUnit
+    ? singleJob.paymentUnit === 'Hour'
+      ? t('jobAndPay.compensation.types.hourly')
+      : singleJob.paymentUnit === 'Salary' || singleJob.paymentUnit === 'Year'
+        ? t('jobAndPay.compensation.types.salary')
+        : singleJob.paymentUnit
+    : null
 
   const [isReviewOpen, setIsReviewOpen] = useState(false)
   const renderDetail = usePendingChangeDetailRenderer(employeeFirstName)
@@ -683,47 +691,27 @@ export function JobAndPayView({
               ) : singleJob ? (
                 <Components.DescriptionList
                   items={[
-                    ...(singleJob.title
-                      ? [
-                          {
-                            term: t('jobAndPay.compensation.jobTitle'),
-                            description: singleJob.title,
-                          },
-                        ]
-                      : []),
-                    ...(singleJob.paymentUnit
-                      ? [
-                          {
-                            term: t('jobAndPay.compensation.type'),
-                            description:
-                              singleJob.paymentUnit === 'Hour'
-                                ? t('jobAndPay.compensation.types.hourly')
-                                : singleJob.paymentUnit === 'Salary' ||
-                                    singleJob.paymentUnit === 'Year'
-                                  ? t('jobAndPay.compensation.types.salary')
-                                  : singleJob.paymentUnit,
-                          },
-                        ]
-                      : []),
-                    ...(singleJobNumericRate !== null && singleJob.paymentUnit
-                      ? [
-                          {
-                            term: t('jobAndPay.compensation.wage'),
-                            description: formatCompensationRate(
-                              singleJobNumericRate,
-                              singleJob.paymentUnit,
-                            ),
-                          },
-                        ]
-                      : []),
-                    ...(singleJobCurrentComp?.effectiveDate
-                      ? [
-                          {
-                            term: t('jobAndPay.compensation.effectiveDate'),
-                            description: formatDateLongWithYear(singleJobCurrentComp.effectiveDate),
-                          },
-                        ]
-                      : []),
+                    {
+                      term: t('jobAndPay.compensation.jobTitle'),
+                      description: singleJob.title || emptyPlaceholder,
+                    },
+                    {
+                      term: t('jobAndPay.compensation.type'),
+                      description: singleJobPaymentTypeLabel || emptyPlaceholder,
+                    },
+                    {
+                      term: t('jobAndPay.compensation.wage'),
+                      description:
+                        singleJobNumericRate !== null && singleJob.paymentUnit
+                          ? formatCompensationRate(singleJobNumericRate, singleJob.paymentUnit)
+                          : emptyPlaceholder,
+                    },
+                    {
+                      term: t('jobAndPay.compensation.effectiveDate'),
+                      description: singleJobCurrentComp?.effectiveDate
+                        ? formatDateLongWithYear(singleJobCurrentComp.effectiveDate)
+                        : emptyPlaceholder,
+                    },
                     ...(singleJobIsPendingNew
                       ? [
                           {

--- a/src/components/Employee/Dashboard/TaxesView.tsx
+++ b/src/components/Employee/Dashboard/TaxesView.tsx
@@ -125,6 +125,8 @@ export function TaxesView({
     return answer
   }
 
+  const emptyPlaceholder = <span aria-label={t('listEmptyPlaceholder')}>–</span>
+
   return (
     <Flex flexDirection="column" gap={24}>
       <Components.Box
@@ -149,54 +151,47 @@ export function TaxesView({
           ) : federalTaxes ? (
             <Components.DescriptionList
               items={[
-                ...(federalTaxes.filingStatus
-                  ? [
-                      {
-                        term: t('taxes.federal.filingStatus'),
-                        description: federalTaxes.filingStatus,
-                      },
-                    ]
-                  : []),
-                ...('twoJobs' in federalTaxes && federalTaxes.twoJobs !== null
-                  ? [
-                      {
-                        term: t('taxes.federal.multipleJobs'),
-                        description: federalTaxes.twoJobs ? t('common.yes') : t('common.no'),
-                      },
-                    ]
-                  : []),
-                ...('dependentsAmount' in federalTaxes && federalTaxes.dependentsAmount
-                  ? [
-                      {
-                        term: t('taxes.federal.dependentsAndOtherCredits'),
-                        description: formatCurrency(parseFloat(federalTaxes.dependentsAmount)),
-                      },
-                    ]
-                  : []),
-                ...('otherIncome' in federalTaxes && federalTaxes.otherIncome
-                  ? [
-                      {
-                        term: t('taxes.federal.otherIncome'),
-                        description: formatCurrency(parseFloat(federalTaxes.otherIncome)),
-                      },
-                    ]
-                  : []),
-                ...('deductions' in federalTaxes && federalTaxes.deductions
-                  ? [
-                      {
-                        term: t('taxes.federal.deductions'),
-                        description: formatCurrency(parseFloat(federalTaxes.deductions)),
-                      },
-                    ]
-                  : []),
-                ...('extraWithholding' in federalTaxes && federalTaxes.extraWithholding
-                  ? [
-                      {
-                        term: t('taxes.federal.extraWithholding'),
-                        description: formatCurrency(parseFloat(federalTaxes.extraWithholding)),
-                      },
-                    ]
-                  : []),
+                {
+                  term: t('taxes.federal.filingStatus'),
+                  description: federalTaxes.filingStatus || emptyPlaceholder,
+                },
+                {
+                  term: t('taxes.federal.multipleJobs'),
+                  description:
+                    'twoJobs' in federalTaxes && federalTaxes.twoJobs !== null
+                      ? federalTaxes.twoJobs
+                        ? t('common.yes')
+                        : t('common.no')
+                      : emptyPlaceholder,
+                },
+                {
+                  term: t('taxes.federal.dependentsAndOtherCredits'),
+                  description:
+                    'dependentsAmount' in federalTaxes && federalTaxes.dependentsAmount
+                      ? formatCurrency(parseFloat(federalTaxes.dependentsAmount))
+                      : emptyPlaceholder,
+                },
+                {
+                  term: t('taxes.federal.otherIncome'),
+                  description:
+                    'otherIncome' in federalTaxes && federalTaxes.otherIncome
+                      ? formatCurrency(parseFloat(federalTaxes.otherIncome))
+                      : emptyPlaceholder,
+                },
+                {
+                  term: t('taxes.federal.deductions'),
+                  description:
+                    'deductions' in federalTaxes && federalTaxes.deductions
+                      ? formatCurrency(parseFloat(federalTaxes.deductions))
+                      : emptyPlaceholder,
+                },
+                {
+                  term: t('taxes.federal.extraWithholding'),
+                  description:
+                    'extraWithholding' in federalTaxes && federalTaxes.extraWithholding
+                      ? formatCurrency(parseFloat(federalTaxes.extraWithholding))
+                      : emptyPlaceholder,
+                },
               ]}
             />
           ) : null}
@@ -239,15 +234,15 @@ export function TaxesView({
 
                     {hasQuestions ? (
                       <Components.DescriptionList
-                        items={stateTax.questions!.flatMap(question => {
+                        items={stateTax.questions!.map(question => {
                           const answer = question.answers[0]?.value
-                          if (answer === null || answer === undefined) return []
-                          return [
-                            {
-                              term: question.label,
-                              description: formatStateTaxAnswer(question, answer),
-                            },
-                          ]
+                          return {
+                            term: question.label,
+                            description:
+                              answer === null || answer === undefined
+                                ? emptyPlaceholder
+                                : formatStateTaxAnswer(question, answer),
+                          }
                         })}
                       />
                     ) : (

--- a/src/components/Employee/Dashboard/TaxesView.tsx
+++ b/src/components/Employee/Dashboard/TaxesView.tsx
@@ -147,71 +147,58 @@ export function TaxesView({
           {isFederalTaxesLoading ? (
             <Loading />
           ) : federalTaxes ? (
-            <Flex flexDirection="column" gap={12}>
-              {federalTaxes.filingStatus && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('taxes.federal.filingStatus')}
-                  </Components.Text>
-                  <Components.Text>{federalTaxes.filingStatus}</Components.Text>
-                </Flex>
-              )}
-
-              {'twoJobs' in federalTaxes && federalTaxes.twoJobs !== null && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('taxes.federal.multipleJobs')}
-                  </Components.Text>
-                  <Components.Text>
-                    {federalTaxes.twoJobs ? t('common.yes') : t('common.no')}
-                  </Components.Text>
-                </Flex>
-              )}
-
-              {'dependentsAmount' in federalTaxes && federalTaxes.dependentsAmount && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('taxes.federal.dependentsAndOtherCredits')}
-                  </Components.Text>
-                  <Components.Text>
-                    {formatCurrency(parseFloat(federalTaxes.dependentsAmount))}
-                  </Components.Text>
-                </Flex>
-              )}
-
-              {'otherIncome' in federalTaxes && federalTaxes.otherIncome && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('taxes.federal.otherIncome')}
-                  </Components.Text>
-                  <Components.Text>
-                    {formatCurrency(parseFloat(federalTaxes.otherIncome))}
-                  </Components.Text>
-                </Flex>
-              )}
-
-              {'deductions' in federalTaxes && federalTaxes.deductions && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('taxes.federal.deductions')}
-                  </Components.Text>
-                  <Components.Text>
-                    {formatCurrency(parseFloat(federalTaxes.deductions))}
-                  </Components.Text>
-                </Flex>
-              )}
-
-              {'extraWithholding' in federalTaxes && federalTaxes.extraWithholding && (
-                <Flex flexDirection="column" gap={0}>
-                  <Components.Text variant="supporting">
-                    {t('taxes.federal.extraWithholding')}
-                  </Components.Text>
-                  <Components.Text>
-                    {formatCurrency(parseFloat(federalTaxes.extraWithholding))}
-                  </Components.Text>
-                </Flex>
-              )}
-            </Flex>
+            <Components.DescriptionList
+              items={[
+                ...(federalTaxes.filingStatus
+                  ? [
+                      {
+                        term: t('taxes.federal.filingStatus'),
+                        description: federalTaxes.filingStatus,
+                      },
+                    ]
+                  : []),
+                ...('twoJobs' in federalTaxes && federalTaxes.twoJobs !== null
+                  ? [
+                      {
+                        term: t('taxes.federal.multipleJobs'),
+                        description: federalTaxes.twoJobs ? t('common.yes') : t('common.no'),
+                      },
+                    ]
+                  : []),
+                ...('dependentsAmount' in federalTaxes && federalTaxes.dependentsAmount
+                  ? [
+                      {
+                        term: t('taxes.federal.dependentsAndOtherCredits'),
+                        description: formatCurrency(parseFloat(federalTaxes.dependentsAmount)),
+                      },
+                    ]
+                  : []),
+                ...('otherIncome' in federalTaxes && federalTaxes.otherIncome
+                  ? [
+                      {
+                        term: t('taxes.federal.otherIncome'),
+                        description: formatCurrency(parseFloat(federalTaxes.otherIncome)),
+                      },
+                    ]
+                  : []),
+                ...('deductions' in federalTaxes && federalTaxes.deductions
+                  ? [
+                      {
+                        term: t('taxes.federal.deductions'),
+                        description: formatCurrency(parseFloat(federalTaxes.deductions)),
+                      },
+                    ]
+                  : []),
+                ...('extraWithholding' in federalTaxes && federalTaxes.extraWithholding
+                  ? [
+                      {
+                        term: t('taxes.federal.extraWithholding'),
+                        description: formatCurrency(parseFloat(federalTaxes.extraWithholding)),
+                      },
+                    ]
+                  : []),
+              ]}
+            />
           ) : null}
         </Flex>
       </Components.Box>
@@ -251,23 +238,18 @@ export function TaxesView({
                     ) : null}
 
                     {hasQuestions ? (
-                      <Flex flexDirection="column" gap={12}>
-                        {stateTax.questions!.map((question, qIndex) => {
+                      <Components.DescriptionList
+                        items={stateTax.questions!.flatMap(question => {
                           const answer = question.answers[0]?.value
-                          if (answer === null || answer === undefined) return null
-
-                          return (
-                            <Flex key={question.key || qIndex} flexDirection="column" gap={0}>
-                              <Components.Text variant="supporting">
-                                {question.label}
-                              </Components.Text>
-                              <Components.Text>
-                                {formatStateTaxAnswer(question, answer)}
-                              </Components.Text>
-                            </Flex>
-                          )
+                          if (answer === null || answer === undefined) return []
+                          return [
+                            {
+                              term: question.label,
+                              description: formatStateTaxAnswer(question, answer),
+                            },
+                          ]
                         })}
-                      </Flex>
+                      />
                     ) : (
                       <Components.Text variant="supporting">
                         {t('taxes.state.noWithholdingForState')}

--- a/src/i18n/en/Employee.Dashboard.json
+++ b/src/i18n/en/Employee.Dashboard.json
@@ -2,6 +2,7 @@
   "title": "Employee Dashboard",
   "employeeRoleLabel": "Employee",
   "tabsLabel": "Employee dashboard tabs",
+  "listEmptyPlaceholder": "No value",
   "tabs": {
     "basicDetails": "Basic details",
     "jobAndPay": "Job and pay",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1419,6 +1419,7 @@ export interface EmployeeDashboard{
 "title":string;
 "employeeRoleLabel":string;
 "tabsLabel":string;
+"listEmptyPlaceholder":string;
 "tabs":{
 "basicDetails":string;
 "jobAndPay":string;


### PR DESCRIPTION
## Summary

Standardize the employee dashboard's steady-state detail rendering on `DescriptionList` and align its term/description typography with the rest of the SDK.

## Changes

- Route `DescriptionList` term/description through `Components.Text` (`weight="medium"` / `variant="supporting"`) so dt/dd styling is driven by the same typography primitives as the rest of the SDK instead of hardcoded SCSS overrides.
- Migrate JobAndPay (single-job compensation, payment method) and Taxes (federal, state questions) views to render their detail rows through `DescriptionList`.
- In BasicDetailsView, drop the redundant "current address" supporting label and use `Text` weight/variant to differentiate street vs. city/state/zip.
- Wrap the Dashboard tabs + selected tab content in a tighter `Flex gap={8}` so the tab strip sits closer to the panel; soften the dashboard header role label to `variant="supporting"`.

## Demo

Before:

<img width="1268" height="464" alt="Screenshot 2026-05-28 at 4 18 25 PM" src="https://github.com/user-attachments/assets/50b7d743-88e2-45dc-a92f-b0648bf77651" />

After:

<img width="1238" height="609" alt="Screenshot 2026-05-28 at 4 18 08 PM" src="https://github.com/user-attachments/assets/82bb4436-eb05-4a12-99d8-6160e1bfbd1d" />


## Related

<!--
- Jira ticket: [SDK-XXX](https://gustohq.atlassian.net/browse/SDK-XXX)
- Figma: [Design link]
-->

## Testing

- Open Storybook and verify `DescriptionList` renders with the new `Text`-driven typography.
- In the SDK dev app, navigate to the employee dashboard and check the Basic Details, Job & Pay, and Taxes tabs render correctly for both populated and empty/loading states.
- `npm run test -- --run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)