### PR TITLE
docs(SDK-971): backfill phase 4

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -1023,9 +1023,12 @@ export const componentEvents: {
     readonly EMPLOYEE_FEDERAL_TAXES_EDIT: "employee/federalTaxes/edit";
     readonly EMPLOYEE_FEDERAL_TAXES_UPDATED: "employee/federalTaxes/updated";
     readonly EMPLOYEE_FEDERAL_TAXES_DONE: "employee/federalTaxes/done";
-    readonly EMPLOYEE_STATE_TAXES_EDIT: "employee/stateTaxes/edit";
     readonly EMPLOYEE_STATE_TAXES_UPDATED: "employee/stateTaxes/updated";
     readonly EMPLOYEE_STATE_TAXES_DONE: "employee/stateTaxes/done";
+    readonly EMPLOYEE_MANAGEMENT_STATE_TAXES_EDIT_REQUESTED: "employee/management/stateTaxes/editRequested";
+    readonly EMPLOYEE_MANAGEMENT_STATE_TAXES_EDIT_CANCELLED: "employee/management/stateTaxes/editCancelled";
+    readonly EMPLOYEE_MANAGEMENT_STATE_TAXES_UPDATED: "employee/management/stateTaxes/updated";
+    readonly EMPLOYEE_MANAGEMENT_STATE_TAXES_ALERT_DISMISSED: "employee/management/stateTaxes/alertDismissed";
     readonly EMPLOYEE_TAXES_DONE: "employee/taxes/done";
     readonly EMPLOYEE_SPLIT_PAYCHECK: "employee/bankAccount/split";
     readonly EMPLOYEE_JOB_CREATED: "employee/job/created";
@@ -1071,6 +1074,10 @@ export const componentEvents: {
     readonly EMPLOYEE_MANAGEMENT_DEDUCTIONS_EDIT_FORM_UPDATED: "employee/management/deductions/editForm/updated";
     readonly EMPLOYEE_MANAGEMENT_DEDUCTIONS_EDIT_FORM_CANCELLED: "employee/management/deductions/editForm/cancelled";
     readonly EMPLOYEE_MANAGEMENT_DEDUCTIONS_ALERT_DISMISSED: "employee/management/deductions/alertDismissed";
+    readonly EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_CARD_EDIT_REQUESTED: "employee/management/federalTaxes/card/editRequested";
+    readonly EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_EDIT_FORM_SUBMITTED: "employee/management/federalTaxes/editForm/submitted";
+    readonly EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_EDIT_FORM_CANCELLED: "employee/management/federalTaxes/editForm/cancelled";
+    readonly EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_ALERT_DISMISSED: "employee/management/federalTaxes/alertDismissed";
     readonly ROBOT_MACHINE_DONE: "done";
     readonly ERROR: "ERROR";
     readonly CANCEL: "CANCEL";
@@ -2055,9 +2062,17 @@ declare namespace EmployeeManagement {
         WorkAddressCardProps,
         WorkAddressEditFormProps,
         FederalTaxes_2 as FederalTaxes,
+        FederalTaxesCard,
+        FederalTaxesEditForm,
         FederalTaxesProps_2 as FederalTaxesProps,
+        FederalTaxesCardProps,
+        FederalTaxesEditFormProps,
         StateTaxes_2 as StateTaxes,
+        StateTaxesCard,
+        StateTaxesEditForm,
         StateTaxesProps_2 as StateTaxesProps,
+        StateTaxesCardProps,
+        StateTaxesEditFormProps,
         Profile_2 as Profile,
         ProfileCard,
         ProfileEditForm,
@@ -2213,12 +2228,44 @@ function FederalTaxes(props: FederalTaxesProps & BaseComponentInterface): JSX;
 // Warning: (ae-missing-release-tag) "FederalTaxes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-function FederalTaxes_2(input: FederalTaxesProps_2 & Pick<BaseComponentInterface, 'FallbackComponent'>): JSX;
+function FederalTaxes_2(input: FederalTaxesProps_2 & BaseComponentInterface<'Employee.Management.FederalTaxes'>): JSX;
 
 // Warning: (ae-missing-release-tag) "FederalTaxes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 function FederalTaxes_3(input: FederalTaxesProps_3 & Pick<BaseComponentInterface, 'FallbackComponent'>): JSX;
+
+// Warning: (ae-missing-release-tag) "FederalTaxesCard" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function FederalTaxesCard(input: FederalTaxesCardProps): JSX;
+
+// Warning: (ae-missing-release-tag) "FederalTaxesCardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface FederalTaxesCardProps {
+    // (undocumented)
+    employeeId: string;
+    // (undocumented)
+    onEvent: OnEventType<EventType, unknown>;
+}
+
+// Warning: (ae-missing-release-tag) "FederalTaxesEditForm" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+function FederalTaxesEditForm(input: FederalTaxesEditFormProps & Pick<BaseComponentInterface, 'FallbackComponent'>): JSX;
+
+// Warning: (ae-missing-release-tag) "FederalTaxesEditFormProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface FederalTaxesEditFormProps extends CommonComponentInterface<'Employee.Management.FederalTaxes'> {
+    // (undocumented)
+    defaultValues?: Partial<FederalTaxesFormData>;
+    // (undocumented)
+    employeeId: string;
+    // (undocumented)
+    onEvent: BaseComponentInterface['onEvent'];
+}
 
 // Warning: (ae-missing-release-tag) "FederalTaxesErrorCode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2299,13 +2346,11 @@ export type FederalTaxesOptionalFieldsToRequire = OptionalFieldsToRequire<typeof
 // Warning: (ae-missing-release-tag) "FederalTaxesProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-interface FederalTaxesProps_2 extends CommonComponentInterface<'Employee.FederalTaxes'> {
-    // (undocumented)
-    defaultValues?: Partial<FederalTaxesFormData>;
+interface FederalTaxesProps_2 extends CommonComponentInterface<'Employee.Management.FederalTaxes'> {
     // (undocumented)
     employeeId: string;
     // (undocumented)
-    onEvent: BaseComponentInterface['onEvent'];
+    onEvent: OnEventType<EventType, unknown>;
 }
 
 // Warning: (ae-missing-release-tag) "FederalTaxesProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4524,12 +4569,40 @@ function StateTaxes(input: StateTaxesProps): JSX;
 // Warning: (ae-missing-release-tag) "StateTaxes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-function StateTaxes_2(input: StateTaxesProps_2 & Pick<BaseComponentInterface, 'FallbackComponent'>): JSX;
+function StateTaxes_2(input: StateTaxesProps_2 & BaseComponentInterface<'Employee.Management.StateTaxes'>): JSX;
 
 // Warning: (ae-missing-release-tag) "StateTaxes" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 function StateTaxes_3(input: StateTaxesProps_3 & Pick<BaseComponentInterface, 'FallbackComponent'>): JSX;
+
+// Warning: (ae-missing-release-tag) "StateTaxesCard" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function StateTaxesCard(input: StateTaxesCardProps): JSX;
+
+// Warning: (ae-missing-release-tag) "StateTaxesCardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface StateTaxesCardProps {
+    // (undocumented)
+    employeeId: string;
+    // (undocumented)
+    onEvent: OnEventType<EventType, unknown>;
+}
+
+// Warning: (ae-missing-release-tag) "StateTaxesEditForm" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function StateTaxesEditForm(input: StateTaxesEditFormProps & Pick<BaseComponentInterface, 'FallbackComponent'>): JSX;
+
+// Warning: (ae-missing-release-tag) "StateTaxesEditFormProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+type StateTaxesEditFormProps = Omit<CommonComponentInterface<'Employee.Management.StateTaxes'>, 'children'> & {
+    employeeId: string;
+    onEvent: BaseComponentInterface['onEvent'];
+};
 
 // Warning: (ae-forgotten-export) The symbol "StateTaxesFormProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "StateTaxesForm" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4546,10 +4619,12 @@ function StateTaxesList(props: StateTaxesListProps): JSX;
 // Warning: (ae-missing-release-tag) "StateTaxesProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-type StateTaxesProps_2 = Omit<CommonComponentInterface<'Employee.StateTaxes'>, 'children'> & {
+interface StateTaxesProps_2 extends CommonComponentInterface<'Employee.Management.StateTaxes'> {
+    // (undocumented)
     employeeId: string;
-    onEvent: BaseComponentInterface['onEvent'];
-};
+    // (undocumented)
+    onEvent: OnEventType<EventType, unknown>;
+}
 
 // Warning: (ae-missing-release-tag) "StateTaxesProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -1047,8 +1047,6 @@ export const componentEvents: {
     readonly BREADCRUMB_NAVIGATE: "breadcrumb/navigate";
 };
 
-// Warning: (ae-missing-release-tag) "ComponentsContextType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export interface ComponentsContextType {
     Alert: (props: AlertProps) => JSX.Element | null;

--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -145,9 +145,7 @@ export { AfterSuccessContext }
 
 export { AfterSuccessHook }
 
-// Warning: (ae-missing-release-tag) "AlertProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface AlertProps {
     action?: ReactNode;
     children?: ReactNode;
@@ -216,9 +214,7 @@ export interface ApiProviderProps {
 // @public (undocumented)
 function AssignSignatory(props: AssignSignatoryProps): JSX;
 
-// Warning: (ae-missing-release-tag) "BadgeProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface BadgeProps extends Pick<HTMLAttributes<HTMLSpanElement>, 'className' | 'id' | 'aria-label'> {
     children: ReactNode;
     dismissAriaLabel?: string;
@@ -311,9 +307,7 @@ export interface BankFormSubmitOptions {
     employeeId?: string;
 }
 
-// Warning: (ae-missing-release-tag) "BannerProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface BannerProps extends Pick<HTMLAttributes<HTMLDivElement>, 'className' | 'id' | 'aria-label'> {
     children: ReactNode;
     status?: 'warning' | 'error';
@@ -360,39 +354,24 @@ export { BeforeRequestContext }
 
 export { BeforeRequestHook }
 
-// Warning: (ae-missing-release-tag) "BoxHeaderProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface BoxHeaderProps {
-    // (undocumented)
     action?: ReactNode;
-    // (undocumented)
     description?: ReactNode;
-    // (undocumented)
     headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-    // (undocumented)
     title: ReactNode;
 }
 
-// Warning: (ae-missing-release-tag) "BoxProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface BoxProps {
-    // (undocumented)
     children: ReactNode;
-    // (undocumented)
     className?: string;
-    // (undocumented)
     footer?: ReactNode;
-    // (undocumented)
     header?: ReactNode;
-    // (undocumented)
     withPadding?: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "BreadcrumbsProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface BreadcrumbsProps {
     'aria-label'?: string;
     // Warning: (ae-forgotten-export) The symbol "Breadcrumb" needs to be exported by the entry point index.d.ts
@@ -403,16 +382,12 @@ export interface BreadcrumbsProps {
     onClick?: (id: string) => void;
 }
 
-// Warning: (ae-missing-release-tag) "ButtonIconProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export type ButtonIconProps = ButtonProps & {
     'aria-label': string;
 };
 
-// Warning: (ae-missing-release-tag) "ButtonProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface ButtonProps extends Pick<ButtonHTMLAttributes<HTMLButtonElement>, 'name' | 'id' | 'className' | 'type' | 'onClick' | 'onKeyDown' | 'onKeyUp' | 'aria-label' | 'aria-labelledby' | 'aria-describedby' | 'form' | 'title' | 'tabIndex'> {
     buttonRef?: Ref<HTMLButtonElement>;
     children?: ReactNode;
@@ -424,9 +399,7 @@ export interface ButtonProps extends Pick<ButtonHTMLAttributes<HTMLButtonElement
     variant?: 'primary' | 'secondary' | 'tertiary' | 'error';
 }
 
-// Warning: (ae-missing-release-tag) "CalendarPreviewProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export type CalendarPreviewProps = {
     highlightDates?: Array<{
         date: Date;
@@ -440,9 +413,7 @@ export type CalendarPreviewProps = {
     };
 };
 
-// Warning: (ae-missing-release-tag) "CardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface CardProps {
     action?: ReactNode;
     children: ReactNode;
@@ -455,9 +426,7 @@ export interface CardProps {
 // @public (undocumented)
 export type CaseNumberFieldProps = HookFieldProps<TextInputHookFieldProps<ChildSupportGarnishmentRequiredValidation>>;
 
-// Warning: (ae-missing-release-tag) "CheckboxGroupOption" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface CheckboxGroupOption {
     description?: React.ReactNode;
     isDisabled?: boolean;
@@ -466,9 +435,8 @@ export interface CheckboxGroupOption {
 }
 
 // Warning: (ae-forgotten-export) The symbol "SharedFieldLayoutProps" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "CheckboxGroupProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export interface CheckboxGroupProps extends SharedFieldLayoutProps, Pick<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'className'> {
     inputRef?: Ref<HTMLInputElement>;
     isDisabled?: boolean;
@@ -492,9 +460,8 @@ export interface CheckboxHookFieldProps<TErrorCode extends string = never> exten
 }
 
 // Warning: (ae-forgotten-export) The symbol "SharedHorizontalFieldLayoutProps" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "CheckboxProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export interface CheckboxProps extends SharedHorizontalFieldLayoutProps, Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id' | 'className'> {
     inputRef?: Ref<HTMLInputElement>;
     isDisabled?: boolean;
@@ -607,17 +574,13 @@ export type CityFieldProps = HookFieldProps<TextInputHookFieldProps<HomeAddressR
 // @internal (undocumented)
 export function collectErrors(queries: QueryWithError[], submitError: SDKError | null): SDKError[];
 
-// Warning: (ae-missing-release-tag) "ComboBoxOption" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface ComboBoxOption {
     label: string;
     value: string;
 }
 
-// Warning: (ae-missing-release-tag) "ComboBoxProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface ComboBoxProps extends SharedFieldLayoutProps, Pick<InputHTMLAttributes<HTMLInputElement>, 'className' | 'id' | 'name' | 'placeholder'> {
     allowsCustomValue?: boolean;
     inputRef?: Ref<HTMLInputElement>;
@@ -1086,89 +1049,46 @@ export const componentEvents: {
 
 // Warning: (ae-missing-release-tag) "ComponentsContextType" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export interface ComponentsContextType {
-    // (undocumented)
     Alert: (props: AlertProps) => JSX.Element | null;
-    // (undocumented)
     Badge: (props: BadgeProps) => JSX.Element | null;
-    // (undocumented)
     Banner: (props: BannerProps) => JSX.Element | null;
-    // (undocumented)
     Box: (props: BoxProps) => JSX.Element | null;
-    // (undocumented)
     BoxHeader: (props: BoxHeaderProps) => JSX.Element | null;
-    // (undocumented)
     Breadcrumbs: (props: BreadcrumbsProps) => JSX.Element | null;
-    // (undocumented)
     Button: (props: ButtonProps) => JSX.Element | null;
-    // (undocumented)
     ButtonIcon: (props: ButtonIconProps) => JSX.Element | null;
-    // (undocumented)
     CalendarPreview: (props: CalendarPreviewProps) => JSX.Element | null;
-    // (undocumented)
     Card: (props: CardProps) => JSX.Element | null;
-    // (undocumented)
     Checkbox: (props: CheckboxProps) => JSX.Element | null;
-    // (undocumented)
     CheckboxGroup: (props: CheckboxGroupProps) => JSX.Element | null;
-    // (undocumented)
     ComboBox: (props: ComboBoxProps) => JSX.Element | null;
-    // (undocumented)
     DatePicker: (props: DatePickerProps) => JSX.Element | null;
-    // Warning: (ae-forgotten-export) The symbol "DateRangePickerProps" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     DateRangePicker: (props: DateRangePickerProps) => JSX.Element | null;
-    // (undocumented)
     DescriptionList: (props: DescriptionListProps) => JSX.Element | null;
-    // (undocumented)
     Dialog: (props: DialogProps) => JSX.Element | null;
-    // (undocumented)
     FileInput: (props: FileInputProps) => JSX.Element | null;
-    // (undocumented)
     Heading: (props: HeadingProps) => JSX.Element | null;
-    // (undocumented)
     Link: (props: LinkProps) => JSX.Element | null;
-    // (undocumented)
     LoadingSpinner: (props: LoadingSpinnerProps) => JSX.Element | null;
-    // (undocumented)
     Menu: (props: MenuProps) => JSX.Element | null;
-    // (undocumented)
     Modal: (props: ModalProps) => JSX.Element | null;
-    // Warning: (ae-forgotten-export) The symbol "MultiSelectComboBoxProps" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     MultiSelectComboBox: (props: MultiSelectComboBoxProps) => JSX.Element | null;
-    // (undocumented)
     NumberInput: (props: NumberInputProps) => JSX.Element | null;
-    // (undocumented)
     OrderedList: (props: OrderedListProps) => JSX.Element | null;
-    // (undocumented)
     PaginationControl?: (props: PaginationControlProps) => JSX.Element | null;
-    // (undocumented)
     PayrollLoading?: (props: PayrollLoadingProps) => JSX.Element | null;
-    // (undocumented)
     ProgressBar: (props: ProgressBarProps) => JSX.Element | null;
-    // (undocumented)
     Radio: (props: RadioProps) => JSX.Element | null;
-    // (undocumented)
     RadioGroup: (props: RadioGroupProps) => JSX.Element | null;
-    // (undocumented)
     Select: (props: SelectProps) => JSX.Element | null;
-    // (undocumented)
     Switch: (props: SwitchProps) => JSX.Element | null;
-    // (undocumented)
     Table: (props: TableProps) => JSX.Element | null;
-    // (undocumented)
     Tabs: (props: TabsProps) => JSX.Element | null;
-    // (undocumented)
     Text: (props: TextProps) => JSX.Element | null;
-    // (undocumented)
     TextArea: (props: TextAreaProps) => JSX.Element | null;
-    // (undocumented)
     TextInput: (props: TextInputProps) => JSX.Element | null;
-    // (undocumented)
     UnorderedList: (props: UnorderedListProps) => JSX.Element | null;
 }
 
