### PR TITLE
docs(SDK-1010): backfill phase 5

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -434,8 +434,6 @@ export interface CheckboxGroupOption {
     value: string;
 }
 
-// Warning: (ae-forgotten-export) The symbol "SharedFieldLayoutProps" needs to be exported by the entry point index.d.ts
-//
 // @public
 export interface CheckboxGroupProps extends SharedFieldLayoutProps, Pick<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'className'> {
     inputRef?: Ref<HTMLInputElement>;
@@ -459,8 +457,6 @@ export interface CheckboxHookFieldProps<TErrorCode extends string = never> exten
     validationMessages?: ValidationMessages<TErrorCode>;
 }
 
-// Warning: (ae-forgotten-export) The symbol "SharedHorizontalFieldLayoutProps" needs to be exported by the entry point index.d.ts
-//
 // @public
 export interface CheckboxProps extends SharedHorizontalFieldLayoutProps, Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'id' | 'className'> {
     inputRef?: Ref<HTMLInputElement>;
@@ -4314,6 +4310,18 @@ export type SelfOnboardingFieldProps = HookFieldProps<SwitchHookFieldProps>;
 //
 // @public (undocumented)
 const SelfOnboardingFlow: (input: SelfOnboardingFlowProps) => JSX;
+
+// @public
+export interface SharedFieldLayoutProps extends DataAttributes {
+    description?: ReactNode;
+    errorMessage?: string;
+    isRequired?: boolean;
+    label: ReactNode;
+    shouldVisuallyHideLabel?: boolean;
+}
+
+// @public
+export type SharedHorizontalFieldLayoutProps = SharedFieldLayoutProps;
 
 // Warning: (ae-missing-release-tag) "SignatureFieldProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -657,6 +657,72 @@ namespace Compensation_2 {
     EditCompensation: EditCompensation;
 }
 
+// Warning: (ae-missing-release-tag) "Compensation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+function Compensation_3(input: CompensationProps_2 & BaseComponentInterface<'Employee.Management.Compensation'>): JSX;
+
+// Warning: (ae-missing-release-tag) "CompensationAddAnotherJobForm" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+function CompensationAddAnotherJobForm(input: CompensationAddAnotherJobFormProps): JSX;
+
+// Warning: (ae-forgotten-export) The symbol "CommonComponentInterface" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "CompensationAddAnotherJobFormProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface CompensationAddAnotherJobFormProps extends CommonComponentInterface<'Employee.Management.Compensation'> {
+    // (undocumented)
+    employeeId: string;
+    // Warning: (ae-forgotten-export) The symbol "OnEventType" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "EventType" needs to be exported by the entry point index.d.ts
+    onEvent: OnEventType<EventType, unknown>;
+}
+
+// Warning: (ae-missing-release-tag) "CompensationAddJobForm" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function CompensationAddJobForm(input: CompensationAddJobFormProps): JSX;
+
+// Warning: (ae-missing-release-tag) "CompensationAddJobFormProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface CompensationAddJobFormProps extends CommonComponentInterface<'Employee.Management.Compensation'> {
+    // (undocumented)
+    employeeId: string;
+    onEvent: OnEventType<EventType, unknown>;
+}
+
+// Warning: (ae-missing-release-tag) "CompensationCard" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function CompensationCard(props: CompensationCardProps): JSX;
+
+// Warning: (ae-missing-release-tag) "CompensationCardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface CompensationCardProps {
+    // (undocumented)
+    employeeId: string;
+    // (undocumented)
+    onEvent: OnEventType<EventType, unknown>;
+}
+
+// Warning: (ae-missing-release-tag) "CompensationEditForm" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function CompensationEditForm(input: CompensationEditFormProps): JSX;
+
+// Warning: (ae-missing-release-tag) "CompensationEditFormProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface CompensationEditFormProps extends CommonComponentInterface<'Employee.Management.Compensation'> {
+    // (undocumented)
+    employeeId: string;
+    jobId: string;
+    onEvent: OnEventType<EventType, unknown>;
+}
+
 // Warning: (ae-missing-release-tag) "EffectiveDateFieldProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -743,6 +809,16 @@ export type CompensationFormOutputs = CompensationFormData;
 //
 // @public (undocumented)
 export type CompensationOptionalFieldsToRequire = OptionalFieldsToRequire<typeof requiredFieldsConfig_2>;
+
+// Warning: (ae-missing-release-tag) "CompensationProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface CompensationProps_2 extends CommonComponentInterface<'Employee.Management.Compensation'> {
+    // (undocumented)
+    employeeId: string;
+    // (undocumented)
+    onEvent: OnEventType<EventType, unknown>;
+}
 
 // Warning: (ae-missing-release-tag) "RequiredValidation" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1041,6 +1117,19 @@ export const componentEvents: {
     readonly EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_EDIT_FORM_SUBMITTED: "employee/management/federalTaxes/editForm/submitted";
     readonly EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_EDIT_FORM_CANCELLED: "employee/management/federalTaxes/editForm/cancelled";
     readonly EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_ALERT_DISMISSED: "employee/management/federalTaxes/alertDismissed";
+    readonly EMPLOYEE_MANAGEMENT_DOCUMENTS_CARD_VIEW_REQUESTED: "employee/management/documents/card/viewRequested";
+    readonly EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_EDIT_REQUESTED: "employee/management/compensation/card/editRequested";
+    readonly EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_ADD_REQUESTED: "employee/management/compensation/card/addRequested";
+    readonly EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_ADD_ANOTHER_REQUESTED: "employee/management/compensation/card/addAnotherRequested";
+    readonly EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_JOB_DELETED: "employee/management/compensation/card/jobDeleted";
+    readonly EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_CHANGE_CANCELLED: "employee/management/compensation/card/changeCancelled";
+    readonly EMPLOYEE_MANAGEMENT_COMPENSATION_EDIT_FORM_SUBMITTED: "employee/management/compensation/editForm/submitted";
+    readonly EMPLOYEE_MANAGEMENT_COMPENSATION_EDIT_FORM_CANCELLED: "employee/management/compensation/editForm/cancelled";
+    readonly EMPLOYEE_MANAGEMENT_COMPENSATION_ADD_JOB_FORM_SUBMITTED: "employee/management/compensation/addJobForm/submitted";
+    readonly EMPLOYEE_MANAGEMENT_COMPENSATION_ADD_JOB_FORM_CANCELLED: "employee/management/compensation/addJobForm/cancelled";
+    readonly EMPLOYEE_MANAGEMENT_COMPENSATION_ADD_ANOTHER_JOB_FORM_SUBMITTED: "employee/management/compensation/addAnotherJobForm/submitted";
+    readonly EMPLOYEE_MANAGEMENT_COMPENSATION_ADD_ANOTHER_JOB_FORM_CANCELLED: "employee/management/compensation/addAnotherJobForm/cancelled";
+    readonly EMPLOYEE_MANAGEMENT_COMPENSATION_ALERT_DISMISSED: "employee/management/compensation/alertDismissed";
     readonly ROBOT_MACHINE_DONE: "done";
     readonly ERROR: "ERROR";
     readonly CANCEL: "CANCEL";
