### PR TITLE
fix(SDK-931): pin Current home address card to the active row

### DIFF
--- a/src/components/Employee/HomeAddress/management/HomeAddress.test.tsx
+++ b/src/components/Employee/HomeAddress/management/HomeAddress.test.tsx
@@ -173,4 +173,43 @@ describe('HomeAddress (management block)', () => {
     const reopenedDialog = await screen.findByRole('dialog')
     expect(within(reopenedDialog).queryByText("We couldn't save this address")).toBeNull()
   })
+
+  it('keeps the Current home address card pinned to the active row when editing a history row', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<HomeAddress employeeId="employee-123" onEvent={onEvent} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Manage' })).toBeEnabled()
+    })
+    await user.click(screen.getByRole('button', { name: 'Manage' }))
+
+    // Fixture: 100 5th Ave is active, 644 Fay Vista is in history.
+    await waitFor(
+      () => {
+        expect(screen.getByText(/100 5th Ave/)).toBeInTheDocument()
+      },
+      { timeout: 5000 },
+    )
+
+    const currentSection = screen
+      .getByRole('heading', { name: 'Current home address' })
+      .closest<HTMLElement>('[data-testid="data-box"]')
+    expect(currentSection).not.toBeNull()
+    expect(within(currentSection!).getByText(/100 5th Ave/)).toBeInTheDocument()
+
+    // Open Edit on the (inactive) history row via the kebab menu.
+    const menuButtons = screen.getAllByRole('button', {
+      name: 'Open address row actions',
+    })
+    await user.click(menuButtons[0] as HTMLElement)
+    await user.click(await screen.findByRole('menuitem', { name: 'Edit' }))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+
+    // The Current card must still show the active address — not the row being
+    // edited. Without the fix, the card mirrors whichever uuid the edit form
+    // is pointing at.
+    expect(within(currentSection!).getByText(/100 5th Ave/)).toBeInTheDocument()
+    expect(within(currentSection!).queryByText(/644 Fay Vista/)).toBeNull()
+  })
 })

--- a/src/components/Employee/HomeAddress/management/HomeAddressView.tsx
+++ b/src/components/Employee/HomeAddress/management/HomeAddressView.tsx
@@ -113,13 +113,19 @@ export function HomeAddressView({
   }, [addressModal])
 
   const {
-    data: { homeAddress },
     status: editStatus,
     actions: { onSubmit: editOnSubmit },
     form: editForm,
   } = editHomeAddressForm
 
   const homeAddresses = employeeHomeAddresses
+
+  // The "Current home address" card must always show the active address,
+  // independent of which row the edit modal is currently pointed at. Reading
+  // `editHomeAddressForm.data.homeAddress` (which mirrors whichever uuid is
+  // being edited) caused the card to mutate to the history row's content as
+  // soon as the user opened Edit from the kebab menu.
+  const currentHomeAddress = homeAddresses?.find(a => a.active === true) ?? homeAddresses?.[0]
 
   const {
     status: createStatus,
@@ -331,7 +337,7 @@ export function HomeAddressView({
           <Components.BoxHeader
             title={t('currentSectionTitle')}
             action={
-              homeAddress ? (
+              currentHomeAddress ? (
                 <Components.Button
                   variant="secondary"
                   onClick={() => {
@@ -360,18 +366,20 @@ export function HomeAddressView({
         }
       >
         <Flex flexDirection="column" gap={16}>
-          {homeAddress ? (
+          {currentHomeAddress ? (
             <Flex flexDirection="column" gap={4}>
               <FlexItem>
                 <Components.Text weight="medium">
-                  {formatStreetForDisplay(homeAddress)}
+                  {formatStreetForDisplay(currentHomeAddress)}
                 </Components.Text>
-                <Components.Text weight="medium">{getCityStateZip(homeAddress)}</Components.Text>
+                <Components.Text weight="medium">
+                  {getCityStateZip(currentHomeAddress)}
+                </Components.Text>
               </FlexItem>
-              {homeAddress.effectiveDate ? (
+              {currentHomeAddress.effectiveDate ? (
                 <Components.Text variant="supporting">
                   {t('currentSince', {
-                    date: formatDateLongWithYear(homeAddress.effectiveDate.toString()),
+                    date: formatDateLongWithYear(currentHomeAddress.effectiveDate.toString()),
                   })}
                 </Components.Text>
               ) : null}


### PR DESCRIPTION
## Summary

The **Current home address** card on the manage screen mutated to show whatever row the user had just opened **Edit** on. Repro: employee has a current SJ address and a future-dated SF address in the history table → click Edit on the SF history row → the Current card behind the modal flips to "SF" even though nothing has been saved.

Root cause: the card was rendering \`editHomeAddressForm.data.homeAddress\`, which is the address record the edit form is currently pointed at. \`editingHomeAddressUuid = editTargetUuid ?? currentHomeAddress?.uuid\`, so as soon as the kebab menu calls \`setEditAddressTarget(historyRow.uuid)\`, the edit form (and therefore the card source) reads the history row's data.

Fix: derive the displayed address for the card directly from the list query — \`employeeHomeAddresses.find(a => a.active) ?? employeeHomeAddresses[0]\` — same logic \`useHomeAddressManagement\` already uses to compute its own \`currentHomeAddress\`. The edit form's data is still used by the modal itself; only the card display is decoupled.

## Changes

- \`HomeAddressView.tsx\` — stop destructuring \`data.homeAddress\` from the edit form for the Current card. Compute a local \`currentHomeAddress\` from \`employeeHomeAddresses\` and use it for the card's title-row Edit button gate and body.
- \`HomeAddress.test.tsx\` — regression test: with the default two-row fixture (100 5th Ave active + 644 Fay Vista in history), open Edit on the history row via the kebab and assert the Current card still shows "100 5th Ave" (and not "644 Fay Vista"). Verified to fail on \`main\`.

## Related

- Jira: [SDK-931](https://gustohq.atlassian.net/browse/SDK-931)
- Epic: [SDK-517](https://gustohq.atlassian.net/browse/SDK-517) — Test Fest, Employee Dashboard

## Testing

- \`npm run test -- --run src/components/Employee/HomeAddress\` → 13/13 passed
- \`npx tsc --noEmit\` → clean
- Stashed only \`HomeAddressView.tsx\` and re-ran the new test → fails on \`main\`, confirming the test guards the regression.

Manual: \`npm run sdk-app\` → HomeAddress → create a future-dated change so a history row exists → click Edit on the future-dated row via the kebab → confirm the Current card still shows the active address.

[SDK-931]: https://gustohq.atlassian.net/browse/SDK-931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