### PR TITLE
fix: remove gap between tabs and table in management employee list

### DIFF
--- a/src/components/Employee/EmployeeList/management/ManagementEmployeeListView.tsx
+++ b/src/components/Employee/EmployeeList/management/ManagementEmployeeListView.tsx
@@ -217,16 +217,18 @@ export function ManagementEmployeeListView({
           </Components.Button>
         </Flex>
 
-        <Components.Tabs
-          tabs={tabs}
-          selectedId={selectedTab}
-          onSelectionChange={id => {
-            onTabChange(id as EmployeeTab)
-          }}
-          aria-label={t('tabsLabel')}
-        />
+        <Flex flexDirection="column" gap={0}>
+          <Components.Tabs
+            tabs={tabs}
+            selectedId={selectedTab}
+            onSelectionChange={id => {
+              onTabChange(id as EmployeeTab)
+            }}
+            aria-label={t('tabsLabel')}
+          />
 
-        <DataView label={t('employeeListLabel')} {...dataViewProps} />
+          <DataView label={t('employeeListLabel')} {...dataViewProps} />
+        </Flex>
       </Flex>
 
       <Components.Dialog


### PR DESCRIPTION
## Summary
- Wrap `Tabs` and `DataView` in a `Flex` with `gap={0}`. Tabs already have a margin-bottom of 24. Reduces the gap with `ManagementEmployeeListView`.

## Test plan
- [ ] Open Storybook / dev app and verify the management employee list shows no gap between the tab bar and the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)