@@ -1683,7 +1772,7 @@ function Deductions_2(input: DeductionsProps_2 & BaseComponentInterface<'Employe
 // Warning: (ae-missing-release-tag) "DeductionsCard" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-function DeductionsCard(input: DeductionsCardProps): JSX;
+function DeductionsCard(props: DeductionsCardProps): JSX;
 
 // Warning: (ae-missing-release-tag) "DeductionsCardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1691,9 +1780,6 @@ function DeductionsCard(input: DeductionsCardProps): JSX;
 interface DeductionsCardProps {
     // (undocumented)
     employeeId: string;
-    // Warning: (ae-forgotten-export) The symbol "OnEventType" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "EventType" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     onEvent: OnEventType<EventType, unknown>;
 }
@@ -1703,7 +1789,6 @@ interface DeductionsCardProps {
 // @public
 function DeductionsEditForm(input: DeductionsEditFormProps & Pick<BaseComponentInterface, 'FallbackComponent'>): JSX;
 
-// Warning: (ae-forgotten-export) The symbol "CommonComponentInterface" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "DeductionsEditFormProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -1801,11 +1886,41 @@ interface DismissalFlowProps {
 // @public (undocumented)
 function DocumentList(props: DocumentListProps): JSX;
 
-// Warning: (ae-forgotten-export) The symbol "DocumentManagerProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "DocumentManager" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 function DocumentManager(props: DocumentManagerProps & BaseComponentInterface): JSX;
+
+// Warning: (ae-missing-release-tag) "DocumentManagerProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface DocumentManagerProps {
+    // (undocumented)
+    employeeId: string;
+    // (undocumented)
+    formId: string;
+}
+
+// Warning: (ae-missing-release-tag) "Documents" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+function Documents(input: DocumentsProps & BaseComponentInterface<'Employee.Management.Documents'>): JSX;
+
+// Warning: (ae-missing-release-tag) "DocumentsCard" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@gusto/embedded-react-sdk" does not have an export "useDocumentsList"
+//
+// @public
+function DocumentsCard(props: DocumentsCardProps): JSX;
+
+// Warning: (ae-missing-release-tag) "DocumentsCardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface DocumentsCardProps {
+    // (undocumented)
+    employeeId: string;
+    // (undocumented)
+    onEvent: OnEventType<EventType, unknown>;
+}
 
 // Warning: (ae-forgotten-export) The symbol "DocumentSignerProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "DocumentSigner" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1818,6 +1933,16 @@ function DocumentSigner(props: DocumentSignerProps): JSX;
 //
 // @public (undocumented)
 function DocumentSigner_2(props: DocumentSignerProps_2): JSX;
+
+// Warning: (ae-missing-release-tag) "DocumentsProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface DocumentsProps extends CommonComponentInterface<'Employee.Management.Documents'> {
+    // (undocumented)
+    employeeId: string;
+    // (undocumented)
+    onEvent: OnEventType<EventType, unknown>;
+}
 
 // Warning: (ae-missing-release-tag) "EffectiveDateFieldProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1972,7 +2097,12 @@ declare namespace EmployeeManagement {
         EmployeeListFlow,
         EmployeeListFlowProps,
         EmployeeDocuments,
+        Documents,
+        DocumentsCard,
         DocumentManager,
+        DocumentsProps,
+        DocumentsCardProps,
+        DocumentManagerProps,
         DashboardFlow,
         HomeAddress,
         HomeAddressCard,