@@ -1600,9 +1520,7 @@ export interface DatePickerHookFieldProps<TErrorCode extends string = never> ext
     validationMessages?: ValidationMessages<TErrorCode>;
 }
 
-// Warning: (ae-missing-release-tag) "DatePickerProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface DatePickerProps extends SharedFieldLayoutProps, Pick<InputHTMLAttributes<HTMLInputElement>, 'className' | 'id' | 'name'> {
     inputRef?: Ref<HTMLInputElement>;
     isDateDisabled?: (date: Date) => boolean;
@@ -1616,6 +1534,24 @@ export interface DatePickerProps extends SharedFieldLayoutProps, Pick<InputHTMLA
     placeholder?: string;
     portalContainer?: HTMLElement;
     value?: Date | null;
+}
+
+// @public
+export interface DateRange {
+    end: Date;
+    start: Date;
+}
+
+// @public
+export interface DateRangePickerProps {
+    endDateLabel: string;
+    label: string;
+    maxValue?: Date;
+    minValue?: Date;
+    onChange: (range: DateRange | null) => void;
+    shouldVisuallyHideLabel?: boolean;
+    startDateLabel: string;
+    value: DateRange | null;
 }
 
 // Warning: (ae-missing-release-tag) "DateStateTaxFieldProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1806,25 +1742,16 @@ export type DependentsAmountFieldProps = HookFieldProps<NumberInputHookFieldProp
 // @public (undocumented)
 export type DescriptionFieldProps = HookFieldProps<TextInputHookFieldProps<DeductionFormRequiredValidation>>;
 
-// Warning: (ae-missing-release-tag) "DescriptionListProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface DescriptionListProps {
-    // (undocumented)
     className?: string;
     // Warning: (ae-forgotten-export) The symbol "DescriptionListItem" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     items: DescriptionListItem[];
-    // (undocumented)
     layout?: 'stacked' | 'horizontal';
-    // (undocumented)
     showSeparators?: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "DialogProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface DialogProps {
     children?: ReactNode;
     closeActionLabel: string;
@@ -2394,9 +2321,7 @@ export type FieldsMetadata = {
     [key: string]: FieldMetadata | FieldMetadataWithOptions;
 };
 
-// Warning: (ae-missing-release-tag) "FileInputProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface FileInputProps extends Omit<SharedFieldLayoutProps, 'shouldVisuallyHideLabel'> {
     'aria-describedby'?: string;
     accept?: string[];
@@ -2556,9 +2481,7 @@ export interface GustoProviderProps {
     theme?: GustoSDKTheme;
 }
 
-// Warning: (ae-missing-release-tag) "HeadingProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface HeadingProps extends Pick<HTMLAttributes<HTMLHeadingElement>, 'className' | 'id'> {
     as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     children?: ReactNode;
@@ -2913,9 +2836,7 @@ function Landing(props: SummaryProps_2 & BaseComponentInterface): JSX;
 // @public (undocumented)
 export type LastNameFieldProps = HookFieldProps<TextInputHookFieldProps<NameValidation>>;
 
-// Warning: (ae-missing-release-tag) "LinkProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export type LinkProps = Pick<AnchorHTMLAttributes<HTMLAnchorElement>,
 /**
 * URL that the link points to
@@ -2968,9 +2889,7 @@ export type LinkProps = Pick<AnchorHTMLAttributes<HTMLAnchorElement>,
     children?: ReactNode;
 };
 
-// Warning: (ae-missing-release-tag) "LoadingSpinnerProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface LoadingSpinnerProps extends Pick<HTMLAttributes<HTMLDivElement>, 'className' | 'id' | 'aria-label'> {
     size?: 'lg' | 'sm';
     style?: 'inline' | 'block';
@@ -3005,9 +2924,8 @@ function ManagementEmployeeList(input: ManagementEmployeeListProps & BaseCompone
 export const MAX_PREPARERS = 4;
 
 // Warning: (ae-forgotten-export) The symbol "DataAttributes" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "MenuItem" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export interface MenuItem extends DataAttributes {
     href?: string;
     icon?: ReactNode;
@@ -3016,9 +2934,7 @@ export interface MenuItem extends DataAttributes {
     onClick: () => void;
 }
 
-// Warning: (ae-missing-release-tag) "MenuProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface MenuProps extends DataAttributes {
     'aria-label': string;
     isOpen?: boolean;
@@ -3046,9 +2962,7 @@ export type MixedErrorSource = QueryWithRefetch | {
     errorHandling: HookErrorHandling;
 };
 
-// Warning: (ae-missing-release-tag) "ModalProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface ModalProps {
     children?: ReactNode;
     containerRef?: React.RefObject<HTMLDivElement | null>;
@@ -3056,6 +2970,25 @@ export interface ModalProps {
     isOpen?: boolean;
     onClose?: () => void;
     shouldCloseOnBackdropClick?: boolean;
+}
+
+// @public
+export interface MultiSelectComboBoxOption {
+    label: string;
+    value: string;
+}
+
+// @public
+export interface MultiSelectComboBoxProps extends SharedFieldLayoutProps, Pick<InputHTMLAttributes<HTMLInputElement>, 'className' | 'id' | 'name' | 'placeholder'> {
+    inputRef?: Ref<HTMLInputElement>;
+    isDisabled?: boolean;
+    isInvalid?: boolean;
+    isLoading?: boolean;
+    label: string;
+    onBlur?: () => void;
+    onChange?: (values: string[]) => void;
+    options: MultiSelectComboBoxOption[];
+    value?: string[];
 }
 
 // Warning: (ae-missing-release-tag) "NameFieldProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3096,9 +3029,7 @@ export interface NumberInputHookFieldProps<TErrorCode extends string = never> ex
     validationMessages?: ValidationMessages<TErrorCode>;
 }
 
-// Warning: (ae-missing-release-tag) "NumberInputProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface NumberInputProps extends SharedFieldLayoutProps, Pick<InputHTMLAttributes<HTMLInputElement>, 'min' | 'max' | 'name' | 'id' | 'placeholder' | 'className'> {
     adornmentEnd?: InputProps['adornmentEnd'];
     // Warning: (ae-forgotten-export) The symbol "InputProps" needs to be exported by the entry point index.d.ts
@@ -3373,9 +3304,8 @@ function OnboardingOverview(props: OnboardingOverviewProps & BaseComponentInterf
 function OnboardingSummary(props: SummaryProps & BaseComponentInterface): JSX;
 
 // Warning: (ae-forgotten-export) The symbol "BaseListProps" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "OrderedListProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export type OrderedListProps = BaseListProps;
 
 // Warning: (ae-missing-release-tag) "OrderNumberFieldProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -3388,9 +3318,7 @@ export type OrderNumberFieldProps = HookFieldProps<TextInputHookFieldProps<Child
 // @public (undocumented)
 export type OtherIncomeFieldProps = HookFieldProps<NumberInputHookFieldProps<FederalTaxesRequiredValidation>>;
 
-// Warning: (ae-missing-release-tag) "PaginationControlProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export type PaginationControlProps = {
     handleFirstPage: () => void;
     handlePreviousPage: () => void;
@@ -3404,8 +3332,6 @@ export type PaginationControlProps = {
     isFetching?: boolean;
 };
 
-// Warning: (ae-missing-release-tag) "PaginationItemsPerPage" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type PaginationItemsPerPage = 5 | 10 | 25 | 50;
 
@@ -3742,9 +3668,7 @@ function PayrollLanding(props: PayrollLandingProps): JSX;
 // @public
 function PayrollList(props: PayrollListBlockProps): JSX;
 
-// Warning: (ae-missing-release-tag) "PayrollLoadingProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface PayrollLoadingProps {
     // (undocumented)
     description?: ReactNode;
@@ -4039,9 +3963,7 @@ interface ProfileProps_2 extends CommonComponentInterface<'Employee.Profile.Mana
     onEvent: OnEventType<EventType, unknown>;
 }
 
-// Warning: (ae-missing-release-tag) "ProgressBarProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface ProgressBarProps {
     className?: string;
     cta?: React.ComponentType | null;
@@ -4064,9 +3986,7 @@ export interface RadioGroupHookFieldProps<TErrorCode extends string = never, TEn
     validationMessages?: ValidationMessages<TErrorCode>;
 }
 
-// Warning: (ae-missing-release-tag) "RadioGroupOption" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface RadioGroupOption {
     description?: React.ReactNode;
     isDisabled?: boolean;
@@ -4074,9 +3994,7 @@ export interface RadioGroupOption {
     value: string;
 }
 
-// Warning: (ae-missing-release-tag) "RadioGroupProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface RadioGroupProps extends SharedFieldLayoutProps, Pick<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'className'> {
     defaultValue?: string;
     inputRef?: Ref<HTMLInputElement>;
@@ -4087,9 +4005,7 @@ export interface RadioGroupProps extends SharedFieldLayoutProps, Pick<FieldsetHT
     value?: string | null;
 }
 
-// Warning: (ae-missing-release-tag) "RadioProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface RadioProps extends SharedHorizontalFieldLayoutProps, Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id' | 'className' | 'onBlur'> {
     inputRef?: Ref<HTMLInputElement>;
     isDisabled?: boolean;
@@ -4212,17 +4128,13 @@ export interface SelectHookFieldProps<TErrorCode extends string = never, TEntry 
     validationMessages?: ValidationMessages<TErrorCode>;
 }
 
-// Warning: (ae-missing-release-tag) "SelectOption" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface SelectOption {
     label: string;
     value: string;
 }
 
-// Warning: (ae-missing-release-tag) "SelectProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface SelectProps extends SharedFieldLayoutProps, Pick<SelectHTMLAttributes<HTMLSelectElement>, 'id' | 'name' | 'className'> {
     inputRef?: Ref<HTMLButtonElement>;
     isDisabled?: boolean;
@@ -4729,9 +4641,7 @@ export interface SwitchHookFieldProps<TErrorCode extends string = never> extends
     validationMessages?: ValidationMessages<TErrorCode>;
 }
 
-// Warning: (ae-missing-release-tag) "SwitchProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface SwitchProps extends SharedHorizontalFieldLayoutProps, Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id'>, Pick<AriaAttributes, 'aria-controls'> {
     className?: string;
     inputRef?: Ref<HTMLInputElement>;
@@ -4743,17 +4653,13 @@ export interface SwitchProps extends SharedHorizontalFieldLayoutProps, Pick<Inpu
     value?: boolean;
 }
 
-// Warning: (ae-missing-release-tag) "TableData" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface TableData {
     content: ReactNode;
     key: string;
 }
 
-// Warning: (ae-missing-release-tag) "TableProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface TableProps extends Pick<TableHTMLAttributes<HTMLTableElement>, 'className' | 'aria-label' | 'id' | 'role' | 'aria-labelledby' | 'aria-describedby'> {
     emptyState?: ReactNode;
     footer?: TableData[];
@@ -4763,16 +4669,12 @@ export interface TableProps extends Pick<TableHTMLAttributes<HTMLTableElement>, 
     rows: TableRow[];
 }
 
-// Warning: (ae-missing-release-tag) "TableRow" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface TableRow {
     data: TableData[];
     key: string;
 }
 
-// Warning: (ae-missing-release-tag) "TabsProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export interface TabsProps {
     'aria-label'?: string;
@@ -4839,15 +4741,14 @@ interface TerminationSummaryProps extends BaseComponentInterface<'Employee.Termi
     payrollUuid?: string;
 }
 
-// Warning: (ae-missing-release-tag) "TextAreaProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export interface TextAreaProps extends SharedFieldLayoutProps, Pick<TextareaHTMLAttributes<HTMLTextAreaElement>, 'name' | 'id' | 'placeholder' | 'className' | 'rows' | 'cols'>, Pick<TextareaHTMLAttributes<HTMLTextAreaElement>, 'aria-describedby'> {
+// @public
+export interface TextAreaProps extends SharedFieldLayoutProps, Pick<TextareaHTMLAttributes<HTMLTextAreaElement>, 'name' | 'id' | 'placeholder' | 'className' | 'cols'>, Pick<TextareaHTMLAttributes<HTMLTextAreaElement>, 'aria-describedby'> {
     inputRef?: Ref<HTMLTextAreaElement>;
     isDisabled?: boolean;
     isInvalid?: boolean;
     onBlur?: () => void;
     onChange?: (value: string) => void;
+    rows?: number;
     value?: string;
 }
 
@@ -4866,9 +4767,7 @@ export interface TextInputHookFieldProps<TErrorCode extends string = never, TOpt
     validationMessages?: ValidationMessages<TErrorCode, TOptionalErrorCode>;
 }
 
-// Warning: (ae-missing-release-tag) "TextInputProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface TextInputProps extends SharedFieldLayoutProps, Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id' | 'placeholder' | 'className' | 'type' | 'min' | 'max' | 'maxLength'>, Pick<InputHTMLAttributes<HTMLInputElement>, 'aria-describedby' | 'aria-labelledby'> {
     adornmentEnd?: InputProps['adornmentEnd'];
     adornmentStart?: InputProps['adornmentStart'];
@@ -4880,9 +4779,7 @@ export interface TextInputProps extends SharedFieldLayoutProps, Pick<InputHTMLAt
     value?: string;
 }
 
-// Warning: (ae-missing-release-tag) "TextProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface TextProps extends Pick<HTMLAttributes<HTMLParagraphElement>, 'className' | 'id'> {
     as?: 'p' | 'span' | 'div' | 'pre';
     children?: ReactNode;
@@ -5064,9 +4961,7 @@ export type TwoPercentShareholderFieldProps = HookFieldProps<CheckboxHookFieldPr
 // @public (undocumented)
 export type TypeFieldProps = HookFieldProps<RadioGroupHookFieldProps<PaymentMethodFormRequiredValidation, PaymentMethodType>>;
 
-// Warning: (ae-missing-release-tag) "UnorderedListProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export type UnorderedListProps = BaseListProps;
 
 // Warning: (ae-missing-release-tag) "useBankForm" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/docs/component-adapter/component-inventory.md
+++ b/docs/component-adapter/component-inventory.md
@@ -18,6 +18,8 @@
 - [ComboBoxProps](#comboboxprops)
   - [ComboBoxOption](#comboboxoption)
 - [DatePickerProps](#datepickerprops)
+- [DateRangePickerProps](#daterangepickerprops)
+  - [DateRange](#daterange)
 - [DescriptionListProps](#descriptionlistprops)
   - [DescriptionListItem](#descriptionlistitem)
 - [DialogProps](#dialogprops)
@@ -28,6 +30,8 @@
 - [MenuProps](#menuprops)
   - [MenuItem](#menuitem)
 - [ModalProps](#modalprops)
+- [MultiSelectComboBoxProps](#multiselectcomboboxprops)
+  - [MultiSelectComboBoxOption](#multiselectcomboboxoption)
 - [NumberInputProps](#numberinputprops)
 - [OrderedListProps](#orderedlistprops)
 - [PaginationControlProps](#paginationcontrolprops)
@@ -99,22 +103,22 @@
 
 ## BoxHeaderProps
 
-| Prop             | Type                                           | Required | Description |
-| ---------------- | ---------------------------------------------- | -------- | ----------- |
-| **title**        | `React.ReactNode`                              | Yes      | -           |
-| **description**  | `React.ReactNode`                              | No       | -           |
-| **action**       | `React.ReactNode`                              | No       | -           |
-| **headingLevel** | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6"` | No       | -           |
+| Prop             | Type                                           | Required | Description                                                                 |
+| ---------------- | ---------------------------------------------- | -------- | --------------------------------------------------------------------------- |
+| **title**        | `React.ReactNode`                              | Yes      | Title content rendered as the heading.                                      |
+| **description**  | `React.ReactNode`                              | No       | Optional supporting description rendered below the title.                   |
+| **action**       | `React.ReactNode`                              | No       | Optional action content (e.g. a Button) rendered inline opposite the title. |
+| **headingLevel** | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6"` | No       | Semantic heading level for the title. Defaults to `h3`.                     |
 
 ## BoxProps
 
-| Prop            | Type              | Required | Description |
-| --------------- | ----------------- | -------- | ----------- |
-| **children**    | `React.ReactNode` | Yes      | -           |
-| **header**      | `React.ReactNode` | No       | -           |
-| **footer**      | `React.ReactNode` | No       | -           |
-| **withPadding** | `boolean`         | No       | -           |
-| **className**   | `string`          | No       | -           |
+| Prop            | Type              | Required | Description                                                                                                                                    |
+| --------------- | ----------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **children**    | `React.ReactNode` | Yes      | Content rendered inside the box body.                                                                                                          |
+| **header**      | `React.ReactNode` | No       | Optional content rendered above the body in the box header section.                                                                            |
+| **footer**      | `React.ReactNode` | No       | Optional content rendered below the body in the box footer section.                                                                            |
+| **withPadding** | `boolean`         | No       | Whether the body should apply the default inner padding. Defaults to true; set to false for content that needs to be flush with the box edges. |
+| **className**   | `string`          | No       | CSS className to be applied to the root element.                                                                                               |
 
 ## BreadcrumbsProps
 
@@ -129,11 +133,11 @@
 
 ### Breadcrumb
 
-| Prop            | Type              | Required | Description                                                                                         |
-| --------------- | ----------------- | -------- | --------------------------------------------------------------------------------------------------- |
-| **id**          | `string`          | Yes      | -                                                                                                   |
-| **label**       | `React.ReactNode` | Yes      | -                                                                                                   |
-| **isClickable** | `boolean`         | No       | When false, the breadcrumb is rendered as plain text even if onClick is provided. Defaults to true. |
+| Prop            | Type              | Required | Description                                                                                             |
+| --------------- | ----------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| **id**          | `string`          | Yes      | Unique identifier for the breadcrumb. Matches against `currentBreadcrumbId` and is passed to `onClick`. |
+| **label**       | `React.ReactNode` | Yes      | Display content rendered for the breadcrumb.                                                            |
+| **isClickable** | `boolean`         | No       | When false, the breadcrumb is rendered as plain text even if onClick is provided. Defaults to true.     |
 
 ## ButtonIconProps
 
@@ -302,21 +306,41 @@
 | **id**                      | `string`                        | No       | -                                                                                             |
 | **name**                    | `string`                        | No       | -                                                                                             |
 
+## DateRangePickerProps
+
+| Prop                        | Type                                               | Required | Description                                                                              |
+| --------------------------- | -------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------- |
+| **label**                   | `string`                                           | Yes      | Label text for the date range field.                                                     |
+| **shouldVisuallyHideLabel** | `boolean`                                          | No       | Hides the label visually while keeping it accessible to screen readers.                  |
+| **value**                   | `null \| [DateRange](#daterange)`                  | Yes      | Currently selected date range, or null when nothing is selected.                         |
+| **onChange**                | `(range: [DateRange](#daterange) \| null) => void` | Yes      | Callback fired when the selected range changes. Receives null when the range is cleared. |
+| **startDateLabel**          | `string`                                           | Yes      | Accessible label for the start-date input.                                               |
+| **endDateLabel**            | `string`                                           | Yes      | Accessible label for the end-date input.                                                 |
+| **minValue**                | `Date`                                             | No       | Earliest selectable date. Dates before this are disabled.                                |
+| **maxValue**                | `Date`                                             | No       | Latest selectable date. Dates after this are disabled.                                   |
+
+### DateRange
+
+| Prop      | Type   | Required | Description                         |
+| --------- | ------ | -------- | ----------------------------------- |
+| **start** | `Date` | Yes      | First date in the range, inclusive. |
+| **end**   | `Date` | Yes      | Last date in the range, inclusive.  |
+
 ## DescriptionListProps
 
-| Prop               | Type                                          | Required | Description |
-| ------------------ | --------------------------------------------- | -------- | ----------- |
-| **items**          | [DescriptionListItem](#descriptionlistitem)[] | Yes      | -           |
-| **layout**         | `"stacked" \| "horizontal"`                   | No       | -           |
-| **showSeparators** | `boolean`                                     | No       | -           |
-| **className**      | `string`                                      | No       | -           |
+| Prop               | Type                                          | Required | Description                                                                |
+| ------------------ | --------------------------------------------- | -------- | -------------------------------------------------------------------------- |
+| **items**          | [DescriptionListItem](#descriptionlistitem)[] | Yes      | Term/description pairs to render in order.                                 |
+| **layout**         | `"stacked" \| "horizontal"`                   | No       | Visual arrangement of each term/description pair. Defaults to `'stacked'`. |
+| **showSeparators** | `boolean`                                     | No       | Whether to render dividers between rows. Defaults to `true`.               |
+| **className**      | `string`                                      | No       | Additional class name applied to the root `<dl>`.                          |
 
 ### DescriptionListItem
 
-| Prop            | Type                                   | Required | Description |
-| --------------- | -------------------------------------- | -------- | ----------- |
-| **term**        | `React.ReactNode \| React.ReactNode[]` | Yes      | -           |
-| **description** | `React.ReactNode \| React.ReactNode[]` | Yes      | -           |
+| Prop            | Type                                   | Required | Description                                                                                           |
+| --------------- | -------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| **term**        | `React.ReactNode \| React.ReactNode[]` | Yes      | Term content (the `<dt>`). Pass an array to render multiple `<dt>` elements for the same description. |
+| **description** | `React.ReactNode \| React.ReactNode[]` | Yes      | Description content (the `<dd>`). Pass an array to render multiple `<dd>` elements for the same term. |
 
 ## DialogProps
 
@@ -422,6 +446,35 @@
 | **children**                   | `React.ReactNode` | No       | Main content to be rendered in the modal body            |
 | **footer**                     | `React.ReactNode` | No       | Footer content to be rendered at the bottom of the modal |
 | **containerRef**               | `RefObject`       | No       | Optional ref to the backdrop container                   |
+
+## MultiSelectComboBoxProps
+
+| Prop                        | Type                                                      | Required | Description                                                                     |
+| --------------------------- | --------------------------------------------------------- | -------- | ------------------------------------------------------------------------------- |
+| **inputRef**                | `Ref<HTMLInputElement \| null>`                           | No       | React ref for the combo box input element                                       |
+| **isDisabled**              | `boolean`                                                 | No       | Disables the combo box and prevents interaction                                 |
+| **isInvalid**               | `boolean`                                                 | No       | Indicates that the field has an error                                           |
+| **isLoading**               | `boolean`                                                 | No       | Shows a loading message in the description slot while options are being fetched |
+| **label**                   | `string`                                                  | Yes      | Label text for the combo box field                                              |
+| **options**                 | [MultiSelectComboBoxOption](#multiselectcomboboxoption)[] | Yes      | Array of options to display in the dropdown                                     |
+| **value**                   | `string[]`                                                | No       | Currently selected values                                                       |
+| **onChange**                | `(values: string[]) => void`                              | No       | Callback when the set of selected values changes                                |
+| **onBlur**                  | `() => void`                                              | No       | Handler for blur events                                                         |
+| **description**             | `React.ReactNode`                                         | No       | Optional description text for the field                                         |
+| **errorMessage**            | `string`                                                  | No       | Error message to display when the field is invalid                              |
+| **isRequired**              | `boolean`                                                 | No       | Indicates if the field is required                                              |
+| **shouldVisuallyHideLabel** | `boolean`                                                 | No       | Hides the label visually while keeping it accessible to screen readers          |
+| **className**               | `string`                                                  | No       | -                                                                               |
+| **id**                      | `string`                                                  | No       | -                                                                               |
+| **name**                    | `string`                                                  | No       | -                                                                               |
+| **placeholder**             | `string`                                                  | No       | -                                                                               |
+
+### MultiSelectComboBoxOption
+
+| Prop      | Type     | Required | Description                                         |
+| --------- | -------- | -------- | --------------------------------------------------- |
+| **label** | `string` | Yes      | Display text for the option                         |
+| **value** | `string` | Yes      | Value of the option that will be passed to onChange |
 
 ## NumberInputProps
 
@@ -648,6 +701,7 @@ type PaginationItemsPerPage = 5 | 10 | 25 | 50
 | **isInvalid**               | `boolean`                          | No       | Indicates that the field has an error                                  |
 | **isDisabled**              | `boolean`                          | No       | Disables the textarea and prevents interaction                         |
 | **onBlur**                  | `() => void`                       | No       | Handler for blur events                                                |
+| **rows**                    | `number`                           | No       | Number of visible text rows                                            |
 | **description**             | `React.ReactNode`                  | No       | Optional description text for the field                                |
 | **errorMessage**            | `string`                           | No       | Error message to display when the field is invalid                     |
 | **isRequired**              | `boolean`                          | No       | Indicates if the field is required                                     |
@@ -657,7 +711,6 @@ type PaginationItemsPerPage = 5 | 10 | 25 | 50
 | **id**                      | `string`                           | No       | -                                                                      |
 | **name**                    | `string`                           | No       | -                                                                      |
 | **placeholder**             | `string`                           | No       | -                                                                      |
-| **rows**                    | `number`                           | No       | -                                                                      |
 | **cols**                    | `number`                           | No       | -                                                                      |
 | **aria-describedby**        | `string`                           | No       | Identifies the element (or elements) that describes the object.        |
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -192,6 +192,7 @@ export default [
       'src/components/Common/UI/**/*.{ts,tsx}',
       'src/components/Flow/**/*.{ts,tsx}',
       'src/contexts/ApiProvider/**/*.{ts,tsx}',
