### PR TITLE
docs(SDK-1011): backfill phase 6

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -172,17 +172,11 @@ export type AnchorPayDateFieldProps = HookFieldProps<DatePickerHookFieldProps<Pa
 // @public (undocumented)
 export type AnnualMaximumFieldProps = HookFieldProps<NumberInputHookFieldProps<DeductionFormCapValidation>>;
 
-// Warning: (ae-missing-release-tag) "APIConfig" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface APIConfig {
-    // (undocumented)
     baseUrl: string;
-    // (undocumented)
     headers?: HeadersInit;
-    // (undocumented)
     hooks?: SDKHooks;
-    // (undocumented)
     observability?: ObservabilityHook;
 }
 
@@ -2548,68 +2542,40 @@ export function getQuestionVariant(question: EmployeeStateTaxQuestion): StateTax
 // @public (undocumented)
 export function getRequiredAttrKeys(agency?: Agencies | null): Set<SupportedRequiredAttrKey>;
 
-// Warning: (ae-missing-release-tag) "GustoApiProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface GustoApiProps extends Omit<GustoProviderProps, 'components'> {
-    // (undocumented)
     children?: default_2.ReactNode;
-    // (undocumented)
     components?: Partial<ComponentsContextType>;
-    // (undocumented)
     queryClient?: QueryClient;
 }
 
-// Warning: (ae-missing-release-tag) "GustoApiProvider" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public @deprecated (undocumented)
+// @public @deprecated
 export const GustoApiProvider: default_2.FC<GustoApiProps>;
 
-// Warning: (ae-missing-release-tag) "GustoProvider" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export const GustoProvider: default_2.FC<GustoApiProps>;
 
-// Warning: (ae-missing-release-tag) "GustoProviderCustomUIAdapter" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export const GustoProviderCustomUIAdapter: default_2.FC<GustoProviderCustomUIAdapterProps>;
 
-// Warning: (ae-missing-release-tag) "GustoProviderCustomUIAdapterProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface GustoProviderCustomUIAdapterProps extends GustoProviderProps {
-    // (undocumented)
     children?: default_2.ReactNode;
 }
 
-// Warning: (ae-missing-release-tag) "GustoProviderProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export interface GustoProviderProps {
-    // (undocumented)
     components: ComponentsContextType;
-    // (undocumented)
     config: APIConfig;
-    // (undocumented)
     currency?: string;
     // Warning: (ae-forgotten-export) The symbol "ResourceDictionary" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     dictionary?: ResourceDictionary;
-    // (undocumented)
     lng?: string;
     // Warning: (ae-forgotten-export) The symbol "LoadingIndicatorContextProps" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     LoaderComponent?: LoadingIndicatorContextProps['LoadingIndicator'];
-    // (undocumented)
     locale?: string;
-    // (undocumented)
     portalContainer?: HTMLElement;
-    // (undocumented)
     queryClient?: QueryClient;
-    // (undocumented)
     theme?: Partial<GustoSDKTheme>;
 }
 

