### PR TITLE
ci: hand docs build off to embedded-sdk-docs (sync source only)

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -77,12 +77,14 @@ jobs:
 
       # Hand-rolled push instead of peaceiris/actions-gh-pages because
       # Gusto's org actions allowlist doesn't include it. We clone the
-      # existing embedded-sdk-docs repo, replace its tracked files with
-      # the freshly built site, and add one commit per publish — so the
-      # docs repo accumulates a real release-by-release history instead
-      # of being overwritten by an orphan commit each time. The token is
-      # in an env var so the URL doesn't appear verbatim in command logs,
-      # and the App token is auto-redacted by Actions even if it did.
+      # existing embedded-sdk-docs repo, overlay the freshly built site
+      # on top of whatever is already there, and add one commit per
+      # publish — so the docs repo accumulates a real release-by-release
+      # history. We deliberately never delete anything we didn't build,
+      # so infrastructure files that live in embedded-sdk-docs directly
+      # (e.g. `.buildkite/`) survive every publish. The token is in an
+      # env var so the URL doesn't appear verbatim in command logs, and
+      # the App token is auto-redacted by Actions even if it did.
       # `concurrency: publish-docs` above prevents overlapping pushes, so
       # a non-force push is safe.
       - name: Push built site to embedded-sdk-docs
@@ -97,11 +99,10 @@ jobs:
           git config user.name "gusto-embedded-docs[bot]"
           git config user.email "gusto-embedded-docs[bot]@users.noreply.github.com"
 
-          # Wipe currently-tracked files (keeps .git intact), then copy
-          # the fresh build in. `git add -A` afterwards picks up both
-          # additions and deletions relative to the previous publish.
-          git ls-files -z | xargs -0 -r rm -f
-          find . -type d -empty -not -path './.git*' -delete
+          # Overlay the freshly built site onto the docs repo. `git add -A`
+          # below picks up modifications and additions; nothing is staged
+          # for deletion because nothing was deleted, which is what keeps
+          # docs-repo-owned files (e.g. `.buildkite/`) intact.
           cp -R ../docs-site/build/. .
 
           # Always commit (even with no file changes) so every publish run

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,8 +1,9 @@
-name: Publish Docs
+name: Sync Docs Source
 
-# Fires after a successful NPM publish on main. Builds the Docusaurus site
-# from docs/ + docs-site/ and pushes the built output to the main branch of
-# Gusto/embedded-sdk-docs, which serves what's on main.
+# Fires after a successful NPM publish on main. Pushes the Docusaurus
+# source (docs/ + docs-site/ + .nvmrc) to the main branch of
+# Gusto/embedded-sdk-docs. That repo's Buildkite pipeline runs the
+# Docusaurus build and publishes the result to its gh-pages branch.
 #
 # Auth: a GitHub App installed on Gusto/embedded-sdk-docs with
 # Contents: write. Credentials live in this repo's `publish-docs`
@@ -33,7 +34,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
+  sync:
     # workflow_dispatch always allowed (for manual testing). workflow_run
     # only fires when DOCS_PUBLISH_ENABLED=true, so the next NPM release
     # won't auto-publish docs until that variable is explicitly set.
@@ -51,20 +52,9 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-
       - name: Read SDK version
         id: version
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-
-      - name: Install docs dependencies
-        working-directory: docs-site
-        run: npm ci
-
-      - name: Build docs
-        run: npm run docs:build
 
       - name: Mint GitHub App token for docs repo
         id: app-token
@@ -75,19 +65,16 @@ jobs:
           owner: Gusto
           repositories: embedded-sdk-docs
 