+      'src/contexts/ComponentAdapter/**/*.{ts,tsx}',
       'src/contexts/LocaleProvider/**/*.{ts,tsx}',
       'src/contexts/LoadingIndicatorProvider/**/*.{ts,tsx}',
       'src/contexts/ObservabilityProvider/**/*.{ts,tsx}',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -189,6 +189,7 @@ export default [
     files: [
       'src/components/Base/**/*.{ts,tsx}',
       'src/components/Common/Fields/**/*.{ts,tsx}',
+      'src/components/Common/UI/**/*.{ts,tsx}',
       'src/components/Flow/**/*.{ts,tsx}',
       'src/contexts/ApiProvider/**/*.{ts,tsx}',
       'src/contexts/LocaleProvider/**/*.{ts,tsx}',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -190,6 +190,8 @@ export default [
       'src/components/Base/**/*.{ts,tsx}',
       'src/components/Common/Fields/**/*.{ts,tsx}',
       'src/components/Common/UI/**/*.{ts,tsx}',
+      'src/components/Common/PaginationControl/**',
+      'src/components/Common/PayrollLoading/**',
       'src/components/Flow/**/*.{ts,tsx}',
       'src/contexts/ApiProvider/**/*.{ts,tsx}',
       'src/contexts/ComponentAdapter/**/*.{ts,tsx}',

--- a/src/components/Common/PaginationControl/PaginationControl.tsx
+++ b/src/components/Common/PaginationControl/PaginationControl.tsx
@@ -95,6 +95,7 @@ const DefaultPaginationControl = ({
   )
 }
 
+/** @internal */
 export const PaginationControl = (props: PaginationControlProps) => {
   const Components = useComponentContext()
 

--- a/src/components/Common/PaginationControl/PaginationControlTypes.ts
+++ b/src/components/Common/PaginationControl/PaginationControlTypes.ts
@@ -1,5 +1,12 @@
+/** @public */
 export type PaginationItemsPerPage = 5 | 10 | 25 | 50
 
+/**
+ * Props your `PaginationControl` implementation must accept from the component adapter.
+ * Renders pagination controls for navigating between pages of results.
+ *
+ * @public
+ */
 export type PaginationControlProps = {
   handleFirstPage: () => void
   handlePreviousPage: () => void

--- a/src/components/Common/PaginationControl/PaginationControlTypes.ts
+++ b/src/components/Common/PaginationControl/PaginationControlTypes.ts
@@ -8,14 +8,24 @@ export type PaginationItemsPerPage = 5 | 10 | 25 | 50
  * @public
  */
 export type PaginationControlProps = {
+  /** Navigate to the first page. */
   handleFirstPage: () => void
+  /** Navigate to the previous page. */
   handlePreviousPage: () => void
+  /** Navigate to the next page. */
   handleNextPage: () => void
+  /** Navigate to the last page. */
   handleLastPage: () => void
+  /** Called when the user changes the number of items displayed per page. */
   handleItemsPerPageChange: (n: PaginationItemsPerPage) => void
+  /** The currently active page (1-based). */
   currentPage: number
+  /** Total number of pages. */
   totalPages: number
+  /** Total number of items across all pages. */
   totalCount?: number
+  /** Number of items shown per page. */
   itemsPerPage?: PaginationItemsPerPage
+  /** Whether a page fetch is in progress. */
   isFetching?: boolean
 }

--- a/src/components/Common/PayrollLoading/PayrollLoading.tsx
+++ b/src/components/Common/PayrollLoading/PayrollLoading.tsx
@@ -18,6 +18,7 @@ const DefaultPayrollLoading = ({ title, description }: PayrollLoadingProps) => {
   )
 }
 
+/** @internal */
 export const PayrollLoading = (props: PayrollLoadingProps) => {
   const Components = useComponentContext()
 

--- a/src/components/Common/PayrollLoading/PayrollLoadingTypes.ts
+++ b/src/components/Common/PayrollLoading/PayrollLoadingTypes.ts
@@ -1,5 +1,11 @@
 import type { ReactNode } from 'react'
 
+/**
+ * Props your `PayrollLoading` implementation must accept from the component adapter.
+ * Renders a loading state during payroll calculation.
+ *
+ * @public
+ */
 export interface PayrollLoadingProps {
   title: ReactNode
   description?: ReactNode

--- a/src/components/Common/PayrollLoading/PayrollLoadingTypes.ts
+++ b/src/components/Common/PayrollLoading/PayrollLoadingTypes.ts
@@ -7,6 +7,8 @@ import type { ReactNode } from 'react'
  * @public
  */
 export interface PayrollLoadingProps {
+  /** The heading text displayed above the loading animation. */
   title: ReactNode
+  /** Optional supporting text displayed below the title. */
   description?: ReactNode
 }

--- a/src/components/Common/UI/Alert/Alert.tsx
+++ b/src/components/Common/UI/Alert/Alert.tsx
@@ -10,6 +10,16 @@ import WarningIcon from '@/assets/icons/warning.svg?react'
 import ErrorIcon from '@/assets/icons/error.svg?react'
 import CloseIcon from '@/assets/icons/close.svg?react'
 
+/**
+ * Renders an inline alert that conveys status information about the surrounding content, with an optional action button and dismiss control.
+ *
+ * @remarks
+ * Scrolls itself into view and receives focus on mount so the user notices it. Pass `disableScrollIntoView` when rendering inside a modal or other container that should retain focus.
+ *
+ * @param rawProps - The {@link AlertProps} controlling the alert label, status, icon, and dismiss behavior.
+ * @returns The rendered alert.
+ * @internal
+ */
 export function Alert(rawProps: AlertProps) {
   const resolvedProps = applyMissingDefaults(rawProps, AlertDefaults)
   const { label, children, action, status, icon, className, onDismiss, disableScrollIntoView } =

--- a/src/components/Common/UI/Alert/AlertTypes.ts
+++ b/src/components/Common/UI/Alert/AlertTypes.ts
@@ -1,8 +1,16 @@
 import type { ReactNode } from 'react'
 
+/**
+ * Props your `Alert` implementation must accept from the component adapter.
+ * Renders a status message with an optional dismiss action; used for errors, warnings, success confirmations, and informational messages.
+ *
+ * @public
+ */
 export interface AlertProps {
   /**
    * The visual status that the alert should convey
+   *
+   * @defaultValue `'info'`
    */
   status?: 'info' | 'success' | 'warning' | 'error'
   /**
@@ -41,6 +49,8 @@ export interface AlertProps {
 
 /**
  * Default prop values for Alert component.
+ *
+ * @internal
  */
 export const AlertDefaults = {
   status: 'info',

--- a/src/components/Common/UI/Alert/index.ts
+++ b/src/components/Common/UI/Alert/index.ts
@@ -1,1 +1,0 @@
-export { Alert } from './Alert'

--- a/src/components/Common/UI/Badge/Badge.tsx
+++ b/src/components/Common/UI/Badge/Badge.tsx
@@ -6,6 +6,13 @@ import { BadgeDefaults } from './BadgeTypes'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import CloseIcon from '@/assets/icons/close.svg?react'
 
+/**
+ * Renders a compact status indicator with optional dismiss control, used to label rows, tags, or summary chips.
+ *
+ * @param rawProps - The {@link BadgeProps} controlling the badge content, status variant, and dismiss behavior.
+ * @returns The rendered badge.
+ * @internal
+ */
 export const Badge: React.FC<BadgeProps> = rawProps => {
   const resolvedProps = applyMissingDefaults(rawProps, BadgeDefaults)
   const {

--- a/src/components/Common/UI/Badge/BadgeTypes.ts
+++ b/src/components/Common/UI/Badge/BadgeTypes.ts
@@ -1,5 +1,11 @@
 import type { HTMLAttributes, ReactNode } from 'react'
 
+/**
+ * Props your `Badge` implementation must accept from the component adapter.
+ * Renders a small inline label for status, counts, or tags; optionally dismissible.
+ *
+ * @public
+ */
 export interface BadgeProps extends Pick<
   HTMLAttributes<HTMLSpanElement>,
   'className' | 'id' | 'aria-label'
@@ -10,6 +16,8 @@ export interface BadgeProps extends Pick<
   children: ReactNode
   /**
    * Visual style variant of the badge
+   *
+   * @defaultValue `'info'`
    */
   status?: 'success' | 'warning' | 'error' | 'info'
   /**
@@ -28,6 +36,8 @@ export interface BadgeProps extends Pick<
 
 /**
  * Default prop values for Badge component.
+ *
+ * @internal
  */
 export const BadgeDefaults = {
   status: 'info',

--- a/src/components/Common/UI/Banner/Banner.tsx
+++ b/src/components/Common/UI/Banner/Banner.tsx
@@ -7,6 +7,13 @@ import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import InfoIcon from '@/assets/icons/icon-info-outline.svg?react'
 import ErrorIcon from '@/assets/icons/icon-error-outline.svg?react'
 
+/**
+ * Renders a prominent banner with a titled header and supporting content, used to surface warnings or errors that affect the current screen.
+ *
+ * @param rawProps - The {@link BannerProps} controlling the banner title, status variant, and content.
+ * @returns The rendered banner.
+ * @internal
+ */
 export const Banner: React.FC<BannerProps> = rawProps => {
   const resolvedProps = applyMissingDefaults(rawProps, BannerDefaults)
   const { className, title, children, status, ...otherProps } = resolvedProps

--- a/src/components/Common/UI/Banner/BannerTypes.ts
+++ b/src/components/Common/UI/Banner/BannerTypes.ts
@@ -1,5 +1,11 @@
 import type { HTMLAttributes, ReactNode } from 'react'
 
+/**
+ * Props your `Banner` implementation must accept from the component adapter.
+ * Renders a full-width notification banner with a colored header and body content area; used for prominent warnings and errors.
+ *
+ * @public
+ */
 export interface BannerProps extends Pick<
   HTMLAttributes<HTMLDivElement>,
   'className' | 'id' | 'aria-label'
@@ -14,12 +20,16 @@ export interface BannerProps extends Pick<
   children: ReactNode
   /**
    * Visual status variant of the banner
+   *
+   * @defaultValue `'warning'`
    */
   status?: 'warning' | 'error'
 }
 
 /**
  * Default prop values for Banner component.
+ *
+ * @internal
  */
 export const BannerDefaults = {
   status: 'warning',

--- a/src/components/Common/UI/Banner/index.ts
+++ b/src/components/Common/UI/Banner/index.ts
@@ -1,3 +1,0 @@
-export { Banner } from './Banner'
-export type { BannerProps } from './BannerTypes'
-export { BannerDefaults } from './BannerTypes'

--- a/src/components/Common/UI/Box/Box.tsx
+++ b/src/components/Common/UI/Box/Box.tsx
@@ -2,6 +2,13 @@ import cn from 'classnames'
 import styles from './Box.module.scss'
 import type { BoxProps } from '@/components/Common/UI/Box/BoxTypes'
 
+/**
+ * Renders a bordered container that groups related content, with optional header and footer slots.
+ *
+ * @param props - The {@link BoxProps} controlling the box contents, header, footer, and padding.
+ * @returns The rendered box.
+ * @internal
+ */
 export function Box({ children, header, footer, withPadding = true, className }: BoxProps) {
   return (
     <div className={cn(styles.root, className)} data-testid="data-box">

--- a/src/components/Common/UI/Box/BoxTypes.ts
+++ b/src/components/Common/UI/Box/BoxTypes.ts
@@ -1,9 +1,30 @@
 import type { ReactNode } from 'react'
 
+/**
+ * Props your `Box` implementation must accept from the component adapter.
+ * Renders a sectioned layout container with distinct header, body, and footer areas.
+ *
+ * @public
+ */
 export interface BoxProps {
+  /**
+   * Content rendered inside the box body.
+   */
   children: ReactNode
+  /**
+   * Optional content rendered above the body in the box header section.
+   */
   header?: ReactNode
+  /**
+   * Optional content rendered below the body in the box footer section.
+   */
   footer?: ReactNode
+  /**
+   * Whether the body should apply the default inner padding. Defaults to true; set to false for content that needs to be flush with the box edges.
+   */
   withPadding?: boolean
+  /**
+   * CSS className to be applied to the root element.
+   */
   className?: string
 }

--- a/src/components/Common/UI/Box/index.ts
+++ b/src/components/Common/UI/Box/index.ts
@@ -1,1 +1,0 @@
-export { Box } from './Box'

--- a/src/components/Common/UI/BoxHeader/BoxHeader.tsx
+++ b/src/components/Common/UI/BoxHeader/BoxHeader.tsx
@@ -4,6 +4,13 @@ import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { Flex } from '@/components/Common/Flex'
 
+/**
+ * Renders a titled header for a {@link BoxProps | Box}, with optional description and inline action slot.
+ *
+ * @param rawProps - The {@link BoxHeaderProps} controlling the title, description, action, and heading level.
+ * @returns The rendered box header.
+ * @internal
+ */
 export function BoxHeader(rawProps: BoxHeaderProps) {
   const { title, description, action, headingLevel } = applyMissingDefaults(
     rawProps,

--- a/src/components/Common/UI/BoxHeader/BoxHeaderTypes.ts
+++ b/src/components/Common/UI/BoxHeader/BoxHeaderTypes.ts
@@ -1,12 +1,37 @@
 import type { ReactNode } from 'react'
 
+/**
+ * Props your `BoxHeader` implementation must accept from the component adapter.
+ * Renders the header section of a Box, combining a title, optional description, and an optional inline action slot.
+ *
+ * @public
+ */
 export interface BoxHeaderProps {
+  /**
+   * Title content rendered as the heading.
+   */
   title: ReactNode
+  /**
+   * Optional supporting description rendered below the title.
+   */
   description?: ReactNode
+  /**
+   * Optional action content (e.g. a Button) rendered inline opposite the title.
+   */
   action?: ReactNode
+  /**
+   * Semantic heading level for the title. Defaults to `h3`.
+   *
+   * @defaultValue `'h3'`
+   */
   headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 }
 
+/**
+ * Default prop values for BoxHeader component.
+ *
+ * @internal
+ */
 export const BoxHeaderDefaults = {
   headingLevel: 'h3',
 } as const satisfies Partial<BoxHeaderProps>

--- a/src/components/Common/UI/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Common/UI/Breadcrumbs/Breadcrumbs.tsx
@@ -4,6 +4,13 @@ import { type BreadcrumbsProps, BreadcrumbsDefaults } from './BreadcrumbsTypes'
 import styles from './Breadcrumbs.module.scss'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 
+/**
+ * Renders a navigational breadcrumb trail for multi-step flows, marking the current step and collapsing to a back link on small containers.
+ *
+ * @param rawProps - The {@link BreadcrumbsProps} controlling the list of breadcrumbs, current step, and click behavior.
+ * @returns The rendered breadcrumb navigation.
+ * @internal
+ */
 export function Breadcrumbs(rawProps: BreadcrumbsProps) {
   const resolvedProps = applyMissingDefaults(rawProps, BreadcrumbsDefaults)
   const {

--- a/src/components/Common/UI/Breadcrumbs/BreadcrumbsTypes.ts
+++ b/src/components/Common/UI/Breadcrumbs/BreadcrumbsTypes.ts
@@ -1,7 +1,18 @@
 import type { ReactNode } from 'react'
 
+/**
+ * Single entry in a {@link BreadcrumbsProps | Breadcrumbs} trail.
+ *
+ * @public
+ */
 export interface Breadcrumb {
+  /**
+   * Unique identifier for the breadcrumb. Matches against `currentBreadcrumbId` and is passed to `onClick`.
+   */
   id: string
+  /**
+   * Display content rendered for the breadcrumb.
+   */
   label: ReactNode
   /**
    * When false, the breadcrumb is rendered as plain text even if onClick is provided.
@@ -9,6 +20,12 @@ export interface Breadcrumb {
    */
   isClickable?: boolean
 }
+/**
+ * Props your `Breadcrumbs` implementation must accept from the component adapter.
+ * Renders a navigation breadcrumb trail showing the user's position in a multi-step flow.
+ *
+ * @public
+ */
 export interface BreadcrumbsProps {
   /**
    * Array of breadcrumbs
@@ -20,6 +37,8 @@ export interface BreadcrumbsProps {
   currentBreadcrumbId?: string
   /**
    * Accessibility label for the breadcrumbs
+   *
+   * @defaultValue `'Breadcrumbs'`
    */
   'aria-label'?: string
   /**
@@ -35,12 +54,16 @@ export interface BreadcrumbsProps {
    * At this size, the breadcrumb typically does not have sufficient size to render
    * completely. In our implementation, we switch to a condensed mobile version of
    * the breadcrumbs
+   *
+   * @defaultValue `false`
    */
   isSmallContainer?: boolean
 }
 
 /**
  * Default prop values for Breadcrumbs component.
+ *
+ * @internal
  */
 export const BreadcrumbsDefaults = {
   isSmallContainer: false,

--- a/src/components/Common/UI/Breadcrumbs/index.ts
+++ b/src/components/Common/UI/Breadcrumbs/index.ts
@@ -1,2 +1,2 @@
 export { Breadcrumbs } from './Breadcrumbs'
-export type { BreadcrumbsProps, Breadcrumb } from './BreadcrumbsTypes'
+export type { BreadcrumbsProps } from './BreadcrumbsTypes'

--- a/src/components/Common/UI/Button/Button.tsx
+++ b/src/components/Common/UI/Button/Button.tsx
@@ -4,6 +4,13 @@ import { type ButtonProps, ButtonDefaults } from './ButtonTypes'
 import styles from './Button.module.scss'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 
+/**
+ * Renders an interactive button with primary, secondary, tertiary, or error variants and built-in loading state.
+ *
+ * @param rawProps - The {@link ButtonProps} controlling appearance, content, and click behavior.
+ * @returns The rendered button element.
+ * @internal
+ */
 export function Button(rawProps: ButtonProps) {
   const resolvedProps = applyMissingDefaults(rawProps, ButtonDefaults)
   const {

--- a/src/components/Common/UI/Button/ButtonIcon.tsx
+++ b/src/components/Common/UI/Button/ButtonIcon.tsx
@@ -4,6 +4,13 @@ import { Button } from './Button'
 import styles from './ButtonIcon.module.scss'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 
+/**
+ * Renders an icon-only button. Requires `aria-label` for accessibility since there is no visible text.
+ *
+ * @param rawProps - The {@link ButtonIconProps} controlling appearance, icon content, and click behavior.
+ * @returns The rendered icon button element.
+ * @internal
+ */
 export function ButtonIcon(rawProps: ButtonIconProps) {
   const resolvedProps = applyMissingDefaults(rawProps, ButtonIconDefaults)
   const { children, variant, className, ...props } = resolvedProps

--- a/src/components/Common/UI/Button/ButtonTypes.ts
+++ b/src/components/Common/UI/Button/ButtonTypes.ts
@@ -1,5 +1,11 @@
 import type { Ref, ButtonHTMLAttributes, ReactNode, FocusEvent } from 'react'
 
+/**
+ * Props your `Button` implementation must accept from the component adapter.
+ * Renders an HTML button (`<button>`) with primary, secondary, tertiary, and error variants, a loading state, and an optional leading icon.
+ *
+ * @public
+ */
 export interface ButtonProps extends Pick<
   ButtonHTMLAttributes<HTMLButtonElement>,
   | 'name'
@@ -22,14 +28,20 @@ export interface ButtonProps extends Pick<
   buttonRef?: Ref<HTMLButtonElement>
   /**
    * Visual style variant of the button
+   *
+   * @defaultValue `'primary'`
    */
   variant?: 'primary' | 'secondary' | 'tertiary' | 'error'
   /**
    * Shows a loading spinner and disables the button
+   *
+   * @defaultValue `false`
    */
   isLoading?: boolean
   /**
    * Disables the button and prevents interaction
+   *
+   * @defaultValue `false`
    */
   isDisabled?: boolean
   /**
@@ -50,6 +62,12 @@ export interface ButtonProps extends Pick<
   onFocus?: (e: FocusEvent) => void
 }
 
+/**
+ * Props your `ButtonIcon` implementation must accept from the component adapter.
+ * Renders an icon-only `<button>`; requires `aria-label` since there is no visible text for assistive technologies.
+ *
+ * @public
+ */
 export type ButtonIconProps = ButtonProps & {
   /**
    * Required aria-label for icon buttons to ensure accessibility
@@ -60,6 +78,8 @@ export type ButtonIconProps = ButtonProps & {
 /**
  * Default prop values for Button component.
  * These are used by the component adapter to automatically provide defaults.
+ *
+ * @internal
  */
 export const ButtonDefaults = {
   variant: 'primary',
@@ -69,6 +89,8 @@ export const ButtonDefaults = {
 
 /**
  * Default prop values for ButtonIcon component.
+ *
+ * @internal
  */
 export const ButtonIconDefaults = {
   variant: 'tertiary',

--- a/src/components/Common/UI/Button/index.ts
+++ b/src/components/Common/UI/Button/index.ts
@@ -1,3 +1,1 @@
 export { Button } from './Button'
-export { ButtonIcon } from './ButtonIcon'
-export type { ButtonProps, ButtonIconProps } from './ButtonTypes'

--- a/src/components/Common/UI/CalendarPreview/CalendarLegend.tsx
+++ b/src/components/Common/UI/CalendarPreview/CalendarLegend.tsx
@@ -4,8 +4,20 @@ import { Flex } from '../../Flex/Flex'
 import type { CalendarPreviewProps } from './CalendarPreviewTypes'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
+/**
+ * Props for the CalendarLegend subcomponent rendered alongside {@link CalendarPreviewProps | CalendarPreview}.
+ *
+ * @internal
+ */
 export type CalendarLegendProps = Pick<CalendarPreviewProps, 'highlightDates' | 'dateRange'>
 
+/**
+ * Renders the legend portion of a {@link CalendarPreview}, listing each highlighted date with its color and label.
+ *
+ * @param props - The {@link CalendarLegendProps} controlling which dates appear in the legend.
+ * @returns The rendered legend element.
+ * @internal
+ */
 export const CalendarLegend = ({ highlightDates }: CalendarLegendProps) => {
   const { t } = useTranslation('Company.PaySchedule')
   const { Text } = useComponentContext()

--- a/src/components/Common/UI/CalendarPreview/CalendarPreview.tsx
+++ b/src/components/Common/UI/CalendarPreview/CalendarPreview.tsx
@@ -16,6 +16,13 @@ import styles from './CalendarPreview.module.scss'
 import { formatDateToStringDate } from '@/helpers/dateFormatting'
 import { Flex } from '@/components/Common/Flex'
 
+/**
+ * Renders a read-only calendar showing a date range with optional highlighted dates and an accompanying legend.
+ *
+ * @param props - The {@link CalendarPreviewProps} controlling the displayed range and highlighted dates.
+ * @returns The rendered calendar preview element.
+ * @internal
+ */
 export const CalendarPreview = ({ dateRange, highlightDates }: CalendarPreviewProps) => {
   const highlightMap = useMemo(() => {
     if (!highlightDates) return new Map()

--- a/src/components/Common/UI/CalendarPreview/CalendarPreviewTypes.ts
+++ b/src/components/Common/UI/CalendarPreview/CalendarPreviewTypes.ts
@@ -1,3 +1,9 @@
+/**
+ * Props your `CalendarPreview` implementation must accept from the component adapter.
+ * Renders a read-only calendar display for visualizing a date range with optional highlighted dates.
+ *
+ * @public
+ */
 export type CalendarPreviewProps = {
   /**
    * Array of dates to highlight with custom colors and labels

--- a/src/components/Common/UI/CalendarPreview/index.ts
+++ b/src/components/Common/UI/CalendarPreview/index.ts
@@ -1,3 +1,1 @@
 export { CalendarPreview } from './CalendarPreview'
-export { CalendarLegend } from './CalendarLegend'
-export type { CalendarPreviewProps } from './CalendarPreviewTypes'

--- a/src/components/Common/UI/Card/Card.tsx
+++ b/src/components/Common/UI/Card/Card.tsx
@@ -3,6 +3,13 @@ import { Flex } from '../../Flex/Flex'
 import styles from './Card.module.scss'
 import { type CardProps } from '@/components/Common/UI/Card/CardTypes'
 
+/**
+ * Renders a content card with optional left-side action element and right-side menu.
+ *
+ * @param props - The {@link CardProps} controlling the card's content, optional action, and optional menu.
+ * @returns The rendered card element.
+ * @internal
+ */
 export function Card({ children, menu, className, action }: CardProps) {
   return (
     <div className={cn(styles.cardContainer, className)} data-testid="data-card">

--- a/src/components/Common/UI/Card/CardTypes.ts
+++ b/src/components/Common/UI/Card/CardTypes.ts
@@ -1,5 +1,11 @@
 import type { ReactNode } from 'react'
 
+/**
+ * Props your `Card` implementation must accept from the component adapter.
+ * Renders a content container with an optional overflow menu and a leading action slot.
+ *
+ * @public
+ */
 export interface CardProps {
   /**
    * Content to be displayed inside the card

--- a/src/components/Common/UI/Checkbox/Checkbox.tsx
+++ b/src/components/Common/UI/Checkbox/Checkbox.tsx
@@ -8,6 +8,13 @@ import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import { HorizontalFieldLayout } from '@/components/Common/HorizontalFieldLayout'
 import IconChecked from '@/assets/icons/checkbox.svg?react'
 
+/**
+ * Renders a labeled checkbox input with optional description and error message.
+ *
+ * @param rawProps - The {@link CheckboxProps} controlling the checked state, label, and validation messaging.
+ * @returns The rendered checkbox element.
+ * @internal
+ */
 export const Checkbox = (rawProps: CheckboxProps) => {
   const resolvedProps = applyMissingDefaults(rawProps, CheckboxDefaults)
   const {

--- a/src/components/Common/UI/Checkbox/CheckboxTypes.ts
+++ b/src/components/Common/UI/Checkbox/CheckboxTypes.ts
@@ -1,6 +1,12 @@
 import type { InputHTMLAttributes, Ref } from 'react'
 import type { SharedHorizontalFieldLayoutProps } from '@/components/Common/HorizontalFieldLayout/HorizontalFieldLayoutTypes'
 
+/**
+ * Props your `Checkbox` implementation must accept from the component adapter.
+ * Renders a form field wrapping an `<input type="checkbox" />` with a label, optional description, and error message.
+ *
+ * @public
+ */
 export interface CheckboxProps
   extends
     SharedHorizontalFieldLayoutProps,
@@ -19,10 +25,14 @@ export interface CheckboxProps
   inputRef?: Ref<HTMLInputElement>
   /**
    * Indicates if the checkbox is in an invalid state
+   *
+   * @defaultValue `false`
    */
   isInvalid?: boolean
   /**
    * Disables the checkbox and prevents interaction
+   *
+   * @defaultValue `false`
    */
   isDisabled?: boolean
   /**
@@ -33,6 +43,8 @@ export interface CheckboxProps
 
 /**
  * Default prop values for Checkbox component.
+ *
+ * @internal
  */
 export const CheckboxDefaults = {
   isInvalid: false,

--- a/src/components/Common/UI/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/Common/UI/CheckboxGroup/CheckboxGroup.tsx
@@ -83,6 +83,13 @@ function ReactAriaCheckboxWrapper(props: Omit<ReactAriaCheckboxProps, 'groupStat
   return groupState ? <ReactAriaCheckbox groupState={groupState} {...props} /> : null
 }
 
+/**
+ * Renders a group of related checkboxes that share a single label, description, and error state.
+ *
+ * @param rawProps - The {@link CheckboxGroupProps} controlling the group's label, options, and selected values.
+ * @returns The rendered checkbox group as a fieldset.
+ * @internal
+ */
 export function CheckboxGroup(rawProps: CheckboxGroupProps) {
   const resolvedProps = applyMissingDefaults(rawProps, CheckboxGroupDefaults)
   const {

--- a/src/components/Common/UI/CheckboxGroup/CheckboxGroupTypes.ts
+++ b/src/components/Common/UI/CheckboxGroup/CheckboxGroupTypes.ts
@@ -1,6 +1,11 @@
 import type { FieldsetHTMLAttributes, Ref } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
+/**
+ * Option entry rendered as a single checkbox within a {@link CheckboxGroupProps | CheckboxGroup}.
+ *
+ * @public
+ */
 export interface CheckboxGroupOption {
   /**
    * Label text or content for the checkbox option
@@ -20,14 +25,24 @@ export interface CheckboxGroupOption {
   description?: React.ReactNode
 }
 
+/**
+ * Props your `CheckboxGroup` implementation must accept from the component adapter.
+ * Renders a form field wrapping multiple `<input type="checkbox" />` elements with a label, optional description, and error message.
+ *
+ * @public
+ */
 export interface CheckboxGroupProps
   extends SharedFieldLayoutProps, Pick<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'className'> {
   /**
    * Indicates if the checkbox group is in an invalid state
+   *
+   * @defaultValue `false`
    */
   isInvalid?: boolean
   /**
    * Disables all checkbox options in the group
+   *
+   * @defaultValue `false`
    */
   isDisabled?: boolean
   /**
@@ -49,7 +64,9 @@ export interface CheckboxGroupProps
 }
 
 /**
- * Default prop values for CheckboxGroup component.
+ * Default prop values for the CheckboxGroup component.
+ *
+ * @internal
  */
 export const CheckboxGroupDefaults = {
   isRequired: false,

--- a/src/components/Common/UI/ComboBox/ComboBox.tsx
+++ b/src/components/Common/UI/ComboBox/ComboBox.tsx
@@ -20,6 +20,13 @@ import { useTheme } from '@/contexts/ThemeProvider'
 import AlertCircle from '@/assets/icons/alert-circle.svg?react'
 import CaretDown from '@/assets/icons/caret-down.svg?react'
 
+/**
+ * Combines a text input with a selectable dropdown list, supporting type-ahead filtering and optional free-form entry.
+ *
+ * @param props - The {@link ComboBoxProps} controlling the field's label, options, and selected value.
+ * @returns The rendered combo box field.
+ * @internal
+ */
 export const ComboBox = ({
   allowsCustomValue,
   className,

--- a/src/components/Common/UI/ComboBox/ComboBoxTypes.ts
+++ b/src/components/Common/UI/ComboBox/ComboBoxTypes.ts
@@ -1,6 +1,11 @@
 import type { InputHTMLAttributes, Ref } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
+/**
+ * Option entry for the ComboBox dropdown list.
+ *
+ * @public
+ */
 export interface ComboBoxOption {
   /**
    * Display text for the option
@@ -12,6 +17,13 @@ export interface ComboBoxOption {
   value: string
 }
 
+/**
+ * Props your `ComboBox` implementation must accept from the component adapter.
+ * Renders a form field wrapping a filterable `<input />` for single-option selection, optionally allowing free-form values.
+ *
+ * @public
+ * @see {@link MultiSelectComboBoxProps}
+ */
 export interface ComboBoxProps
   extends
     SharedFieldLayoutProps,

--- a/src/components/Common/UI/DatePicker/DatePicker.tsx
+++ b/src/components/Common/UI/DatePicker/DatePicker.tsx
@@ -53,6 +53,13 @@ function calendarDateValueToDate(dateValue: DateValue | null): Date | null {
   return date
 }
 
+/**
+ * Renders a date input with an attached calendar popover for selecting a single date.
+ *
+ * @param props - The {@link DatePickerProps} controlling the field's label, value, and date constraints.
+ * @returns The rendered date picker field.
+ * @internal
+ */
 export const DatePicker = ({
   className,
   description,

--- a/src/components/Common/UI/DatePicker/DatePickerTypes.ts
+++ b/src/components/Common/UI/DatePicker/DatePickerTypes.ts
@@ -1,6 +1,12 @@
 import type { InputHTMLAttributes, Ref } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
+/**
+ * Props your `DatePicker` implementation must accept from the component adapter.
+ * Renders a form field wrapping an `<input type="date" />` with a calendar picker popover, optional min/max bounds, and per-date disabling.
+ *
+ * @public
+ */
 export interface DatePickerProps
   extends
     SharedFieldLayoutProps,

--- a/src/components/Common/UI/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/Common/UI/DateRangePicker/DateRangePicker.tsx
@@ -32,6 +32,13 @@ function calendarDateToJsDate(dateValue: DateValue): Date {
   return new Date(dateValue.year, dateValue.month - 1, dateValue.day)
 }
 
+/**
+ * Renders paired date inputs and a calendar popover for selecting a start/end date range.
+ *
+ * @param props - The {@link DateRangePickerProps} controlling the field's labels, selected range, and bounds.
+ * @returns The rendered date range picker field.
+ * @internal
+ */
 export const DateRangePicker = ({
   label,
   value,

--- a/src/components/Common/UI/DateRangePicker/DateRangePickerTypes.ts
+++ b/src/components/Common/UI/DateRangePicker/DateRangePickerTypes.ts
@@ -1,15 +1,56 @@
+/**
+ * Inclusive start/end pair representing a selected date range.
+ *
+ * @public
+ */
 export interface DateRange {
+  /**
+   * First date in the range, inclusive.
+   */
   start: Date
+  /**
+   * Last date in the range, inclusive.
+   */
   end: Date
 }
 
+/**
+ * Props your `DateRangePicker` implementation must accept from the component adapter.
+ * Renders a form field wrapping paired `<input type="date" />` elements for selecting an inclusive date range.
+ *
+ * @public
+ */
 export interface DateRangePickerProps {
+  /**
+   * Label text for the date range field.
+   */
   label: string
+  /**
+   * Hides the label visually while keeping it accessible to screen readers.
+   */
   shouldVisuallyHideLabel?: boolean
+  /**
+   * Currently selected date range, or null when nothing is selected.
+   */
   value: DateRange | null
+  /**
+   * Callback fired when the selected range changes. Receives null when the range is cleared.
+   */
   onChange: (range: DateRange | null) => void
+  /**
+   * Accessible label for the start-date input.
+   */
   startDateLabel: string
+  /**
+   * Accessible label for the end-date input.
+   */
   endDateLabel: string
+  /**
+   * Earliest selectable date. Dates before this are disabled.
+   */
   minValue?: Date
+  /**
+   * Latest selectable date. Dates after this are disabled.
+   */
   maxValue?: Date
 }

--- a/src/components/Common/UI/DescriptionList/DescriptionList.tsx
+++ b/src/components/Common/UI/DescriptionList/DescriptionList.tsx
@@ -5,6 +5,13 @@ import styles from './DescriptionList.module.scss'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
+/**
+ * Renders an HTML description list (`<dl>`) of term/description pairs.
+ *
+ * @param rawProps - The {@link DescriptionListProps} containing the items to render and layout options.
+ * @returns The rendered description list.
+ * @internal
+ */
 export function DescriptionList(rawProps: DescriptionListProps) {
   const resolvedProps = applyMissingDefaults(rawProps, DescriptionListDefaults)
   const { items, layout, showSeparators, className } = resolvedProps

--- a/src/components/Common/UI/DescriptionList/DescriptionListTypes.ts
+++ b/src/components/Common/UI/DescriptionList/DescriptionListTypes.ts
@@ -1,17 +1,55 @@
 import type { ReactNode } from 'react'
 
+/**
+ * Single term/description pair rendered as a row within a {@link DescriptionListProps | DescriptionList}.
+ *
+ * @public
+ */
 export interface DescriptionListItem {
+  /**
+   * Term content (the `<dt>`). Pass an array to render multiple `<dt>` elements for the same description.
+   */
   term: ReactNode | ReactNode[]
+  /**
+   * Description content (the `<dd>`). Pass an array to render multiple `<dd>` elements for the same term.
+   */
   description: ReactNode | ReactNode[]
 }
 
+/**
+ * Props your `DescriptionList` implementation must accept from the component adapter.
+ * Renders an HTML `<dl>` of term/description pairs in either a stacked or horizontal layout.
+ *
+ * @public
+ */
 export interface DescriptionListProps {
+  /**
+   * Term/description pairs to render in order.
+   */
   items: DescriptionListItem[]
+  /**
+   * Visual arrangement of each term/description pair. Defaults to `'stacked'`.
+   *
+   * @defaultValue `'stacked'`
+   */
   layout?: 'stacked' | 'horizontal'
+  /**
+   * Whether to render dividers between rows. Defaults to `true`.
+   *
+   * @defaultValue `true`
+   */
   showSeparators?: boolean
+  /**
+   * Additional class name applied to the root `<dl>`.
+   */
   className?: string
 }
 
+/**
+ * Default prop values for the DescriptionList component.
+ *
+ * @internal
+ */
 export const DescriptionListDefaults = {
   layout: 'stacked',
   showSeparators: true,

--- a/src/components/Common/UI/DescriptionList/index.ts
+++ b/src/components/Common/UI/DescriptionList/index.ts
@@ -1,2 +1,1 @@
 export { DescriptionList } from './DescriptionList'
-export type { DescriptionListProps, DescriptionListItem } from './DescriptionListTypes'

--- a/src/components/Common/UI/Dialog/Dialog.tsx
+++ b/src/components/Common/UI/Dialog/Dialog.tsx
@@ -6,6 +6,17 @@ import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import { useContainerBreakpoints } from '@/hooks/useContainerBreakpoints/useContainerBreakpoints'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
+/**
+ * Modal dialog with a title, body, primary action, and close action.
+ *
+ * @remarks
+ * Renders through the ComponentsContext adapter, so partners can override the
+ * underlying `Modal` and `Button` primitives with their own design system.
+ *
+ * @param rawProps - Dialog configuration including labels, open state, and action callbacks.
+ * @returns The rendered dialog element.
+ * @internal
+ */
 export function Dialog(rawProps: DialogProps) {
   const resolvedProps = applyMissingDefaults(rawProps, DialogDefaults)
   const {

--- a/src/components/Common/UI/Dialog/DialogTypes.ts
+++ b/src/components/Common/UI/Dialog/DialogTypes.ts
@@ -1,8 +1,15 @@
 import type { ReactNode } from 'react'
 
+/**
+ * Props your `Dialog` implementation must accept from the component adapter.
+ * Renders a modal confirmation dialog with a primary action and a cancel action.
+ *
+ * @public
+ */
 export interface DialogProps {
   /**
    * Controls whether the dialog is open or closed
+   * @defaultValue `false`
    */
   isOpen?: boolean
   /**
@@ -15,10 +22,12 @@ export interface DialogProps {
   onPrimaryActionClick?: () => void
   /**
    * Whether the primary action is destructive (changes button style to error variant)
+   * @defaultValue `false`
    */
   isDestructive?: boolean
   /**
    * Whether the primary action button is in loading state
+   * @defaultValue `false`
    */
   isPrimaryActionLoading?: boolean
   /**
@@ -39,12 +48,15 @@ export interface DialogProps {
   children?: ReactNode
   /**
    * Whether clicking the backdrop should close the dialog
+   * @defaultValue `false`
    */
   shouldCloseOnBackdropClick?: boolean
 }
 
 /**
- * Default prop values for Dialog component.
+ * Default prop values for the Dialog component.
+ *
+ * @internal
  */
 export const DialogDefaults = {
   isOpen: false,

--- a/src/components/Common/UI/Dialog/index.ts
+++ b/src/components/Common/UI/Dialog/index.ts
@@ -1,3 +1,1 @@
 export { Dialog } from './Dialog'
-export type { DialogProps } from './DialogTypes'
-export { DialogDefaults } from './DialogTypes'

--- a/src/components/Common/UI/FileInput/FileInput.tsx
+++ b/src/components/Common/UI/FileInput/FileInput.tsx
@@ -75,6 +75,18 @@ function formatAcceptedTypes(accept: string[] | undefined): string | null {
   return uniqueExtensions.join(', ')
 }
 
+/**
+ * File upload input with drag-and-drop, file type filtering, and a preview of the selected file.
+ *
+ * @remarks
+ * Renders a drop zone with click-to-upload until a file is selected, then swaps to a
+ * preview row showing the file name, size, and a remove button. Wraps `react-aria-components`'
+ * `FileTrigger` and `DropZone` to provide accessible keyboard and screen reader support.
+ *
+ * @param rawProps - File input configuration including value, change handler, accepted types, and field layout props.
+ * @returns The rendered file input element.
+ * @internal
+ */
 export function FileInput(rawProps: FileInputProps) {
   const { t } = useTranslation('common')
   const resolvedProps = applyMissingDefaults(rawProps, FileInputDefaults)

--- a/src/components/Common/UI/FileInput/FileInputTypes.ts
+++ b/src/components/Common/UI/FileInput/FileInputTypes.ts
@@ -1,5 +1,11 @@
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
+/**
+ * Props your `FileInput` implementation must accept from the component adapter.
+ * Renders a form field wrapping an `<input type="file" />` with a label, description, error message, and optional file type restrictions.
+ *
+ * @public
+ */
 export interface FileInputProps extends Omit<SharedFieldLayoutProps, 'shouldVisuallyHideLabel'> {
   /**
    * ID for the file input element
@@ -25,10 +31,12 @@ export interface FileInputProps extends Omit<SharedFieldLayoutProps, 'shouldVisu
   accept?: string[]
   /**
    * Indicates that the field has an error
+   * @defaultValue `false`
    */
   isInvalid?: boolean
   /**
    * Disables the input and prevents interaction
+   * @defaultValue `false`
    */
   isDisabled?: boolean
   /**
@@ -41,6 +49,11 @@ export interface FileInputProps extends Omit<SharedFieldLayoutProps, 'shouldVisu
   'aria-describedby'?: string
 }
 
+/**
+ * Default prop values for the FileInput component.
+ *
+ * @internal
+ */
 export const FileInputDefaults = {
   isInvalid: false,
   isDisabled: false,

--- a/src/components/Common/UI/FileInput/index.ts
+++ b/src/components/Common/UI/FileInput/index.ts
@@ -1,3 +1,1 @@
 export { FileInput } from './FileInput'
-export type { FileInputProps } from './FileInputTypes'
-export { FileInputDefaults } from './FileInputTypes'

--- a/src/components/Common/UI/Heading/Heading.tsx
+++ b/src/components/Common/UI/Heading/Heading.tsx
@@ -2,6 +2,19 @@ import classNames from 'classnames'
 import type { HeadingProps } from './HeadingTypes'
 import styles from './Heading.module.scss'
 
+/**
+ * Semantic heading element (h1–h6) with optional independent visual styling.
+ *
+ * @remarks
+ * The `as` prop chooses the semantic heading level for accessibility and document
+ * outline; the optional `styledAs` prop applies a different visual size without
+ * changing the rendered tag. Use this when you need an h2 for document structure
+ * but want it to look like an h1, for example.
+ *
+ * @param props - Heading configuration including the semantic level, optional visual styling, alignment, and content.
+ * @returns The rendered heading element.
+ * @internal
+ */
 export const Heading = ({
   as: Component,
   styledAs,

--- a/src/components/Common/UI/Heading/HeadingTypes.ts
+++ b/src/components/Common/UI/Heading/HeadingTypes.ts
@@ -1,5 +1,11 @@
 import type { HTMLAttributes, ReactNode } from 'react'
 
+/**
+ * Props your `Heading` implementation must accept from the component adapter.
+ * Renders an HTML heading (`<h1>`–`<h6>`) whose visual style level is controlled independently from its semantic level.
+ *
+ * @public
+ */
 export interface HeadingProps extends Pick<HTMLAttributes<HTMLHeadingElement>, 'className' | 'id'> {
   /**
    * The HTML heading element to render (h1-h6)

--- a/src/components/Common/UI/Heading/index.ts
+++ b/src/components/Common/UI/Heading/index.ts
@@ -1,2 +1,1 @@
 export { Heading } from './Heading'
-export type { HeadingProps } from './HeadingTypes'

--- a/src/components/Common/UI/Input/Input.tsx
+++ b/src/components/Common/UI/Input/Input.tsx
@@ -6,6 +6,15 @@ import { InputDefaults } from './InputTypes'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import AlertCircle from '@/assets/icons/alert-circle.svg?react'
 
+/**
+ * Low-level text input primitive with optional start and end adornments.
+ *
+ * @remarks
+ * The building block used by higher-level field components such as TextInput
+ * and NumberInput. Most consumers should reach for those instead.
+ *
+ * @internal
+ */
 export function Input(rawProps: InputProps) {
   const resolvedProps = applyMissingDefaults(rawProps, InputDefaults)
   const {

--- a/src/components/Common/UI/Input/InputTypes.ts
+++ b/src/components/Common/UI/Input/InputTypes.ts
@@ -1,5 +1,14 @@
 import type { InputHTMLAttributes, ReactNode, Ref } from 'react'
 
+/**
+ * Base text-input primitive used internally by `TextInput` and `NumberInput`.
+ *
+ * @remarks
+ * Higher-level field components like TextInput and NumberInput reuse the
+ * `adornmentStart` and `adornmentEnd` slots from this interface.
+ *
+ * @public
+ */
 export interface InputProps extends Pick<
   InputHTMLAttributes<HTMLInputElement>,
   | 'className'
@@ -35,13 +44,15 @@ export interface InputProps extends Pick<
 
   /**
    * Whether the input is disabled
+   * @defaultValue `false`
    */
   isDisabled?: boolean
 }
 
 /**
- * Default prop values for Input component.
- * These are used by the component adapter to automatically provide defaults.
+ * Default prop values for the Input primitive, applied through the component adapter.
+ *
+ * @internal
  */
 export const InputDefaults = {
   isDisabled: false,

--- a/src/components/Common/UI/Input/index.ts
+++ b/src/components/Common/UI/Input/index.ts
@@ -1,2 +1,1 @@
 export { Input } from './Input'
-export type { InputProps } from './InputTypes'

--- a/src/components/Common/UI/Link/Link.tsx
+++ b/src/components/Common/UI/Link/Link.tsx
@@ -3,6 +3,13 @@ import classNames from 'classnames'
 import type { LinkProps } from './LinkTypes'
 import styles from './Link.module.scss'
 
+/**
+ * Anchor element styled as a link, with accessible keyboard and focus behavior.
+ *
+ * @param props - Link configuration, accepting the standard anchor attributes plus content as `children`.
+ * @returns The rendered anchor element.
+ * @internal
+ */
 export function Link({ className, ...props }: LinkProps) {
   return <AriaLink className={classNames(styles.root, className)} {...props} />
 }

--- a/src/components/Common/UI/Link/LinkTypes.ts
+++ b/src/components/Common/UI/Link/LinkTypes.ts
@@ -1,5 +1,11 @@
 import type { AnchorHTMLAttributes, ReactNode } from 'react'
 
+/**
+ * Props your `Link` implementation must accept from the component adapter.
+ * Renders an HTML anchor (`<a>`) for inline navigation.
+ *
+ * @public
+ */
 export type LinkProps = Pick<
   AnchorHTMLAttributes<HTMLAnchorElement>,
   /**

--- a/src/components/Common/UI/List/ListTypes.ts
+++ b/src/components/Common/UI/List/ListTypes.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 
 // Base list props without HTML element specific attributes
-export interface BaseListProps {
+interface BaseListProps {
   /**
    * The list items to render
    */
@@ -28,6 +28,18 @@ export interface BaseListProps {
   'aria-describedby'?: string
 }
 
+/**
+ * Props your `UnorderedList` implementation must accept from the component adapter.
+ * Renders an unordered (bulleted) list of items.
+ *
+ * @public
+ */
 export type UnorderedListProps = BaseListProps
 
+/**
+ * Props your `OrderedList` implementation must accept from the component adapter.
+ * Renders an ordered (numbered) list of items.
+ *
+ * @public
+ */
 export type OrderedListProps = BaseListProps

--- a/src/components/Common/UI/List/OrderedList.tsx
+++ b/src/components/Common/UI/List/OrderedList.tsx
@@ -2,6 +2,13 @@ import classnames from 'classnames'
 import type { OrderedListProps } from './ListTypes'
 import styles from './List.module.scss'
 
+/**
+ * Renders an ordered (numbered) list from an array of item nodes.
+ *
+ * @param props - See {@link OrderedListProps}.
+ * @returns The rendered ordered list element.
+ * @internal
+ */
 export function OrderedList({ items, className, ...props }: OrderedListProps) {
   return (
     <ol className={classnames(styles.list, className)} data-variant="ordered" {...props}>

--- a/src/components/Common/UI/List/UnorderedList.tsx
+++ b/src/components/Common/UI/List/UnorderedList.tsx
@@ -2,6 +2,13 @@ import classnames from 'classnames'
 import type { UnorderedListProps } from './ListTypes'
 import styles from './List.module.scss'
 
+/**
+ * Renders an unordered (bulleted) list from an array of item nodes.
+ *
+ * @param props - See {@link UnorderedListProps}.
+ * @returns The rendered unordered list element.
+ * @internal
+ */
 export function UnorderedList({ items, className, ...props }: UnorderedListProps) {
   return (
     <ul className={classnames(styles.list, className)} data-variant="unordered" {...props}>

--- a/src/components/Common/UI/List/index.ts
+++ b/src/components/Common/UI/List/index.ts
@@ -1,3 +1,3 @@
 export { OrderedList } from './OrderedList'
 export { UnorderedList } from './UnorderedList'
-export type { BaseListProps, OrderedListProps, UnorderedListProps } from './ListTypes'
+export type { OrderedListProps, UnorderedListProps } from './ListTypes'

--- a/src/components/Common/UI/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/Common/UI/LoadingSpinner/LoadingSpinner.tsx
@@ -6,6 +6,13 @@ import { LoadingSpinnerDefaults } from './LoadingSpinnerTypes'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import SpinnerIcon from '@/assets/icons/spinner_large.svg?react'
 
+/**
+ * Indeterminate loading indicator with a built-in `role="status"` and accessible label.
+ *
+ * @param rawProps - See {@link LoadingSpinnerProps}.
+ * @returns The rendered spinner element.
+ * @internal
+ */
 export const LoadingSpinner: React.FC<LoadingSpinnerProps> = rawProps => {
   const resolvedProps = applyMissingDefaults(rawProps, LoadingSpinnerDefaults)
   const { className, size, style, ...otherProps } = resolvedProps

--- a/src/components/Common/UI/LoadingSpinner/LoadingSpinnerTypes.ts
+++ b/src/components/Common/UI/LoadingSpinner/LoadingSpinnerTypes.ts
@@ -1,21 +1,33 @@
 import type { HTMLAttributes } from 'react'
 
+/**
+ * Props your `LoadingSpinner` implementation must accept from the component adapter.
+ * Renders a spinner indicating that content is loading.
+ *
+ * @public
+ */
 export interface LoadingSpinnerProps extends Pick<
   HTMLAttributes<HTMLDivElement>,
   'className' | 'id' | 'aria-label'
 > {
   /**
    * Size of the spinner
+   *
+   * @defaultValue `'lg'`
    */
   size?: 'lg' | 'sm'
   /**
    * Display style of the spinner
+   *
+   * @defaultValue `'block'`
    */
   style?: 'inline' | 'block'
 }
 
 /**
- * Default prop values for LoadingSpinner component.
+ * Default prop values for the {@link LoadingSpinner} component.
+ *
+ * @internal
  */
 export const LoadingSpinnerDefaults = {
   size: 'lg',

--- a/src/components/Common/UI/LoadingSpinner/index.ts
+++ b/src/components/Common/UI/LoadingSpinner/index.ts
@@ -1,3 +1,1 @@
 export { LoadingSpinner } from './LoadingSpinner'
-export type { LoadingSpinnerProps } from './LoadingSpinnerTypes'
-export { LoadingSpinnerDefaults } from './LoadingSpinnerTypes'

--- a/src/components/Common/UI/Menu/Menu.tsx
+++ b/src/components/Common/UI/Menu/Menu.tsx
@@ -4,6 +4,13 @@ import { type MenuProps, MenuDefaults } from './MenuTypes'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import { useTheme } from '@/contexts/ThemeProvider'
 
+/**
+ * Popover menu anchored to a trigger element, with a configurable list of actions.
+ *
+ * @param rawProps - See {@link MenuProps}.
+ * @returns The rendered menu popover, or `null` content when closed.
+ * @internal
+ */
 export function Menu(rawProps: MenuProps) {
   const resolvedProps = applyMissingDefaults(rawProps, MenuDefaults)
   const {

--- a/src/components/Common/UI/Menu/MenuTypes.ts
+++ b/src/components/Common/UI/Menu/MenuTypes.ts
@@ -1,6 +1,12 @@
 import type { ReactNode, RefObject } from 'react'
 import type { DataAttributes } from '@/types/Helpers'
 
+/**
+ * Action entry your `Menu` implementation must accept for each entry in its `items` array
+ * from the component adapter.
+ *
+ * @public
+ */
 export interface MenuItem extends DataAttributes {
   /**
    * Text label for the menu item
@@ -24,6 +30,12 @@ export interface MenuItem extends DataAttributes {
   href?: string
 }
 
+/**
+ * Props your `Menu` implementation must accept from the component adapter.
+ * Renders a popover menu of actions anchored to a trigger element.
+ *
+ * @public
+ */
 export interface MenuProps extends DataAttributes {
   /**
    * Reference to the element that triggers the menu
@@ -35,6 +47,8 @@ export interface MenuProps extends DataAttributes {
   items?: MenuItem[]
   /**
    * Controls whether the menu is currently open
+   *
+   * @defaultValue `false`
    */
   isOpen?: boolean
   /**
@@ -52,6 +66,8 @@ export interface MenuProps extends DataAttributes {
   portalContainer?: HTMLElement
   /**
    * Controls the placement of the menu popover relative to the trigger
+   *
+   * @defaultValue `'bottom start'`
    */
   placement?:
     | 'top'
@@ -65,7 +81,9 @@ export interface MenuProps extends DataAttributes {
 }
 
 /**
- * Default prop values for Menu component.
+ * Default prop values for the {@link Menu} component.
+ *
+ * @internal
  */
 export const MenuDefaults = {
   isOpen: false,

--- a/src/components/Common/UI/Modal/Modal.tsx
+++ b/src/components/Common/UI/Modal/Modal.tsx
@@ -8,6 +8,16 @@ import { useOverflowDetection } from '@/hooks/useOverflowDetection/useOverflowDe
 import { useForkRef } from '@/hooks/useForkRef/useForkRef'
 import { transitionDuration } from '@/contexts/ThemeProvider/theme'
 
+/**
+ * Native `<dialog>`-backed modal with backdrop dismissal, Escape-key support, and a fixed footer.
+ *
+ * @remarks
+ * Used as the base primitive for higher-level surfaces like {@link DialogProps | Dialog}. Body and footer content scroll independently when the body overflows.
+ *
+ * @param rawProps - See {@link ModalProps}.
+ * @returns The rendered modal element.
+ * @internal
+ */
 export function Modal(rawProps: ModalProps) {
   const resolvedProps = applyMissingDefaults(rawProps, ModalDefaults)
   const { isOpen, onClose, shouldCloseOnBackdropClick, children, footer, containerRef } =

--- a/src/components/Common/UI/Modal/ModalTypes.ts
+++ b/src/components/Common/UI/Modal/ModalTypes.ts
@@ -1,8 +1,16 @@
 import type { ReactNode } from 'react'
 
+/**
+ * Props your `Modal` implementation must accept from the component adapter.
+ * Renders a modal overlay with body and footer content.
+ *
+ * @public
+ */
 export interface ModalProps {
   /**
    * Controls whether the modal is open or closed
+   *
+   * @defaultValue `false`
    */
   isOpen?: boolean
   /**
@@ -11,6 +19,8 @@ export interface ModalProps {
   onClose?: () => void
   /**
    * Whether clicking the backdrop should close the modal
+   *
+   * @defaultValue `false`
    */
   shouldCloseOnBackdropClick?: boolean
   /**
@@ -28,7 +38,9 @@ export interface ModalProps {
 }
 
 /**
- * Default prop values for Modal component.
+ * Default prop values for the {@link Modal} component.
+ *
+ * @internal
  */
 export const ModalDefaults = {
   isOpen: false,

--- a/src/components/Common/UI/Modal/index.ts
+++ b/src/components/Common/UI/Modal/index.ts
@@ -1,2 +1,1 @@
 export { Modal } from './Modal'
-export type { ModalProps } from './ModalTypes'

--- a/src/components/Common/UI/MultiSelectComboBox/MultiSelectComboBox.tsx
+++ b/src/components/Common/UI/MultiSelectComboBox/MultiSelectComboBox.tsx
@@ -22,6 +22,13 @@ import { useForkRef } from '@/hooks/useForkRef/useForkRef'
 import AlertCircle from '@/assets/icons/alert-circle.svg?react'
 import CaretDown from '@/assets/icons/caret-down.svg?react'
 
+/**
+ * Combo box that lets the user pick multiple options, rendering each selection as a dismissable chip below the input.
+ *
+ * @param props - See {@link MultiSelectComboBoxProps}.
+ * @returns The rendered multi-select combo box field.
+ * @internal
+ */
 export function MultiSelectComboBox({
   className,
   description,

--- a/src/components/Common/UI/MultiSelectComboBox/MultiSelectComboBoxTypes.ts
+++ b/src/components/Common/UI/MultiSelectComboBox/MultiSelectComboBoxTypes.ts
@@ -1,22 +1,67 @@
 import type { InputHTMLAttributes, Ref } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
+/**
+ * Option entry for a `MultiSelectComboBox` dropdown list.
+ *
+ * @public
+ */
 export interface MultiSelectComboBoxOption {
+  /**
+   * Display text for the option
+   */
   label: string
+  /**
+   * Value of the option that will be passed to onChange
+   */
   value: string
 }
 
+/**
+ * Props your `MultiSelectComboBox` implementation must accept from the component adapter.
+ * Renders a form field wrapping a typeahead input for multi-option selection.
+ *
+ * @public
+ * @see {@link ComboBoxProps}
+ */
 export interface MultiSelectComboBoxProps
   extends
     SharedFieldLayoutProps,
     Pick<InputHTMLAttributes<HTMLInputElement>, 'className' | 'id' | 'name' | 'placeholder'> {
+  /**
+   * React ref for the combo box input element
+   */
   inputRef?: Ref<HTMLInputElement>
+  /**
+   * Disables the combo box and prevents interaction
+   */
   isDisabled?: boolean
+  /**
+   * Indicates that the field has an error
+   */
   isInvalid?: boolean
+  /**
+   * Shows a loading message in the description slot while options are being fetched
+   */
   isLoading?: boolean
+  /**
+   * Label text for the combo box field
+   */
   label: string
+  /**
+   * Array of options to display in the dropdown
+   */
   options: MultiSelectComboBoxOption[]
+  /**
+   * Currently selected values
+   */
   value?: string[]
+  /**
+   * Callback when the set of selected values changes
+   */
   onChange?: (values: string[]) => void
+  /**
+   * Handler for blur events
+   */
   onBlur?: () => void
 }

--- a/src/components/Common/UI/MultiSelectComboBox/index.ts
+++ b/src/components/Common/UI/MultiSelectComboBox/index.ts
@@ -1,5 +1,0 @@
-export { MultiSelectComboBox } from './MultiSelectComboBox'
-export type {
-  MultiSelectComboBoxProps,
-  MultiSelectComboBoxOption,
-} from './MultiSelectComboBoxTypes'

--- a/src/components/Common/UI/NumberInput/NumberInput.tsx
+++ b/src/components/Common/UI/NumberInput/NumberInput.tsx
@@ -6,6 +6,13 @@ import type { NumberInputProps } from './NumberInputTypes'
 import { FieldLayout } from '@/components/Common/FieldLayout'
 import { useLocale } from '@/contexts/LocaleProvider'
 
+/**
+ * Renders a numeric input with locale-aware formatting for currency, decimal, or percent values.
+ *
+ * @param props - The {@link NumberInputProps} controlling the input's label, value, format, and validation state.
+ * @returns The rendered number input field.
+ * @internal
+ */
 export function NumberInput({
   name,
   format,

--- a/src/components/Common/UI/NumberInput/NumberInputTypes.ts
+++ b/src/components/Common/UI/NumberInput/NumberInputTypes.ts
@@ -2,6 +2,12 @@ import type { InputHTMLAttributes, Ref } from 'react'
 import type { InputProps } from '../Input/InputTypes'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
+/**
+ * Props your `NumberInput` implementation must accept from the component adapter.
+ * Renders a form field wrapping a numeric `<input />` for currency, decimal, or percent values, with optional start/end adornments.
+ *
+ * @public
+ */
 export interface NumberInputProps
   extends
     SharedFieldLayoutProps,

--- a/src/components/Common/UI/ProgressBar/ProgressBar.tsx
+++ b/src/components/Common/UI/ProgressBar/ProgressBar.tsx
@@ -4,6 +4,13 @@ import { Flex } from '../../Flex'
 import type { ProgressBarProps } from './ProgressBarTypes'
 import styles from './ProgressBar.module.scss'
 
+/**
+ * Renders a horizontal progress indicator showing the current step within a multi-step sequence.
+ *
+ * @param props - The {@link ProgressBarProps} controlling the step count, label, and optional CTA.
+ * @returns The rendered progress bar with an accessible progress element.
+ * @internal
+ */
 export function ProgressBar({
   className,
   totalSteps,

--- a/src/components/Common/UI/ProgressBar/ProgressBarTypes.ts
+++ b/src/components/Common/UI/ProgressBar/ProgressBarTypes.ts
@@ -1,3 +1,9 @@
+/**
+ * Props your `ProgressBar` implementation must accept from the component adapter.
+ * Renders a step-based progress indicator for multi-step flows.
+ *
+ * @public
+ */
 export interface ProgressBarProps {
   /**
    * Total number of steps in the progress sequence

--- a/src/components/Common/UI/Radio/Radio.tsx
+++ b/src/components/Common/UI/Radio/Radio.tsx
@@ -7,6 +7,17 @@ import { RadioDefaults } from './RadioTypes'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import { HorizontalFieldLayout } from '@/components/Common/HorizontalFieldLayout'
 
+/**
+ * Renders a single radio button with label, description, and error message support.
+ *
+ * @remarks
+ * Use {@link RadioGroup} when presenting multiple mutually exclusive options together — this
+ * primitive is the building block for a single radio entry.
+ *
+ * @param rawProps - The {@link RadioProps} controlling the radio's label, checked state, and validation.
+ * @returns The rendered radio input with its associated label.
+ * @internal
+ */
 export const Radio = (rawProps: RadioProps) => {
   const resolvedProps = applyMissingDefaults(rawProps, RadioDefaults)
   const {

--- a/src/components/Common/UI/Radio/RadioTypes.ts
+++ b/src/components/Common/UI/Radio/RadioTypes.ts
@@ -1,6 +1,12 @@
 import type { InputHTMLAttributes, Ref } from 'react'
 import type { SharedHorizontalFieldLayoutProps } from '@/components/Common/HorizontalFieldLayout/HorizontalFieldLayoutTypes'
 
+/**
+ * Props your `Radio` implementation must accept from the component adapter.
+ * Renders a form field wrapping an `<input type="radio" />` with a label, optional description, and error message.
+ *
+ * @public
+ */
 export interface RadioProps
   extends
     SharedHorizontalFieldLayoutProps,
@@ -19,16 +25,22 @@ export interface RadioProps
   inputRef?: Ref<HTMLInputElement>
   /**
    * Indicates that the field has an error
+   *
+   * @defaultValue `false`
    */
   isInvalid?: boolean
   /**
    * Disables the radio button and prevents interaction
+   *
+   * @defaultValue `false`
    */
   isDisabled?: boolean
 }
 
 /**
- * Default prop values for Radio component.
+ * Default prop values for the Radio component.
+ *
+ * @internal
  */
 export const RadioDefaults = {
   isInvalid: false,

--- a/src/components/Common/UI/RadioGroup/RadioGroup.tsx
+++ b/src/components/Common/UI/RadioGroup/RadioGroup.tsx
@@ -79,6 +79,13 @@ function ReactAriaRadioWrapper(props: Omit<ReactAriaRadioProps, 'groupState'>) {
   return groupState ? <ReactAriaRadio groupState={groupState} {...props} /> : null
 }
 
+/**
+ * Renders a group of mutually exclusive radio options that share a single label, description, and error state.
+ *
+ * @param rawProps - The {@link RadioGroupProps} controlling the group's label, options, and selected value.
+ * @returns The rendered radio group as a fieldset.
+ * @internal
+ */
 export function RadioGroup(rawProps: RadioGroupProps) {
   const resolvedProps = applyMissingDefaults(rawProps, RadioGroupDefaults)
   const {

--- a/src/components/Common/UI/RadioGroup/RadioGroupTypes.ts
+++ b/src/components/Common/UI/RadioGroup/RadioGroupTypes.ts
@@ -1,6 +1,11 @@
 import type { FieldsetHTMLAttributes, Ref } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
+/**
+ * Option entry your `RadioGroup` implementation receives in the `options` array when rendering each radio button.
+ *
+ * @public
+ */
 export interface RadioGroupOption {
   /**
    * Label text or content for the radio option
@@ -20,14 +25,24 @@ export interface RadioGroupOption {
   description?: React.ReactNode
 }
 
+/**
+ * Props your `RadioGroup` implementation must accept from the component adapter.
+ * Renders a form field wrapping multiple `<input type="radio" />` elements with a label, optional description, and error message.
+ *
+ * @public
+ */
 export interface RadioGroupProps
   extends SharedFieldLayoutProps, Pick<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'className'> {
   /**
    * Indicates that the field has an error
+   *
+   * @defaultValue `false`
    */
   isInvalid?: boolean
   /**
    * Disables all radio options in the group
+   *
+   * @defaultValue `false`
    */
   isDisabled?: boolean
   /**
@@ -53,7 +68,9 @@ export interface RadioGroupProps
 }
 
 /**
- * Default prop values for RadioGroup component.
+ * Default prop values for the RadioGroup component.
+ *
+ * @internal
  */
 export const RadioGroupDefaults = {
   isRequired: false,

--- a/src/components/Common/UI/Select/Select.tsx
+++ b/src/components/Common/UI/Select/Select.tsx
@@ -18,6 +18,13 @@ import CaretDown from '@/assets/icons/caret-down.svg?react'
 import AlertCircle from '@/assets/icons/alert-circle.svg?react'
 import { useTheme } from '@/contexts/ThemeProvider'
 
+/**
+ * Renders a dropdown select with label, description, and error message support.
+ *
+ * @param props - The {@link SelectProps} controlling the select's label, options, and selected value.
+ * @returns The rendered select field with its associated popover listbox.
+ * @internal
+ */
 export const Select = ({
   description,
   errorMessage,

--- a/src/components/Common/UI/Select/SelectTypes.ts
+++ b/src/components/Common/UI/Select/SelectTypes.ts
@@ -1,6 +1,11 @@
 import type { Ref, SelectHTMLAttributes } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
+/**
+ * Option entry your `Select` implementation receives in the `options` array when rendering each item in the dropdown.
+ *
+ * @public
+ */
 export interface SelectOption {
   /**
    * Value of the option that will be passed to onChange
@@ -12,6 +17,12 @@ export interface SelectOption {
   label: string
 }
 
+/**
+ * Props your `Select` implementation must accept from the component adapter.
+ * Renders a form field wrapping a single-select dropdown with a label, description, and error message.
+ *
+ * @public
+ */
 export interface SelectProps
   extends
     SharedFieldLayoutProps,

--- a/src/components/Common/UI/Switch/Switch.tsx
+++ b/src/components/Common/UI/Switch/Switch.tsx
@@ -8,6 +8,13 @@ import { SwitchDefaults } from './SwitchTypes'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import { HorizontalFieldLayout } from '@/components/Common/HorizontalFieldLayout'
 
+/**
+ * Toggle switch control with label, description, and error messaging.
+ *
+ * @param rawProps - Switch configuration; see {@link SwitchProps}.
+ * @returns The rendered switch input.
+ * @public
+ */
 export function Switch(rawProps: SwitchProps) {
   const resolvedProps = applyMissingDefaults(rawProps, SwitchDefaults)
   const {

--- a/src/components/Common/UI/Switch/SwitchTypes.ts
+++ b/src/components/Common/UI/Switch/SwitchTypes.ts
@@ -1,6 +1,12 @@
 import type { AriaAttributes, InputHTMLAttributes, Ref } from 'react'
 import type { SharedHorizontalFieldLayoutProps } from '@/components/Common/HorizontalFieldLayout/HorizontalFieldLayoutTypes'
 
+/**
+ * Props your `Switch` implementation must accept from the component adapter.
+ * Renders a form field wrapping an `<input type="checkbox" />` styled as a boolean on/off toggle.
+ *
+ * @public
+ */
 export interface SwitchProps
   extends
     SharedHorizontalFieldLayoutProps,
@@ -24,10 +30,14 @@ export interface SwitchProps
   inputRef?: Ref<HTMLInputElement>
   /**
    * Indicates that the field has an error
+   *
+   * @defaultValue `false`
    */
   isInvalid?: boolean
   /**
    * Disables the switch and prevents interaction
+   *
+   * @defaultValue `false`
    */
   isDisabled?: boolean
   /**
@@ -41,7 +51,9 @@ export interface SwitchProps
 }
 
 /**
- * Default prop values for Switch component.
+ * Default prop values for the Switch component.
+ *
+ * @internal
  */
 export const SwitchDefaults = {
   isInvalid: false,

--- a/src/components/Common/UI/Table/Table.tsx
+++ b/src/components/Common/UI/Table/Table.tsx
@@ -13,6 +13,13 @@ import { TableDefaults } from './TableTypes'
 import styles from './Table.module.scss'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 
+/**
+ * Data table with headers, rows, optional footer, and empty state.
+ *
+ * @param rawProps - Table configuration; see {@link TableProps}.
+ * @returns The rendered table.
+ * @public
+ */
 export function Table(rawProps: TableProps) {
   const resolvedProps = applyMissingDefaults(rawProps, TableDefaults)
   const { className, headers, rows, footer, emptyState, isWithinBox, hasCheckboxColumn, ...props } =

--- a/src/components/Common/UI/Table/TableTypes.ts
+++ b/src/components/Common/UI/Table/TableTypes.ts
@@ -1,5 +1,10 @@
 import type { ReactNode, TableHTMLAttributes } from 'react'
 
+/**
+ * Shape of a single cell your `Table` implementation receives for headers, rows, and footers.
+ *
+ * @public
+ */
 export interface TableData {
   /**
    * Unique identifier for the table cell
@@ -11,6 +16,11 @@ export interface TableData {
   content: ReactNode
 }
 
+/**
+ * Shape of a single row your `Table` implementation receives, containing an ordered list of cells.
+ *
+ * @public
+ */
 export interface TableRow {
   /**
    * Unique identifier for the table row
@@ -22,6 +32,12 @@ export interface TableRow {
   data: TableData[]
 }
 
+/**
+ * Props your `Table` implementation must accept from the component adapter.
+ * Renders a table with column headers, body rows, an optional footer row, and an optional empty state.
+ *
+ * @public
+ */
 export interface TableProps extends Pick<
   TableHTMLAttributes<HTMLTableElement>,
   'className' | 'aria-label' | 'id' | 'role' | 'aria-labelledby' | 'aria-describedby'
@@ -44,16 +60,22 @@ export interface TableProps extends Pick<
   emptyState?: ReactNode
   /**
    * Removes borders and background for use inside a Box component
+   *
+   * @defaultValue `false`
    */
   isWithinBox?: boolean
   /**
    * Whether the first column contains checkboxes (affects which column gets leading variant)
+   *
+   * @defaultValue `false`
    */
   hasCheckboxColumn?: boolean
 }
 
 /**
- * Default prop values for Table component.
+ * Default prop values for the Table component.
+ *
+ * @internal
  */
 export const TableDefaults = {
   isWithinBox: false,

--- a/src/components/Common/UI/Tabs/Tabs.tsx
+++ b/src/components/Common/UI/Tabs/Tabs.tsx
@@ -12,6 +12,18 @@ import styles from './Tabs.module.scss'
 import { useContainerBreakpoints } from '@/hooks/useContainerBreakpoints/useContainerBreakpoints'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
+/**
+ * Accessible controlled tab navigation that responsively adapts to container width.
+ *
+ * @remarks
+ * At or above the small breakpoint (640px) the component renders horizontal tabs.
+ * Below that breakpoint it falls back to a dropdown select to avoid horizontal
+ * scrolling without positional meaning.
+ *
+ * @param props - Tabs configuration; see {@link TabsProps}.
+ * @returns The rendered tabs with the selected panel.
+ * @public
+ */
 export function Tabs({ tabs, selectedId, onSelectionChange, className, ...ariaProps }: TabsProps) {
   const { t } = useTranslation('common')
   const { Select } = useComponentContext()

--- a/src/components/Common/UI/Tabs/TabsTypes.ts
+++ b/src/components/Common/UI/Tabs/TabsTypes.ts
@@ -1,7 +1,9 @@
 import type { ReactNode } from 'react'
 
 /**
- * Individual tab configuration
+ * Shape of a single tab configuration your `Tabs` implementation receives in its `tabs` prop.
+ *
+ * @public
  */
 export interface TabProps {
   /**
@@ -23,14 +25,10 @@ export interface TabProps {
 }
 
 /**
- * Props for the Tabs component - provides accessible tab navigation (controlled only)
+ * Props your `Tabs` implementation must accept from the component adapter.
+ * Renders tabbed navigation with associated content panels.
  *
- * Responsively adapts to container size:
- * - Below 640px (small breakpoint): renders as a dropdown select for mobile devices
- * - At or above 640px: renders as horizontal tabs for desktop views
- *
- * This adaptive behavior ensures WCAG 2.2 compliance by avoiding horizontal scrolling
- * without positional meaning, while maintaining a familiar tab interface on larger screens.
+ * @public
  */
 export interface TabsProps {
   /**

--- a/src/components/Common/UI/Tabs/index.ts
+++ b/src/components/Common/UI/Tabs/index.ts
@@ -1,2 +1,1 @@
 export { Tabs } from './Tabs'
-export type { TabsProps, TabProps } from './TabsTypes'

--- a/src/components/Common/UI/Text/Text.tsx
+++ b/src/components/Common/UI/Text/Text.tsx
@@ -4,6 +4,13 @@ import { TextDefaults } from './TextTypes'
 import styles from './Text.module.scss'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 
+/**
+ * Renders body text with configurable element, size, weight, alignment, and variant.
+ *
+ * @param rawProps - Text configuration; see {@link TextProps}.
+ * @returns The rendered text element.
+ * @public
+ */
 export const Text = (rawProps: TextProps) => {
   const resolvedProps = applyMissingDefaults(rawProps, TextDefaults)
   const { as: Component, size, textAlign, weight, className, children, variant, id } = resolvedProps

--- a/src/components/Common/UI/Text/TextTypes.ts
+++ b/src/components/Common/UI/Text/TextTypes.ts
@@ -1,12 +1,22 @@
 import type { HTMLAttributes, ReactNode } from 'react'
 
+/**
+ * Props your `Text` implementation must accept from the component adapter.
+ * Renders body text as `<p>`, `<span>`, `<div>`, or `<pre>`, with size, weight, alignment, and variant options.
+ *
+ * @public
+ */
 export interface TextProps extends Pick<HTMLAttributes<HTMLParagraphElement>, 'className' | 'id'> {
   /**
    * HTML element to render the text as
+   *
+   * @defaultValue `'p'`
    */
   as?: 'p' | 'span' | 'div' | 'pre'
   /**
    * Size variant of the text
+   *
+   * @defaultValue `'md'`
    */
   size?: 'xs' | 'sm' | 'md' | 'lg'
   /**
@@ -28,7 +38,9 @@ export interface TextProps extends Pick<HTMLAttributes<HTMLParagraphElement>, 'c
 }
 
 /**
- * Default prop values for Text component.
+ * Default prop values for the Text component.
+ *
+ * @internal
  */
 export const TextDefaults = {
   as: 'p',

--- a/src/components/Common/UI/Text/index.ts
+++ b/src/components/Common/UI/Text/index.ts
@@ -1,2 +1,1 @@
 export { Text } from './Text'
-export type { TextProps } from './TextTypes'

--- a/src/components/Common/UI/TextArea/TextArea.tsx
+++ b/src/components/Common/UI/TextArea/TextArea.tsx
@@ -9,6 +9,13 @@ import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import { FieldLayout } from '@/components/Common/FieldLayout'
 import AlertCircle from '@/assets/icons/alert-circle.svg?react'
 
+/**
+ * Multi-line text input with label, description, and error messaging.
+ *
+ * @param rawProps - TextArea configuration; see {@link TextAreaProps}.
+ * @returns The rendered textarea field.
+ * @public
+ */
 export function TextArea(rawProps: TextAreaProps) {
   const resolvedProps = applyMissingDefaults(rawProps, TextAreaDefaults)
   const {

--- a/src/components/Common/UI/TextArea/TextAreaTypes.ts
+++ b/src/components/Common/UI/TextArea/TextAreaTypes.ts
@@ -1,12 +1,18 @@
 import type { Ref, TextareaHTMLAttributes } from 'react'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
+/**
+ * Props your `TextArea` implementation must accept from the component adapter.
+ * Renders a form field wrapping a `<textarea>` with a label, description, and error message.
+ *
+ * @public
+ */
 export interface TextAreaProps
   extends
     SharedFieldLayoutProps,
     Pick<
       TextareaHTMLAttributes<HTMLTextAreaElement>,
-      'name' | 'id' | 'placeholder' | 'className' | 'rows' | 'cols'
+      'name' | 'id' | 'placeholder' | 'className' | 'cols'
     >,
     Pick<TextareaHTMLAttributes<HTMLTextAreaElement>, 'aria-describedby'> {
   /**
@@ -23,21 +29,32 @@ export interface TextAreaProps
   onChange?: (value: string) => void
   /**
    * Indicates that the field has an error
+   *
+   * @defaultValue `false`
    */
   isInvalid?: boolean
   /**
    * Disables the textarea and prevents interaction
+   *
+   * @defaultValue `false`
    */
   isDisabled?: boolean
   /**
    * Handler for blur events
    */
   onBlur?: () => void
+  /**
+   * Number of visible text rows
+   *
+   * @defaultValue `4`
+   */
+  rows?: number
 }
 
 /**
- * Default prop values for TextArea component.
- * These are used by the component adapter to automatically provide defaults.
+ * Default prop values for the TextArea component.
+ *
+ * @internal
  */
 export const TextAreaDefaults = {
   isInvalid: false,

--- a/src/components/Common/UI/TextArea/index.ts
+++ b/src/components/Common/UI/TextArea/index.ts
@@ -1,3 +1,1 @@
 export { TextArea } from './TextArea'
-export type { TextAreaProps } from './TextAreaTypes'
-export { TextAreaDefaults } from './TextAreaTypes'

--- a/src/components/Common/UI/TextInput/TextInput.tsx
+++ b/src/components/Common/UI/TextInput/TextInput.tsx
@@ -6,6 +6,13 @@ import { TextInputDefaults } from './TextInputTypes'
 import { applyMissingDefaults } from '@/helpers/applyMissingDefaults'
 import { FieldLayout } from '@/components/Common/FieldLayout'
 
+/**
+ * Renders a single-line text input with a label, optional description, error message, and adornments.
+ *
+ * @param rawProps - The {@link TextInputProps} controlling the input's value, label, validation state, and surrounding layout.
+ * @returns The rendered text input wrapped in its field layout.
+ * @internal
+ */
 export function TextInput(rawProps: TextInputProps) {
   const resolvedProps = applyMissingDefaults(rawProps, TextInputDefaults)
   const {

--- a/src/components/Common/UI/TextInput/TextInputTypes.ts
+++ b/src/components/Common/UI/TextInput/TextInputTypes.ts
@@ -2,6 +2,12 @@ import type { Ref, InputHTMLAttributes } from 'react'
 import type { InputProps } from '../Input/InputTypes'
 import type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
 
+/**
+ * Props your `TextInput` implementation must accept from the component adapter.
+ * Renders a form field wrapping an `<input />` with a label, description, error message, and start/end adornment slots.
+ *
+ * @public
+ */
 export interface TextInputProps
   extends
     SharedFieldLayoutProps,
@@ -24,10 +30,14 @@ export interface TextInputProps
   onChange?: (value: string) => void
   /**
    * Indicates that the field has an error
+   *
+   * @defaultValue `false`
    */
   isInvalid?: boolean
   /**
    * Disables the input and prevents interaction
+   *
+   * @defaultValue `false`
    */
   isDisabled?: boolean
   /**
@@ -45,8 +55,9 @@ export interface TextInputProps
 }
 
 /**
- * Default prop values for TextInput component.
- * These are used by the component adapter to automatically provide defaults.
+ * Default prop values for the TextInput component.
+ *
+ * @internal
  */
 export const TextInputDefaults = {
   type: 'text',

--- a/src/components/Common/UI/hooks/useFieldIds.ts
+++ b/src/components/Common/UI/hooks/useFieldIds.ts
@@ -9,6 +9,7 @@ interface UseFieldIdsProps {
   ariaDescribedBy?: string
 }
 
+/** @internal */
 export function useFieldIds({
   inputId: providedInputId,
   errorMessage,

--- a/src/contexts/ComponentAdapter/ComponentsProvider.tsx
+++ b/src/contexts/ComponentAdapter/ComponentsProvider.tsx
@@ -3,11 +3,13 @@ import { useMemo } from 'react'
 import type { ComponentsContextType } from './useComponentContext'
 import { ComponentsContext } from './useComponentContext'
 
+/** @internal */
 interface ComponentsProviderProps {
   children: React.ReactNode
   value: ComponentsContextType | undefined
 }
 
+/** @internal */
 export const ComponentsProvider = ({ children, value }: ComponentsProviderProps) => {
   const contextValue = useMemo(() => {
     return value

--- a/src/contexts/ComponentAdapter/adapters/defaultComponentAdapter.tsx
+++ b/src/contexts/ComponentAdapter/adapters/defaultComponentAdapter.tsx
@@ -75,6 +75,7 @@ import { DescriptionList } from '@/components/Common/UI/DescriptionList'
 import type { FileInputProps } from '@/components/Common/UI/FileInput/FileInputTypes'
 import { FileInput } from '@/components/Common/UI/FileInput'
 
+/** @internal */
 export const defaultComponents: ComponentsContextType = {
   Alert: (props: AlertProps) => <Alert {...props} />,
   Badge: (props: BadgeProps) => <Badge {...props} />,

--- a/src/contexts/ComponentAdapter/componentAdapterTypes.ts
+++ b/src/contexts/ComponentAdapter/componentAdapterTypes.ts
@@ -10,7 +10,15 @@ export type {
   CheckboxGroupOption,
 } from '@/components/Common/UI/CheckboxGroup/CheckboxGroupTypes'
 export type { ComboBoxProps, ComboBoxOption } from '@/components/Common/UI/ComboBox/ComboBoxTypes'
+export type {
+  MultiSelectComboBoxProps,
+  MultiSelectComboBoxOption,
+} from '@/components/Common/UI/MultiSelectComboBox/MultiSelectComboBoxTypes'
 export type { DatePickerProps } from '@/components/Common/UI/DatePicker/DatePickerTypes'
+export type {
+  DateRangePickerProps,
+  DateRange,
+} from '@/components/Common/UI/DateRangePicker/DateRangePickerTypes'
 export type { LinkProps } from '@/components/Common/UI/Link/LinkTypes'
 export type { MenuProps, MenuItem } from '@/components/Common/UI/Menu/MenuTypes'
 export type { NumberInputProps } from '@/components/Common/UI/NumberInput/NumberInputTypes'

--- a/src/contexts/ComponentAdapter/createComponentsWithDefaults.ts
+++ b/src/contexts/ComponentAdapter/createComponentsWithDefaults.ts
@@ -40,6 +40,7 @@ import { BoxHeaderDefaults } from '@/components/Common/UI/BoxHeader/BoxHeaderTyp
 import type { DescriptionListProps } from '@/components/Common/UI/DescriptionList/DescriptionListTypes'
 import { DescriptionListDefaults } from '@/components/Common/UI/DescriptionList/DescriptionListTypes'
 
+/** @internal */
 function composeWithDefaults<TProps>(defaults: Partial<TProps>, componentName: string) {
   return (customComponent: (props: TProps) => React.ReactElement | null) => {
     const wrappedComponent = (props: TProps) => {
@@ -51,7 +52,7 @@ function composeWithDefaults<TProps>(defaults: Partial<TProps>, componentName: s
   }
 }
 
-// Component creators with defaults
+/** @internal */
 export const componentCreators = {
   Alert: composeWithDefaults<AlertProps>(AlertDefaults, 'Alert'),
   Badge: composeWithDefaults<BadgeProps>(BadgeDefaults, 'Badge'),
@@ -83,6 +84,8 @@ export const componentCreators = {
 /**
  * Creates components with automatic default prop handling.
  * Supports both partial (GustoProvider) and full (GustoProviderCustomUIAdapter) component sets.
+ *
+ * @internal
  */
 export function createComponents(
   providedComponents: Partial<ComponentsContextType> = {},

--- a/src/contexts/ComponentAdapter/useComponentContext.ts
+++ b/src/contexts/ComponentAdapter/useComponentContext.ts
@@ -38,6 +38,61 @@ import type { BoxHeaderProps } from '@/components/Common/UI/BoxHeader/BoxHeaderT
 import type { MultiSelectComboBoxProps } from '@/components/Common/UI/MultiSelectComboBox/MultiSelectComboBoxTypes'
 import type { PayrollLoadingProps } from '@/components/Common/PayrollLoading/PayrollLoadingTypes'
 
+/**
+ * Full map of UI components used by the SDK. Every property is a React component that the
+ * SDK renders internally — override any of them to substitute your own design system.
+ *
+ * Pass a `Partial<ComponentsContextType>` to `GustoProvider` via the `components` prop to
+ * replace specific components while keeping SDK defaults for the rest.
+ *
+ * To take full control of every UI component (and eliminate the React Aria dependency),
+ * pass a complete `ComponentsContextType` to `GustoProviderCustomUIAdapter` instead.
+ * All properties are then required except `PaginationControl` and `PayrollLoading`,
+ * which fall back to built-in SDK implementations when omitted.
+ *
+ * @public
+ *
+ * @example Partial override with GustoProvider
+ * ```tsx
+ * import { GustoProvider } from '@gusto/embedded-react-sdk'
+ *
+ * function App() {
+ *   return (
+ *     <GustoProvider
+ *       config={{ baseUrl: '/api/gusto/' }}
+ *       components={{
+ *         Button: MyButton,
+ *         TextInput: MyTextInput,
+ *       }}
+ *     >
+ *       <EmployeeOnboardingFlow companyId="company_123" />
+ *     </GustoProvider>
+ *   )
+ * }
+ * ```
+ *
+ * @example Full replacement with GustoProviderCustomUIAdapter
+ * ```tsx
+ * import { GustoProviderCustomUIAdapter, type ComponentsContextType } from '@gusto/embedded-react-sdk'
+ *
+ * const myComponents: ComponentsContextType = {
+ *   Alert: props => <MyAlert {...props} />,
+ *   Button: props => <MyButton {...props} />,
+ *   // ... all required components
+ * }
+ *
+ * function App() {
+ *   return (
+ *     <GustoProviderCustomUIAdapter
+ *       config={{ baseUrl: '/api/gusto/' }}
+ *       components={myComponents}
+ *     >
+ *       <EmployeeOnboardingFlow companyId="company_123" />
+ *     </GustoProviderCustomUIAdapter>
+ *   )
+ * }
+ * ```
+ */
 export interface ComponentsContextType {
   /** Status message with an optional dismiss action; used for errors, warnings, success, and info. */
   Alert: (props: AlertProps) => JSX.Element | null
@@ -119,8 +174,11 @@ export interface ComponentsContextType {
   /** Loading indicator for payroll calculation. Defaults to the SDK's built-in loading state when omitted. */
   PayrollLoading?: (props: PayrollLoadingProps) => JSX.Element | null
 }
+
+/** @internal */
 export const ComponentsContext = createContext<ComponentsContextType | null>(null)
 
+/** @internal */
 export const useComponentContext = () => {
   const context = useContext(ComponentsContext)
   if (!context) {

--- a/src/contexts/ComponentAdapter/useComponentContext.ts
+++ b/src/contexts/ComponentAdapter/useComponentContext.ts
@@ -39,47 +39,86 @@ import type { MultiSelectComboBoxProps } from '@/components/Common/UI/MultiSelec
 import type { PayrollLoadingProps } from '@/components/Common/PayrollLoading/PayrollLoadingTypes'
 
 export interface ComponentsContextType {
+  /** Status message with an optional dismiss action; used for errors, warnings, success, and info. */
   Alert: (props: AlertProps) => JSX.Element | null
+  /** Small inline label for status, counts, or tags; optionally dismissible. */
   Badge: (props: BadgeProps) => JSX.Element | null
+  /** Full-width notification banner for prominent warnings and errors. */
   Banner: (props: BannerProps) => JSX.Element | null
+  /** HTML `<button>` with primary, secondary, tertiary, and error variants. */
   Button: (props: ButtonProps) => JSX.Element | null
+  /** Icon-only `<button>`; requires `aria-label` since there is no visible text for assistive technologies. */
   ButtonIcon: (props: ButtonIconProps) => JSX.Element | null
-  Card: (props: CardProps) => JSX.Element | null
+  /** Sectioned layout container with distinct header, body, and footer areas. */
   Box: (props: BoxProps) => JSX.Element | null
+  /** Header section of a Box with a title, optional description, and optional inline action. */
   BoxHeader: (props: BoxHeaderProps) => JSX.Element | null
-  Checkbox: (props: CheckboxProps) => JSX.Element | null
-  CheckboxGroup: (props: CheckboxGroupProps) => JSX.Element | null
-  ComboBox: (props: ComboBoxProps) => JSX.Element | null
-  MultiSelectComboBox: (props: MultiSelectComboBoxProps) => JSX.Element | null
-  DatePicker: (props: DatePickerProps) => JSX.Element | null
-  DateRangePicker: (props: DateRangePickerProps) => JSX.Element | null
-  OrderedList: (props: OrderedListProps) => JSX.Element | null
-  UnorderedList: (props: UnorderedListProps) => JSX.Element | null
-  NumberInput: (props: NumberInputProps) => JSX.Element | null
-  Radio: (props: RadioProps) => JSX.Element | null
-  RadioGroup: (props: RadioGroupProps) => JSX.Element | null
-  Select: (props: SelectProps) => JSX.Element | null
-  Switch: (props: SwitchProps) => JSX.Element | null
-  TextInput: (props: TextInputProps) => JSX.Element | null
-  TextArea: (props: TextAreaProps) => JSX.Element | null
-  Link: (props: LinkProps) => JSX.Element | null
-  Menu: (props: MenuProps) => JSX.Element | null
-  Table: (props: TableProps) => JSX.Element | null
-  Heading: (props: HeadingProps) => JSX.Element | null
-  PaginationControl?: (props: PaginationControlProps) => JSX.Element | null
-  PayrollLoading?: (props: PayrollLoadingProps) => JSX.Element | null
-  Text: (props: TextProps) => JSX.Element | null
+  /** Read-only calendar for visualizing a date range with optional highlighted dates. */
   CalendarPreview: (props: CalendarPreviewProps) => JSX.Element | null
-  ProgressBar: (props: ProgressBarProps) => JSX.Element | null
-  Breadcrumbs: (props: BreadcrumbsProps) => JSX.Element | null
-  Tabs: (props: TabsProps) => JSX.Element | null
-  Dialog: (props: DialogProps) => JSX.Element | null
-  Modal: (props: ModalProps) => JSX.Element | null
-  LoadingSpinner: (props: LoadingSpinnerProps) => JSX.Element | null
+  /** Content container with an optional overflow menu and a leading action slot. */
+  Card: (props: CardProps) => JSX.Element | null
+  /** Form field wrapping a single `<input type="checkbox" />`. */
+  Checkbox: (props: CheckboxProps) => JSX.Element | null
+  /** Form field grouping `<input type="checkbox" />` elements for multi-option selection. */
+  CheckboxGroup: (props: CheckboxGroupProps) => JSX.Element | null
+  /** Form field wrapping a typeahead `<input />` for single-option selection. */
+  ComboBox: (props: ComboBoxProps) => JSX.Element | null
+  /** Form field wrapping an `<input type="date" />` with a calendar picker popover. */
+  DatePicker: (props: DatePickerProps) => JSX.Element | null
+  /** Form field wrapping paired `<input type="date" />` elements for a date range. */
+  DateRangePicker: (props: DateRangePickerProps) => JSX.Element | null
+  /** HTML `<dl>` of term/description pairs in stacked or horizontal layout. */
   DescriptionList: (props: DescriptionListProps) => JSX.Element | null
+  /** Modal confirmation dialog with a primary action and a cancel action. */
+  Dialog: (props: DialogProps) => JSX.Element | null
+  /** Form field wrapping an `<input type="file" />`. */
   FileInput: (props: FileInputProps) => JSX.Element | null
-}
+  /** HTML `<h1>`–`<h6>` with visual style controlled independently from semantic level. */
+  Heading: (props: HeadingProps) => JSX.Element | null
+  /** HTML `<a>` for inline navigation. */
+  Link: (props: LinkProps) => JSX.Element | null
+  /** Spinner shown while data or an action is pending. */
+  LoadingSpinner: (props: LoadingSpinnerProps) => JSX.Element | null
+  /** Popover menu of actions anchored to a trigger element. */
+  Menu: (props: MenuProps) => JSX.Element | null
+  /** Overlay modal with customizable body content and footer. */
+  Modal: (props: ModalProps) => JSX.Element | null
+  /** Form field wrapping a typeahead `<input />` for multi-option selection. */
+  MultiSelectComboBox: (props: MultiSelectComboBoxProps) => JSX.Element | null
+  /** Form field wrapping a numeric `<input />` for currency, decimal, or percent values. */
+  NumberInput: (props: NumberInputProps) => JSX.Element | null
+  /** HTML `<ol>` for a numbered list of items. */
+  OrderedList: (props: OrderedListProps) => JSX.Element | null
+  /** Step-based progress indicator for multi-step flows. */
+  ProgressBar: (props: ProgressBarProps) => JSX.Element | null
+  /** Navigation breadcrumb trail showing the user's position in a multi-step flow. */
+  Breadcrumbs: (props: BreadcrumbsProps) => JSX.Element | null
+  /** Form field wrapping a single `<input type="radio" />`. */
+  Radio: (props: RadioProps) => JSX.Element | null
+  /** Form field grouping `<input type="radio" />` elements for single-option selection. */
+  RadioGroup: (props: RadioGroupProps) => JSX.Element | null
+  /** Form field wrapping a single-select dropdown. */
+  Select: (props: SelectProps) => JSX.Element | null
+  /** Form field wrapping an `<input type="checkbox" />` styled as a toggle. */
+  Switch: (props: SwitchProps) => JSX.Element | null
+  /** Tabbed navigation with associated content panels. */
+  Tabs: (props: TabsProps) => JSX.Element | null
+  /** Tabular data display with headers, rows, optional footer, and empty state. */
+  Table: (props: TableProps) => JSX.Element | null
+  /** Body text element rendered as `<p>`, `<span>`, `<div>`, or `<pre>`. */
+  Text: (props: TextProps) => JSX.Element | null
+  /** Form field wrapping an `<input />`. */
+  TextInput: (props: TextInputProps) => JSX.Element | null
+  /** Form field wrapping a `<textarea>`. */
+  TextArea: (props: TextAreaProps) => JSX.Element | null
+  /** HTML `<ul>` for an unordered list of items. */
+  UnorderedList: (props: UnorderedListProps) => JSX.Element | null
 
+  /** Pagination controls for list views. Defaults to the SDK's built-in pagination UI when omitted. */
+  PaginationControl?: (props: PaginationControlProps) => JSX.Element | null
+  /** Loading indicator for payroll calculation. Defaults to the SDK's built-in loading state when omitted. */
+  PayrollLoading?: (props: PayrollLoadingProps) => JSX.Element | null
+}
 export const ComponentsContext = createContext<ComponentsContextType | null>(null)
 
 export const useComponentContext = () => {


### PR DESCRIPTION
## Summary

### Phase 4 — Component adapter (parallel pair, no refactor)

These two are tightly coupled — document together.

| Directory | Reference Doc(s) | Notes |
|-----------|-----------------|-------|
| `src/components/Common/UI/` | `docs/component-adapter/component-inventory.md` | All \*Props interfaces for ~30 UI primitives (Alert, Button, TextInput, etc.) |
| `src/contexts/ComponentAdapter/` | `docs/component-adapter/component-adapter-types.md`, `how-the-component-adapter-works.md`, `setting-up-your-component-adapter.md` | ComponentsContextType, defaultComponents |

**Must complete before Phase 5** (Common/ parent sweep depends on UI/ being clean).

## Changes

Each commit represents running `/tsdoc-directory <directory>` in claude, using the new agent skills. This represents phase 4 of backfilling docs according to the docs audit and plan in [Notion](https://app.notion.com/p/374ad673c6c280dd8437d204f11e8470#f7f7eca5c37141919d33d7e1fed0a4c5).

## Related

- Jira ticket: [SDK-971](https://gustohq.atlassian.net/browse/SDK-971)

[SDK-971]: https://gustohq.atlassian.net/browse/SDK-971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