--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -2609,10 +2609,88 @@ export interface GustoProviderProps {
     portalContainer?: HTMLElement;
     // (undocumented)
     queryClient?: QueryClient;
-    // Warning: (ae-forgotten-export) The symbol "GustoSDKTheme" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
-    theme?: GustoSDKTheme;
+    theme?: Partial<GustoSDKTheme>;
+}
+
+// Warning: (ae-missing-release-tag) "GustoSDKTheme" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export interface GustoSDKTheme extends GustoSDKThemeColors {
+    badgeRadius: string;
+    bannerRadius: string;
+    boxRadius: string;
+    buttonRadius: string;
+    cardRadius: string;
+    focusRingColor: string;
+    focusRingWidth: string;
+    fontFamily: string;
+    fontLineHeightExtraSmall: string;
+    fontLineHeightLarge: string;
+    fontLineHeightRegular: string;
+    fontLineHeightSmall: string;
+    fontSizeExtraSmall: string;
+    fontSizeHeading1: string;
+    fontSizeHeading2: string;
+    fontSizeHeading3: string;
+    fontSizeHeading4: string;
+    fontSizeHeading5: string;
+    fontSizeHeading6: string;
+    fontSizeLarge: string;
+    fontSizeRegular: string;
+    fontSizeRoot: string;
+    fontSizeSmall: string;
+    fontWeightBold: string;
+    fontWeightMedium: string;
+    fontWeightRegular: string;
+    fontWeightSemibold: string;
+    inputAdornmentColor: string;
+    inputBackgroundColor: string;
+    inputBorderColor: string;
+    inputBorderWidth: string;
+    inputContentColor: string;
+    inputDescriptionColor: string;
+    inputDisabledBackgroundColor: string;
+    inputErrorColor: string;
+    inputLabelColor: string;
+    inputLabelFontSize: string;
+    inputLabelFontWeight: string;
+    inputPlaceholderColor: string;
+    inputRadius: string;
+    shadowResting: string;
+    shadowTopmost: string;
+    transitionDuration: string;
+}
+
+// Warning: (ae-missing-release-tag) "GustoSDKThemeColors" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export interface GustoSDKThemeColors {
+    colorBody: string;
+    colorBodyAccent: string;
+    colorBodyContent: string;
+    colorBodySubContent: string;
+    colorBorderPrimary: string;
+    colorBorderSecondary: string;
+    colorButtonIcon: string;
+    colorError: string;
+    colorErrorAccent: string;
+    colorErrorContent: string;
+    colorInfo: string;
+    colorInfoAccent: string;
+    colorInfoContent: string;
+    colorPrimary: string;
+    colorPrimaryAccent: string;
+    colorPrimaryContent: string;
+    colorSecondary: string;
+    colorSecondaryAccent: string;
+    colorSecondaryContent: string;
+    colorSuccess: string;
+    colorSuccessAccent: string;
+    colorSuccessContent: string;
+    colorWarning: string;
+    colorWarningAccent: string;
+    colorWarningContent: string;
 }
 
 // @public

--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -2579,8 +2579,6 @@ export interface GustoProviderProps {
     theme?: Partial<GustoSDKTheme>;
 }
 
-// Warning: (ae-missing-release-tag) "GustoSDKTheme" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export interface GustoSDKTheme extends GustoSDKThemeColors {
     badgeRadius: string;
@@ -2628,8 +2626,6 @@ export interface GustoSDKTheme extends GustoSDKThemeColors {
     transitionDuration: string;
 }
 