@@ -2020,6 +2150,16 @@ declare namespace EmployeeManagement {
         DeductionsProps_2 as DeductionsProps,
         DeductionsCardProps,
         DeductionsEditFormProps,
+        Compensation_3 as Compensation,
+        CompensationCard,
+        CompensationEditForm,
+        CompensationAddJobForm,
+        CompensationAddAnotherJobForm,
+        CompensationProps_2 as CompensationProps,
+        CompensationCardProps,
+        CompensationEditFormProps,
+        CompensationAddJobFormProps,
+        CompensationAddAnotherJobFormProps,
         TerminateEmployee,
         TerminationSummary,
         TerminationFlow
@@ -2163,7 +2303,7 @@ function FederalTaxes_3(input: FederalTaxesProps_3 & Pick<BaseComponentInterface
 // Warning: (ae-missing-release-tag) "FederalTaxesCard" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-function FederalTaxesCard(input: FederalTaxesCardProps): JSX;
+function FederalTaxesCard(props: FederalTaxesCardProps): JSX;
 
 // Warning: (ae-missing-release-tag) "FederalTaxesCardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2562,7 +2702,7 @@ function HomeAddress(input: HomeAddressProps & BaseComponentInterface<'Employee.
 // Warning: (ae-missing-release-tag) "HomeAddressCard" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-function HomeAddressCard(input: HomeAddressCardProps): JSX;
+function HomeAddressCard(props: HomeAddressCardProps): JSX;
 
 // Warning: (ae-missing-release-tag) "HomeAddressCardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3367,6 +3507,7 @@ function PaymentMethod_2(input: PaymentMethodProps_2 & BaseComponentInterface): 
 function PaymentMethod_3(input: PaymentMethodProps_3 & BaseComponentInterface<'Employee.Management.PaymentMethod'>): JSX;
 
 // Warning: (ae-missing-release-tag) "PaymentMethodBankForm" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@gusto/embedded-react-sdk" does not have an export "BankFormBody"
 //
 // @public
 function PaymentMethodBankForm(input: PaymentMethodBankFormProps): JSX;
@@ -3385,7 +3526,7 @@ interface PaymentMethodBankFormProps extends Omit<UseBankFormProps, 'employeeId'
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@gusto/embedded-react-sdk" does not have an export "usePaymentMethodList"
 //
 // @public
-function PaymentMethodCard(input: PaymentMethodCardProps): JSX;
+function PaymentMethodCard(props: PaymentMethodCardProps): JSX;
 
 // Warning: (ae-missing-release-tag) "PaymentMethodCardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3484,6 +3625,7 @@ interface PaymentMethodProps_3 extends CommonComponentInterface<'Employee.Manage
 }
 
 // Warning: (ae-missing-release-tag) "PaymentMethodSplitForm" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@gusto/embedded-react-sdk" does not have an export "SplitPaymentsFormBody"
 //
 // @public
 function PaymentMethodSplitForm(input: PaymentMethodSplitFormProps): JSX;
@@ -3668,9 +3810,7 @@ function PayrollList(props: PayrollListBlockProps): JSX;
 
 // @public
 export interface PayrollLoadingProps {
-    // (undocumented)
     description?: ReactNode;
-    // (undocumented)
     title: ReactNode;
 }
 
@@ -3759,7 +3899,7 @@ export type PayScheduleRequiredValidation = typeof PayScheduleErrorCodes.REQUIRE
 // Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@gusto/embedded-react-sdk" does not have an export "usePaystubsList"
 //
 // @public
-function PaystubsCard(input: PaystubsCardProps): JSX;
+function PaystubsCard(props: PaystubsCardProps): JSX;
 
 // Warning: (ae-missing-release-tag) "PaystubsCardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3924,7 +4064,7 @@ function Profile_2(input: ProfileProps_2 & BaseComponentInterface<'Employee.Mana
 // Warning: (ae-missing-release-tag) "ProfileCard" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-function ProfileCard(input: ProfileCardProps): JSX;
+function ProfileCard(props: ProfileCardProps): JSX;
 
 // Warning: (ae-missing-release-tag) "ProfileCardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3944,7 +4084,7 @@ function ProfileEditForm(input: ProfileEditFormProps & Pick<BaseComponentInterfa
 // Warning: (ae-missing-release-tag) "ProfileEditFormProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-interface ProfileEditFormProps extends CommonComponentInterface<'Employee.Profile'> {
+interface ProfileEditFormProps extends CommonComponentInterface<'Employee.Management.Profile'> {
     // (undocumented)
     employeeId: string;
     // (undocumented)
@@ -4489,7 +4629,7 @@ function StateTaxes_3(input: StateTaxesProps_3 & Pick<BaseComponentInterface, 'F
 // Warning: (ae-missing-release-tag) "StateTaxesCard" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-function StateTaxesCard(input: StateTaxesCardProps): JSX;
+function StateTaxesCard(props: StateTaxesCardProps): JSX;
 
 // Warning: (ae-missing-release-tag) "StateTaxesCardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -5793,7 +5933,7 @@ function WorkAddress(input: WorkAddressProps & BaseComponentInterface<'Employee.
 // Warning: (ae-missing-release-tag) "WorkAddressCard" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-function WorkAddressCard(input: WorkAddressCardProps): JSX;
+function WorkAddressCard(props: WorkAddressCardProps): JSX;
 
 // Warning: (ae-missing-release-tag) "WorkAddressCardProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -5929,7 +6069,7 @@ export type ZipValidation = (typeof HomeAddressErrorCodes)['REQUIRED' | 'INVALID
 
 // Warnings were encountered during analysis:
 //
-// dist/partner-hook-utils/types.d.ts:268:13 - (ae-forgotten-export) The symbol "FieldElementRegistry" needs to be exported by the entry point index.d.ts
+// dist/partner-hook-utils/types.d.ts:270:13 - (ae-forgotten-export) The symbol "FieldElementRegistry" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -188,6 +188,7 @@ export default [
   {
     files: [
       'src/components/Base/**/*.{ts,tsx}',
+      'src/components/Common/**/*.{ts,tsx}',
       'src/components/Common/Fields/**/*.{ts,tsx}',
       'src/components/Common/UI/**/*.{ts,tsx}',
       'src/components/Common/PaginationControl/**',

--- a/src/components/Common/ActionsLayout/ActionsLayout.tsx
+++ b/src/components/Common/ActionsLayout/ActionsLayout.tsx
@@ -6,6 +6,7 @@ interface ActionsLayoutProps {
   justifyContent?: GridProps['justifyContent']
 }
 
+/** @internal */
 export const ActionsLayout = ({ children, justifyContent = 'end' }: ActionsLayoutProps) => {
   const childrenArray = Children.toArray(children).filter(Boolean)
   return (

--- a/src/components/Common/Alert/Alert.tsx
+++ b/src/components/Common/Alert/Alert.tsx
@@ -5,6 +5,7 @@ import SuccessIcon from '@/assets/icons/success_check.svg?react'
 import WarningIcon from '@/assets/icons/warning.svg?react'
 import ErrorIcon from '@/assets/icons/error.svg?react'
 
+/** @internal */
 export interface AlertProps {
   variant?: 'info' | 'success' | 'warning' | 'error'
   label: string
@@ -12,6 +13,7 @@ export interface AlertProps {
   icon?: React.ComponentType<React.SVGProps<SVGSVGElement> & { title?: string }>
 }
 
+/** @internal */
 export function Alert({ label, children, variant = 'info', icon }: AlertProps) {
   const id = useId()
   const alertRef = useRef<HTMLDivElement>(null)

--- a/src/components/Common/DataView/DataCards/DataCards.tsx
+++ b/src/components/Common/DataView/DataCards/DataCards.tsx
@@ -8,6 +8,7 @@ import { useSelectionState } from '@/components/Common/DataView/useSelectionStat
 import { Flex } from '@/components/Common/Flex/Flex'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
+/** @internal */
 export type DataCardsProps<T> = {
   label: string
   columns: useDataViewPropReturn<T>['columns']
@@ -23,6 +24,7 @@ export type DataCardsProps<T> = {
   isWithinBox?: TableProps['isWithinBox']
 }
 
+/** @internal */
 export const DataCards = <T,>({
   label,
   data,

--- a/src/components/Common/DataView/DataTable/DataTable.tsx
+++ b/src/components/Common/DataView/DataTable/DataTable.tsx
@@ -12,6 +12,7 @@ function withJustify(content: React.ReactNode, justify?: 'start' | 'end') {
   return <div className={styles.cellEnd}>{content}</div>
 }
 
+/** @internal */
 export type DataTableProps<T> = {
   label: string
   columns: useDataViewPropReturn<T>['columns']
@@ -43,6 +44,7 @@ function getCellContent<T>(
   return ''
 }
 
+/** @internal */
 export const DataTable = <T,>({
   label,
   data,

--- a/src/components/Common/DataView/DataView.tsx
+++ b/src/components/Common/DataView/DataView.tsx
@@ -8,6 +8,7 @@ import { DataCards } from './DataCards/DataCards'
 import type { useContainerBreakpointsProps } from '@/hooks/useContainerBreakpoints/useContainerBreakpoints'
 import useContainerBreakpoints from '@/hooks/useContainerBreakpoints/useContainerBreakpoints'
 
+/** @internal */
 export type DataViewProps<T> = {
   columns: useDataViewPropReturn<T>['columns']
   data: T[]
@@ -27,6 +28,7 @@ export type DataViewProps<T> = {
   selectionMode?: SelectionMode
 }
 
+/** @internal */
 export const DataView = <T,>({
   pagination,
   isFetching,

--- a/src/components/Common/DataView/useDataView.ts
+++ b/src/components/Common/DataView/useDataView.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import type { PaginationControlProps } from '@/components/Common/PaginationControl/PaginationControlTypes'
 
+/** @internal */
 export type SelectionMode = 'multiple' | 'single'
 
 type DataViewColumn<T> =
@@ -66,9 +67,11 @@ type MultipleSelectionProps<T> = {
   getIsItemSelected: (item: T) => boolean
 }
 
+/** @internal */
 export type useDataViewProp<T> = BaseDataViewProps<T> &
   (NoSelectionProps | SingleSelectionProps<T> | MultipleSelectionProps<T>)
 
+/** @internal */
 export type useDataViewPropReturn<T> = {
   pagination?: PaginationControlProps
   data: T[]
@@ -84,6 +87,7 @@ export type useDataViewPropReturn<T> = {
   selectionMode?: SelectionMode
 }
 
+/** @internal */
 export const useDataView = <T>({
   columns,
   data,

--- a/src/components/Common/DataView/useSelectionState.ts
+++ b/src/components/Common/DataView/useSelectionState.ts
@@ -4,6 +4,7 @@ type SelectionState = {
   allSelected: boolean
 }
 
+/** @internal */
 export function useSelectionState<T>(
   data: T[],
   getIsItemSelected?: (item: T) => boolean,

--- a/src/components/Common/DateRangeFilter/DateRangeFilter.tsx
+++ b/src/components/Common/DateRangeFilter/DateRangeFilter.tsx
@@ -28,6 +28,7 @@ interface DateRangeFilterProps {
   minStartDate?: Date
 }
 
+/** @internal */
 export const DateRangeFilter = ({
   startDate,
   endDate,

--- a/src/components/Common/DetailViewLayout/DetailViewLayout.tsx
+++ b/src/components/Common/DetailViewLayout/DetailViewLayout.tsx
@@ -5,6 +5,7 @@ import styles from './DetailViewLayout.module.scss'
 import CaretLeftIcon from '@/assets/icons/caret-left.svg?react'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
+/** @internal */
 export function DetailViewLayout({
   title,
   subtitle,

--- a/src/components/Common/DetailViewLayout/DetailViewLayoutTypes.ts
+++ b/src/components/Common/DetailViewLayout/DetailViewLayoutTypes.ts
@@ -38,4 +38,5 @@ type BaseDetailViewLayoutProps = {
   className?: string
 }
 
+/** @internal */
 export type DetailViewLayoutProps = BaseDetailViewLayoutProps & BackNavigation & TabbedContent

--- a/src/components/Common/DocumentList/DocumentList.tsx
+++ b/src/components/Common/DocumentList/DocumentList.tsx
@@ -3,10 +3,15 @@ import { EmptyData } from '../EmptyData/EmptyData'
 import styles from './DocumentList.module.scss'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
+/** @internal */
 export interface FormData {
+  /** Unique identifier for the form. */
   uuid: string
+  /** Display title shown in the list row. */
   title?: string
+  /** Secondary description shown beneath the title. */
   description?: string
+  /** Whether the form still requires a signature. */
   requires_signing?: boolean
 }
 
@@ -29,6 +34,7 @@ interface DocumentListProps {
   errorLabel: string
 }
 
+/** @internal */
 function DocumentList({
   forms,
   canSign = true,

--- a/src/components/Common/DocumentViewer/DocumentViewer.tsx
+++ b/src/components/Common/DocumentViewer/DocumentViewer.tsx
@@ -11,6 +11,7 @@ interface DocumentViewerProps {
   headingLevel?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 }
 
+/** @internal */
 export function DocumentViewer({
   url,
   title,

--- a/src/components/Common/EmptyData/EmptyData.tsx
+++ b/src/components/Common/EmptyData/EmptyData.tsx
@@ -13,6 +13,7 @@ type EmptyDataProps = {
    */
   icon?: React.ReactNode
 }
+/** @internal */
 export function EmptyData({ title, description, children, icon }: EmptyDataProps) {
   const { t } = useTranslation()
   const { Text } = useComponentContext()

--- a/src/components/Common/FadeIn/FadeIn.tsx
+++ b/src/components/Common/FadeIn/FadeIn.tsx
@@ -2,6 +2,7 @@ import type { FC, ReactNode } from 'react'
 import { useState, useEffect } from 'react'
 import styles from './FadeIn.module.scss'
 
+/** @internal */
 export const FadeIn: FC<{ children: ReactNode }> = ({ children }) => {
   const [visible, setVisible] = useState(false)
 

--- a/src/components/Common/FieldCaption/FieldCaption.tsx
+++ b/src/components/Common/FieldCaption/FieldCaption.tsx
@@ -3,15 +3,23 @@ import classNames from 'classnames'
 import { VisuallyHidden } from '../VisuallyHidden'
 import styles from './FieldCaption.module.scss'
 
+/** @internal */
 export interface FieldCaptionProps {
+  /** Caption content rendered inside the label or legend element. */
   children: React.ReactNode
+  /** HTML element to render as — `label` for individual inputs, `legend` for fieldsets. */
   as?: 'label' | 'legend'
+  /** Associates a `label` with an input by id. Ignored when `as` is `legend`. */
   htmlFor?: string
+  /** When false, appends a localized optional indicator after the caption. */
   isRequired?: boolean
+  /** Visually hides the caption while keeping it available to assistive technology. */
   isVisuallyHidden?: boolean
+  /** Additional class names appended to the root element. */
   className?: string
 }
 
+/** @internal */
 export const FieldCaption: React.FC<FieldCaptionProps> = ({
   children,
   as = 'label',

--- a/src/components/Common/FieldDescription/FieldDescription.tsx
+++ b/src/components/Common/FieldDescription/FieldDescription.tsx
@@ -7,6 +7,11 @@ interface FieldDescriptionProps {
   id?: string
 }
 
+/**
+ * Renders a field's helper description text beneath its label.
+ *
+ * @internal
+ */
 export const FieldDescription: React.FC<FieldDescriptionProps> = ({
   children,
   className,

--- a/src/components/Common/FieldErrorMessage/FieldErrorMessage.tsx
+++ b/src/components/Common/FieldErrorMessage/FieldErrorMessage.tsx
@@ -7,6 +7,11 @@ interface FieldErrorMessageProps extends HTMLAttributes<HTMLParagraphElement> {
   withErrorIcon?: boolean
 }
 
+/**
+ * Renders a field's validation error message via the component adapter's `Text` primitive.
+ *
+ * @internal
+ */
 export function FieldErrorMessage({
   children,
   id,

--- a/src/components/Common/FieldLayout/FieldLayout.tsx
+++ b/src/components/Common/FieldLayout/FieldLayout.tsx
@@ -6,6 +6,11 @@ import styles from './FieldLayout.module.scss'
 import type { FieldLayoutProps } from './FieldLayoutTypes'
 import { getDataProps } from '@/helpers/getDataProps'
 
+/**
+ * Wraps a form control with its label, description, and error message in a consistent vertical layout.
+ *
+ * @internal
+ */
 export const FieldLayout: React.FC<FieldLayoutProps> = ({
   label,
   description,

--- a/src/components/Common/FieldLayout/FieldLayoutTypes.ts
+++ b/src/components/Common/FieldLayout/FieldLayoutTypes.ts
@@ -1,6 +1,15 @@
 import type { ReactNode } from 'react'
 import type { DataAttributes } from '@/types/Helpers'
 
+/**
+ * Common layout props shared by form controls — label, description, error message, required state, and visual label hiding.
+ *
+ * @remarks
+ * Extended by the props interfaces of UI primitive components (such as `TextInputProps`, `SelectProps`, and `CheckboxGroupProps`)
+ * so each control exposes a consistent surface for labeling, helper text, and validation messaging.
+ *
+ * @public
+ */
 export interface SharedFieldLayoutProps extends DataAttributes {
   /**
    * Optional description text for the field
@@ -24,6 +33,9 @@ export interface SharedFieldLayoutProps extends DataAttributes {
   shouldVisuallyHideLabel?: boolean
 }
 
+/**
+ * @internal
+ */
 export interface InternalFieldLayoutProps {
   /**
    * Content to be rendered inside the field layout
@@ -51,4 +63,7 @@ export interface InternalFieldLayoutProps {
   withErrorIcon?: boolean
 }
 
+/**
+ * @internal
+ */
 export interface FieldLayoutProps extends SharedFieldLayoutProps, InternalFieldLayoutProps {}

--- a/src/components/Common/Fieldset/Fieldset.tsx
+++ b/src/components/Common/Fieldset/Fieldset.tsx
@@ -7,6 +7,7 @@ import type { SharedFieldLayoutProps } from '../FieldLayout/FieldLayoutTypes'
 import styles from './Fieldset.module.scss'
 import { getDataProps } from '@/helpers/getDataProps'
 
+/** @internal */
 export interface FieldsetProps extends Omit<
   SharedFieldLayoutProps,
   'label' | 'shouldVisuallyHideLabel'
@@ -20,6 +21,7 @@ export interface FieldsetProps extends Omit<
   className?: string
 }
 
+/** @internal */
 export const Fieldset: React.FC<FieldsetProps> = ({
   children,
   description,

--- a/src/components/Common/Flex/Flex.tsx
+++ b/src/components/Common/Flex/Flex.tsx
@@ -5,6 +5,7 @@ import {
   type CustomPropertyValue,
 } from '@/helpers/responsive'
 
+/** @internal */
 export interface FlexProps {
   children: React.ReactNode
   flexDirection?: Responsive<'row' | 'column'>
@@ -22,6 +23,7 @@ export interface FlexProps {
   gap?: Responsive<CustomPropertyValue>
 }
 
+/** @internal */
 export function Flex({
   children,
   flexDirection = 'row',
@@ -47,11 +49,13 @@ export function Flex({
   )
 }
 
+/** @internal */
 export interface FlexItemProps {
   flexGrow?: number | 'initial'
   children: React.ReactNode
 }
 
+/** @internal */
 export function FlexItem({ flexGrow = 'initial', children }: FlexItemProps) {
   return <div style={{ flexGrow: flexGrow }}>{children}</div>
 }

--- a/src/components/Common/FlowBreadcrumbs/FlowBreadcrumbs.tsx
+++ b/src/components/Common/FlowBreadcrumbs/FlowBreadcrumbs.tsx
@@ -9,6 +9,26 @@ import { useLocale } from '@/contexts/LocaleProvider/useLocale'
 import { useContainerBreakpoints } from '@/hooks/useContainerBreakpoints/useContainerBreakpoints'
 import { useDateFormatter } from '@/hooks/useDateFormatter'
 
+/**
+ * Renders the breadcrumb trail for a multi-step flow.
+ *
+ * @remarks
+ * Translates each breadcrumb's label via i18next using the optional `namespace`
+ * and `variables`, formats `startDate`/`endDate` variables through the locale's
+ * short-with-year date formatter, and emits a `breadcrumb/navigate` event when
+ * a clickable breadcrumb is selected. A breadcrumb is clickable when
+ * `isNavigable` is true, or when `isNavigable` is omitted and `onNavigate` is
+ * defined. Switches to a condensed mobile layout when the container only
+ * contains the base breakpoint.
+ *
+ * | Event | Description | Data |
+ * | ----- | ----------- | ---- |
+ * | `breadcrumb/navigate` | Emitted when a clickable breadcrumb is selected | `{ key: string; onNavigate: (ctx: unknown) => unknown }` |
+ *
+ * @param props - See {@link FlowBreadcrumbsProps}.
+ * @returns The breadcrumb trail rendered through the component adapter.
+ * @internal
+ */
 export function FlowBreadcrumbs({
   breadcrumbs,
   currentBreadcrumbId,

--- a/src/components/Common/FlowBreadcrumbs/FlowBreadcrumbsTypes.ts
+++ b/src/components/Common/FlowBreadcrumbs/FlowBreadcrumbsTypes.ts
@@ -1,34 +1,55 @@
 import type { OnEventType } from '@/components/Base/useBase'
 import type { EventType } from '@/types/Helpers'
 
+/**
+ * A single step in a flow's breadcrumb trail.
+ *
+ * @remarks
+ * Labels are resolved through i18next. When `namespace` is set, the label is
+ * looked up in that namespace; otherwise the global namespace is used. The
+ * label string itself is also used as the i18n key, with the raw value as a
+ * fallback when no translation is registered. Date-typed `variables` (the
+ * `startDate` and `endDate` keys) are auto-formatted with the active locale's
+ * short-with-year date format before interpolation.
+ *
+ * @public
+ */
 export interface FlowBreadcrumb {
   /**
-   * Unique key for the breadcrumb step
+   * Unique identifier for the breadcrumb step. Matched against the current
+   * breadcrumb to mark the active entry and passed to `onNavigate` when the
+   * breadcrumb is selected.
    */
   id: string
   /**
-   * Translation key for the breadcrumb label
+   * i18next translation key for the breadcrumb label. Falls back to the raw
+   * string when no translation is registered.
    */
   label: string
   /**
-   * Optional translation namespace
+   * Optional i18next namespace to resolve `label` against. Defaults to the
+   * global namespace when omitted.
    */
   namespace?: string
   /**
-   * Optional variables for the breadcrumb label
+   * Optional interpolation variables for the translated label. `startDate` and
+   * `endDate` values typed as strings are auto-formatted with the active
+   * locale's short-with-year date format before interpolation.
    */
   variables?: Record<string, unknown>
   /**
-   * Event handler for breadcrumb navigation
+   * Callback invoked when the breadcrumb is selected. Receives the current
+   * flow context and returns the next context.
    */
   onNavigate?: (context: unknown) => unknown
   /**
-   * When false, the breadcrumb is rendered as non-clickable even if onNavigate is defined.
-   * Defaults to true when onNavigate is present, false otherwise.
+   * Overrides the default clickability of the breadcrumb. When omitted, the
+   * breadcrumb is clickable iff `onNavigate` is defined.
    */
   isNavigable?: boolean
 }
 
+/** @internal */
 export interface BreadcrumbNode {
   /**
    * Parent node key (null for root nodes)
@@ -40,11 +61,16 @@ export interface BreadcrumbNode {
   item: FlowBreadcrumb
 }
 
+/** @internal */
 export type BreadcrumbNodes = Record<string, BreadcrumbNode>
+/** @internal */
 export type BreadcrumbTrail = Record<string, FlowBreadcrumb[]>
 
+/** @internal */
 export interface FlowBreadcrumbsProps {
+  /** Breadcrumb steps to render, in order. */
   breadcrumbs: FlowBreadcrumb[]
+  /** Identifier of the active breadcrumb step. */
   currentBreadcrumbId?: string
 
   /**

--- a/src/components/Common/FlowBreadcrumbs/breadcrumbTransitionHelpers.ts
+++ b/src/components/Common/FlowBreadcrumbs/breadcrumbTransitionHelpers.ts
@@ -26,6 +26,7 @@ type BreadcrumbNavigateEvent<TContext> = {
  * @internal
  */
 export const createBreadcrumbNavigateTransition = <TContext>() => {
+  /* eslint-enable @typescript-eslint/no-unnecessary-type-parameters */
   return (targetState: string, canNavigate?: (ctx: TContext) => boolean) =>
     transition(
       componentEvents.BREADCRUMB_NAVIGATE,

--- a/src/components/Common/FlowBreadcrumbs/breadcrumbTransitionHelpers.ts
+++ b/src/components/Common/FlowBreadcrumbs/breadcrumbTransitionHelpers.ts
@@ -8,7 +8,23 @@ type BreadcrumbNavigateEvent<TContext> = {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+/* eslint-disable @typescript-eslint/no-unnecessary-type-parameters */
+/**
+ * Builds a factory that produces robot3 transitions handling a
+ * `breadcrumb/navigate` event for a given target state.
+ *
+ * @remarks
+ * The returned factory takes a target state name and an optional `canNavigate`
+ * guard. The resulting transition only fires when the event payload's `key`
+ * matches the target state and the guard (if provided) returns true, then
+ * reduces the machine context by invoking the breadcrumb's `onNavigate`. The
+ * outer generic is used purely to anchor `TContext` for the inner closures.
+ *
+ * @typeParam TContext - The state machine context shape.
+ * @returns A factory `(targetState, canNavigate?) => transition` that emits a
+ * guarded robot3 transition for the `breadcrumb/navigate` event.
+ * @internal
+ */
 export const createBreadcrumbNavigateTransition = <TContext>() => {
   return (targetState: string, canNavigate?: (ctx: TContext) => boolean) =>
     transition(

--- a/src/components/Common/Form/Form.tsx
+++ b/src/components/Common/Form/Form.tsx
@@ -1,8 +1,10 @@
 import classNames from 'classnames'
 import styles from './Form.module.scss'
 
+/** @internal */
 export type FormProps = React.FormHTMLAttributes<HTMLFormElement>
 
+/** @internal */
 export const Form = ({ children, className, onSubmit, ...props }: FormProps) => {
   return (
     <form

--- a/src/components/Common/Grid/Grid.tsx
+++ b/src/components/Common/Grid/Grid.tsx
@@ -10,6 +10,7 @@ import {
 type Flow = 'row' | 'column' | 'row dense' | 'column dense'
 type Alignment = 'start' | 'end' | 'center' | 'stretch'
 
+/** @internal */
 export interface GridProps {
   children: ReactNode
   gap?: Responsive<CustomPropertyValue>
@@ -25,6 +26,7 @@ export interface GridProps {
   className?: string
 }
 
+/** @internal */
 export function Grid({
   children,
   gap = 24,

--- a/src/components/Common/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/components/Common/HamburgerMenu/HamburgerMenu.tsx
@@ -4,6 +4,13 @@ import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentCon
 import HamburgerIcon from '@/assets/icons/hamburger.svg?react'
 import { useMenu } from '@/hooks/useMenu'
 
+/**
+ * Hamburger icon button that opens a menu of actions when activated.
+ *
+ * @param props - See {@link HamburgerMenuProps}.
+ * @returns A button-and-menu pair rendered through the components context.
+ * @internal
+ */
 export function HamburgerMenu({
   items,
   triggerLabel,

--- a/src/components/Common/HamburgerMenu/HamburgerMenuTypes.ts
+++ b/src/components/Common/HamburgerMenu/HamburgerMenuTypes.ts
@@ -1,11 +1,22 @@
 import type { MenuProps } from '../UI/Menu/MenuTypes'
 import type { DataAttributes } from '@/types/Helpers'
 
+/**
+ * Props for the {@link HamburgerMenu} component.
+ *
+ * @internal
+ */
 export interface HamburgerMenuProps extends DataAttributes {
+  /** Accessible label for the trigger button. Defaults to a localized "Open menu" string. */
   triggerLabel?: string
+  /** Accessible label for the menu popover. Defaults to a localized menu label. */
   menuLabel?: string
+  /** Items rendered inside the menu popover. */
   items: MenuProps['items']
+  /** Called when the menu is dismissed. */
   onClose?: () => void
+  /** Renders the trigger button in a loading state when true. */
   isLoading?: boolean
+  /** Placement of the menu popover relative to the trigger. Defaults to `'bottom end'`. */
   placement?: MenuProps['placement']
 }

--- a/src/components/Common/HorizontalFieldLayout/HorizontalFieldLayout.tsx
+++ b/src/components/Common/HorizontalFieldLayout/HorizontalFieldLayout.tsx
@@ -6,6 +6,13 @@ import styles from './HorizontalFieldLayout.module.scss'
 import type { HorizontalFieldLayoutProps } from './HorizontalFieldLayoutTypes'
 import { getDataProps } from '@/helpers/getDataProps'
 
+/**
+ * Layout that positions a form control's children alongside its label, description, and error message.
+ *
+ * @param props - See {@link HorizontalFieldLayoutProps}.
+ * @returns The control's children laid out horizontally with associated label and helper text.
+ * @internal
+ */
 export const HorizontalFieldLayout: React.FC<HorizontalFieldLayoutProps> = ({
   label,
   description,

--- a/src/components/Common/HorizontalFieldLayout/HorizontalFieldLayoutTypes.ts
+++ b/src/components/Common/HorizontalFieldLayout/HorizontalFieldLayoutTypes.ts
@@ -3,6 +3,20 @@ import type {
   SharedFieldLayoutProps,
 } from '../FieldLayout/FieldLayoutTypes'
 
+/**
+ * Shared layout props consumed by horizontally-laid-out form controls — label, description, error message, required state, and visual label hiding.
+ *
+ * @remarks
+ * Extended by props interfaces for inline controls such as `CheckboxProps`, `RadioProps`, and `SwitchProps`.
+ * Alias of {@link SharedFieldLayoutProps} — exposed as a distinct name to mirror the horizontal layout used by these controls.
+ *
+ * @public
+ */
 export type SharedHorizontalFieldLayoutProps = SharedFieldLayoutProps
 
+/**
+ * Props for the {@link HorizontalFieldLayout} component.
+ *
+ * @internal
+ */
 export type HorizontalFieldLayoutProps = SharedHorizontalFieldLayoutProps & InternalFieldLayoutProps

--- a/src/components/Common/InlineSpinner/InlineSpinner.tsx
+++ b/src/components/Common/InlineSpinner/InlineSpinner.tsx
@@ -7,6 +7,7 @@ interface InlineSpinnerProps {
   size?: 'small' | 'medium' | 'large'
 }
 
+/** @internal */
 export const InlineSpinner = ({ ariaLabel, size = 'small' }: InlineSpinnerProps) => {
   const { t } = useTranslation('common')
   const defaultAriaLabel = t('status.loading')

--- a/src/components/Common/InternalError/InternalError.tsx
+++ b/src/components/Common/InternalError/InternalError.tsx
@@ -3,6 +3,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import styles from './InternalError.module.scss'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
+/** @internal */
 export const InternalError = ({ error, resetErrorBoundary }: FallbackProps) => {
   const { t } = useTranslation('common')
   const Components = useComponentContext()

--- a/src/components/Common/Loading/Loading.tsx
+++ b/src/components/Common/Loading/Loading.tsx
@@ -4,10 +4,12 @@ import type { ReactNode } from 'react'
 import styles from './Loading.module.scss'
 import { FadeIn } from '@/components/Common/FadeIn/FadeIn'
 
+/** @internal */
 export interface LoadingProps {
   children?: ReactNode
 }
 
+/** @internal */
 export const Loading = ({ children }: LoadingProps) => {
   const { t } = useTranslation('common')
   return (

--- a/src/components/Common/OnboardingStatusBadge/index.tsx
+++ b/src/components/Common/OnboardingStatusBadge/index.tsx
@@ -10,6 +10,7 @@ interface OnboardingStatusBadgeProps<T extends OnboardingStatuses> {
   onboardingEntity: 'contractor' | 'employee'
   onboardingStatus?: T | null
 }
+/** @internal */
 export const OnboardingStatusBadge = <T extends OnboardingStatuses>({
   onboarded,
   onboardingEntity,
@@ -30,6 +31,7 @@ interface ContractorOnboardingStatusBadgeProps {
   onboarded?: boolean
   onboardingStatus?: ContractorOnboardingStatus1 | null
 }
+/** @internal */
 export const ContractorOnboardingStatusBadge = (props: ContractorOnboardingStatusBadgeProps) => (
   <OnboardingStatusBadge {...props} onboardingEntity="contractor" />
 )
@@ -38,6 +40,7 @@ interface EmployeeOnboardingStatusBadgeProps {
   onboarded?: boolean
   onboardingStatus?: OnboardingStatus | null
 }
+/** @internal */
 export const EmployeeOnboardingStatusBadge = (props: EmployeeOnboardingStatusBadgeProps) => (
   <OnboardingStatusBadge {...props} onboardingEntity="employee" />
 )

--- a/src/components/Common/ReorderableList/DropZone.tsx
+++ b/src/components/Common/ReorderableList/DropZone.tsx
@@ -15,6 +15,7 @@ interface DropZoneProps {
   className?: string
 }
 
+/** @internal */
 export const DropZone = memo(function DropZone({
   position,
   isActive,

--- a/src/components/Common/ReorderableList/ReorderableItem.tsx
+++ b/src/components/Common/ReorderableList/ReorderableItem.tsx
@@ -32,9 +32,7 @@ interface ReorderableItemProps {
   className?: string
 }
 
-/**
- * Component for an individual reorderable item
- */
+/** @internal */
 export const ReorderableItem = memo(function ReorderableItem({
   item,
   index,

--- a/src/components/Common/ReorderableList/ReorderableList.tsx
+++ b/src/components/Common/ReorderableList/ReorderableList.tsx
@@ -89,6 +89,7 @@ const DEFAULT_ANIMATION_CONFIG: ReorderableListAnimationConfig = {
   disabled: false,
 }
 
+/** @internal */
 export function ReorderableList({
   items,
   label,

--- a/src/components/Common/ReorderableList/ReorderableListTypes.ts
+++ b/src/components/Common/ReorderableList/ReorderableListTypes.ts
@@ -1,7 +1,11 @@
 import type { ReactElement } from 'react'
 
+/** @internal */
 export interface ReorderableListItem {
+  /** Rendered content displayed inside the reorderable row. */
   content: ReactElement
+  /** Accessible name announced for the item by screen readers. */
   label: string
+  /** Stable identifier used as a React key; falls back to the item's index when omitted. */
   id?: string
 }

--- a/src/components/Common/ReorderableList/constants.ts
+++ b/src/components/Common/ReorderableList/constants.ts
@@ -1,4 +1,2 @@
-/**
- * Define item type for react-dnd with a unique identifier to avoid conflicts
- */
+/** @internal */
 export const ITEM_TYPE = 'reorderable-item'

--- a/src/components/Common/RequirementsList/RequirementsList.tsx
+++ b/src/components/Common/RequirementsList/RequirementsList.tsx
@@ -12,6 +12,7 @@ interface RequirementsListProps {
     completed: boolean
   }[]
 }
+/** @internal */
 export const RequirementsList = ({ requirements }: RequirementsListProps) => {
   const Components = useComponentContext()
   const id = useId()

--- a/src/components/Common/TaxInputs/TaxInputs.tsx
+++ b/src/components/Common/TaxInputs/TaxInputs.tsx
@@ -30,6 +30,7 @@ type NumberFieldProps = { isCurrency?: boolean; isPercent?: boolean }
 
 type TextInputProps = { type?: string; isPercent?: boolean }
 
+/** @internal */
 export function QuestionInput({
   questionType,
   ...props
@@ -63,6 +64,7 @@ export function QuestionInput({
   }
 }
 
+/** @internal */
 export function SelectInput({ question, requirement, isDisabled = false }: EmpQ | CompR) {
   const { key, label, description } = question ? question : requirement
   const value = question ? question.answers[0]?.value : requirement.value
@@ -90,6 +92,7 @@ export function SelectInput({ question, requirement, isDisabled = false }: EmpQ 
   )
 }
 
+/** @internal */
 export function TextInput({
   question,
   requirement,
@@ -120,6 +123,7 @@ export function TextInput({
   )
 }
 
+/** @internal */
 export function NumberInput({
   question,
   requirement,
@@ -158,6 +162,7 @@ export function NumberInput({
   )
 }
 
+/** @internal */
 export function RadioInput({ question, requirement, isDisabled = false }: EmpQ | CompR) {
   const { key, label, description } = question ? question : requirement
   const value = question ? question.answers[0]?.value : requirement.value
@@ -194,6 +199,7 @@ export function RadioInput({ question, requirement, isDisabled = false }: EmpQ |
   )
 }
 //TODO: This type is untested as of yet
+/** @internal */
 export function DateField({
   question,
   requirement,
@@ -218,6 +224,7 @@ export function DateField({
   )
 }
 
+/** @internal */
 export function TaxRateInput({ requirement, question, ...props }: EmpQ | CompR) {
   const { locale } = useLocale()
 

--- a/src/components/Common/Toast/Toast.tsx
+++ b/src/components/Common/Toast/Toast.tsx
@@ -1,5 +1,6 @@
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 //TODO: Style appropriately once design is available
+/** @internal */
 export function Toast({ message, onClose }: { message: string | null; onClose: () => void }) {
   const Components = useComponentContext()
   if (!message) return

--- a/src/components/Common/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/Common/VisuallyHidden/VisuallyHidden.tsx
@@ -3,6 +3,7 @@ import type React from 'react'
 import classnames from 'classnames'
 import styles from './VisuallyHidden.module.scss'
 
+/** @internal */
 export interface VisuallyHiddenProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * The element to render the visually hidden content as.
@@ -15,6 +16,7 @@ export interface VisuallyHiddenProps extends HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
 }
 
+/** @internal */
 export function VisuallyHidden({
   as: Component = 'div',
   children,

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,8 @@ export type {
   DatePickerHookFieldProps,
   RadioGroupHookFieldProps,
   SwitchHookFieldProps,
+  SharedFieldLayoutProps,
+  SharedHorizontalFieldLayoutProps,
   TextInputProps,
   SelectProps,
   SelectOption,

--- a/src/partner-hook-utils/form/fields/index.ts
+++ b/src/partner-hook-utils/form/fields/index.ts
@@ -6,6 +6,8 @@ export { DatePickerHookField, type DatePickerHookFieldProps } from './DatePicker
 export { RadioGroupHookField, type RadioGroupHookFieldProps } from './RadioGroupHookField'
 export { SwitchHookField, type SwitchHookFieldProps } from './SwitchHookField'
 
+export type { SharedFieldLayoutProps } from '@/components/Common/FieldLayout/FieldLayoutTypes'
+export type { SharedHorizontalFieldLayoutProps } from '@/components/Common/HorizontalFieldLayout/HorizontalFieldLayoutTypes'
 export type { TextInputProps } from '@/components/Common/UI/TextInput/TextInputTypes'
 export type { SelectProps, SelectOption } from '@/components/Common/UI/Select/SelectTypes'
 export type { CheckboxProps } from '@/components/Common/UI/Checkbox/CheckboxTypes'

--- a/src/partner-hook-utils/form/index.ts
+++ b/src/partner-hook-utils/form/index.ts
@@ -28,6 +28,8 @@ export {
   type DatePickerHookFieldProps,
   RadioGroupHookField,
   type RadioGroupHookFieldProps,
+  type SharedFieldLayoutProps,
+  type SharedHorizontalFieldLayoutProps,
   type TextInputProps,
   type SelectProps,
   type SelectOption,


### PR DESCRIPTION
## Summary

Phase 5 of the TSDoc backfill project (SDK-758). Adds `@internal` or `@public` TSDoc tags and comments to all exported symbols in `src/components/Common/`, clearing ~178 ESLint violations across 43 files in ~30 subdirectories.

Enables strict `tsdoc-coverage` linting for `src/components/Common/**/*.{ts,tsx}` by adding it to the ESLint allowlist.

## Changes

- Added `'src/components/Common/**/*.{ts,tsx}'` to the "Library: well-documented code" ESLint allowlist in `eslint.config.ts`
- Tagged all exported symbols in `src/components/Common/` with `@internal` (most are leaked barrel exports, not partner-facing) or `@public` where the API report confirms they're on the public surface (`SharedFieldLayoutProps`, `SharedHorizontalFieldLayoutProps`, `FlowBreadcrumb`)
- Refreshed `api-report:derive` to pick up type changes

## Related

- Jira ticket: [SDK-1010](https://gustohq.atlassian.net/browse/SDK-1010)
- Parent epic: [SDK-758](https://gustohq.atlassian.net/browse/SDK-758)
- Reference PR: #1996

## Testing

- `npm run build` — passes clean
- `npm run api-report:derive` — no new warnings
- `npx eslint 'src/components/Common/' --fix` — 0 errors (1 pre-existing `react-hooks/exhaustive-deps` warning in `FlowBreadcrumbs.tsx`, unrelated)

[SDK-1010]: https://gustohq.atlassian.net/browse/SDK-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-758]: https://gustohq.atlassian.net/browse/SDK-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