### PR TITLE
feat(SDK-767): wire "Edit this page" links to the SDK repo on GitHub

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -50,6 +50,8 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           breadcrumbs: true,
           exclude: ['test-fests/**'],
+          editUrl: ({ docPath }) =>
+            `https://github.com/Gusto/embedded-react-sdk/edit/main/docs/${docPath}`,
         },
         blog: false,
         theme: {


### PR DESCRIPTION
## Summary

Second of three subject-focused PRs for [SDK-767](https://gustohq.atlassian.net/browse/SDK-767). Adds the "Edit this page" link to every rendered docs page.

**Stacked on:** #2067 (SEO/sitemap). Review that one first.

**Stack order:**
1. #2067 — SEO, sitemap, OG, descriptions, test-fests exclusion
2. **This PR** — Edit-this-page links
3. PR C — a11y fixes _(link added after open)_

## What changed

`docs-site/docusaurus.config.ts` — one addition to the classic preset's `docs` block:

```ts
editUrl: ({ docPath }) =>
  `https://github.com/Gusto/embedded-react-sdk/edit/main/docs/${docPath}`,
```

## Why the function form, not the string form

The string form is more concise but Docusaurus would concatenate the preset's `path` config (`'../docs'`) into the URL, producing ugly results like:

```
https://github.com/Gusto/embedded-react-sdk/edit/main/docs/../docs/integration-guide/integration-guide.md
```

GitHub normalizes that on click but it looks broken on hover. The function form receives `docPath` directly relative to the docs root, so the rendered URL is clean.

## Verification

- `cd docs-site && npm run build` — clean
- Rendered HTML on `/docs/integration-guide/`:
  ```
  href="https://github.com/Gusto/embedded-react-sdk/edit/main/docs/integration-guide/integration-guide.md"
  ```
- Spot-checked across `/docs/component-adapter/`, `/docs/hooks/`, `/docs/theming/theming-guide/` — all resolve cleanly to existing files in the repo.

## Known pre-existing issue (not caused by this PR)

`docs/hooks/useCompensationForm.md` renders without its theme footer at all — no pagination, no related-pages, and now no edit link either. Other hook pages are fine. Something in that file's body trips Docusaurus's footer rendering. The edit link working everywhere else proves the config is right; the missing link on this one page is a downstream issue worth a separate ticket.

## Test plan

- [ ] CI's `docs-build` job passes
- [ ] Open a deploy preview if available, click "Edit this page" on a few pages, confirm GitHub opens the right file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-767]: https://gustohq.atlassian.net/browse/SDK-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