### PR TITLE
fix: wrap code samples in dev app code panel

### DIFF
--- a/sdk-app/src/CodePanel.module.scss
+++ b/sdk-app/src/CodePanel.module.scss
@@ -80,19 +80,32 @@
 .code {
   flex: 1;
   margin: 0;
-  padding: 1rem 1.25rem;
+  padding: 1.25rem 1.25rem 0 0;
   font-size: 0.8125rem;
   line-height: 1.5;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, monospace;
   background: transparent;
 }
 
+.line {
+  display: flex;
+  align-items: flex-start;
+}
+
 .lineNumber {
-  display: inline-block;
+  flex-shrink: 0;
   min-width: 1.75rem;
   margin-right: 0.75rem;
   text-align: right;
   color: var(--color-text-muted);
   user-select: none;
+}
+
+.lineContent {
+  flex: 1;
+  min-width: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }

--- a/sdk-app/src/CodePanel.tsx
+++ b/sdk-app/src/CodePanel.tsx
@@ -66,14 +66,19 @@ export function CodePanel({ onClose }: CodePanelProps) {
           <Highlight code={snippet} language="tsx" theme={prismTheme}>
             {({ className, style, tokens, getLineProps, getTokenProps }) => (
               <pre className={`${styles.code} ${className}`} style={style}>
-                {tokens.map((line, i) => (
-                  <div key={i} {...getLineProps({ line })}>
-                    <span className={styles.lineNumber}>{i + 1}</span>
-                    {line.map((token, key) => (
-                      <span key={key} {...getTokenProps({ token })} />
-                    ))}
-                  </div>
-                ))}
+                {tokens.map((line, i) => {
+                  const lineProps = getLineProps({ line })
+                  return (
+                    <div key={i} {...lineProps} className={`${styles.line} ${lineProps.className}`}>
+                      <span className={styles.lineNumber}>{i + 1}</span>
+                      <span className={styles.lineContent}>
+                        {line.map((token, key) => (
+                          <span key={key} {...getTokenProps({ token })} />
+                        ))}
+                      </span>
+                    </div>
+                  )
+                })}
               </pre>
             )}
           </Highlight>


### PR DESCRIPTION
## Summary

Long lines in the SDK dev app's `CodePanel` flowed off-screen horizontally instead of wrapping, making code samples hard to read without scrolling. Make wrapping behave like a typical IDE: the code wraps softly, and continuation rows appear under the code column with a blank line-number gutter.

## Changes

- Wrap each highlighted line in a flex row: fixed-width line-number gutter on the left, a `pre-wrap` content column on the right
- Switch the `<pre>` from `overflow: auto` to `overflow-x: hidden; overflow-y: auto` so the panel only scrolls vertically

## Demo

<!-- Screenshots/recording showing wrapped code with line numbers aligned to the first visual row of each line -->

## Testing

- Run `npm run sdk-app`
- Open the Code panel and select a component whose generated snippet contains a long line (e.g. one with several props or a long string literal)
- Confirm the line wraps within the panel, the line number stays on the first visual row, and continuation rows are indented under the code column with an empty gutter
- Resize the panel narrower and confirm wrapping reflows accordingly with no horizontal scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)