### PR TITLE
feat!: flsa-aware alerts and aligned wage labels in compensation forms

### DIFF
--- a/docs/hooks/useCompensationForm.md
+++ b/docs/hooks/useCompensationForm.md
@@ -122,6 +122,7 @@ The hook returns a discriminated union on `isLoading`.
     willDeleteSecondaryJobs: boolean              // see "Derived helpers" below
     showCommissionFederalMinimumPayAlert: boolean // see "Derived helpers" below
     showCommissionMinimumWageAlert: boolean       // see "Derived helpers" below
+    showOwnerSalaryAlert: boolean                 // see "Derived helpers" below
   }
   actions: {
     onSubmit: (
@@ -175,6 +176,7 @@ The hook exposes derived values for driving UX. Static, entity-derived values li
 - **`status.willDeleteSecondaryJobs`** — reactive: `true` when the form is currently positioned to delete the employee's secondary jobs server-side (the "carve-out" branch). Conditions: update mode, the loaded compensation is `Nonexempt`, the form's `flsaStatus` has been changed to a non-`Nonexempt` value, and the employee has at least one secondary job. While this flag is `true` the hook also locks the `effectiveDate` field — it forces the form value to today and exposes `fieldsMetadata.effectiveDate.isDisabled = true` so `Fields.EffectiveDate` renders as disabled. Reverting `flsaStatus` back to `Nonexempt` restores the prior `effectiveDate`. Use the flag to render an inline warning ("Saving will delete this employee's secondary jobs"); choose either to render the disabled `Fields.EffectiveDate` (so users can see why the date is forced) or to hide it entirely while the flag is on.
 - **`status.showCommissionFederalMinimumPayAlert`** — reactive: `true` when `flsaStatus` is `Commission Only Exempt` (Commission Only/No Overtime). Render a warning explaining that commission-only exempt employees must still earn the federal minimum pay (currently $684/week, $35,568/year) and meet the Department of Labor's exempt definition. While this flag is `true`, `Fields.Rate` and `Fields.PaymentUnit` are also `undefined` and the hook forces `rate=0`, `paymentUnit=Year` on the form values (so submits stay valid even with the inputs hidden).
 - **`status.showCommissionMinimumWageAlert`** — reactive: `true` when `flsaStatus` is `Commission Only Nonexempt` (Commission Only/Eligible for overtime). Render a warning that commission-only employees must earn at least the local minimum wage, ideally with a link to your local regulations reference. While this flag is `true`, `Fields.Rate` and `Fields.PaymentUnit` are also `undefined` and the hook forces `rate=0`, `paymentUnit=Year` on the form values.
+- **`status.showOwnerSalaryAlert`** — reactive: `true` when `flsaStatus` is `Owner` (Owner's draw). Render an informational alert reminding the partner that the IRS requires S-corp owners to pay themselves a reasonable salary for similar work before taking distributions. `Fields.PaymentUnit` stays rendered but is `isDisabled` and locked to `Paycheck` while this flag is `true`.
 - **`data.minimumEffectiveDate`** — lower bound for the `effectiveDate` field. Typically the parent job's `hireDate`. Pass this as `min` to the date picker.
 - **`data.maximumEffectiveDate`** — upper bound for the `effectiveDate` field, when a future-dated compensation already exists for this job. Pass this as `max` to the date picker so users can't push a new entry past a pending one.
 - **`data.hasPendingFutureCompensation`** — `true` when at least one future-dated compensation exists for this job. Use this to render an explanatory note ("A future rate change is already scheduled for …").
@@ -401,6 +403,7 @@ function CompensationFormReady({ compensation }: { compensation: UseCompensation
     willDeleteSecondaryJobs,
     showCommissionFederalMinimumPayAlert,
     showCommissionMinimumWageAlert,
+    showOwnerSalaryAlert,
   } = compensation.status
 
   return (
@@ -434,6 +437,13 @@ function CompensationFormReady({ compensation }: { compensation: UseCompensation
 
         {showCommissionMinimumWageAlert && (
           <p role="alert">Commission-only employees must earn at least the local minimum wage.</p>
+        )}
+
+        {showOwnerSalaryAlert && (
+          <p>
+            The IRS requires S-corp owners to pay themselves a reasonable salary before taking
+            distributions.
+          </p>
         )}
 
         {Fields.Rate && (

--- a/docs/hooks/useCompensationForm.md
+++ b/docs/hooks/useCompensationForm.md
@@ -119,7 +119,9 @@ The hook returns a discriminated union on `isLoading`.
   status: {
     isPending: boolean
     mode: 'create' | 'update'
-    willDeleteSecondaryJobs: boolean    // see "Derived helpers" below
+    willDeleteSecondaryJobs: boolean              // see "Derived helpers" below
+    showCommissionFederalMinimumPayAlert: boolean // see "Derived helpers" below
+    showCommissionMinimumWageAlert: boolean       // see "Derived helpers" below
   }
   actions: {
     onSubmit: (
@@ -171,6 +173,8 @@ interface CompensationSubmitOptions {
 The hook exposes derived values for driving UX. Static, entity-derived values live under `data.*`; reactive values that flip with form input live under `status.*`.
 
 - **`status.willDeleteSecondaryJobs`** — reactive: `true` when the form is currently positioned to delete the employee's secondary jobs server-side (the "carve-out" branch). Conditions: update mode, the loaded compensation is `Nonexempt`, the form's `flsaStatus` has been changed to a non-`Nonexempt` value, and the employee has at least one secondary job. While this flag is `true` the hook also locks the `effectiveDate` field — it forces the form value to today and exposes `fieldsMetadata.effectiveDate.isDisabled = true` so `Fields.EffectiveDate` renders as disabled. Reverting `flsaStatus` back to `Nonexempt` restores the prior `effectiveDate`. Use the flag to render an inline warning ("Saving will delete this employee's secondary jobs"); choose either to render the disabled `Fields.EffectiveDate` (so users can see why the date is forced) or to hide it entirely while the flag is on.
+- **`status.showCommissionFederalMinimumPayAlert`** — reactive: `true` when `flsaStatus` is `Commission Only Exempt` (Commission Only/No Overtime). Render a warning explaining that commission-only exempt employees must still earn the federal minimum pay (currently $684/week, $35,568/year) and meet the Department of Labor's exempt definition. While this flag is `true`, `Fields.Rate` and `Fields.PaymentUnit` are also `undefined` and the hook forces `rate=0`, `paymentUnit=Year` on the form values (so submits stay valid even with the inputs hidden).
+- **`status.showCommissionMinimumWageAlert`** — reactive: `true` when `flsaStatus` is `Commission Only Nonexempt` (Commission Only/Eligible for overtime). Render a warning that commission-only employees must earn at least the local minimum wage, ideally with a link to your local regulations reference. While this flag is `true`, `Fields.Rate` and `Fields.PaymentUnit` are also `undefined` and the hook forces `rate=0`, `paymentUnit=Year` on the form values.
 - **`data.minimumEffectiveDate`** — lower bound for the `effectiveDate` field. Typically the parent job's `hireDate`. Pass this as `min` to the date picker.
 - **`data.maximumEffectiveDate`** — upper bound for the `effectiveDate` field, when a future-dated compensation already exists for this job. Pass this as `max` to the date picker so users can't push a new entry past a pending one.
 - **`data.hasPendingFutureCompensation`** — `true` when at least one future-dated compensation exists for this job. Use this to render an explanatory note ("A future rate change is already scheduled for …").
@@ -258,17 +262,21 @@ Number input for the compensation amount. Formatted as currency.
 | `RATE_MINIMUM`          | Rate is less than $1.00                                                              |
 | `RATE_EXEMPT_THRESHOLD` | FLSA Exempt employees must meet the federal salary threshold (annualized rate check) |
 
-This field is automatically **disabled** when the FLSA status is Commission Only (rate is forced to `0`).
+**Conditional availability:** This field is `undefined` when the FLSA status is `Commission Only Exempt` or `Commission Only Nonexempt` — those statuses don't accept a partner-supplied rate, so the hook removes the field and forces `rate=0` on the form values. `fieldsMetadata.rate.isDisabled` is also `true` in that state for partners reading metadata directly.
 
 ```tsx
-<Fields.Rate
-  label="Compensation amount"
-  validationMessages={{
-    REQUIRED: 'Amount is a required field',
-    RATE_MINIMUM: 'Amount must be at least $1.00',
-    RATE_EXEMPT_THRESHOLD: 'FLSA Exempt employees must meet salary threshold of $35,568/year',
-  }}
-/>
+{
+  Fields.Rate && (
+    <Fields.Rate
+      label="Compensation amount"
+      validationMessages={{
+        REQUIRED: 'Amount is a required field',
+        RATE_MINIMUM: 'Amount must be at least $1.00',
+        RATE_EXEMPT_THRESHOLD: 'FLSA Exempt employees must meet salary threshold of $35,568/year',
+      }}
+    />
+  )
+}
 ```
 
 ---
@@ -287,7 +295,9 @@ Select dropdown for the pay period unit.
 
 **Options:** `Hour`, `Week`, `Month`, `Year`, `Paycheck`.
 
-This field is automatically **disabled** when the FLSA status is Owner (forced to `Paycheck`) or Commission Only (forced to `Year`).
+This field is automatically **disabled** when the FLSA status is Owner (forced to `Paycheck`).
+
+**Conditional availability:** This field is `undefined` when the FLSA status is `Commission Only Exempt` or `Commission Only Nonexempt` — the hook forces `paymentUnit=Year` on the form values and removes the field from `Fields`. `fieldsMetadata.paymentUnit.isDisabled` is also `true` in that state.
 
 ---
 
@@ -387,7 +397,11 @@ function CompensationEditPage({
 function CompensationFormReady({ compensation }: { compensation: UseCompensationFormReady }) {
   const { Fields } = compensation.form
   const { hasPendingFutureCompensation, maximumEffectiveDate } = compensation.data
-  const { willDeleteSecondaryJobs } = compensation.status
+  const {
+    willDeleteSecondaryJobs,
+    showCommissionFederalMinimumPayAlert,
+    showCommissionMinimumWageAlert,
+  } = compensation.status
 
   return (
     <SDKFormProvider formHookResult={compensation}>
@@ -412,23 +426,37 @@ function CompensationFormReady({ compensation }: { compensation: UseCompensation
           />
         )}
 
-        <Fields.Rate
-          label="Compensation amount"
-          validationMessages={{
-            REQUIRED: 'Amount is required',
-            RATE_MINIMUM: 'Amount must be at least $1.00',
-            RATE_EXEMPT_THRESHOLD: 'Exempt employees must meet the salary threshold',
-          }}
-        />
+        {showCommissionFederalMinimumPayAlert && (
+          <p role="alert">
+            Commission-only exempt employees must still earn at least the federal minimum pay.
+          </p>
+        )}
 
-        <Fields.PaymentUnit
-          label="Per"
-          validationMessages={{
-            REQUIRED: 'Payment unit is required',
-            PAYMENT_UNIT_OWNER: 'Owners must be paid per paycheck',
-            PAYMENT_UNIT_COMMISSION: 'Commission-only employees must be paid annually',
-          }}
-        />
+        {showCommissionMinimumWageAlert && (
+          <p role="alert">Commission-only employees must earn at least the local minimum wage.</p>
+        )}
+
+        {Fields.Rate && (
+          <Fields.Rate
+            label="Compensation amount"
+            validationMessages={{
+              REQUIRED: 'Amount is required',
+              RATE_MINIMUM: 'Amount must be at least $1.00',
+              RATE_EXEMPT_THRESHOLD: 'Exempt employees must meet the salary threshold',
+            }}
+          />
+        )}
+
+        {Fields.PaymentUnit && (
+          <Fields.PaymentUnit
+            label="Per"
+            validationMessages={{
+              REQUIRED: 'Payment unit is required',
+              PAYMENT_UNIT_OWNER: 'Owners must be paid per paycheck',
+              PAYMENT_UNIT_COMMISSION: 'Commission-only employees must be paid annually',
+            }}
+          />
+        )}
 
         {Fields.EffectiveDate && (
           <Fields.EffectiveDate

--- a/e2e/utils/employeeFlowDrivers.ts
+++ b/e2e/utils/employeeFlowDrivers.ts
@@ -85,7 +85,13 @@ async function fillCompensation(page: Page) {
     }
   }
 
-  const compAmountField = page.getByRole('textbox', { name: /compensation amount/i })
+  // The wage amount input. The current SDK label is "Wage"
+  // (Employee.Compensation.wageLabel); the older "Compensation amount" name
+  // is kept as a fallback in case staging is mid-rollout.
+  const compAmountField = page
+    .getByRole('textbox', { name: /^wage$/i })
+    .or(page.getByRole('textbox', { name: /compensation amount/i }))
+    .first()
   const compValue = await compAmountField.inputValue().catch(() => '')
   if (!compValue || compValue === '0.00') {
     await compAmountField.clear()
@@ -93,7 +99,7 @@ async function fillCompensation(page: Page) {
   }
 
   // Wage frequency select. The current SDK label is "Wage frequency"
-  // (Employee.Compensation.paymentUnitLabel); the older "Per" name is kept
+  // (Employee.Compensation.wageFrequencyLabel); the older "Per" name is kept
   // as a fallback in case staging is mid-rollout. The control is required
   // on this form, so assert visibility loudly — otherwise a Continue click
   // would fail validation 5 minutes downstream with no clear cause.

--- a/src/components/Employee/Compensation/management/ManagementCompensationFormBody.tsx
+++ b/src/components/Employee/Compensation/management/ManagementCompensationFormBody.tsx
@@ -1,3 +1,4 @@
+import { useWatch } from 'react-hook-form'
 import { Trans, useTranslation } from 'react-i18next'
 import type { PaymentUnit } from '@gusto/embedded-api-v-2025-11-15/models/components/compensation'
 import type { FlsaStatusType } from '@gusto/embedded-api-v-2025-11-15/models/components/flsastatustype'
@@ -6,7 +7,7 @@ import type { UseJobFormReady } from '../shared/useJobForm'
 import type { UseCompensationFormReady } from '../shared/useCompensationForm'
 import { ActionsLayout, Flex } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
-import { FLSA_OVERTIME_SALARY_LIMIT } from '@/shared/constants'
+import { FLSA_OVERTIME_SALARY_LIMIT, FlsaStatus } from '@/shared/constants'
 import useNumberFormatter from '@/hooks/useNumberFormatter'
 
 export interface ManagementCompensationFormBodyProps {
@@ -40,6 +41,11 @@ export function ManagementCompensationFormBody({
   const JobFields = jobForm.form.Fields
   const CompFields = compensationForm.form.Fields
 
+  const watchedFlsaStatus = useWatch({
+    control: compensationForm.form.hookFormInternals.formMethods.control,
+    name: 'flsaStatus',
+  })
+
   return (
     <Flex flexDirection="column" gap={32}>
       <Components.Heading as="h2">{title}</Components.Heading>
@@ -51,135 +57,192 @@ export function ManagementCompensationFormBody({
         />
       )}
 
-      <CompFields.Title
-        label={t('management.jobTitleLabel')}
-        validationMessages={{ REQUIRED: t('validations.jobTitleSentence') }}
-        formHookResult={compensationForm}
-      />
-
-      {JobFields.HireDate && (
-        <JobFields.HireDate
-          label={t('management.hireDateLabel')}
-          validationMessages={{
-            REQUIRED: t('validations.hireDate'),
-          }}
-          formHookResult={jobForm}
-        />
-      )}
-
-      {CompFields.FlsaStatus && (
-        <CompFields.FlsaStatus
-          label={t('employeeClassification')}
-          description={
-            <Trans
-              t={t}
-              i18nKey="classificationLink"
-              components={{ ClassificationLink: <Components.Link /> }}
-            />
-          }
-          validationMessages={{
-            REQUIRED: t('validations.exemptThreshold', {
-              limit: format(FLSA_OVERTIME_SALARY_LIMIT),
-            }),
-          }}
-          getOptionLabel={(status: FlsaStatusType) => t(`flsaStatusLabels.${status}`)}
+      <Flex flexDirection="column" gap={20}>
+        <CompFields.Title
+          label={t('management.jobTitleLabel')}
+          validationMessages={{ REQUIRED: t('validations.jobTitleSentence') }}
           formHookResult={compensationForm}
         />
-      )}
 
-      <CompFields.Rate
-        label={t('management.wageLabel')}
-        validationMessages={{
-          REQUIRED: t('validations.rate'),
-          RATE_MINIMUM: t('validations.nonZeroRate'),
-          RATE_EXEMPT_THRESHOLD: t('validations.rateExemptThreshold', {
-            limit: format(FLSA_OVERTIME_SALARY_LIMIT),
-          }),
-        }}
-        formHookResult={compensationForm}
-      />
+        {JobFields.HireDate && (
+          <JobFields.HireDate
+            label={t('management.hireDateLabel')}
+            validationMessages={{
+              REQUIRED: t('validations.hireDate'),
+            }}
+            formHookResult={jobForm}
+          />
+        )}
 
-      <CompFields.PaymentUnit
-        label={t('management.wageFrequencyLabel')}
-        description={t('paymentUnitDescription')}
-        validationMessages={{ REQUIRED: t('validations.paymentUnit') }}
-        getOptionLabel={(unit: PaymentUnit) => t(`paymentUnitOptions.${unit}` as const)}
-        formHookResult={compensationForm}
-      />
-
-      {CompFields.EffectiveDate && (
-        <CompFields.EffectiveDate
-          label={t('effectiveDateLabel')}
-          validationMessages={{
-            REQUIRED: t('validations.effectiveDate'),
-            EFFECTIVE_DATE_BEFORE_HIRE: t('validations.effectiveDateBeforeHire'),
-            EFFECTIVE_DATE_BEFORE_MIN: t('validations.effectiveDateBeforeMin'),
-          }}
-          formHookResult={compensationForm}
-        />
-      )}
-
-      {CompFields.AdjustForMinimumWage && (
-        <CompFields.AdjustForMinimumWage
-          label={t('adjustForMinimumWage')}
-          description={t('adjustForMinimumWageDescription')}
-          formHookResult={compensationForm}
-        />
-      )}
-
-      {CompFields.MinimumWageId && (
-        <CompFields.MinimumWageId
-          label={t('minimumWageLabel')}
-          description={t('minimumWageDescription')}
-          validationMessages={{ REQUIRED: t('validations.minimumWage') }}
-          getOptionLabel={(wage: MinimumWage) =>
-            `${format(Number(wage.wage))} - ${wage.authority}: ${wage.notes ?? ''}`
-          }
-          formHookResult={compensationForm}
-        />
-      )}
-
-      {JobFields.TwoPercentShareholder && (
-        <JobFields.TwoPercentShareholder
-          label={t('management.twoPercentShareholderLabel')}
-          formHookResult={jobForm}
-        />
-      )}
-
-      {JobFields.StateWcCovered && (
-        <JobFields.StateWcCovered
-          label={t('stateWcCoveredLabel')}
-          description={
-            <Trans
-              t={t}
-              i18nKey="stateWcCoveredDescription"
-              components={{
-                wcLink: (
-                  <Components.Link
-                    href="https://www.lni.wa.gov/insurance/rates-risk-classes/risk-classes-for-workers-compensation/risk-class-lookup#/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  />
-                ),
+        {CompFields.FlsaStatus && (
+          <>
+            <CompFields.FlsaStatus
+              label={t('employeeClassification')}
+              description={
+                <Trans
+                  t={t}
+                  i18nKey="classificationLink"
+                  components={{ ClassificationLink: <Components.Link /> }}
+                />
+              }
+              validationMessages={{
+                REQUIRED: t('validations.exemptThreshold', {
+                  limit: format(FLSA_OVERTIME_SALARY_LIMIT),
+                }),
               }}
+              getOptionLabel={(status: FlsaStatusType) => t(`flsaStatusLabels.${status}`)}
+              formHookResult={compensationForm}
             />
-          }
-          getOptionLabel={(covered: boolean) =>
-            covered ? t('stateWcCoveredOptions.yes') : t('stateWcCoveredOptions.no')
-          }
-          formHookResult={jobForm}
-        />
-      )}
+            {(watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_EXEMPT ||
+              watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_NONEXEMPT) && (
+              <Flex flexDirection="column" gap={0}>
+                <Components.Alert
+                  status="info"
+                  label={t('commissionAlerts.timeTrackingImpact.label')}
+                  disableScrollIntoView
+                >
+                  {t('commissionAlerts.timeTrackingImpact.intro')}
+                  <Components.UnorderedList
+                    items={[
+                      t('commissionAlerts.timeTrackingImpact.items.notEligibleForTimeTracking'),
+                      t('commissionAlerts.timeTrackingImpact.items.overtimeNotRetroactive'),
+                    ]}
+                  />
+                </Components.Alert>
+                {watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_EXEMPT && (
+                  <Components.Alert
+                    status="warning"
+                    label={t('commissionAlerts.federalMinimumPay.label')}
+                    disableScrollIntoView
+                  >
+                    {t('commissionAlerts.federalMinimumPay.body')}
+                  </Components.Alert>
+                )}
+                {watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_NONEXEMPT && (
+                  <Components.Alert
+                    status="warning"
+                    label={t('commissionAlerts.minimumWage.label')}
+                    disableScrollIntoView
+                  >
+                    <Trans
+                      t={t}
+                      i18nKey="commissionAlerts.minimumWage.body"
+                      components={{
+                        minimumWageLink: (
+                          <Components.Link
+                            href="https://support.gusto.com/article/112472520100000/manage-tip-wages-distributed-service-charges-and-tip-credits-in-gusto-for-admins"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          />
+                        ),
+                      }}
+                    />
+                  </Components.Alert>
+                )}
+              </Flex>
+            )}
+          </>
+        )}
 
-      {JobFields.StateWcClassCode && (
-        <JobFields.StateWcClassCode
-          label={t('stateWcClassCodeLabel')}
-          description={t('stateWcClassCodeDescription')}
-          placeholder={t('stateWcClassCodeLabel')}
-          validationMessages={{ REQUIRED: t('validations.stateWcClassCode') }}
-          formHookResult={jobForm}
-        />
-      )}
+        {watchedFlsaStatus !== FlsaStatus.COMMISSION_ONLY_EXEMPT &&
+          watchedFlsaStatus !== FlsaStatus.COMMISSION_ONLY_NONEXEMPT && (
+            <>
+              <CompFields.Rate
+                label={t('management.wageLabel')}
+                validationMessages={{
+                  REQUIRED: t('validations.rate'),
+                  RATE_MINIMUM: t('validations.nonZeroRate'),
+                  RATE_EXEMPT_THRESHOLD: t('validations.rateExemptThreshold', {
+                    limit: format(FLSA_OVERTIME_SALARY_LIMIT),
+                  }),
+                }}
+                formHookResult={compensationForm}
+              />
+
+              <CompFields.PaymentUnit
+                label={t('management.wageFrequencyLabel')}
+                description={t('paymentUnitDescription')}
+                validationMessages={{ REQUIRED: t('validations.paymentUnit') }}
+                getOptionLabel={(unit: PaymentUnit) => t(`paymentUnitOptions.${unit}` as const)}
+                formHookResult={compensationForm}
+              />
+            </>
+          )}
+
+        {CompFields.EffectiveDate && (
+          <CompFields.EffectiveDate
+            label={t('effectiveDateLabel')}
+            validationMessages={{
+              REQUIRED: t('validations.effectiveDate'),
+              EFFECTIVE_DATE_BEFORE_HIRE: t('validations.effectiveDateBeforeHire'),
+              EFFECTIVE_DATE_BEFORE_MIN: t('validations.effectiveDateBeforeMin'),
+            }}
+            formHookResult={compensationForm}
+          />
+        )}
+
+        {CompFields.AdjustForMinimumWage && (
+          <CompFields.AdjustForMinimumWage
+            label={t('adjustForMinimumWage')}
+            description={t('adjustForMinimumWageDescription')}
+            formHookResult={compensationForm}
+          />
+        )}
+
+        {CompFields.MinimumWageId && (
+          <CompFields.MinimumWageId
+            label={t('minimumWageLabel')}
+            description={t('minimumWageDescription')}
+            validationMessages={{ REQUIRED: t('validations.minimumWage') }}
+            getOptionLabel={(wage: MinimumWage) =>
+              `${format(Number(wage.wage))} - ${wage.authority}: ${wage.notes ?? ''}`
+            }
+            formHookResult={compensationForm}
+          />
+        )}
+
+        {JobFields.TwoPercentShareholder && (
+          <JobFields.TwoPercentShareholder
+            label={t('management.twoPercentShareholderLabel')}
+            formHookResult={jobForm}
+          />
+        )}
+
+        {JobFields.StateWcCovered && (
+          <JobFields.StateWcCovered
+            label={t('stateWcCoveredLabel')}
+            description={
+              <Trans
+                t={t}
+                i18nKey="stateWcCoveredDescription"
+                components={{
+                  wcLink: (
+                    <Components.Link
+                      href="https://www.lni.wa.gov/insurance/rates-risk-classes/risk-classes-for-workers-compensation/risk-class-lookup#/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    />
+                  ),
+                }}
+              />
+            }
+            getOptionLabel={(covered: boolean) =>
+              covered ? t('stateWcCoveredOptions.yes') : t('stateWcCoveredOptions.no')
+            }
+            formHookResult={jobForm}
+          />
+        )}
+
+        {JobFields.StateWcClassCode && (
+          <JobFields.StateWcClassCode
+            label={t('stateWcClassCodeLabel')}
+            description={t('stateWcClassCodeDescription')}
+            placeholder={t('stateWcClassCodeLabel')}
+            validationMessages={{ REQUIRED: t('validations.stateWcClassCode') }}
+            formHookResult={jobForm}
+          />
+        )}
+      </Flex>
 
       <ActionsLayout>
         {onCancel && (

--- a/src/components/Employee/Compensation/management/ManagementCompensationFormBody.tsx
+++ b/src/components/Employee/Compensation/management/ManagementCompensationFormBody.tsx
@@ -117,12 +117,19 @@ export function ManagementCompensationFormBody({
                 />
               </Components.Alert>
             )}
+            {compensationForm.status.showOwnerSalaryAlert && (
+              <Components.Alert
+                status="info"
+                label={t('commissionAlerts.ownerSalary.label')}
+                disableScrollIntoView
+              />
+            )}
           </>
         )}
 
         {CompFields.Rate && (
           <CompFields.Rate
-            label={t('management.wageLabel')}
+            label={t('wageLabel')}
             validationMessages={{
               REQUIRED: t('validations.rate'),
               RATE_MINIMUM: t('validations.nonZeroRate'),
@@ -136,7 +143,7 @@ export function ManagementCompensationFormBody({
 
         {CompFields.PaymentUnit && (
           <CompFields.PaymentUnit
-            label={t('management.wageFrequencyLabel')}
+            label={t('wageFrequencyLabel')}
             description={t('paymentUnitDescription')}
             validationMessages={{ REQUIRED: t('validations.paymentUnit') }}
             getOptionLabel={(unit: PaymentUnit) => t(`paymentUnitOptions.${unit}` as const)}

--- a/src/components/Employee/Compensation/management/ManagementCompensationFormBody.tsx
+++ b/src/components/Employee/Compensation/management/ManagementCompensationFormBody.tsx
@@ -1,4 +1,3 @@
-import { useWatch } from 'react-hook-form'
 import { Trans, useTranslation } from 'react-i18next'
 import type { PaymentUnit } from '@gusto/embedded-api-v-2025-11-15/models/components/compensation'
 import type { FlsaStatusType } from '@gusto/embedded-api-v-2025-11-15/models/components/flsastatustype'
@@ -7,7 +6,7 @@ import type { UseJobFormReady } from '../shared/useJobForm'
 import type { UseCompensationFormReady } from '../shared/useCompensationForm'
 import { ActionsLayout, Flex } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
-import { FLSA_OVERTIME_SALARY_LIMIT, FlsaStatus } from '@/shared/constants'
+import { FLSA_OVERTIME_SALARY_LIMIT } from '@/shared/constants'
 import useNumberFormatter from '@/hooks/useNumberFormatter'
 
 export interface ManagementCompensationFormBodyProps {
@@ -40,11 +39,6 @@ export function ManagementCompensationFormBody({
 
   const JobFields = jobForm.form.Fields
   const CompFields = compensationForm.form.Fields
-
-  const watchedFlsaStatus = useWatch({
-    control: compensationForm.form.hookFormInternals.formMethods.control,
-    name: 'flsaStatus',
-  })
 
   return (
     <Flex flexDirection="column" gap={32}>
@@ -93,81 +87,62 @@ export function ManagementCompensationFormBody({
               getOptionLabel={(status: FlsaStatusType) => t(`flsaStatusLabels.${status}`)}
               formHookResult={compensationForm}
             />
-            {(watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_EXEMPT ||
-              watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_NONEXEMPT) && (
-              <Flex flexDirection="column" gap={0}>
-                <Components.Alert
-                  status="info"
-                  label={t('commissionAlerts.timeTrackingImpact.label')}
-                  disableScrollIntoView
-                >
-                  {t('commissionAlerts.timeTrackingImpact.intro')}
-                  <Components.UnorderedList
-                    items={[
-                      t('commissionAlerts.timeTrackingImpact.items.notEligibleForTimeTracking'),
-                      t('commissionAlerts.timeTrackingImpact.items.overtimeNotRetroactive'),
-                    ]}
-                  />
-                </Components.Alert>
-                {watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_EXEMPT && (
-                  <Components.Alert
-                    status="warning"
-                    label={t('commissionAlerts.federalMinimumPay.label')}
-                    disableScrollIntoView
-                  >
-                    {t('commissionAlerts.federalMinimumPay.body')}
-                  </Components.Alert>
-                )}
-                {watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_NONEXEMPT && (
-                  <Components.Alert
-                    status="warning"
-                    label={t('commissionAlerts.minimumWage.label')}
-                    disableScrollIntoView
-                  >
-                    <Trans
-                      t={t}
-                      i18nKey="commissionAlerts.minimumWage.body"
-                      components={{
-                        minimumWageLink: (
-                          <Components.Link
-                            href="https://support.gusto.com/article/112472520100000/manage-tip-wages-distributed-service-charges-and-tip-credits-in-gusto-for-admins"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          />
-                        ),
-                      }}
-                    />
-                  </Components.Alert>
-                )}
-              </Flex>
+            {compensationForm.status.showCommissionFederalMinimumPayAlert && (
+              <Components.Alert
+                status="warning"
+                label={t('commissionAlerts.federalMinimumPay.label')}
+                disableScrollIntoView
+              >
+                {t('commissionAlerts.federalMinimumPay.body')}
+              </Components.Alert>
+            )}
+            {compensationForm.status.showCommissionMinimumWageAlert && (
+              <Components.Alert
+                status="warning"
+                label={t('commissionAlerts.minimumWage.label')}
+                disableScrollIntoView
+              >
+                <Trans
+                  t={t}
+                  i18nKey="commissionAlerts.minimumWage.body"
+                  components={{
+                    minimumWageLink: (
+                      <Components.Link
+                        href="https://support.gusto.com/article/112472520100000/manage-tip-wages-distributed-service-charges-and-tip-credits-in-gusto-for-admins"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      />
+                    ),
+                  }}
+                />
+              </Components.Alert>
             )}
           </>
         )}
 
-        {watchedFlsaStatus !== FlsaStatus.COMMISSION_ONLY_EXEMPT &&
-          watchedFlsaStatus !== FlsaStatus.COMMISSION_ONLY_NONEXEMPT && (
-            <>
-              <CompFields.Rate
-                label={t('management.wageLabel')}
-                validationMessages={{
-                  REQUIRED: t('validations.rate'),
-                  RATE_MINIMUM: t('validations.nonZeroRate'),
-                  RATE_EXEMPT_THRESHOLD: t('validations.rateExemptThreshold', {
-                    limit: format(FLSA_OVERTIME_SALARY_LIMIT),
-                  }),
-                }}
-                formHookResult={compensationForm}
-              />
+        {CompFields.Rate && (
+          <CompFields.Rate
+            label={t('management.wageLabel')}
+            validationMessages={{
+              REQUIRED: t('validations.rate'),
+              RATE_MINIMUM: t('validations.nonZeroRate'),
+              RATE_EXEMPT_THRESHOLD: t('validations.rateExemptThreshold', {
+                limit: format(FLSA_OVERTIME_SALARY_LIMIT),
+              }),
+            }}
+            formHookResult={compensationForm}
+          />
+        )}
 
-              <CompFields.PaymentUnit
-                label={t('management.wageFrequencyLabel')}
-                description={t('paymentUnitDescription')}
-                validationMessages={{ REQUIRED: t('validations.paymentUnit') }}
-                getOptionLabel={(unit: PaymentUnit) => t(`paymentUnitOptions.${unit}` as const)}
-                formHookResult={compensationForm}
-              />
-            </>
-          )}
+        {CompFields.PaymentUnit && (
+          <CompFields.PaymentUnit
+            label={t('management.wageFrequencyLabel')}
+            description={t('paymentUnitDescription')}
+            validationMessages={{ REQUIRED: t('validations.paymentUnit') }}
+            getOptionLabel={(unit: PaymentUnit) => t(`paymentUnitOptions.${unit}` as const)}
+            formHookResult={compensationForm}
+          />
+        )}
 
         {CompFields.EffectiveDate && (
           <CompFields.EffectiveDate

--- a/src/components/Employee/Compensation/onboarding/Compensation.test.tsx
+++ b/src/components/Employee/Compensation/onboarding/Compensation.test.tsx
@@ -47,7 +47,7 @@ describe('Compensation', () => {
       })
       expect(employmentTypeControl).toBeInTheDocument()
 
-      const compensationAmountInput = screen.getByLabelText('Compensation amount')
+      const compensationAmountInput = screen.getByLabelText('Wage')
       expect(compensationAmountInput).toBeInTheDocument()
       expect(compensationAmountInput).toHaveValue('0.00')
 
@@ -104,7 +104,7 @@ describe('Compensation', () => {
       })
       await user.click(hourlyOption)
 
-      const compensationAmountInput = screen.getByLabelText('Compensation amount')
+      const compensationAmountInput = screen.getByLabelText('Wage')
       await user.clear(compensationAmountInput)
       await user.type(compensationAmountInput, '50000')
       await user.tab()
@@ -142,7 +142,7 @@ describe('Compensation', () => {
       })
       await user.click(exemptOption)
 
-      const compensationAmountInput = screen.getByLabelText('Compensation amount')
+      const compensationAmountInput = screen.getByLabelText('Wage')
       await user.clear(compensationAmountInput)
       await user.type(compensationAmountInput, '60000')
       await user.tab()
@@ -225,7 +225,7 @@ describe('Compensation', () => {
       const jobTitleInput = screen.getByLabelText('Job Title')
       await user.type(jobTitleInput, 'My Job')
 
-      const compensationAmountInput = screen.getByLabelText('Compensation amount')
+      const compensationAmountInput = screen.getByLabelText('Wage')
       await user.clear(compensationAmountInput)
       await user.type(compensationAmountInput, '50')
       await user.tab()
@@ -341,7 +341,7 @@ describe('Compensation', () => {
       })
       expect(employmentTypeControl).toBeInTheDocument()
 
-      const compensationAmountInput = screen.getByLabelText('Compensation amount')
+      const compensationAmountInput = screen.getByLabelText('Wage')
       expect(compensationAmountInput).toBeInTheDocument()
       expect(compensationAmountInput).toHaveValue('100,000.00')
 
@@ -861,7 +861,7 @@ describe('Compensation', () => {
       })
       await user.click(exemptOption)
 
-      const compensationAmountInput = screen.getByLabelText('Compensation amount')
+      const compensationAmountInput = screen.getByLabelText('Wage')
       await user.clear(compensationAmountInput)
 
       const continueButton = screen.getByRole('button', {
@@ -893,7 +893,7 @@ describe('Compensation', () => {
       })
       await user.click(exemptOption)
 
-      const compensationAmountInput = screen.getByLabelText('Compensation amount')
+      const compensationAmountInput = screen.getByLabelText('Wage')
       await user.clear(compensationAmountInput)
       await user.type(compensationAmountInput, '0')
 
@@ -926,7 +926,7 @@ describe('Compensation', () => {
       })
       await user.click(exemptOption)
 
-      const compensationAmountInput = screen.getByLabelText('Compensation amount')
+      const compensationAmountInput = screen.getByLabelText('Wage')
       await user.clear(compensationAmountInput)
       await user.type(compensationAmountInput, '0')
 
@@ -1000,7 +1000,7 @@ describe('Compensation', () => {
       await user.type(screen.getByLabelText('Job Title'), 'My Job')
       await user.click(screen.getByRole('button', { name: /Select an item/i }))
       await user.click(screen.getByRole('option', { name: 'Paid by the hour' }))
-      const amount = screen.getByLabelText('Compensation amount')
+      const amount = screen.getByLabelText('Wage')
       await user.clear(amount)
       await user.type(amount, '50')
       await user.tab()
@@ -1216,7 +1216,7 @@ describe('Compensation', () => {
       await screen.findByRole('heading', { name: 'Add job' })
 
       await user.type(screen.getByLabelText('Job Title'), 'My Job')
-      const amount = screen.getByLabelText('Compensation amount')
+      const amount = screen.getByLabelText('Wage')
       await user.clear(amount)
       await user.type(amount, '50')
       await user.tab()

--- a/src/components/Employee/Compensation/shared/AddCompensationFormBody.tsx
+++ b/src/components/Employee/Compensation/shared/AddCompensationFormBody.tsx
@@ -87,25 +87,61 @@ export function AddCompensationFormBody({
         />
       )}
 
-      <CompFields.Rate
-        label={t('amount')}
-        validationMessages={{
-          REQUIRED: t('validations.rate'),
-          RATE_MINIMUM: t('validations.nonZeroRate'),
-          RATE_EXEMPT_THRESHOLD: t('validations.rateExemptThreshold', {
-            limit: format(FLSA_OVERTIME_SALARY_LIMIT),
-          }),
-        }}
-        formHookResult={compensationForm}
-      />
+      {compensationForm.status.showCommissionFederalMinimumPayAlert && (
+        <Components.Alert
+          status="warning"
+          label={t('commissionAlerts.federalMinimumPay.label')}
+          disableScrollIntoView
+        >
+          {t('commissionAlerts.federalMinimumPay.body')}
+        </Components.Alert>
+      )}
 
-      <CompFields.PaymentUnit
-        label={t('paymentUnitLabel')}
-        description={t('paymentUnitDescription')}
-        validationMessages={{ REQUIRED: t('validations.paymentUnit') }}
-        getOptionLabel={(unit: PaymentUnit) => t(`paymentUnitOptions.${unit}`)}
-        formHookResult={compensationForm}
-      />
+      {compensationForm.status.showCommissionMinimumWageAlert && (
+        <Components.Alert
+          status="warning"
+          label={t('commissionAlerts.minimumWage.label')}
+          disableScrollIntoView
+        >
+          <Trans
+            t={t}
+            i18nKey="commissionAlerts.minimumWage.body"
+            components={{
+              minimumWageLink: (
+                <Components.Link
+                  href="https://support.gusto.com/article/112472520100000/manage-tip-wages-distributed-service-charges-and-tip-credits-in-gusto-for-admins"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              ),
+            }}
+          />
+        </Components.Alert>
+      )}
+
+      {CompFields.Rate && (
+        <CompFields.Rate
+          label={t('amount')}
+          validationMessages={{
+            REQUIRED: t('validations.rate'),
+            RATE_MINIMUM: t('validations.nonZeroRate'),
+            RATE_EXEMPT_THRESHOLD: t('validations.rateExemptThreshold', {
+              limit: format(FLSA_OVERTIME_SALARY_LIMIT),
+            }),
+          }}
+          formHookResult={compensationForm}
+        />
+      )}
+
+      {CompFields.PaymentUnit && (
+        <CompFields.PaymentUnit
+          label={t('paymentUnitLabel')}
+          description={t('paymentUnitDescription')}
+          validationMessages={{ REQUIRED: t('validations.paymentUnit') }}
+          getOptionLabel={(unit: PaymentUnit) => t(`paymentUnitOptions.${unit}`)}
+          formHookResult={compensationForm}
+        />
+      )}
 
       {CompFields.AdjustForMinimumWage && (
         <CompFields.AdjustForMinimumWage

--- a/src/components/Employee/Compensation/shared/AddCompensationFormBody.tsx
+++ b/src/components/Employee/Compensation/shared/AddCompensationFormBody.tsx
@@ -119,9 +119,17 @@ export function AddCompensationFormBody({
         </Components.Alert>
       )}
 
+      {compensationForm.status.showOwnerSalaryAlert && (
+        <Components.Alert
+          status="info"
+          label={t('commissionAlerts.ownerSalary.label')}
+          disableScrollIntoView
+        />
+      )}
+
       {CompFields.Rate && (
         <CompFields.Rate
-          label={t('amount')}
+          label={t('wageLabel')}
           validationMessages={{
             REQUIRED: t('validations.rate'),
             RATE_MINIMUM: t('validations.nonZeroRate'),
@@ -135,7 +143,7 @@ export function AddCompensationFormBody({
 
       {CompFields.PaymentUnit && (
         <CompFields.PaymentUnit
-          label={t('paymentUnitLabel')}
+          label={t('wageFrequencyLabel')}
           description={t('paymentUnitDescription')}
           validationMessages={{ REQUIRED: t('validations.paymentUnit') }}
           getOptionLabel={(unit: PaymentUnit) => t(`paymentUnitOptions.${unit}`)}

--- a/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.test.tsx
+++ b/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.test.tsx
@@ -799,6 +799,70 @@ describe('useCompensationForm', () => {
       })
     })
 
+    it('exposes commission-only alert flags and hides Rate/PaymentUnit fields by FLSA status', async () => {
+      server.use(
+        handleGetEmployeeJobs(() =>
+          HttpResponse.json(buildEmployeeWithJobs({ scenario: 'singleExempt' })),
+        ),
+      )
+      const { result } = renderHook(
+        () =>
+          useCompensationForm({
+            employeeId: 'employee-uuid',
+            jobId: 'job-uuid',
+            compensationId: 'compensation-uuid',
+          }),
+        { wrapper: GustoTestProvider },
+      )
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+      assertReady(result.current)
+      const { formMethods } = result.current.form.hookFormInternals
+
+      expect(result.current.status).toMatchObject({
+        showCommissionFederalMinimumPayAlert: false,
+        showCommissionMinimumWageAlert: false,
+      })
+      expect(typeof result.current.form.Fields.Rate).toBe('function')
+      expect(typeof result.current.form.Fields.PaymentUnit).toBe('function')
+
+      act(() => {
+        formMethods.setValue('flsaStatus', FlsaStatus.COMMISSION_ONLY_EXEMPT)
+      })
+      await waitFor(() => {
+        assertReady(result.current)
+        expect(result.current.status.showCommissionFederalMinimumPayAlert).toBe(true)
+        expect(result.current.status.showCommissionMinimumWageAlert).toBe(false)
+        expect(result.current.form.Fields.Rate).toBeUndefined()
+        expect(result.current.form.Fields.PaymentUnit).toBeUndefined()
+        expect(result.current.form.fieldsMetadata.rate?.isDisabled).toBe(true)
+        expect(result.current.form.fieldsMetadata.paymentUnit?.isDisabled).toBe(true)
+      })
+
+      act(() => {
+        formMethods.setValue('flsaStatus', FlsaStatus.COMMISSION_ONLY_NONEXEMPT)
+      })
+      await waitFor(() => {
+        assertReady(result.current)
+        expect(result.current.status.showCommissionFederalMinimumPayAlert).toBe(false)
+        expect(result.current.status.showCommissionMinimumWageAlert).toBe(true)
+        expect(result.current.form.Fields.Rate).toBeUndefined()
+        expect(result.current.form.Fields.PaymentUnit).toBeUndefined()
+      })
+
+      act(() => {
+        formMethods.setValue('flsaStatus', FlsaStatus.EXEMPT)
+      })
+      await waitFor(() => {
+        assertReady(result.current)
+        expect(result.current.status.showCommissionFederalMinimumPayAlert).toBe(false)
+        expect(result.current.status.showCommissionMinimumWageAlert).toBe(false)
+        expect(typeof result.current.form.Fields.Rate).toBe('function')
+        expect(typeof result.current.form.Fields.PaymentUnit).toBe('function')
+      })
+    })
+
     it('resets adjustForMinimumWage and minimumWageId when FLSA leaves Nonexempt', async () => {
       // Min-wage adjustment is API-side gated to flsa_status: Nonexempt, but
       // because Fields.AdjustForMinimumWage / MinimumWageId stop rendering as

--- a/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.test.tsx
+++ b/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.test.tsx
@@ -823,6 +823,7 @@ describe('useCompensationForm', () => {
       expect(result.current.status).toMatchObject({
         showCommissionFederalMinimumPayAlert: false,
         showCommissionMinimumWageAlert: false,
+        showOwnerSalaryAlert: false,
       })
       expect(typeof result.current.form.Fields.Rate).toBe('function')
       expect(typeof result.current.form.Fields.PaymentUnit).toBe('function')
@@ -852,12 +853,23 @@ describe('useCompensationForm', () => {
       })
 
       act(() => {
+        formMethods.setValue('flsaStatus', FlsaStatus.OWNER)
+      })
+      await waitFor(() => {
+        assertReady(result.current)
+        expect(result.current.status.showOwnerSalaryAlert).toBe(true)
+        expect(result.current.status.showCommissionFederalMinimumPayAlert).toBe(false)
+        expect(result.current.status.showCommissionMinimumWageAlert).toBe(false)
+      })
+
+      act(() => {
         formMethods.setValue('flsaStatus', FlsaStatus.EXEMPT)
       })
       await waitFor(() => {
         assertReady(result.current)
         expect(result.current.status.showCommissionFederalMinimumPayAlert).toBe(false)
         expect(result.current.status.showCommissionMinimumWageAlert).toBe(false)
+        expect(result.current.status.showOwnerSalaryAlert).toBe(false)
         expect(typeof result.current.form.Fields.Rate).toBe('function')
         expect(typeof result.current.form.Fields.PaymentUnit).toBe('function')
       })

--- a/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.tsx
+++ b/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.tsx
@@ -97,8 +97,8 @@ export interface UseCompensationFormProps {
 export interface CompensationFormFields {
   Title: typeof TitleField
   FlsaStatus: typeof FlsaStatusField | undefined
-  Rate: typeof RateField
-  PaymentUnit: typeof PaymentUnitField
+  Rate: typeof RateField | undefined
+  PaymentUnit: typeof PaymentUnitField | undefined
   AdjustForMinimumWage: typeof AdjustForMinimumWageField | undefined
   MinimumWageId: typeof MinimumWageIdField | undefined
   EffectiveDate: typeof EffectiveDateField | undefined
@@ -145,6 +145,22 @@ export interface UseCompensationFormReady extends BaseFormHookReady<
      * this flag — no separate confirmation step is needed.
      */
     willDeleteSecondaryJobs: boolean
+    /**
+     * True when the current `flsaStatus` is `COMMISSION_ONLY_EXEMPT`
+     * (Commission Only/No Overtime). Render the federal-minimum-pay
+     * warning alert when this flag is true. While this flag is true,
+     * `Fields.Rate` and `Fields.PaymentUnit` are also `undefined` (the
+     * hook forces `rate=0`, `paymentUnit=YEAR` on the form values).
+     */
+    showCommissionFederalMinimumPayAlert: boolean
+    /**
+     * True when the current `flsaStatus` is `COMMISSION_ONLY_NONEXEMPT`
+     * (Commission Only/Eligible for overtime). Render the local-minimum-wage
+     * warning alert when this flag is true. While this flag is true,
+     * `Fields.Rate` and `Fields.PaymentUnit` are also `undefined` (the
+     * hook forces `rate=0`, `paymentUnit=YEAR` on the form values).
+     */
+    showCommissionMinimumWageAlert: boolean
   }
   actions: {
     onSubmit: (
@@ -707,6 +723,8 @@ export function useCompensationForm({
       isPending,
       mode,
       willDeleteSecondaryJobs,
+      showCommissionFederalMinimumPayAlert: watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_EXEMPT,
+      showCommissionMinimumWageAlert: watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_NONEXEMPT,
     },
     actions: { onSubmit },
     errorHandling,
@@ -714,8 +732,8 @@ export function useCompensationForm({
       Fields: {
         Title: TitleField,
         FlsaStatus: isFlsaSelectionEnabled ? FlsaStatusField : undefined,
-        Rate: RateField,
-        PaymentUnit: PaymentUnitField,
+        Rate: isCommissionOnly ? undefined : RateField,
+        PaymentUnit: isCommissionOnly ? undefined : PaymentUnitField,
         AdjustForMinimumWage: isAdjustMinimumWageEnabled ? AdjustForMinimumWageField : undefined,
         MinimumWageId:
           isAdjustMinimumWageEnabled && watchedAdjustForMinimumWage

--- a/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.tsx
+++ b/src/components/Employee/Compensation/shared/useCompensationForm/useCompensationForm.tsx
@@ -161,6 +161,13 @@ export interface UseCompensationFormReady extends BaseFormHookReady<
      * hook forces `rate=0`, `paymentUnit=YEAR` on the form values).
      */
     showCommissionMinimumWageAlert: boolean
+    /**
+     * True when the current `flsaStatus` is `OWNER` (Owner's draw). Render
+     * an informational alert reminding partners that the IRS requires
+     * S-corp owners to pay themselves a reasonable salary for similar
+     * work before taking distributions.
+     */
+    showOwnerSalaryAlert: boolean
   }
   actions: {
     onSubmit: (
@@ -725,6 +732,7 @@ export function useCompensationForm({
       willDeleteSecondaryJobs,
       showCommissionFederalMinimumPayAlert: watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_EXEMPT,
       showCommissionMinimumWageAlert: watchedFlsaStatus === FlsaStatus.COMMISSION_ONLY_NONEXEMPT,
+      showOwnerSalaryAlert: watchedFlsaStatus === FlsaStatus.OWNER,
     },
     actions: { onSubmit },
     errorHandling,

--- a/src/components/Employee/OnboardingFlow/OnboardingFlow.test.tsx
+++ b/src/components/Employee/OnboardingFlow/OnboardingFlow.test.tsx
@@ -145,7 +145,7 @@ describe('EmployeeOnboardingFlow', () => {
       await user.type(await screen.findByLabelText(/job title/i), 'cat herder')
       await user.click(await screen.findByLabelText('Employee type'))
       await user.click(await screen.findByRole('option', { name: 'Paid by the hour' }))
-      await user.type(await screen.findByLabelText(/compensation amount/i), '100')
+      await user.type(await screen.findByLabelText(/^wage$/i), '100')
       await user.click(await screen.findByRole('button', { name: 'Continue' }))
 
       // Page - Compensation pt 2

--- a/src/i18n/en/Employee.Compensation.json
+++ b/src/i18n/en/Employee.Compensation.json
@@ -20,14 +20,6 @@
   "cancelNewJobCta": "Cancel",
   "classificationLink": "<ClassificationLink href=\"https://support.gusto.com/team-management/team-payments/pay-rates/1001671771/Employee-classification-options.htm\" target=\"_blank\">Learn more about employee classifications.</ClassificationLink>",
   "commissionAlerts": {
-    "timeTrackingImpact": {
-      "label": "This change may impact time tracking eligibility and overtime.",
-      "intro": "Before saving changes to employee type, keep in mind:",
-      "items": {
-        "notEligibleForTimeTracking": "Commission-only employees are not eligible for time tracking.",
-        "overtimeNotRetroactive": "Overtime eligibility changes won’t apply retroactively to time tracking, and overtime hours may require additional admin review."
-      }
-    },
     "federalMinimumPay": {
       "label": "Commission-only employees must earn the federal minimum pay",
       "body": "Federal laws say that employees not eligible for overtime should be paid at least $684 per week ($35,568 per year). You’ve classified this employee as not eligible for overtime—make sure they meet the Department of Labor’s definition of an exempt employee."

--- a/src/i18n/en/Employee.Compensation.json
+++ b/src/i18n/en/Employee.Compensation.json
@@ -19,6 +19,24 @@
   "cancelCta": "Cancel",
   "cancelNewJobCta": "Cancel",
   "classificationLink": "<ClassificationLink href=\"https://support.gusto.com/team-management/team-payments/pay-rates/1001671771/Employee-classification-options.htm\" target=\"_blank\">Learn more about employee classifications.</ClassificationLink>",
+  "commissionAlerts": {
+    "timeTrackingImpact": {
+      "label": "This change may impact time tracking eligibility and overtime.",
+      "intro": "Before saving changes to employee type, keep in mind:",
+      "items": {
+        "notEligibleForTimeTracking": "Commission-only employees are not eligible for time tracking.",
+        "overtimeNotRetroactive": "Overtime eligibility changes won’t apply retroactively to time tracking, and overtime hours may require additional admin review."
+      }
+    },
+    "federalMinimumPay": {
+      "label": "Commission-only employees must earn the federal minimum pay",
+      "body": "Federal laws say that employees not eligible for overtime should be paid at least $684 per week ($35,568 per year). You’ve classified this employee as not eligible for overtime—make sure they meet the Department of Labor’s definition of an exempt employee."
+    },
+    "minimumWage": {
+      "label": "Commission-only employees must earn at least the minimum wage",
+      "body": "To stay compliant, <minimumWageLink>check your local regulations</minimumWageLink>."
+    }
+  },
   "employeeClassification": "Employee type",
   "flsaStatusLabels": {
     "Commission Only Exempt": "Commission Only/No Overtime",

--- a/src/i18n/en/Employee.Compensation.json
+++ b/src/i18n/en/Employee.Compensation.json
@@ -14,7 +14,6 @@
     "tableLabel": "List of all jobs for the employee",
     "typeColumn": "Pay type"
   },
-  "amount": "Compensation amount",
   "backCta": "Back",
   "cancelCta": "Cancel",
   "cancelNewJobCta": "Cancel",
@@ -27,6 +26,9 @@
     "minimumWage": {
       "label": "Commission-only employees must earn at least the minimum wage",
       "body": "To stay compliant, <minimumWageLink>check your local regulations</minimumWageLink>."
+    },
+    "ownerSalary": {
+      "label": "The IRS requires owners of S corps to pay themselves a reasonable salary similar to others in the same role, before taking any distributions."
     }
   },
   "employeeClassification": "Employee type",
@@ -41,7 +43,8 @@
   "hamburgerTitle": "Job actions",
   "jobTitle": "Job Title",
   "paymentUnitDescription": "The period over which the compensation amount is tracked (e.g., hourly, daily, weekly, monthly, annually).",
-  "paymentUnitLabel": "Wage frequency",
+  "wageLabel": "Wage",
+  "wageFrequencyLabel": "Wage frequency",
   "paymentUnitOptions": {
     "Hour": "Hour",
     "Month": "Month",
@@ -61,8 +64,6 @@
   "management": {
     "editCompensationTitle": "Edit compensation",
     "jobTitleLabel": "Job title",
-    "wageLabel": "Wage",
-    "wageFrequencyLabel": "Wage frequency",
     "hireDateLabel": "Hire date",
     "twoPercentShareholderLabel": "This employee is a 2% shareholder",
     "saveCta": "Save"

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1351,6 +1351,24 @@ export interface EmployeeCompensation{
 "cancelCta":string;
 "cancelNewJobCta":string;
 "classificationLink":string;
+"commissionAlerts":{
+"timeTrackingImpact":{
+"label":string;
+"intro":string;
+"items":{
+"notEligibleForTimeTracking":string;
+"overtimeNotRetroactive":string;
+};
+};
+"federalMinimumPay":{
+"label":string;
+"body":string;
+};
+"minimumWage":{
+"label":string;
+"body":string;
+};
+};
 "employeeClassification":string;
 "flsaStatusLabels":{
 "Commission Only Exempt":string;

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1352,14 +1352,6 @@ export interface EmployeeCompensation{
 "cancelNewJobCta":string;
 "classificationLink":string;
 "commissionAlerts":{
-"timeTrackingImpact":{
-"label":string;
-"intro":string;
-"items":{
-"notEligibleForTimeTracking":string;
-"overtimeNotRetroactive":string;
-};
-};
 "federalMinimumPay":{
 "label":string;
 "body":string;

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1346,7 +1346,6 @@ export interface EmployeeCompensation{
 "tableLabel":string;
 "typeColumn":string;
 };
-"amount":string;
 "backCta":string;
 "cancelCta":string;
 "cancelNewJobCta":string;
@@ -1359,6 +1358,9 @@ export interface EmployeeCompensation{
 "minimumWage":{
 "label":string;
 "body":string;
+};
+"ownerSalary":{
+"label":string;
 };
 };
 "employeeClassification":string;
@@ -1373,7 +1375,8 @@ export interface EmployeeCompensation{
 "hamburgerTitle":string;
 "jobTitle":string;
 "paymentUnitDescription":string;
-"paymentUnitLabel":string;
+"wageLabel":string;
+"wageFrequencyLabel":string;
 "paymentUnitOptions":{
 "Hour":string;
 "Month":string;
@@ -1393,8 +1396,6 @@ export interface EmployeeCompensation{
 "management":{
 "editCompensationTitle":string;
 "jobTitleLabel":string;
-"wageLabel":string;
-"wageFrequencyLabel":string;
 "hireDateLabel":string;
 "twoPercentShareholderLabel":string;
 "saveCta":string;


### PR DESCRIPTION
## Summary

When a user selects a particular FLSA status on the compensation edit / add screens, the form now shows context-appropriate alerts and hides inputs that aren't meaningful for that status. The visibility logic lives entirely in `useCompensationForm`, so any partner consuming the hook (not just our screens) gets the same UX automatically. Also aligns the wage / wage-frequency input labels across the Add and Management screens.

## Changes

### FLSA-driven hook surface

`useCompensationForm` exposes three new reactive boolean flags on `status` (mirroring the existing `status.willDeleteSecondaryJobs` precedent):

- `showCommissionFederalMinimumPayAlert` — `true` when FLSA is `Commission Only Exempt`. Render the federal-minimum-pay warning.
- `showCommissionMinimumWageAlert` — `true` when FLSA is `Commission Only Nonexempt`. Render the local-minimum-wage warning (with support-article link).
- `showOwnerSalaryAlert` — `true` when FLSA is `Owner`. Render the IRS reasonable-salary reminder.

`Fields.Rate` and `Fields.PaymentUnit` are now exposed as `Field | undefined`, with both set to `undefined` when FLSA is either commission-only status. `fieldsMetadata.rate.isDisabled` / `paymentUnit.isDisabled` are left untouched so partners reading metadata directly still get the correct interaction signal.

### Screens

`ManagementCompensationFormBody` and `AddCompensationFormBody` both:

- Render the three new alerts gated on the corresponding `status.show*Alert` flags.
- Use the standard `{CompFields.X && <CompFields.X ... />}` pattern for `Rate` / `PaymentUnit`.
- No longer reach into the form's `useWatch` directly — they read the hook's published flags instead.

### Label alignment (breaking i18n change)

Consolidates the wage / wage-frequency input labels under top-level `wageLabel: "Wage"` and `wageFrequencyLabel: "Wage frequency"` i18n keys. The Add form previously rendered "Compensation amount"; it now matches the Management form's "Wage".

### Docs

`docs/hooks/useCompensationForm.md` updated to document the three new status flags, the conditional availability of `Fields.Rate` / `Fields.PaymentUnit`, and the realigned label keys in the usage example.

## BREAKING CHANGE

The following i18n keys in the `Employee.Compensation` namespace have been removed. Partners who override these via the `dictionary` prop on `GustoProvider` must migrate to the new keys:

| Removed key                       | Use instead                       |
| --------------------------------- | --------------------------------- |
| `amount`                          | `wageLabel`                       |
| `paymentUnitLabel`                | `wageFrequencyLabel`              |
| `management.wageLabel`            | `wageLabel`                       |
| `management.wageFrequencyLabel`   | `wageFrequencyLabel`              |

If you have not overridden any of these keys, no action is required — the SDK ships with the new keys populated.

## Demo

<!-- Add screenshots/recordings of each FLSA state -->

## Related

<!-- Jira/Figma links if applicable -->

## Testing

- Open `EditCompensation` / `EditPendingCompensation` / `AddAnotherJob` / onboarding `Compensation`.
- Cycle FLSA through each status:
  - `Commission Only/No Overtime`: federal-minimum-pay warning; wage and wage-frequency inputs hidden.
  - `Commission Only/Eligible for overtime`: minimum-wage warning with support link; wage and wage-frequency inputs hidden.
  - `Owner's draw`: IRS reasonable-salary info alert; wage-frequency input remains rendered but disabled and locked to `Paycheck`.
  - Other statuses: no contextual alerts; wage and wage-frequency render normally.
- Submit each commission-only state — request body carries `rate: "0"`, `payment_unit: "Year"` (hook-forced values).
- `npm run test -- --run src/components/Employee/Compensation` — 147 / 147 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)