-      # Hand-rolled push instead of peaceiris/actions-gh-pages because
-      # Gusto's org actions allowlist doesn't include it. We clone the
-      # existing embedded-sdk-docs repo, overlay the freshly built site
-      # on top of whatever is already there, and add one commit per
-      # publish — so the docs repo accumulates a real release-by-release
-      # history. We deliberately never delete anything we didn't build,
-      # so infrastructure files that live in embedded-sdk-docs directly
-      # (e.g. `.buildkite/`) survive every publish. The token is in an
-      # env var so the URL doesn't appear verbatim in command logs, and
-      # the App token is auto-redacted by Actions even if it did.
-      # `concurrency: publish-docs` above prevents overlapping pushes, so
-      # a non-force push is safe.
-      - name: Push built site to embedded-sdk-docs
+      # Push docs source (markdown + Docusaurus config + Node pin) to
+      # embedded-sdk-docs/main. Its Buildkite pipeline then builds and
+      # publishes the result to gh-pages.
+      #
+      # .buildkite/ on the docs repo is owned by that repo and excluded
+      # from the wipe so it survives across syncs.
+      #
+      # `concurrency: publish-docs` above prevents overlapping pushes,
+      # so a non-force push is safe.
+      - name: Push docs source to embedded-sdk-docs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SDK_VERSION: ${{ steps.version.outputs.version }}
@@ -99,15 +86,23 @@ jobs:
           git config user.name "gusto-embedded-docs[bot]"
           git config user.email "gusto-embedded-docs[bot]@users.noreply.github.com"
 
-          # Overlay the freshly built site onto the docs repo. `git add -A`
-          # below picks up modifications and additions; nothing is staged
-          # for deletion because nothing was deleted, which is what keeps
-          # docs-repo-owned files (e.g. `.buildkite/`) intact.
-          cp -R ../docs-site/build/. .
+          # Wipe currently-tracked files, but preserve .buildkite/ (the
+          # docs repo owns its own CI config). `git add -A` afterwards
+          # picks up additions and deletions relative to the previous sync.
+          git ls-files -z ':!.buildkite/' | xargs -0 -r rm -f
+          find . -type d -empty -not -path './.git*' -not -path './.buildkite*' -delete
 
-          # Always commit (even with no file changes) so every publish run
+          # Copy markdown source + Docusaurus config + Node pin.
+          cp -R ../docs .
+          cp -R ../docs-site .
+          cp ../.nvmrc .
+
+          # Strip anything that shouldn't ship with source.
+          rm -rf docs-site/node_modules docs-site/build
+
+          # Always commit (even with no file changes) so every sync run
           # leaves a release-marker in the docs repo's history, matching
           # 1:1 with the NPM releases that triggered it.
           git add -A
-          git commit -q --allow-empty -m "docs: publish SDK $SDK_VERSION"
+          git commit -q --allow-empty -m "docs: sync source for SDK $SDK_VERSION"
           git push origin main

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -69,8 +69,13 @@ jobs:
       # embedded-sdk-docs/main. Its Buildkite pipeline then builds and
       # publishes the result to gh-pages.
       #
-      # .buildkite/ on the docs repo is owned by that repo and excluded
-      # from the wipe so it survives across syncs.
+      # Safety model: this workflow only touches paths it explicitly
+      # manages (docs/, docs-site/, .nvmrc). Everything else in the
+      # docs repo (.buildkite/, README.md, CODEOWNERS, CNAME, .github/,
+      # …) is left untouched, ever. A defense-in-depth check at the
+      # end fails the push if any staged change escapes the allowlist
+      # — so if someone later widens the cp/rm logic by accident, the
+      # push fails closed instead of silently wiping unrelated files.
       #
       # `concurrency: publish-docs` above prevents overlapping pushes,
       # so a non-force push is safe.
@@ -86,13 +91,13 @@ jobs:
           git config user.name "gusto-embedded-docs[bot]"
           git config user.email "gusto-embedded-docs[bot]@users.noreply.github.com"
 
-          # Wipe currently-tracked files, but preserve .buildkite/ (the
-          # docs repo owns its own CI config). `git add -A` afterwards
-          # picks up additions and deletions relative to the previous sync.
-          git ls-files -z ':!.buildkite/' | xargs -0 -r rm -f
-          find . -type d -empty -not -path './.git*' -not -path './.buildkite*' -delete
+          # Remove only the paths this workflow owns. Anything else in
+          # the docs repo (.buildkite/, README.md, etc.) stays put.
+          # --ignore-unmatch so first-run (no prior docs/ on the repo)
+          # doesn't fail.
+          git rm -rf --quiet --ignore-unmatch docs docs-site .nvmrc
 
