### PR TITLE
ci: always commit on docs publish, even when site unchanged

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -104,10 +104,9 @@ jobs:
           find . -type d -empty -not -path './.git*' -delete
           cp -R ../docs-site/build/. .
 
+          # Always commit (even with no file changes) so every publish run
+          # leaves a release-marker in the docs repo's history, matching
+          # 1:1 with the NPM releases that triggered it.
           git add -A
-          if git diff --cached --quiet; then
-            echo "No documentation changes since last publish; nothing to push."
-            exit 0
-          fi
-          git commit -q -m "docs: publish SDK $SDK_VERSION"
+          git commit -q --allow-empty -m "docs: publish SDK $SDK_VERSION"
           git push origin main


### PR DESCRIPTION
## Summary

- Drop the early-exit when the built docs site matches the previous publish; use `git commit --allow-empty` so every Publish Docs run lands one commit in `Gusto/embedded-sdk-docs`.
- Keeps the docs repo's history 1:1 with the NPM releases that triggered it — manual `workflow_dispatch` reruns and zero-diff releases no longer leave the history out of sync (as seen in run [27026858588](https://github.com/Gusto/embedded-react-sdk/actions/runs/27026858588/job/79768967986), which completed green but didn't push).

## Test plan

- [ ] After merge, trigger `Publish Docs` manually via `workflow_dispatch` and confirm a new commit appears on `Gusto/embedded-sdk-docs@main` even though `docs-site/build` output hasn't changed since the previous run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)