### PR TITLE
refactor: move dashboard tab loading to per-card Suspense boundaries

### DIFF
--- a/src/components/Employee/Compensation/management/CompensationCard/CompensationCard.tsx
+++ b/src/components/Employee/Compensation/management/CompensationCard/CompensationCard.tsx
@@ -14,7 +14,7 @@ import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { DataView, useDataView, EmptyData, Loading, VisuallyHidden } from '@/components/Common'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
-import { BaseLayout } from '@/components/Base/Base'
+import { BaseBoundaries, BaseLayout } from '@/components/Base/Base'
 import { formatDateLongWithYear, formatDateToStringDate } from '@/helpers/dateFormatting'
 import { useFormatCompensationRate } from '@/helpers/formattedStrings'
 import { useI18n } from '@/i18n'
@@ -44,7 +44,15 @@ export interface CompensationCardProps {
  * (the `Compensation` block or the dashboard) routes those to the edit/add
  * surfaces and renders any success alerts.
  */
-export function CompensationCard({ employeeId, onEvent }: CompensationCardProps) {
+export function CompensationCard(props: CompensationCardProps) {
+  return (
+    <BaseBoundaries componentName="Employee.Management.Compensation">
+      <CompensationCardContent {...props} />
+    </BaseBoundaries>
+  )
+}
+
+function CompensationCardContent({ employeeId, onEvent }: CompensationCardProps) {
   useI18n('Employee.Management.Compensation')
   const { t } = useTranslation('Employee.Management.Compensation')
   const Components = useComponentContext()

--- a/src/components/Employee/Dashboard/Dashboard.tsx
+++ b/src/components/Employee/Dashboard/Dashboard.tsx
@@ -7,7 +7,7 @@ import { TaxesViewWithData } from './TaxesView'
 import { DocumentsCard } from '@/components/Employee/Documents/management/DocumentsCard'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
-import { BaseBoundaries, BaseLayout, type BaseComponentInterface } from '@/components/Base/Base'
+import { BaseBoundaries, type BaseComponentInterface } from '@/components/Base/Base'
 import { useComponentDictionary, useI18n } from '@/i18n'
 import { componentEvents } from '@/shared/constants'
 import { firstLastName } from '@/helpers/formattedStrings'
@@ -75,27 +75,19 @@ function DashboardRoot({
 
         <Flex flexDirection="column" gap={24}>
           {selectedTab === 'basicDetails' && (
-            <Suspense fallback={<BaseLayout isLoading />}>
-              <BasicDetailsView employeeId={employeeId} onEvent={onEvent} />
-            </Suspense>
+            <BasicDetailsView employeeId={employeeId} onEvent={onEvent} />
           )}
 
           {selectedTab === 'jobAndPay' && (
-            <Suspense fallback={<BaseLayout isLoading />}>
-              <JobAndPayView employeeId={employeeId} onEvent={onEvent} />
-            </Suspense>
+            <JobAndPayView employeeId={employeeId} onEvent={onEvent} />
           )}
 
           {selectedTab === 'taxes' && (
-            <Suspense fallback={<BaseLayout isLoading />}>
-              <TaxesViewWithData employeeId={employeeId} onEvent={onEvent} />
-            </Suspense>
+            <TaxesViewWithData employeeId={employeeId} onEvent={onEvent} />
           )}
 
           {selectedTab === 'documents' && (
-            <Suspense fallback={<BaseLayout isLoading />}>
-              <DocumentsCard employeeId={employeeId} onEvent={onEvent} />
-            </Suspense>
+            <DocumentsCard employeeId={employeeId} onEvent={onEvent} />
           )}
         </Flex>
       </Flex>

--- a/src/components/Employee/Deductions/management/DeductionsCard/DeductionsCard.tsx
+++ b/src/components/Employee/Deductions/management/DeductionsCard/DeductionsCard.tsx
@@ -6,7 +6,7 @@ import { DeleteDeductionDialog } from '../../shared/DeleteDeductionDialog'
 import { formatDeductionAmount } from '../../shared/formatDeductionAmount'
 import { DataView, useDataView, EmptyData, Loading } from '@/components/Common'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
-import { BaseLayout } from '@/components/Base/Base'
+import { BaseBoundaries, BaseLayout } from '@/components/Base/Base'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import useNumberFormatter from '@/hooks/useNumberFormatter'
 import { useI18n } from '@/i18n'
@@ -31,7 +31,15 @@ export interface DeductionsCardProps {
  * `DeductionsCardContextual` for standalone consumption, dashboard chrome
  * for dashboard consumption).
  */
-export function DeductionsCard({ employeeId, onEvent }: DeductionsCardProps) {
+export function DeductionsCard(props: DeductionsCardProps) {
+  return (
+    <BaseBoundaries componentName="Employee.Management.Deductions">
+      <DeductionsCardContent {...props} />
+    </BaseBoundaries>
+  )
+}
+
+function DeductionsCardContent({ employeeId, onEvent }: DeductionsCardProps) {
   useI18n('Employee.Management.Deductions')
   const { t } = useTranslation('Employee.Management.Deductions')
   const Components = useComponentContext()

--- a/src/components/Employee/Documents/management/DocumentsCard/DocumentsCard.tsx
+++ b/src/components/Employee/Documents/management/DocumentsCard/DocumentsCard.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import type { Form } from '@gusto/embedded-api-v-2025-11-15/models/components/form'
 import { useDocumentsList } from '../../shared/useDocumentsList'
 import { DataView, useDataView, EmptyData, Loading } from '@/components/Common'
-import { BaseLayout } from '@/components/Base/Base'
+import { BaseBoundaries, BaseLayout } from '@/components/Base/Base'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
 import { componentEvents, type EventType } from '@/shared/constants'
@@ -24,7 +24,15 @@ export interface DocumentsCardProps {
  * `DocumentsCardContextual` for standalone consumption; the dashboard chrome
  * for dashboard consumption).
  */
-export function DocumentsCard({ employeeId, onEvent }: DocumentsCardProps) {
+export function DocumentsCard(props: DocumentsCardProps) {
+  return (
+    <BaseBoundaries componentName="Employee.Management.Documents">
+      <DocumentsCardContent {...props} />
+    </BaseBoundaries>
+  )
+}
+
+function DocumentsCardContent({ employeeId, onEvent }: DocumentsCardProps) {
   useI18n('Employee.Management.Documents')
   const { t } = useTranslation('Employee.Management.Documents')
   const Components = useComponentContext()

--- a/src/components/Employee/FederalTaxes/management/FederalTaxesCard/FederalTaxesCard.tsx
+++ b/src/components/Employee/FederalTaxes/management/FederalTaxesCard/FederalTaxesCard.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { useFederalTaxesSummary } from '../../shared/useFederalTaxesSummary'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { Loading } from '@/components/Common'
-import { BaseLayout } from '@/components/Base/Base'
+import { BaseBoundaries, BaseLayout } from '@/components/Base/Base'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import useNumberFormatter from '@/hooks/useNumberFormatter'
 import { useI18n } from '@/i18n'
@@ -21,7 +21,15 @@ export interface FederalTaxesCardProps {
  * button is clicked. The card has no alert API — alert rendering (when
  * introduced) is the orchestrator's responsibility.
  */
-export function FederalTaxesCard({ employeeId, onEvent }: FederalTaxesCardProps) {
+export function FederalTaxesCard(props: FederalTaxesCardProps) {
+  return (
+    <BaseBoundaries componentName="Employee.Management.FederalTaxes">
+      <FederalTaxesCardContent {...props} />
+    </BaseBoundaries>
+  )
+}
+
+function FederalTaxesCardContent({ employeeId, onEvent }: FederalTaxesCardProps) {
   useI18n('Employee.Management.FederalTaxes')
   const { t } = useTranslation('Employee.Management.FederalTaxes')
   const Components = useComponentContext()

--- a/src/components/Employee/HomeAddress/management/HomeAddressCard/HomeAddressCard.tsx
+++ b/src/components/Employee/HomeAddress/management/HomeAddressCard/HomeAddressCard.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { useHomeAddressSummary } from '../../shared/useHomeAddressSummary'
 import { Loading } from '@/components/Common'
 import { Flex } from '@/components/Common/Flex/Flex'
-import { BaseLayout } from '@/components/Base/Base'
+import { BaseBoundaries, BaseLayout } from '@/components/Base/Base'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { getStreet, getCityStateZip } from '@/helpers/formattedStrings'
 import { useI18n } from '@/i18n'
@@ -21,7 +21,15 @@ export interface HomeAddressCardProps {
  * button is clicked. The card has no alert API — alert rendering
  * (when introduced) is the orchestrator's responsibility.
  */
-export function HomeAddressCard({ employeeId, onEvent }: HomeAddressCardProps) {
+export function HomeAddressCard(props: HomeAddressCardProps) {
+  return (
+    <BaseBoundaries componentName="Employee.Management.HomeAddress">
+      <HomeAddressCardContent {...props} />
+    </BaseBoundaries>
+  )
+}
+
+function HomeAddressCardContent({ employeeId, onEvent }: HomeAddressCardProps) {
   useI18n('Employee.Management.HomeAddress')
   const { t } = useTranslation('Employee.Management.HomeAddress')
   const Components = useComponentContext()

--- a/src/components/Employee/PaymentMethod/management/PaymentMethodCard.tsx
+++ b/src/components/Employee/PaymentMethod/management/PaymentMethodCard.tsx
@@ -9,7 +9,7 @@ import styles from './PaymentMethodCard.module.scss'
 import { DataView, useDataView, Loading } from '@/components/Common'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
-import { BaseLayout } from '@/components/Base/Base'
+import { BaseBoundaries, BaseLayout } from '@/components/Base/Base'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
@@ -33,7 +33,15 @@ export interface PaymentMethodCardProps {
  * `PaymentMethodCardContextual` for standalone consumption; the dashboard
  * chrome for dashboard consumption).
  */
-export function PaymentMethodCard({ employeeId, onEvent }: PaymentMethodCardProps) {
+export function PaymentMethodCard(props: PaymentMethodCardProps) {
+  return (
+    <BaseBoundaries componentName="Employee.Management.PaymentMethod">
+      <PaymentMethodCardContent {...props} />
+    </BaseBoundaries>
+  )
+}
+
+function PaymentMethodCardContent({ employeeId, onEvent }: PaymentMethodCardProps) {
   useI18n('Employee.Management.PaymentMethod')
   const { t } = useTranslation('Employee.Management.PaymentMethod')
   const Components = useComponentContext()

--- a/src/components/Employee/Paystubs/management/PaystubsCard/PaystubsCard.tsx
+++ b/src/components/Employee/Paystubs/management/PaystubsCard/PaystubsCard.tsx
@@ -7,7 +7,7 @@ import {
   type UsePaystubsListReady,
 } from '../../shared/usePaystubsList'
 import { DataView, EmptyData, useDataView, Loading } from '@/components/Common'
-import { BaseLayout } from '@/components/Base/Base'
+import { BaseBoundaries, BaseLayout } from '@/components/Base/Base'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { composeErrorHandler } from '@/partner-hook-utils/composeErrorHandler'
 import {
@@ -35,7 +35,15 @@ export interface PaystubsCardProps {
  * paystubs is a read-only surface whose only action is a download side
  * effect that opens the PDF in a new tab.
  */
-export function PaystubsCard({ employeeId, onEvent }: PaystubsCardProps) {
+export function PaystubsCard(props: PaystubsCardProps) {
+  return (
+    <BaseBoundaries componentName="Employee.Management.Paystubs">
+      <PaystubsCardContent {...props} />
+    </BaseBoundaries>
+  )
+}
+
+function PaystubsCardContent({ employeeId, onEvent }: PaystubsCardProps) {
   useI18n('Employee.Management.Paystubs')
   const { t } = useTranslation('Employee.Management.Paystubs')
   const Components = useComponentContext()

--- a/src/components/Employee/Profile/management/ProfileCard/ProfileCard.tsx
+++ b/src/components/Employee/Profile/management/ProfileCard/ProfileCard.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useEmployeeProfileSummary } from '../../shared/useEmployeeProfileSummary'
 import { Loading } from '@/components/Common'
-import { BaseLayout } from '@/components/Base/Base'
+import { BaseBoundaries, BaseLayout } from '@/components/Base/Base'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { formatDateLongWithYear } from '@/helpers/dateFormatting'
 import { firstLastName } from '@/helpers/formattedStrings'
@@ -22,7 +22,15 @@ export interface ProfileCardProps {
  * orchestrator's responsibility (block's `CardContextual` for standalone
  * consumption, dashboard chrome for dashboard consumption).
  */
-export function ProfileCard({ employeeId, onEvent }: ProfileCardProps) {
+export function ProfileCard(props: ProfileCardProps) {
+  return (
+    <BaseBoundaries componentName="Employee.Management.Profile">
+      <ProfileCardContent {...props} />
+    </BaseBoundaries>
+  )
+}
+
+function ProfileCardContent({ employeeId, onEvent }: ProfileCardProps) {
   useI18n('Employee.Management.Profile')
   const { t } = useTranslation('Employee.Management.Profile')
   const Components = useComponentContext()

--- a/src/components/Employee/StateTaxes/management/StateTaxesCard/StateTaxesCard.tsx
+++ b/src/components/Employee/StateTaxes/management/StateTaxesCard/StateTaxesCard.tsx
@@ -3,7 +3,7 @@ import type { EmployeeStateTaxQuestion } from '@gusto/embedded-api-v-2025-11-15/
 import { useStateTaxesSummary } from '../../shared/useStateTaxesSummary'
 import { Flex } from '@/components/Common/Flex/Flex'
 import { Loading } from '@/components/Common'
-import { BaseLayout } from '@/components/Base/Base'
+import { BaseBoundaries, BaseLayout } from '@/components/Base/Base'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import useNumberFormatter from '@/hooks/useNumberFormatter'
 import { useI18n } from '@/i18n'
@@ -23,7 +23,15 @@ export interface StateTaxesCardProps {
  * record has any tax-withholding questions (e.g. WA), matching the
  * product rule that a state with no income tax has nothing to edit.
  */
-export function StateTaxesCard({ employeeId, onEvent }: StateTaxesCardProps) {
+export function StateTaxesCard(props: StateTaxesCardProps) {
+  return (
+    <BaseBoundaries componentName="Employee.Management.StateTaxes">
+      <StateTaxesCardContent {...props} />
+    </BaseBoundaries>
+  )
+}
+
+function StateTaxesCardContent({ employeeId, onEvent }: StateTaxesCardProps) {
   useI18n('Employee.Management.StateTaxes')
   const { t } = useTranslation('Employee.Management.StateTaxes')
   const { t: tCommon } = useTranslation('common')

--- a/src/components/Employee/WorkAddress/management/WorkAddressCard/WorkAddressCard.tsx
+++ b/src/components/Employee/WorkAddress/management/WorkAddressCard/WorkAddressCard.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { useEmployeeWorkAddressSummary } from '../../shared/useEmployeeWorkAddressSummary'
 import { Loading } from '@/components/Common'
 import { Flex } from '@/components/Common/Flex/Flex'
-import { BaseLayout } from '@/components/Base/Base'
+import { BaseBoundaries, BaseLayout } from '@/components/Base/Base'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
 import { componentEvents, type EventType } from '@/shared/constants'
@@ -21,7 +21,15 @@ export interface WorkAddressCardProps {
  * orchestrator's responsibility (block's `WorkAddressCardContextual` for
  * standalone consumption, dashboard chrome for dashboard consumption).
  */
-export function WorkAddressCard({ employeeId, onEvent }: WorkAddressCardProps) {
+export function WorkAddressCard(props: WorkAddressCardProps) {
+  return (
+    <BaseBoundaries componentName="Employee.Management.WorkAddress">
+      <WorkAddressCardContent {...props} />
+    </BaseBoundaries>
+  )
+}
+
+function WorkAddressCardContent({ employeeId, onEvent }: WorkAddressCardProps) {
   useI18n('Employee.Management.WorkAddress')
   const { t } = useTranslation('Employee.Management.WorkAddress')
   const Components = useComponentContext()


### PR DESCRIPTION
## Summary

- Each standalone management card (`ProfileCard`, `HomeAddressCard`, `WorkAddressCard`, `CompensationCard`, `PaymentMethodCard`, `DeductionsCard`, `PaystubsCard`, `FederalTaxesCard`, `StateTaxesCard`, `DocumentsCard`) now wraps its export in `BaseBoundaries`, splitting the body into a `<…>Content` subcomponent. This gives every card its own Suspense + error boundary so it can locally absorb the suspension `useI18n` throws when its translation namespace is first loaded, and render its own partial-loading chrome.
- With cards owning their loading, the redundant per-tab `<Suspense fallback={<BaseLayout isLoading />}>` wrappers in `Dashboard.tsx` are removed. Switching tabs no longer flashes a full-tab loader before the cards' partial-loading states take over. (The `DashboardHeader` keeps its own Suspense since it drives a suspense query.)

No event names, i18n copy, or public APIs changed — this is purely where the Suspense boundary lives.

## Notes

- Stacked on top of #2048 (the loading-standardization PR). #2048 already has latest `main` merged in, so the cards' `componentName` namespaces (e.g. `Employee.Management.Profile`) line up. Base will be retargeted to `main` after #2048 merges.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] Dashboard + all 10 management card suites green (190/190 across 29 files)

Made with [Cursor](https://cursor.com)