-          # Copy markdown source + Docusaurus config + Node pin.
+          # Copy fresh source in.
           cp -R ../docs .
           cp -R ../docs-site .
           cp ../.nvmrc .
@@ -100,9 +105,22 @@ jobs:
           # Strip anything that shouldn't ship with source.
           rm -rf docs-site/node_modules docs-site/build
 
+          # Stage only the paths we manage. NOT `git add -A` — that
+          # could pick up unrelated tree changes if anything went sideways.
+          git add docs docs-site .nvmrc
+
+          # Defense in depth: refuse to push if any staged change
+          # escapes the managed allowlist. No-op when the workflow is
+          # correct; catches future drift.
+          unexpected=$(git diff --cached --name-only | grep -vE '^(docs/|docs-site/|\.nvmrc$)' || true)
+          if [[ -n "$unexpected" ]]; then
+            echo "ERROR: refusing to push — staged changes outside managed paths:" >&2
+            echo "$unexpected" >&2
+            exit 1
+          fi
+
           # Always commit (even with no file changes) so every sync run
           # leaves a release-marker in the docs repo's history, matching
           # 1:1 with the NPM releases that triggered it.
-          git add -A
           git commit -q --allow-empty -m "docs: sync source for SDK $SDK_VERSION"
           git push origin main


### PR DESCRIPTION
## Summary

This PR now does three things, layered:

1. **First commit (already approved)** — switches the docs-repo push from "wipe + copy build" to an overlay so `.buildkite/` and other docs-repo-owned files survive each publish.
2. **Second commit** — goes further: stop building upstream entirely. Sync only source (`docs/` + `docs-site/` + `.nvmrc`) into the docs repo. That repo's Buildkite pipeline builds Docusaurus and publishes to its `gh-pages` branch (see Gusto/embedded-sdk-docs#8).
3. **Third commit (safety hardening)** — replaces "wipe everything except `.buildkite/`" with "only touch the paths this workflow manages." Plus a defense-in-depth check that fails the push if any staged change escapes the allowlist (`docs/`, `docs-site/`, `.nvmrc`). Same root-cause fix as #1, but generalized: any future file we add to the docs repo (README, CODEOWNERS, CNAME, `.github/`, …) is safe by default, not just `.buildkite/`.

Net result: this workflow is now a source-sync, not a publisher. The build moves to the place where the published artifact lives. The sync touches only what it owns; everything else in the docs repo is left alone, fail-closed.

## What changed in the third commit

- Replaced `git ls-files -z ':!.buildkite/' | xargs -0 -r rm -f` with `git rm -rf --quiet --ignore-unmatch docs docs-site .nvmrc` — remove only the paths this workflow owns.
- Replaced `git add -A` with `git add docs docs-site .nvmrc` — stage only the managed paths.
- Added an allowlist check before commit: any staged path outside `docs/`, `docs-site/`, `.nvmrc` fails the push with an error.

## Paired with

- Gusto/embedded-sdk-docs#8 — the Buildkite pipeline that builds + publishes from the synced source.
- Gusto/embedded-sdk-docs#7 — interim restoration of the `.buildkite/` files the bot already deleted.

## Supersedes

#2041 (closed). All of its changes are now part of this PR.

## Test plan

- [ ] Once Gusto/embedded-sdk-docs#8 is merged, trigger this workflow via `workflow_dispatch`
- [ ] Confirm the resulting commit on `embedded-sdk-docs/main` contains `docs/`, `docs-site/` (no `node_modules`, no `build/`), `.nvmrc`, and still has `.buildkite/` plus any other top-level files unchanged
- [ ] Confirm the docs repo's Buildkite build kicks off, succeeds, and lands a publish commit on `gh-pages`
- [ ] Flip `embedded-sdk-docs` Pages source from `main` to `gh-pages`
- [ ] Confirm the live site renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)