### PR TITLE
ci: preserve embedded-sdk-docs history on publish

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -76,21 +76,38 @@ jobs:
           repositories: embedded-sdk-docs
 
       # Hand-rolled push instead of peaceiris/actions-gh-pages because
-      # Gusto's org actions allowlist doesn't include it. Initializing a
-      # fresh repo inside docs-site/build/ and force-pushing means each
-      # publish replaces embedded-sdk-docs:main with a single-commit
-      # orphan history — no merge logic, no conflicts. The token is in an
-      # env var so the URL doesn't appear verbatim in command logs, and
-      # the App token is auto-redacted by Actions even if it did.
+      # Gusto's org actions allowlist doesn't include it. We clone the
+      # existing embedded-sdk-docs repo, replace its tracked files with
+      # the freshly built site, and add one commit per publish — so the
+      # docs repo accumulates a real release-by-release history instead
+      # of being overwritten by an orphan commit each time. The token is
+      # in an env var so the URL doesn't appear verbatim in command logs,
+      # and the App token is auto-redacted by Actions even if it did.
+      # `concurrency: publish-docs` above prevents overlapping pushes, so
+      # a non-force push is safe.
       - name: Push built site to embedded-sdk-docs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SDK_VERSION: ${{ steps.version.outputs.version }}
-        working-directory: docs-site/build
         run: |
-          git init -q -b main
+          git clone --depth 50 \
+            "https://x-access-token:$GH_TOKEN@github.com/Gusto/embedded-sdk-docs.git" \
+            docs-repo
+          cd docs-repo
           git config user.name "gusto-embedded-docs[bot]"
           git config user.email "gusto-embedded-docs[bot]@users.noreply.github.com"
-          git add .
+
+          # Wipe currently-tracked files (keeps .git intact), then copy
+          # the fresh build in. `git add -A` afterwards picks up both
+          # additions and deletions relative to the previous publish.
+          git ls-files -z | xargs -0 -r rm -f
+          find . -type d -empty -not -path './.git*' -delete
+          cp -R ../docs-site/build/. .
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No documentation changes since last publish; nothing to push."
+            exit 0
+          fi
           git commit -q -m "docs: publish SDK $SDK_VERSION"
-          git push --force "https://x-access-token:$GH_TOKEN@github.com/Gusto/embedded-sdk-docs.git" HEAD:main
+          git push origin main


### PR DESCRIPTION
## Summary

Changes the `Publish Docs` workflow's final step from "init a fresh repo and force-push an orphan commit" to "clone the existing repo, swap in the new build, and commit on top." Each release now appends to `embedded-sdk-docs:main` instead of wiping its history.

The pipeline scaffolding (Docusaurus build, App-token mint, gating on `DOCS_PUBLISH_ENABLED`, concurrency group) landed via #1988. This PR amends only the final push step.

## Why

The version in #1988 ran:
```
git init -q -b main
git add . && git commit ...
git push --force https://.../embedded-sdk-docs.git HEAD:main
```
That replaces `embedded-sdk-docs:main` with a single orphan commit per release. No release-to-release diff, no history, no rollback target.

## What this PR does

- Clone `Gusto/embedded-sdk-docs` (depth 50) instead of initializing a fresh repo.
- Wipe currently-tracked files (`git ls-files | xargs rm`) before copying in the new build, so deletions from the build are picked up.
- `git push origin main` — non-force. The `concurrency: publish-docs` group already serializes runs, so this is safe.
- Skip the commit + push when the build produces no diff against the previous publish (avoids empty `docs: publish $VERSION` commits on re-runs).

## Validation

Exercised on the branch via a temp `push:` trigger (since reverted, not on this PR's tip). Workflow run [27024973157](https://github.com/Gusto/embedded-react-sdk/actions/runs/27024973157) finished green in 1m41s and pushed a commit to `embedded-sdk-docs:main` with parent `9ad0eda` — confirmed additive via:

- `git fetch` reported `9ad0eda..2346d30 main -> origin/main` (two-dot fast-forward, not `+ ... (forced update)`).
- `git cat-file -p origin/main` on the new commit shows `parent 9ad0edaaec03273093a9a0829297dced1b88c8da`.
- `git merge-base --is-ancestor 9ad0eda 2346d30` → 0 (the prior tip is reachable from the new tip).

## Activation steps (deferred until after merge)

Unchanged from #1988:
1. Install the cross-repo publishing GitHub App on `Gusto/embedded-sdk-docs` with `Contents: write`.
2. In this repo's `publish-docs` environment, add `DOCS_APP_ID` and `DOCS_APP_PRIVATE_KEY`.
3. Run the workflow once via `workflow_dispatch` and confirm `embedded-sdk-docs:main` gains a new commit on top of the existing tip.
4. Set repo variable `DOCS_PUBLISH_ENABLED=true` to enable auto-publish on release.

## Note on current `embedded-sdk-docs:main` state

`origin/main` on the docs repo is currently down to two commits (`2346d30` from the validation run, `9ad0eda` from #1988's first manual run). The pre-orphan history is still reachable on side branches (`gh-pages`, `revert/deploy-pages-workflow`, `ci/restore-buildkite-publish`); decide whether to re-parent that onto `main` before flipping the activation gate so future publishes build on top of the full history rather than the orphan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)