### PR TITLE
fix(SDK-945): stop showing "0% per paycheck" for fixed-cap garnishments

### DIFF
--- a/src/components/Employee/Deductions/onboarding/DeductionsList/DeductionsList.test.tsx
+++ b/src/components/Employee/Deductions/onboarding/DeductionsList/DeductionsList.test.tsx
@@ -83,6 +83,31 @@ describe('DeductionsList', () => {
     expect(onAdd).toHaveBeenCalledTimes(1)
   })
 
+  it('shows the dollar cap instead of "0%" for a percentage garnishment saved with only a payPeriodMaximum (SDK-945)', async () => {
+    const childSupport: Garnishment = {
+      ...buildDeduction('cs-1', 'Child Support'),
+      deductAsPercentage: true,
+      amount: '0',
+      payPeriodMaximum: '300',
+      recurring: true,
+    }
+    renderWithProviders(
+      <DeductionsList
+        deductionsList={buildReady([childSupport])}
+        onAdd={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onContinue={vi.fn()}
+      />,
+    )
+
+    await screen.findByText('Child Support')
+    // The fixed dollar cap the user entered is shown...
+    expect(screen.getByText(/300/)).toBeInTheDocument()
+    // ...and the misleading "0%" label is gone (the named behavior under test).
+    expect(screen.queryByText(/0\s*%/)).toBeNull()
+  })
+
   it('invokes onContinue when "Continue" is clicked', async () => {
     const onContinue = vi.fn()
     renderWithProviders(

--- a/src/components/Employee/Deductions/shared/formatDeductionAmount.test.ts
+++ b/src/components/Employee/Deductions/shared/formatDeductionAmount.test.ts
@@ -8,10 +8,14 @@ const formatters = {
   formatPerPaycheck: (value: string) => `${value} per paycheck`,
 }
 
-const baseDeduction: Pick<Garnishment, 'amount' | 'deductAsPercentage' | 'recurring'> = {
+const baseDeduction: Pick<
+  Garnishment,
+  'amount' | 'deductAsPercentage' | 'recurring' | 'payPeriodMaximum'
+> = {
   amount: '50',
   deductAsPercentage: false,
   recurring: false,
+  payPeriodMaximum: null,
 }
 
 describe('formatDeductionAmount', () => {
@@ -36,7 +40,10 @@ describe('formatDeductionAmount', () => {
 
   it('formats a recurring percentage deduction as percent with per-paycheck suffix', () => {
     expect(
-      formatDeductionAmount({ amount: '5', deductAsPercentage: true, recurring: true }, formatters),
+      formatDeductionAmount(
+        { amount: '5', deductAsPercentage: true, recurring: true, payPeriodMaximum: null },
+        formatters,
+      ),
     ).toBe('5% per paycheck')
   })
 
@@ -50,10 +57,49 @@ describe('formatDeductionAmount', () => {
     )
   })
 
+  // SDK-945: child-support garnishments are stored as deductAsPercentage:true
+  // even when the user only set a fixed dollar cap (payPeriodMaximum) and no
+  // percentage. The amount is then "0", which must not render as "0%".
+  it('shows the dollar cap (not "0%") for a percentage deduction with no percentage but a payPeriodMaximum', () => {
+    expect(
+      formatDeductionAmount(
+        { amount: '0', deductAsPercentage: true, recurring: true, payPeriodMaximum: '300' },
+        formatters,
+      ),
+    ).toBe('$300.00 per paycheck')
+  })
+
+  it('shows the dollar cap without suffix for a one-time percentage deduction with only a payPeriodMaximum', () => {
+    expect(
+      formatDeductionAmount(
+        { amount: '0', deductAsPercentage: true, recurring: false, payPeriodMaximum: '300' },
+        formatters,
+      ),
+    ).toBe('$300.00')
+  })
+
+  it('returns "-" for a percentage deduction with neither a percentage nor a payPeriodMaximum', () => {
+    expect(
+      formatDeductionAmount(
+        { amount: '0', deductAsPercentage: true, recurring: true, payPeriodMaximum: null },
+        formatters,
+      ),
+    ).toBe('-')
+  })
+
+  it('still formats a non-zero percentage normally even when a payPeriodMaximum is also set', () => {
+    expect(
+      formatDeductionAmount(
+        { amount: '25', deductAsPercentage: true, recurring: true, payPeriodMaximum: '300' },
+        formatters,
+      ),
+    ).toBe('25% per paycheck')
+  })
+
   it('routes the suffix through formatPerPaycheck so the caller owns the i18n template', () => {
     const formatPerPaycheck = vi.fn((value: string) => `${value} per paycheck`)
     formatDeductionAmount(
-      { amount: '100', deductAsPercentage: false, recurring: true },
+      { amount: '100', deductAsPercentage: false, recurring: true, payPeriodMaximum: null },
       { ...formatters, formatPerPaycheck },
     )
     expect(formatPerPaycheck).toHaveBeenCalledWith('$100.00')

--- a/src/components/Employee/Deductions/shared/formatDeductionAmount.ts
+++ b/src/components/Employee/Deductions/shared/formatDeductionAmount.ts
@@ -7,11 +7,26 @@ export interface DeductionAmountFormatters {
 }
 
 export function formatDeductionAmount(
-  deduction: Pick<Garnishment, 'amount' | 'deductAsPercentage' | 'recurring'>,
+  deduction: Pick<Garnishment, 'amount' | 'deductAsPercentage' | 'recurring' | 'payPeriodMaximum'>,
   { formatCurrency, formatPercent, formatPerPaycheck }: DeductionAmountFormatters,
 ): string {
   const numericAmount = Number(deduction.amount)
   if (Number.isNaN(numericAmount)) return '-'
+
+  // Child-support garnishments are always stored as `deductAsPercentage: true`,
+  // but the percentage is optional — a user may withhold only a fixed dollar
+  // amount (`payPeriodMaximum`). Rendering that as "0% per paycheck" is
+  // misleading (SDK-945). When there's no percentage, show the dollar cap the
+  // user actually entered, or "-" when neither is set.
+  if (deduction.deductAsPercentage && numericAmount === 0) {
+    const cap = Number(deduction.payPeriodMaximum ?? 0)
+    if (!Number.isNaN(cap) && cap > 0) {
+      const capFormatted = formatCurrency(cap)
+      return deduction.recurring ? formatPerPaycheck(capFormatted) : capFormatted
+    }
+    return '-'
+  }
+
   const formatted = deduction.deductAsPercentage
     ? formatPercent(numericAmount)
     : formatCurrency(numericAmount)


### PR DESCRIPTION
## Summary

A Child Support garnishment saved with only a "Total amount withheld" (a fixed dollar cap) and no percentage rendered as a misleading **"0% per paycheck"** in the deductions list and Job & pay.

**Root cause:** child-support garnishments are always persisted with `deductAsPercentage: true`, but the percentage is optional. When the user withholds only a fixed dollar amount (`payPeriodMaximum`) and leaves the percentage at `0`, `formatDeductionAmount` formatted the `0` as `0%`, ignoring the dollar cap the user actually entered.

## Changes

- `formatDeductionAmount.ts`: when a percentage deduction has no percentage (`amount` is 0), fall back to the `payPeriodMaximum` dollar cap (wrapped per-paycheck when recurring), or `-` when neither is set. All other cases are unchanged. Both display sites (`JobAndPayView`, `DeductionsList`) already pass the whole garnishment, so no call-site edits were needed.
- Tests: unit cases on the helper (cap fallback, "-" when nothing set, non-zero percentage unchanged) and an integration guard in `DeductionsList.test.tsx`.

## Scope

This addresses **part A only** — the misleading display. Whether the percentage and dollar-cap fields are independent / both-required / mutually exclusive (and clearer field labels) is a **product** question and remains open on SDK-945.

## Testing

- `npm run test -- --run src/components/Employee/Deductions/shared/formatDeductionAmount.test.ts src/components/Employee/Deductions/DeductionsList/DeductionsList.test.tsx` — 15 passed.
- `npm run tsc`, eslint, prettier — clean.

## Related

- Jira: SDK-945 (part A)
- Parent: SDK-517 — Employee Steady State Management Implementation - Milestone 1
- Source: Test Fest — Employee Dashboard (2026-05-21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)