### PR TITLE
fix: tighten federal taxes form field spacing

### DIFF
--- a/src/components/Company/FederalTaxes/Form.tsx
+++ b/src/components/Company/FederalTaxes/Form.tsx
@@ -35,7 +35,7 @@ export function Form() {
   )
 
   return (
-    <Flex flexDirection="column" gap={28}>
+    <Flex flexDirection="column" gap={20}>
       <TextInputField
         name="federalEin"
         label={t('federalEinLabel')}


### PR DESCRIPTION
## Summary

Tightens the vertical gap between fields in the Federal Taxes form to better match adjacent forms in the SDK.

## Changes

- Reduce `Flex` `gap` from `28` to `20` in [src/components/Company/FederalTaxes/Form.tsx](src/components/Company/FederalTaxes/Form.tsx)

## Demo

<!-- Add before/after screenshots of the Federal Taxes form -->

## Related

<!-- Link to relevant resources:
- Jira ticket: [SDK-XXX](https://gustohq.atlassian.net/browse/SDK-XXX)
- Figma: [Design link]
-->

## Testing

- Open Storybook and view the Federal Taxes form story; verify the vertical spacing between fields matches adjacent forms.
- `npm run test -- --run src/components/Company/FederalTaxes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)