### PR TITLE
build: run ci on merge_group

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 on:
   push:
+  merge_group:
   workflow_dispatch:
 
 # Limit the permissions of the GITHUB_TOKEN


### PR DESCRIPTION
Before we can enable merge queues in this repository, we need to make sure our CI GitHub action is configured to run. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues