### PR TITLE
fix: align onboarding compensation form layout and alert conditions with management forms

### DIFF
--- a/src/components/Employee/Compensation/shared/AddCompensationFormBody.tsx
+++ b/src/components/Employee/Compensation/shared/AddCompensationFormBody.tsx
@@ -64,186 +64,195 @@ export function AddCompensationFormBody({
     <Flex flexDirection="column" gap={32}>
       <Components.Heading as="h2">{title}</Components.Heading>
 
-      {compensationForm.status.willDeleteSecondaryJobs && (
-        <Components.Alert
-          label={t('validations.classificationChangeNotification')}
-          status="warning"
-        />
-      )}
-
-      {JobFields.Title && (
-        <JobFields.Title
-          label={t('jobTitle')}
-          validationMessages={{ REQUIRED: t('validations.title') }}
-          formHookResult={jobForm}
-        />
-      )}
-
-      {JobFields.HireDate && (
-        <JobFields.HireDate
-          label={t('hireDate')}
-          validationMessages={{ REQUIRED: t('validations.hireDate') }}
-          formHookResult={jobForm}
-        />
-      )}
-
-      {CompFields.FlsaStatus && (
-        <CompFields.FlsaStatus
-          label={t('employeeClassification')}
-          description={
-            <Trans
-              t={t}
-              i18nKey="classificationLink"
-              components={{ ClassificationLink: <Components.Link /> }}
-            />
-          }
-          validationMessages={{
-            REQUIRED: t('validations.exemptThreshold', {
-              limit: format(FLSA_OVERTIME_SALARY_LIMIT),
-            }),
-          }}
-          getOptionLabel={(status: FlsaStatusType) => t(`flsaStatusLabels.${status}`)}
-          formHookResult={compensationForm}
-        />
-      )}
-
-      {compensationForm.status.showCommissionFederalMinimumPayAlert && (
-        <Components.Alert
-          status="warning"
-          label={t('commissionAlerts.federalMinimumPay.label')}
-          disableScrollIntoView
-        >
-          {t('commissionAlerts.federalMinimumPay.body')}
-        </Components.Alert>
-      )}
-
-      {compensationForm.status.showCommissionMinimumWageAlert && (
-        <Components.Alert
-          status="warning"
-          label={t('commissionAlerts.minimumWage.label')}
-          disableScrollIntoView
-        >
-          <Trans
-            t={t}
-            i18nKey="commissionAlerts.minimumWage.body"
-            components={{
-              minimumWageLink: (
-                <Components.Link
-                  href="https://support.gusto.com/article/112472520100000/manage-tip-wages-distributed-service-charges-and-tip-credits-in-gusto-for-admins"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />
-              ),
-            }}
+      <Flex flexDirection="column" gap={20}>
+        {JobFields.Title && (
+          <JobFields.Title
+            label={t('jobTitle')}
+            validationMessages={{ REQUIRED: t('validations.title') }}
+            formHookResult={jobForm}
           />
-        </Components.Alert>
-      )}
+        )}
 
-      {compensationForm.status.showOwnerSalaryAlert && (
-        <Components.Alert
-          status="info"
-          label={t('commissionAlerts.ownerSalary.label')}
-          disableScrollIntoView
-        />
-      )}
+        {JobFields.HireDate && (
+          <JobFields.HireDate
+            label={t('hireDate')}
+            validationMessages={{ REQUIRED: t('validations.hireDate') }}
+            formHookResult={jobForm}
+          />
+        )}
 
-      {CompFields.Rate && (
-        <CompFields.Rate
-          label={t('wageLabel')}
-          validationMessages={{
-            REQUIRED: t('validations.rate'),
-            RATE_MINIMUM: t('validations.nonZeroRate'),
-            RATE_EXEMPT_THRESHOLD: t('validations.rateExemptThreshold', {
-              limit: format(FLSA_OVERTIME_SALARY_LIMIT),
-            }),
-          }}
-          formHookResult={compensationForm}
-        />
-      )}
-
-      {CompFields.PaymentUnit && (
-        <CompFields.PaymentUnit
-          label={t('wageFrequencyLabel')}
-          description={t('paymentUnitDescription')}
-          validationMessages={{ REQUIRED: t('validations.paymentUnit') }}
-          getOptionLabel={(unit: PaymentUnit) => t(`paymentUnitOptions.${unit}`)}
-          formHookResult={compensationForm}
-        />
-      )}
-
-      {CompFields.AdjustForMinimumWage && (
-        <CompFields.AdjustForMinimumWage
-          label={t('adjustForMinimumWage')}
-          description={t('adjustForMinimumWageDescription')}
-          formHookResult={compensationForm}
-        />
-      )}
-
-      {CompFields.MinimumWageId && (
-        <CompFields.MinimumWageId
-          label={t('minimumWageLabel')}
-          description={t('minimumWageDescription')}
-          validationMessages={{ REQUIRED: t('validations.minimumWage') }}
-          getOptionLabel={(wage: MinimumWage) =>
-            `${format(Number(wage.wage))} - ${wage.authority}: ${wage.notes ?? ''}`
-          }
-          formHookResult={compensationForm}
-        />
-      )}
-
-      {CompFields.EffectiveDate && (
-        <CompFields.EffectiveDate
-          label={t('effectiveDate')}
-          validationMessages={{
-            REQUIRED: t('validations.effectiveDate'),
-            EFFECTIVE_DATE_BEFORE_HIRE: t('validations.effectiveDateBeforeHire'),
-            EFFECTIVE_DATE_BEFORE_MIN: t('validations.effectiveDateBeforeMin'),
-          }}
-          formHookResult={compensationForm}
-        />
-      )}
-
-      {JobFields.TwoPercentShareholder && (
-        <JobFields.TwoPercentShareholder
-          label={t('twoPercentStakeholderLabel')}
-          formHookResult={jobForm}
-        />
-      )}
-
-      {JobFields.StateWcCovered && (
-        <JobFields.StateWcCovered
-          label={t('stateWcCoveredLabel')}
-          description={
-            <Trans
-              t={t}
-              i18nKey="stateWcCoveredDescription"
-              components={{
-                wcLink: (
-                  <Components.Link
-                    href="https://www.lni.wa.gov/insurance/rates-risk-classes/risk-classes-for-workers-compensation/risk-class-lookup#/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  />
-                ),
+        {CompFields.FlsaStatus && (
+          <>
+            <CompFields.FlsaStatus
+              label={t('employeeClassification')}
+              description={
+                <Trans
+                  t={t}
+                  i18nKey="classificationLink"
+                  components={{ ClassificationLink: <Components.Link /> }}
+                />
+              }
+              validationMessages={{
+                REQUIRED: t('validations.exemptThreshold', {
+                  limit: format(FLSA_OVERTIME_SALARY_LIMIT),
+                }),
               }}
+              getOptionLabel={(status: FlsaStatusType) => t(`flsaStatusLabels.${status}`)}
+              formHookResult={compensationForm}
             />
-          }
-          getOptionLabel={(covered: boolean) =>
-            covered ? t('stateWcCoveredOptions.yes') : t('stateWcCoveredOptions.no')
-          }
-          formHookResult={jobForm}
-        />
-      )}
+            {(compensationForm.status.showCommissionFederalMinimumPayAlert ||
+              compensationForm.status.showCommissionMinimumWageAlert ||
+              compensationForm.status.showOwnerSalaryAlert ||
+              compensationForm.status.willDeleteSecondaryJobs) && (
+              <Flex flexDirection="column" gap={0}>
+                {compensationForm.status.willDeleteSecondaryJobs && (
+                  <Components.Alert
+                    label={t('validations.classificationChangeNotification')}
+                    status="warning"
+                  >
+                    {t('validations.classificationChangeRemovesSecondaryJobs')}
+                  </Components.Alert>
+                )}
+                {compensationForm.status.showCommissionFederalMinimumPayAlert && (
+                  <Components.Alert
+                    status="info"
+                    label={t('commissionAlerts.federalMinimumPay.label')}
+                    disableScrollIntoView
+                  >
+                    {t('commissionAlerts.federalMinimumPay.body')}
+                  </Components.Alert>
+                )}
+                {compensationForm.status.showCommissionMinimumWageAlert && (
+                  <Components.Alert
+                    status="info"
+                    label={t('commissionAlerts.minimumWage.label')}
+                    disableScrollIntoView
+                  >
+                    <Trans
+                      t={t}
+                      i18nKey="commissionAlerts.minimumWage.body"
+                      components={{
+                        minimumWageLink: (
+                          <Components.Link
+                            href="https://support.gusto.com/article/112472520100000/manage-tip-wages-distributed-service-charges-and-tip-credits-in-gusto-for-admins"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          />
+                        ),
+                      }}
+                    />
+                  </Components.Alert>
+                )}
+                {compensationForm.status.showOwnerSalaryAlert && (
+                  <Components.Alert
+                    status="info"
+                    label={t('commissionAlerts.ownerSalary.label')}
+                    disableScrollIntoView
+                  />
+                )}
+              </Flex>
+            )}
+          </>
+        )}
 
-      {JobFields.StateWcClassCode && (
-        <JobFields.StateWcClassCode
-          label={t('stateWcClassCodeLabel')}
-          description={t('stateWcClassCodeDescription')}
-          placeholder={t('stateWcClassCodeLabel')}
-          validationMessages={{ REQUIRED: t('validations.stateWcClassCode') }}
-          formHookResult={jobForm}
-        />
-      )}
+        {CompFields.Rate && (
+          <CompFields.Rate
+            label={t('wageLabel')}
+            validationMessages={{
+              REQUIRED: t('validations.rate'),
+              RATE_MINIMUM: t('validations.nonZeroRate'),
+              RATE_EXEMPT_THRESHOLD: t('validations.rateExemptThreshold', {
+                limit: format(FLSA_OVERTIME_SALARY_LIMIT),
+              }),
+            }}
+            formHookResult={compensationForm}
+          />
+        )}
+
+        {CompFields.PaymentUnit && (
+          <CompFields.PaymentUnit
+            label={t('wageFrequencyLabel')}
+            description={t('paymentUnitDescription')}
+            validationMessages={{ REQUIRED: t('validations.paymentUnit') }}
+            getOptionLabel={(unit: PaymentUnit) => t(`paymentUnitOptions.${unit}`)}
+            formHookResult={compensationForm}
+          />
+        )}
+
+        {CompFields.AdjustForMinimumWage && (
+          <CompFields.AdjustForMinimumWage
+            label={t('adjustForMinimumWage')}
+            description={t('adjustForMinimumWageDescription')}
+            formHookResult={compensationForm}
+          />
+        )}
+
+        {CompFields.MinimumWageId && (
+          <CompFields.MinimumWageId
+            label={t('minimumWageLabel')}
+            description={t('minimumWageDescription')}
+            validationMessages={{ REQUIRED: t('validations.minimumWage') }}
+            getOptionLabel={(wage: MinimumWage) =>
+              `${format(Number(wage.wage))} - ${wage.authority}: ${wage.notes ?? ''}`
+            }
+            formHookResult={compensationForm}
+          />
+        )}
+
+        {CompFields.EffectiveDate && (
+          <CompFields.EffectiveDate
+            label={t('effectiveDate')}
+            validationMessages={{
+              REQUIRED: t('validations.effectiveDate'),
+              EFFECTIVE_DATE_BEFORE_HIRE: t('validations.effectiveDateBeforeHire'),
+              EFFECTIVE_DATE_BEFORE_MIN: t('validations.effectiveDateBeforeMin'),
+            }}
+            formHookResult={compensationForm}
+          />
+        )}
+
+        {JobFields.TwoPercentShareholder && (
+          <JobFields.TwoPercentShareholder
+            label={t('twoPercentStakeholderLabel')}
+            formHookResult={jobForm}
+          />
+        )}
+
+        {JobFields.StateWcCovered && (
+          <JobFields.StateWcCovered
+            label={t('stateWcCoveredLabel')}
+            description={
+              <Trans
+                t={t}
+                i18nKey="stateWcCoveredDescription"
+                components={{
+                  wcLink: (
+                    <Components.Link
+                      href="https://www.lni.wa.gov/insurance/rates-risk-classes/risk-classes-for-workers-compensation/risk-class-lookup#/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    />
+                  ),
+                }}
+              />
+            }
+            getOptionLabel={(covered: boolean) =>
+              covered ? t('stateWcCoveredOptions.yes') : t('stateWcCoveredOptions.no')
+            }
+            formHookResult={jobForm}
+          />
+        )}
+
+        {JobFields.StateWcClassCode && (
+          <JobFields.StateWcClassCode
+            label={t('stateWcClassCodeLabel')}
+            description={t('stateWcClassCodeDescription')}
+            placeholder={t('stateWcClassCodeLabel')}
+            validationMessages={{ REQUIRED: t('validations.stateWcClassCode') }}
+            formHookResult={jobForm}
+          />
+        )}
+      </Flex>
 
       <ActionsLayout>
         {onCancel && (


### PR DESCRIPTION
## Summary

Aligns the onboarding compensation form layout and alert conditions with the management (edit) variant so the two surfaces look and behave consistently.

## Changes

- Wrap the field stack in a `Flex` with `gap={20}` to match management form spacing.
- Group classification-related alerts (secondary-job deletion, commission federal minimum pay, commission minimum wage, owner salary) immediately under the FLSA classification field, rendered in a single zero-gap stack so adjacent alerts read as one block.
- Switch commission alerts (federal minimum pay, minimum wage) from `warning` to `info` status to match the management form.
- Add the missing `classificationChangeRemovesSecondaryJobs` body to the secondary-jobs warning.

## Demo

<!-- Add before/after screenshots of the onboarding compensation step -->

## Related

<!-- Jira / Figma if applicable -->

## Testing

- Storybook: open the onboarding compensation stories and verify spacing matches the management variant.
- Toggle FLSA classification to surface the secondary-jobs warning and commission/owner alerts; confirm they group beneath the classification field with the new statuses and copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)