### PR TITLE
refactor: give ProfileEditForm a dedicated management i18n namespace

### DIFF
--- a/src/components/Employee/Profile/management/ProfileEditForm.tsx
+++ b/src/components/Employee/Profile/management/ProfileEditForm.tsx
@@ -17,7 +17,7 @@ import { useI18n, useComponentDictionary } from '@/i18n'
 import { componentEvents } from '@/shared/constants'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
-export interface ProfileEditFormProps extends CommonComponentInterface<'Employee.Profile'> {
+export interface ProfileEditFormProps extends CommonComponentInterface<'Employee.Management.Profile'> {
   employeeId: string
   onEvent: BaseComponentInterface['onEvent']
 }
@@ -27,16 +27,19 @@ export function ProfileEditForm({
   ...props
 }: ProfileEditFormProps & Pick<BaseComponentInterface, 'FallbackComponent'>) {
   return (
-    <BaseBoundaries componentName="Employee.Profile" FallbackComponent={FallbackComponent}>
+    <BaseBoundaries
+      componentName="Employee.Management.Profile"
+      FallbackComponent={FallbackComponent}
+    >
       <ProfileEditFormRoot {...props} />
     </BaseBoundaries>
   )
 }
 
 function ProfileEditFormRoot({ employeeId, className, dictionary, onEvent }: ProfileEditFormProps) {
-  useI18n('Employee.Profile')
-  useComponentDictionary('Employee.Profile', dictionary)
-  const { t } = useTranslation('Employee.Profile')
+  useI18n('Employee.Management.Profile')
+  useComponentDictionary('Employee.Management.Profile', dictionary)
+  const { t } = useTranslation('Employee.Management.Profile')
   const Components = useComponentContext()
 
   const employeeDetails = useEmployeeDetailsForm({
@@ -73,7 +76,7 @@ function ProfileEditFormRoot({ employeeId, className, dictionary, onEvent }: Pro
   const alert = showSuccess ? (
     <Components.Alert
       status="success"
-      label={t('successAlert')}
+      label={t('form.successAlert')}
       onDismiss={() => {
         setShowSuccess(false)
       }}
@@ -86,53 +89,53 @@ function ProfileEditFormRoot({ employeeId, className, dictionary, onEvent }: Pro
         <SDKFormProvider formHookResult={employeeDetails}>
           <Form onSubmit={handleSubmit}>
             {alert}
-            <Components.Heading as="h1">{t('title')}</Components.Heading>
+            <Components.Heading as="h1">{t('form.title')}</Components.Heading>
             <Grid
               gap={{ base: 20, small: 8 }}
               gridTemplateColumns={{ base: '1fr', small: ['1fr', 200] }}
             >
               <Fields.FirstName
-                label={t('firstName')}
+                label={t('form.firstName')}
                 validationMessages={{
-                  REQUIRED: t('validations.firstName'),
-                  INVALID_NAME: t('validations.firstName'),
+                  REQUIRED: t('form.validations.firstName'),
+                  INVALID_NAME: t('form.validations.firstName'),
                 }}
               />
-              <Fields.MiddleInitial label={t('middleInitial')} />
+              <Fields.MiddleInitial label={t('form.middleInitial')} />
             </Grid>
             <Fields.LastName
-              label={t('lastName')}
+              label={t('form.lastName')}
               validationMessages={{
-                REQUIRED: t('validations.lastName'),
-                INVALID_NAME: t('validations.lastName'),
+                REQUIRED: t('form.validations.lastName'),
+                INVALID_NAME: t('form.validations.lastName'),
               }}
             />
             <Fields.Email
-              label={t('email')}
-              description={t('emailDescription')}
+              label={t('form.email')}
+              description={t('form.emailDescription')}
               validationMessages={{
-                REQUIRED: t('validations.email'),
-                INVALID_EMAIL: t('validations.email'),
-                EMAIL_REQUIRED_FOR_SELF_ONBOARDING: t('validations.email'),
+                REQUIRED: t('form.validations.email'),
+                INVALID_EMAIL: t('form.validations.email'),
+                EMAIL_REQUIRED_FOR_SELF_ONBOARDING: t('form.validations.email'),
               }}
             />
             <Fields.Ssn
-              label={t('ssnLabel')}
+              label={t('form.ssnLabel')}
               validationMessages={{
                 INVALID_SSN: t('validations.ssn', { ns: 'common' }),
                 REQUIRED: t('validations.ssnRequired', { ns: 'common' }),
               }}
             />
             <Fields.DateOfBirth
-              label={t('dobLabel')}
+              label={t('form.dobLabel')}
               validationMessages={{ REQUIRED: t('validations.dob', { ns: 'common' }) }}
             />
             <ActionsLayout>
               <Components.Button variant="secondary" onClick={handleCancel}>
-                {t('cancelCta')}
+                {t('form.cancelCta')}
               </Components.Button>
               <Components.Button type="submit" isLoading={employeeDetails.status.isPending}>
-                {t('saveCta')}
+                {t('form.saveCta')}
               </Components.Button>
             </ActionsLayout>
           </Form>

--- a/src/i18n/en/Employee.Management.Profile.json
+++ b/src/i18n/en/Employee.Management.Profile.json
@@ -9,5 +9,23 @@
   "listEmptyPlaceholder": "No value",
   "alerts": {
     "profileUpdated": "Profile updated"
+  },
+  "form": {
+    "title": "Basics",
+    "firstName": "Legal first name",
+    "middleInitial": "Middle initial",
+    "lastName": "Legal last name",
+    "email": "Personal email",
+    "emailDescription": "Use an email that's not associated with your company.",
+    "ssnLabel": "Social Security Number (9 digit)",
+    "dobLabel": "Date of birth",
+    "cancelCta": "Cancel",
+    "saveCta": "Save",
+    "successAlert": "Successfully updated profile",
+    "validations": {
+      "email": "Valid email is required",
+      "firstName": "Please enter valid first name",
+      "lastName": "Please enter valid last name"
+    }
   }
 }

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -2399,6 +2399,24 @@ export interface EmployeeManagementProfile{
 "alerts":{
 "profileUpdated":string;
 };
+"form":{
+"title":string;
+"firstName":string;
+"middleInitial":string;
+"lastName":string;
+"email":string;
+"emailDescription":string;
+"ssnLabel":string;
+"dobLabel":string;
+"cancelCta":string;
+"saveCta":string;
+"successAlert":string;
+"validations":{
+"email":string;
+"firstName":string;
+"lastName":string;
+};
+};
 };
 export interface EmployeeManagementStateTaxes{
 "card":{


### PR DESCRIPTION
## Summary

- `ProfileEditForm` (management) was borrowing the onboarding `Employee.Profile` i18n namespace. This points it at its own `Employee.Management.Profile` namespace, consistent with `ProfileCard`.
- The edit-form copy is nested under `form.*` in `Employee.Management.Profile.json` so it doesn't collide with the card's top-level keys (e.g. `title` = "Basic details" vs the form's "Basics").
- The partner-facing `dictionary` prop now targets the management namespace, so partners can override management edit-form copy independently of onboarding.
- SSN/DOB validation messages still resolve from the shared `common` namespace (intentional — those are app-wide).

The English copy is identical to what the form previously rendered, so this is a namespace/override-surface change, not a copy change.

## Notes

- Stacked on top of #2044 (which created the `Employee.Management.Profile` namespace and renamed the management events). Base will be retargeted to `main` after #2044 merges.
- `ProfileEditFormProps` is part of the public surface (exported from `employeeManagement.ts`); its `dictionary` prop type changes from `Employee.Profile` → `Employee.Management.Profile`, which is the correct surface for a management component.

## Test plan

- [x] `npm run i18n:generate` (types regenerated)
- [x] `tsc --noEmit` clean in the main checkout (worktree shows only symlink-path artifacts in untouched test-util files)
- [x] Profile suite green (78/78)

Made with [Cursor](https://cursor.com)