### PR TITLE
chore: remove dead i18n keys and unused code from employee dashboard

### DIFF
--- a/src/i18n/en/Employee.Dashboard.json
+++ b/src/i18n/en/Employee.Dashboard.json
@@ -1,17 +1,11 @@
 {
-  "title": "Employee Dashboard",
   "employeeRoleLabel": "Employee",
   "tabsLabel": "Employee dashboard tabs",
-  "listEmptyPlaceholder": "No value",
   "tabs": {
     "basicDetails": "Basic details",
     "jobAndPay": "Job and pay",
     "taxes": "Taxes",
     "documents": "Documents"
-  },
-  "common": {
-    "yes": "Yes",
-    "no": "No"
   },
   "alerts": {
     "bankAccountAdded": "Bank account successfully added.",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1421,19 +1421,13 @@ export interface EmployeeCompensation{
 "twoPercentStakeholderLabel":string;
 };
 export interface EmployeeDashboard{
-"title":string;
 "employeeRoleLabel":string;
 "tabsLabel":string;
-"listEmptyPlaceholder":string;
 "tabs":{
 "basicDetails":string;
 "jobAndPay":string;
 "taxes":string;
 "documents":string;
-};
-"common":{
-"yes":string;
-"no":string;
 };
 "alerts":{
 "bankAccountAdded":string;


### PR DESCRIPTION
## Summary

Track 5 of the Employee Dashboard card-to-block cleanup: conservative dead-code removal. No behavior or `dashboardStateMachine` architecture changes.

- Remove four proven-unused keys from `src/i18n/en/Employee.Dashboard.json`: `title`, `listEmptyPlaceholder`, `common.yes`, `common.no`. Verified zero references across `src/` and `sdk-app/` — the only consumers of the `Employee.Dashboard` namespace are `Dashboard.tsx` and `DashboardComponents.tsx`, which use `employeeRoleLabel`, `tabsLabel`, `tabs.*`, and `alerts.*` only.
- Regenerate the i18next typed key contract (`src/types/i18next.d.ts`) via `npm run i18n:generate` to match.
- Scanned `src/components/Employee/Dashboard/` for migration-leftover unused imports/vars/dead helpers — `lint:check` surfaced none, so no code changes were needed there. Tab-view wrappers, alert wiring, and the state machine were intentionally left untouched (deferred).

Kept (still used): `employeeRoleLabel`, `tabsLabel`, `tabs.*`, and the entire `alerts.*` block (centralized dashboard success toasts still rendered by `DashboardComponents.tsx`).

Stacked on #2044 — base branch is `refactor/align-profile-homeaddress-management-naming`.

## Test plan

- [x] `npm run i18n:generate` (regenerated types committed)
- [x] `npm run test -- --run src/components/Employee/Dashboard` — 47 passed
- [x] `npm run lint:check` — no new errors (one pre-existing `mockServiceWorker.js` parsing error unrelated to this change)
- [x] `npm run format:check` — clean

Made with [Cursor](https://cursor.com)