### PR TITLE
fix: simplify payment method nickname cell rendering

### DIFF
--- a/src/components/Employee/PaymentMethod/management/PaymentMethodCard.tsx
+++ b/src/components/Employee/PaymentMethod/management/PaymentMethodCard.tsx
@@ -86,12 +86,12 @@ function PaymentMethodCardReady({
         key: 'name',
         title: t('nicknameColumn'),
         render: bankAccount => (
-          <Flex flexDirection="column" gap={0}>
-            <Components.Text>{bankAccount.name}</Components.Text>
-            <Components.Text variant="supporting">
+          <>
+            {bankAccount.name}
+            <Components.Text variant="supporting" size="sm">
               {bankAccount.hiddenAccountNumber}
             </Components.Text>
-          </Flex>
+          </>
         ),
       },
       { key: 'routingNumber', title: t('routingNumberColumn') },


### PR DESCRIPTION
## Summary

Drops the `Flex` wrapper from the nickname column in `PaymentMethodCard` and lets the bank account nickname inherit the table cell's default text styling. The hidden account number stays as a supporting `Text` but now renders at `size="sm"`.

## Changes

- Replace the `Flex` + `Text` wrapper around `bankAccount.name` with the plain string so the nickname renders using the table's default text style
- Add `size="sm"` to the supporting hidden-account-number `Text`

## Demo

<!-- Include screenshots or screen recordings showing the changes. Delete this section if not applicable -->

## Related

<!-- Link to relevant resources:
- Jira ticket: [SDK-XXX](https://gustohq.atlassian.net/browse/SDK-XXX)
- Figma: [Design link]
- Related PRs: #123
-->

## Testing

- Open the Payment Method card in Storybook / the SDK dev app
- Verify the nickname row shows the account name in the table's normal text style, with the hidden account number rendered smaller underneath

🤖 Generated with [Claude Code](https://claude.com/claude-code)