-// Warning: (ae-missing-release-tag) "GustoSDKThemeColors" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export interface GustoSDKThemeColors {
     colorBody: string;

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -196,6 +196,7 @@ export default [
       'src/components/Flow/**/*.{ts,tsx}',
       'src/contexts/ApiProvider/**/*.{ts,tsx}',
       'src/contexts/ComponentAdapter/**/*.{ts,tsx}',
+      'src/contexts/GustoProvider/**/*.{ts,tsx}',
       'src/contexts/LocaleProvider/**/*.{ts,tsx}',
       'src/contexts/LoadingIndicatorProvider/**/*.{ts,tsx}',
       'src/contexts/ObservabilityProvider/**/*.{ts,tsx}',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -200,6 +200,7 @@ export default [
       'src/contexts/LocaleProvider/**/*.{ts,tsx}',
       'src/contexts/LoadingIndicatorProvider/**/*.{ts,tsx}',
       'src/contexts/ObservabilityProvider/**/*.{ts,tsx}',
+      'src/contexts/ThemeProvider/**/*.{ts,tsx}',
     ],
     ignores: LIBRARY_IGNORE_PATHS,
     rules: {

--- a/src/contexts/GustoProvider/GustoProvider.tsx
+++ b/src/contexts/GustoProvider/GustoProvider.tsx
@@ -11,12 +11,40 @@ import {
   type GustoProviderProps,
 } from './GustoProviderCustomUIAdapter'
 
+/**
+ * Props for {@link GustoProvider}.
+ *
+ * @remarks
+ * Extends {@link GustoProviderProps} but makes `components` optional and partial: any components
+ * you do not supply fall back to the SDK's built-in React Aria implementations.
+ *
+ * @public
+ */
 export interface GustoApiProps extends Omit<GustoProviderProps, 'components'> {
+  /** Optional TanStack Query `QueryClient` to share with the rest of your app. When omitted, the SDK creates its own client configured for Gusto's API. */
   queryClient?: QueryClient
+  /** Partial component overrides. Any component you do not supply uses the SDK's default React Aria implementation. */
   components?: Partial<ComponentsContextType>
+  /** The application tree that should have access to the SDK. */
   children?: React.ReactNode
 }
 
+/**
+ * Top-level provider that configures the SDK at the application level.
+ *
+ * @remarks
+ * Wrap your application's component tree with `GustoProvider` so that any SDK component below it
+ * has access to the API client, theme, locale, translations, and UI components. Components you
+ * provide via the `components` prop override the SDK's React Aria defaults; any component you do
+ * not supply uses the default.
+ *
+ * For full UI control without the bundled React Aria defaults, use {@link GustoProviderCustomUIAdapter}
+ * instead and supply a complete component map.
+ *
+ * @param props - See {@link GustoApiProps}.
+ * @returns The configured provider tree wrapping `children`.
+ * @public
+ */
 const GustoProvider: React.FC<GustoApiProps> = props => {
   const { children, components = {}, locale, queryClient, ...remainingProps } = props
 
@@ -35,5 +63,10 @@ const GustoProvider: React.FC<GustoApiProps> = props => {
 
 export { GustoProvider }
 
-/** @deprecated Import from `GustoProvider` instead */
+/**
+ * Alias for {@link GustoProvider}.
+ *
+ * @deprecated Use {@link GustoProvider} instead.
+ * @public
+ */
 export const GustoApiProvider = GustoProvider

--- a/src/contexts/GustoProvider/GustoProviderCustomUIAdapter.tsx
+++ b/src/contexts/GustoProvider/GustoProviderCustomUIAdapter.tsx
@@ -34,7 +34,7 @@ export interface GustoProviderProps {
   lng?: string
   locale?: string
   currency?: string
-  theme?: GustoSDKTheme
+  theme?: Partial<GustoSDKTheme>
   portalContainer?: HTMLElement
   queryClient?: QueryClient
   components: ComponentsContextType

--- a/src/contexts/GustoProvider/GustoProviderCustomUIAdapter.tsx
+++ b/src/contexts/GustoProvider/GustoProviderCustomUIAdapter.tsx
@@ -21,32 +21,72 @@ import type { SDKHooks } from '@/types/hooks'
 import type { ObservabilityHook } from '@/types/observability'
 import { normalizeToSDKError } from '@/types/sdkError'
 
+/**
+ * API client configuration passed to {@link GustoProvider} (and {@link GustoProviderCustomUIAdapter}).
+ *
+ * @public
+ */
 export interface APIConfig {
+  /** URL of your backend proxy that forwards SDK requests to the Gusto Embedded API. SDK components never call Gusto directly. */
   baseUrl: string
+  /** Extra headers applied to every API request. Combined with any headers your proxy adds. */
   headers?: HeadersInit
+  /** Request interceptor hooks. Use these to inspect, modify, or react to requests and responses. See {@link SDKHooks}. */
   hooks?: SDKHooks
+  /** Observability hook for surfacing errors and metrics from the SDK to your monitoring stack. See {@link ObservabilityHook}. */
   observability?: ObservabilityHook
 }
 
+/**
+ * Shared configuration props accepted by {@link GustoProvider} and {@link GustoProviderCustomUIAdapter}.
+ *
+ * @public
+ */
 export interface GustoProviderProps {
+  /** API client configuration, including the proxy `baseUrl`, request hooks, and observability. See {@link APIConfig}. */
   config: APIConfig
+  /** Translation overrides keyed by language and i18next namespace. Strings supplied here replace the SDK defaults for the matching keys. */
   dictionary?: ResourceDictionary
+  /** Active i18next language. Defaults to `'en'`. */
   lng?: string
+  /** BCP 47 locale used for number, date, and currency formatting throughout the SDK. Defaults to `'en-US'`. */
   locale?: string
+  /** ISO 4217 currency code used for monetary formatting. Defaults to `'USD'`. */
   currency?: string
+  /** Theme overrides applied to SDK components. See {@link GustoSDKTheme}. */
   theme?: Partial<GustoSDKTheme>
+  /** Element to use as the portal container for SDK popovers and dropdowns. Useful when rendering inside a modal or shadow root. */
   portalContainer?: HTMLElement
+  /** Optional TanStack Query `QueryClient`. When omitted, the SDK creates its own client configured for Gusto's API. */
   queryClient?: QueryClient
+  /** Complete map of UI components the SDK renders. Required because this adapter ships no defaults. */
   components: ComponentsContextType
+  /** Loading indicator rendered while SDK queries are pending. Overrides the SDK default spinner. */
   LoaderComponent?: LoadingIndicatorContextProps['LoadingIndicator']
 }
 
+/**
+ * Props for {@link GustoProviderCustomUIAdapter}.
+ *
+ * @public
+ */
 export interface GustoProviderCustomUIAdapterProps extends GustoProviderProps {
+  /** The application tree that should have access to the SDK. */
   children?: React.ReactNode
 }
 
 /**
- * A provider that accepts UI component adapters through the components prop
+ * Top-level provider that requires a complete component map and ships no UI defaults.
+ *
+ * @remarks
+ * Use this adapter when you want full control over every UI primitive the SDK renders, or when
+ * you want to avoid the React Aria dependency for tree-shaking. Unlike {@link GustoProvider}, the
+ * `components` prop on {@link GustoProviderProps} is required and must supply every component the
+ * SDK renders.
+ *
+ * @param props - See {@link GustoProviderCustomUIAdapterProps}.
+ * @returns The configured provider tree wrapping `children`.
+ * @public
  */
 const GustoProviderCustomUIAdapter: React.FC<GustoProviderCustomUIAdapterProps> = props => {
   const {

--- a/src/contexts/GustoProvider/SDKI18next.ts
+++ b/src/contexts/GustoProvider/SDKI18next.ts
@@ -4,7 +4,7 @@ import { initReactI18next } from 'react-i18next'
 import { defaultNS } from '@/i18n'
 import commonEn from '@/i18n/en/common.json'
 
-/**Creating new i18next instance to avoid global clashing */
+/** @internal */
 const SDKI18next: i18n = i18next.createInstance({
   debug: false,
   fallbackLng: 'en',

--- a/src/contexts/GustoProvider/index.ts
+++ b/src/contexts/GustoProvider/index.ts
@@ -1,9 +1,4 @@
 export { GustoProvider, GustoApiProvider } from './GustoProvider'
 export type { GustoApiProps } from './GustoProvider'
-export { SDKI18next } from './SDKI18next'
+
 export { GustoProviderCustomUIAdapter } from './GustoProviderCustomUIAdapter'
-export type {
-  GustoProviderProps,
-  GustoProviderCustomUIAdapterProps,
-  APIConfig,
-} from './GustoProviderCustomUIAdapter'

--- a/src/contexts/ThemeProvider/ThemeProvider.tsx
+++ b/src/contexts/ThemeProvider/ThemeProvider.tsx
@@ -4,7 +4,9 @@ import { ThemeContext } from './useTheme'
 import { mergePartnerTheme, type GustoSDKTheme } from './theme'
 import '@/styles/sdk.scss'
 
+/** @internal */
 export interface ThemeProviderProps {
+  /** Partial set of theme tokens that override the SDK defaults. */
   theme?: Partial<GustoSDKTheme>
   /**
    * Element to use as the portal container for all SDK overlays (Select, ComboBox,
@@ -14,9 +16,11 @@ export interface ThemeProviderProps {
    * when your app's scroll or clipping context interferes with overlay positioning.
    */
   portalContainer?: HTMLElement
+  /** Subtree rendered inside the SDK's themed root element. */
   children?: React.ReactNode
 }
 
+/** @internal */
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   theme: partnerThemeOverrides = {},
   portalContainer,

--- a/src/contexts/ThemeProvider/ThemeProvider.tsx
+++ b/src/contexts/ThemeProvider/ThemeProvider.tsx
@@ -5,7 +5,7 @@ import { mergePartnerTheme, type GustoSDKTheme } from './theme'
 import '@/styles/sdk.scss'
 
 export interface ThemeProviderProps {
-  theme?: GustoSDKTheme
+  theme?: Partial<GustoSDKTheme>
   /**
    * Element to use as the portal container for all SDK overlays (Select, ComboBox,
    * DatePicker, Menu, etc.). Defaults to the SDK's root article element.
@@ -64,7 +64,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
 /**
  * Recursive flattening of the theme object into css variable format
  */
-const parseThemeToCSS = (theme: GustoSDKTheme, prefix?: string): string[] => {
+const parseThemeToCSS = (theme: Partial<GustoSDKTheme>, prefix?: string): string[] => {
   const cssProps: string[] = []
   for (const [key, value] of Object.entries(theme)) {
     if (typeof value === 'object') {

--- a/src/contexts/ThemeProvider/customRender.ts
+++ b/src/contexts/ThemeProvider/customRender.ts
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { AllTheProviders } from './test-utils'
 
+/** @internal */
 const customRender = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
   render(ui, { wrapper: AllTheProviders, ...options })
 

--- a/src/contexts/ThemeProvider/index.ts
+++ b/src/contexts/ThemeProvider/index.ts
@@ -1,3 +1,2 @@
 export { ThemeProvider, type ThemeProviderProps } from './ThemeProvider'
 export { useTheme } from './useTheme'
-export { render } from './customRender'

--- a/src/contexts/ThemeProvider/theme.ts
+++ b/src/contexts/ThemeProvider/theme.ts
@@ -44,6 +44,7 @@ const baseColors = {
   },
 }
 
+/** @internal */
 export const transitionDuration = 200
 
 const defaultThemeColors: GustoSDKThemeColors = {
@@ -74,6 +75,7 @@ const defaultThemeColors: GustoSDKThemeColors = {
   colorButtonIcon: baseColors.neutral[400],
 }
 
+/** @internal */
 export const createTheme = (colors: Partial<GustoSDKThemeColors> = {}): GustoSDKTheme => {
   const mergedColors = { ...defaultThemeColors, ...colors }
 
@@ -126,6 +128,7 @@ export const createTheme = (colors: Partial<GustoSDKThemeColors> = {}): GustoSDK
   }
 }
 
+/** @internal */
 export const mergePartnerTheme = (partnerTheme: Partial<GustoSDKTheme>): GustoSDKTheme => {
   const colors = Object.entries(defaultThemeColors).reduce(
     (acc, [key, value]) => {

--- a/src/contexts/ThemeProvider/theme.ts
+++ b/src/contexts/ThemeProvider/theme.ts
@@ -1,4 +1,7 @@
+import type { GustoSDKTheme, GustoSDKThemeColors } from './types'
 import { getRootFontSize, toRem } from '@/helpers/rem'
+
+export type { GustoSDKTheme, GustoSDKThemeColors }
 
 // Colors are for internal use in our theme currently
 // We don't export them for partner use or overrides
@@ -43,7 +46,7 @@ const baseColors = {
 
 export const transitionDuration = 200
 
-const defaultThemeColors = {
+const defaultThemeColors: GustoSDKThemeColors = {
   colorBody: baseColors.neutral[25],
   colorBodyAccent: baseColors.neutral[100],
   colorBodyContent: baseColors.neutral[1000],
@@ -71,35 +74,29 @@ const defaultThemeColors = {
   colorButtonIcon: baseColors.neutral[400],
 }
 
-export type GustoSDKThemeColors = Partial<typeof defaultThemeColors>
+export const createTheme = (colors: Partial<GustoSDKThemeColors> = {}): GustoSDKTheme => {
+  const mergedColors = { ...defaultThemeColors, ...colors }
 
-export const createTheme = (colors: GustoSDKThemeColors = {}) => {
   return {
-    // Colors
-    ...defaultThemeColors,
-    ...colors,
-    // Input Colors
-    inputBackgroundColor: colors.colorBody,
+    ...mergedColors,
+    inputBackgroundColor: mergedColors.colorBody,
     inputBorderColor: baseColors.neutral[300],
-    inputContentColor: colors.colorBodyContent,
+    inputContentColor: mergedColors.colorBodyContent,
     inputBorderWidth: '1px',
-    inputPlaceholderColor: colors.colorBodySubContent,
-    inputAdornmentColor: colors.colorBodySubContent,
-    inputDisabledBackgroundColor: colors.colorBodyAccent,
-    // Field Colors
-    inputLabelColor: colors.colorBodyContent,
+    inputPlaceholderColor: mergedColors.colorBodySubContent,
+    inputAdornmentColor: mergedColors.colorBodySubContent,
+    inputDisabledBackgroundColor: mergedColors.colorBodyAccent,
+    inputLabelColor: mergedColors.colorBodyContent,
     inputLabelFontSize: toRem(16),
     inputLabelFontWeight: '500',
-    inputDescriptionColor: colors.colorBodySubContent,
-    inputErrorColor: colors.colorErrorAccent,
-    // Radius
+    inputDescriptionColor: mergedColors.colorBodySubContent,
+    inputErrorColor: mergedColors.colorErrorAccent,
     inputRadius: toRem(8),
     buttonRadius: toRem(8),
     cardRadius: toRem(8),
     badgeRadius: toRem(6),
     bannerRadius: toRem(8),
     boxRadius: toRem(8),
-    // Font
     fontSizeRoot: getRootFontSize(),
     fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
     fontLineHeightLarge: toRem(28),
@@ -120,34 +117,27 @@ export const createTheme = (colors: GustoSDKThemeColors = {}) => {
     fontWeightMedium: '500',
     fontWeightSemibold: '600',
     fontWeightBold: '700',
-    // Transitions
     transitionDuration: `${transitionDuration}ms`,
-    // Shadows
     shadowResting: '0px 1px 2px 0px rgba(10, 13, 18, 0.05)',
     shadowTopmost:
       '0px 4px 6px 0px rgba(28, 28, 28, 0.05), 0px 10px 15px 0px rgba(28, 28, 28, 0.10)',
-    // Focus
-    focusRingColor: colors.colorPrimary,
+    focusRingColor: mergedColors.colorPrimary,
     focusRingWidth: '2px',
   }
 }
 
-export type GustoSDKTheme = Partial<ReturnType<typeof createTheme>>
-
-export const mergePartnerTheme = (partnerTheme: GustoSDKTheme): GustoSDKTheme => {
+export const mergePartnerTheme = (partnerTheme: Partial<GustoSDKTheme>): GustoSDKTheme => {
   const colors = Object.entries(defaultThemeColors).reduce(
-    (acc: GustoSDKThemeColors, [key, value]) => {
-      acc[key as keyof typeof defaultThemeColors] =
-        partnerTheme[key as keyof typeof defaultThemeColors] || value
+    (acc, [key, value]) => {
+      acc[key as keyof GustoSDKThemeColors] =
+        partnerTheme[key as keyof GustoSDKThemeColors] || value
       return acc
     },
-    {},
+    { ...defaultThemeColors },
   )
 
-  const theme = createTheme(colors)
-
   return {
-    ...theme,
+    ...createTheme(colors),
     ...partnerTheme,
   }
 }

--- a/src/contexts/ThemeProvider/types.ts
+++ b/src/contexts/ThemeProvider/types.ts
@@ -2,6 +2,8 @@
  * Color tokens that can be overridden to customize the SDK's visual theme.
  * Pass a `Partial<GustoSDKThemeColors>` when constructing a `Partial<GustoSDKTheme>`
  * to supply to `ThemeProvider`.
+ *
+ * @public
  */
 export interface GustoSDKThemeColors {
   /** Background color of the main content area. */
@@ -60,6 +62,8 @@ export interface GustoSDKThemeColors {
  * Complete set of design tokens that control the SDK's visual theme. Pass a
  * `Partial<GustoSDKTheme>` to `ThemeProvider` to override specific tokens; any
  * token not supplied falls back to the SDK default.
+ *
+ * @public
  */
 export interface GustoSDKTheme extends GustoSDKThemeColors {
   /**

--- a/src/contexts/ThemeProvider/types.ts
+++ b/src/contexts/ThemeProvider/types.ts
@@ -1,0 +1,178 @@
+/**
+ * Color tokens that can be overridden to customize the SDK's visual theme.
+ * Pass a `Partial<GustoSDKThemeColors>` when constructing a `Partial<GustoSDKTheme>`
+ * to supply to `ThemeProvider`.
+ */
+export interface GustoSDKThemeColors {
+  /** Background color of the main content area. */
+  colorBody: string
+  /** Subtle accent background, used for hover states and alternating rows. */
+  colorBodyAccent: string
+  /** Primary text color rendered on body backgrounds. */
+  colorBodyContent: string
+  /** Secondary/muted text color for supporting copy and labels. */
+  colorBodySubContent: string
+  /** Brand primary color, used for primary buttons and active states. */
+  colorPrimary: string
+  /** Hover/pressed tint for primary elements. */
+  colorPrimaryAccent: string
+  /** Text or icon color rendered on primary backgrounds. */
+  colorPrimaryContent: string
+  /** Brand secondary color, used for secondary buttons and surfaces. */
+  colorSecondary: string
+  /** Hover/pressed tint for secondary elements. */
+  colorSecondaryAccent: string
+  /** Text or icon color rendered on secondary backgrounds. */
+  colorSecondaryContent: string
+  /** Background for informational banners and callouts. */
+  colorInfo: string
+  /** Border or icon accent inside informational surfaces. */
+  colorInfoAccent: string
+  /** Text color rendered on informational surfaces. */
+  colorInfoContent: string
+  /** Background for warning banners and callouts. */
+  colorWarning: string
+  /** Border or icon accent inside warning surfaces. */
+  colorWarningAccent: string
+  /** Text color rendered on warning surfaces. */
+  colorWarningContent: string
+  /** Background for error banners and inline validation states. */
+  colorError: string
+  /** Border, icon accent, and field error indicator inside error surfaces. */
+  colorErrorAccent: string
+  /** Text color rendered on error surfaces. */
+  colorErrorContent: string
+  /** Background for success banners and confirmation states. */
+  colorSuccess: string
+  /** Border or icon accent inside success surfaces. */
+  colorSuccessAccent: string
+  /** Text color rendered on success surfaces. */
+  colorSuccessContent: string
+  /** Color of primary borders (inputs, cards, dividers). */
+  colorBorderPrimary: string
+  /** Color of secondary/subtle borders. */
+  colorBorderSecondary: string
+  /** Color of icon-only buttons. */
+  colorButtonIcon: string
+}
+
+/**
+ * Complete set of design tokens that control the SDK's visual theme. Pass a
+ * `Partial<GustoSDKTheme>` to `ThemeProvider` to override specific tokens; any
+ * token not supplied falls back to the SDK default.
+ */
+export interface GustoSDKTheme extends GustoSDKThemeColors {
+  /**
+   * Background color of text inputs and selects.
+   * @defaultValue `colorBody`
+   */
+  inputBackgroundColor: string
+  /** Border color of text inputs and selects. */
+  inputBorderColor: string
+  /**
+   * Text color inside text inputs and selects.
+   * @defaultValue `colorBodyContent`
+   */
+  inputContentColor: string
+  /** Border width of text inputs and selects. */
+  inputBorderWidth: string
+  /**
+   * Placeholder text color inside inputs.
+   * @defaultValue `colorBodySubContent`
+   */
+  inputPlaceholderColor: string
+  /**
+   * Color of leading/trailing adornment icons in inputs.
+   * @defaultValue `colorBodySubContent`
+   */
+  inputAdornmentColor: string
+  /**
+   * Background color of disabled inputs.
+   * @defaultValue `colorBodyAccent`
+   */
+  inputDisabledBackgroundColor: string
+  /**
+   * Color of form field labels.
+   * @defaultValue `colorBodyContent`
+   */
+  inputLabelColor: string
+  /** Font size of form field labels. */
+  inputLabelFontSize: string
+  /** Font weight of form field labels. */
+  inputLabelFontWeight: string
+  /**
+   * Color of form field description/hint text.
+   * @defaultValue `colorBodySubContent`
+   */
+  inputDescriptionColor: string
+  /**
+   * Color of inline field error messages.
+   * @defaultValue `colorErrorAccent`
+   */
+  inputErrorColor: string
+  /** Border radius of text inputs and selects. */
+  inputRadius: string
+  /** Border radius of buttons. */
+  buttonRadius: string
+  /** Border radius of card surfaces. */
+  cardRadius: string
+  /** Border radius of badges. */
+  badgeRadius: string
+  /** Border radius of banners. */
+  bannerRadius: string
+  /** Border radius of box/panel surfaces. */
+  boxRadius: string
+  /** Root document font size as a numeric string (no `px` suffix). Used as the rem base. */
+  fontSizeRoot: string
+  /** Font family stack applied to all SDK text. */
+  fontFamily: string
+  /** Line height for large text. */
+  fontLineHeightLarge: string
+  /** Line height for regular/body text. */
+  fontLineHeightRegular: string
+  /** Line height for small text. */
+  fontLineHeightSmall: string
+  /** Line height for extra-small text. */
+  fontLineHeightExtraSmall: string
+  /** Font size for extra-small text. */
+  fontSizeExtraSmall: string
+  /** Font size for small text. */
+  fontSizeSmall: string
+  /** Font size for regular/body text. */
+  fontSizeRegular: string
+  /** Font size for large text. */
+  fontSizeLarge: string
+  /** Font size for H1 headings. */
+  fontSizeHeading1: string
+  /** Font size for H2 headings. */
+  fontSizeHeading2: string
+  /** Font size for H3 headings. */
+  fontSizeHeading3: string
+  /** Font size for H4 headings. */
+  fontSizeHeading4: string
+  /** Font size for H5 headings. */
+  fontSizeHeading5: string
+  /** Font size for H6 headings. */
+  fontSizeHeading6: string
+  /** Font weight for regular text. */
+  fontWeightRegular: string
+  /** Font weight for medium-emphasis text. */
+  fontWeightMedium: string
+  /** Font weight for semibold text. */
+  fontWeightSemibold: string
+  /** Font weight for bold text. */
+  fontWeightBold: string
+  /** Duration of UI transitions, e.g. `"200ms"`. */
+  transitionDuration: string
+  /** Box shadow for resting/default elevation. */
+  shadowResting: string
+  /** Box shadow for elevated/topmost surfaces such as dropdowns and modals. */
+  shadowTopmost: string
+  /**
+   * Color of the keyboard focus ring.
+   * @defaultValue `colorPrimary`
+   */
+  focusRingColor: string
+  /** Width of the keyboard focus ring. */
+  focusRingWidth: string
+}

--- a/src/contexts/ThemeProvider/useTheme.ts
+++ b/src/contexts/ThemeProvider/useTheme.ts
@@ -1,8 +1,12 @@
 import { createContext, useContext } from 'react'
 
+/** @internal */
 export interface ThemeContextProps {
+  /** Ref to the element used as the portal container for SDK overlays. */
   container: React.RefObject<HTMLElement | null>
 }
+/** @internal */
 export const ThemeContext = createContext({} as ThemeContextProps)
 
+/** @internal */
 export const useTheme = () => useContext(ThemeContext)

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -12,3 +12,4 @@ export type { ComponentsContextType } from './ComponentAdapter/useComponentConte
 export * from './ComponentAdapter/componentAdapterTypes'
 export { ObservabilityProvider, useObservability } from './ObservabilityProvider'
 export type { ObservabilityProviderProps, ObservabilityContextValue } from './ObservabilityProvider'
+export type { GustoSDKTheme, GustoSDKThemeColors } from '@/contexts/ThemeProvider/theme'


### PR DESCRIPTION
## Phase 6 — GustoProvider + ThemeProvider

### Directories

| Directory | Reference Docs | Notes |
| --- | --- | --- |
| `src/contexts/GustoProvider/` | `docs/integration-guide/request-interceptors.md` | GustoProviderProps, APIConfig, GustoProviderCustomUIAdapterProps. SDKHooks types come from `src/types/` (Phase 3) — document re-exports only. |
| `src/contexts/ThemeProvider/` | `docs/theming/theme-variables.md`, `docs/theming/theming-guide.md` | GustoSDKTheme, GustoSDKThemeColors. |

### Changes

**Type refactoring (pre-req for ThemeProvider docs):**
- Introduced explicit `GustoSDKThemeColors` and `GustoSDKTheme` interfaces in `src/contexts/ThemeProvider/types.ts` — fully required, with per-token TSDoc and `@defaultValue` tags. Previously both were inferred (`Partial<typeof const>` / `Partial<ReturnType<fn>>`).
- `createTheme` now merges with defaults internally so computed tokens are never `undefined`.
- Call sites that accept partner overrides now explicitly use `Partial<GustoSDKTheme>`.

**Documentation:**
- `src/contexts/GustoProvider/` — 26 violations resolved across 3 files
- `src/contexts/ThemeProvider/` — 13 violations resolved across 4 files; removed dead `render` re-export from barrel

Reference PR: https://github.com/Gusto/embedded-react-sdk/pull/1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)