### PR TITLE
feat(SDK-767): site-wide a11y pass — landmarks, headings, Prism contrast, link affordance

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -153,7 +153,7 @@ const config: Config = {
     },
     prism: {
       theme: prismThemes.github,
-      darkTheme: prismThemes.dracula,
+      darkTheme: prismThemes.nightOwl,
       additionalLanguages: ['bash', 'json', 'ruby', 'python', 'java'],
     },
   } satisfies Preset.ThemeConfig,

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -450,6 +450,10 @@ aside.theme-doc-sidebar-container {
   margin-top: 1.75rem;
 }
 
+.markdown :is(p, li, td, blockquote) a:not(.hash-link) {
+  text-decoration: underline;
+}
+
 .markdown > p {
   line-height: 1.7;
 }

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -281,7 +281,7 @@ function HeroPreview() {
 
 function HeroSection() {
   return (
-    <section className={styles.hero}>
+    <section className={styles.hero} aria-label="Introduction">
       <div className={styles.heroEffects} aria-hidden="true">
         <div className={styles.heroSpot1} />
         <div className={styles.heroSpot2} />
@@ -317,10 +317,10 @@ function HeroSection() {
 
 function FeaturesSection() {
   return (
-    <section className={styles.features} aria-label="Key features">
+    <section className={styles.features} aria-labelledby="features-heading">
       <div className={styles.featuresInner}>
         <header className={styles.featuresHeader}>
-          <h2 className={styles.featuresHeading}>
+          <h2 id="features-heading" className={styles.featuresHeading}>
             Build it <span className={styles.heroAccent}>your way</span>.
           </h2>
           <p className={styles.featuresIntro}>Everything you need to ship.</p>
@@ -354,8 +354,10 @@ export default function Home(): ReactNode {
 
   return (
     <Layout title={siteConfig.title} description={siteConfig.tagline}>
-      <HeroSection />
-      <FeaturesSection />
+      <main>
+        <HeroSection />
+        <FeaturesSection />
+      </main>
     </Layout>
   )
 }

--- a/docs/component-adapter/component-adapter-faq.md
+++ b/docs/component-adapter/component-adapter-faq.md
@@ -6,19 +6,19 @@ order: 1
 
 This FAQ addresses common questions and potential issues when working with the Component Adapter system in the Gusto Embedded React SDK.
 
-### General Questions
+## General Questions
 
-#### Can I use a different UI framework for my custom components?
+### Can I use a different UI framework for my custom components?
 
 Yes, you can use any React UI framework or library for your custom components, as long as they correctly implement the required props and behaviors. For example, you could use Material UI, Chakra UI, or any other React-compatible UI library.
 
 The only requirement is that your component adapter implements the `ComponentsContextType` interface.
 
-#### How do I know which components I can customize?
+### How do I know which components I can customize?
 
 You can customize any component defined in the `ComponentsContextType` interface ([View interface on GitHub](https://github.com/Gusto/embedded-react-sdk/blob/main/src/contexts/ComponentAdapter/useComponentContext.ts)) or the [Component Inventory](./component-inventory.md). These are all the components in the SDK's UI directory.
 
-#### Do I need to implement all components in the adapter?
+### Do I need to implement all components in the adapter?
 
 No, you only need to implement the components you want to customize. The SDK will use its default components for any components not provided in your adapter.
 
@@ -36,9 +36,9 @@ const myAdapter = {
 }
 ```
 
-### Implementing Components
+## Implementing Components
 
-#### How do I implement components with complex behavior like ComboBox or DatePicker?
+### How do I implement components with complex behavior like ComboBox or DatePicker?
 
 For complex components, you have a few options:
 
@@ -58,7 +58,7 @@ To understand the expected behavior of complex components, you can also refer to
 - [ComboBox on GitHub](https://github.com/Gusto/embedded-react-sdk/blob/main/src/components/Common/UI/ComboBox/ComboBox.tsx)
 - [DatePicker on GitHub](https://github.com/Gusto/embedded-react-sdk/blob/main/src/components/Common/UI/DatePicker/DatePicker.tsx)
 
-#### My custom component isn't working correctly. What should I check?
+### My custom component isn't working correctly. What should I check?
 
 1. **Ensure you've implemented all required props**: Each component has a specific set of props that it expects to receive and use. Make sure your component handles all of these props correctly.
 
@@ -70,7 +70,7 @@ To understand the expected behavior of complex components, you can also refer to
 
 5. **Debug with React DevTools**: Use React DevTools to inspect the props being passed to your components and compare with what you're expecting.
 
-#### How can I ensure my custom components maintain accessibility features?
+### How can I ensure my custom components maintain accessibility features?
 
 **Important**: When using the Component Adapter with your own custom components, you are responsible for ensuring accessibility compliance. The SDK's default components are built with accessibility in mind, but this accessibility is not automatically transferred to your custom implementations.
 
@@ -86,9 +86,9 @@ The prop interfaces include properties like `aria-describedby`, `isInvalid`, and
 
 Study the default components to understand how they handle accessibility concerns. Check your own design system's accessibility guidelines and components, which likely have built-in accessibility features you can leverage.
 
-### Troubleshooting
+## Troubleshooting
 
-#### I'm getting errors about missing components. What's wrong?
+### I'm getting errors about missing components. What's wrong?
 
 If you're seeing errors about missing components and you're using `GustoProviderCustomUIAdapter`, you must implement all components that your integration needs. With the custom provider, you're responsible for providing every component used by the SDK in your adapter.
 
@@ -96,7 +96,7 @@ We recommend using `GustoProvider` instead if you only want to customize a few c
 
 You can check which components are being used by examining the SDK's source code or by adding console logs to your adapter implementation.
 
-#### My form values aren't being captured correctly. What might be wrong?
+### My form values aren't being captured correctly. What might be wrong?
 
 This often happens when the `onChange` handler in your custom form components isn't being called with the correct parameters. The SDK expects specific value formats from each component's onChange handler:
 
@@ -108,7 +108,7 @@ This often happens when the `onChange` handler in your custom form components is
 
 Make sure your components are calling these handlers with the expected data types.
 
-#### How can I test my component adapter?
+### How can I test my component adapter?
 
 You can create unit tests for your custom components using testing libraries like Vitest and React Testing Library. Test that your components:
 
@@ -119,7 +119,7 @@ You can create unit tests for your custom components using testing libraries lik
 
 For examples of how the SDK tests its components, you can look at the test files located alongside each component in the UI directory. For instance, check out [Button.test.tsx](https://github.com/Gusto/embedded-react-sdk/blob/main/src/components/Common/UI/Button/Button.test.tsx), [TextInput.test.tsx](https://github.com/Gusto/embedded-react-sdk/blob/main/src/components/Common/UI/TextInput/TextInput.test.tsx), and other test files in the [UI component directories](https://github.com/Gusto/embedded-react-sdk/tree/main/src/components/Common/UI).
 
-#### Can I contribute my component adapter back to the project?
+### Can I contribute my component adapter back to the project?
 
 If you've created a component adapter for a popular UI library (like Material UI, Chakra UI, etc.), we'd love to hear about it! While the Gusto Embedded React SDK doesn't directly maintain adapters for third-party libraries, we can help guide other users to community solutions.
 

--- a/docs/component-adapter/component-adapter-types.md
+++ b/docs/component-adapter/component-adapter-types.md
@@ -6,13 +6,13 @@ order: 4
 
 The Component Adapter system uses TypeScript interfaces to ensure type safety and consistent behavior. This document provides links to the type definitions you'll need when implementing custom components.
 
-### Core Types
+## Core Types
 
 - [Component Inventory](./component-inventory.md) - Individual component prop interfaces
 - [`ComponentsContextType`](https://github.com/Gusto/embedded-react-sdk/blob/main/src/contexts/ComponentAdapter/useComponentContext.ts) - The main interface defining all customizable UI components
 - [`GustoProviderCustomUIAdapterProps`](https://github.com/Gusto/embedded-react-sdk/blob/main/src/contexts/GustoProvider/GustoProviderCustomUIAdapter.tsx) - Props for the custom UI adapter
 
-### Importing Types
+## Importing Types
 
 All types are exported from the SDK package:
 
@@ -25,7 +25,7 @@ import type {
 } from '@gusto/embedded-react-sdk'
 ```
 
-### Type Safety
+## Type Safety
 
 The Component Adapter system leverages TypeScript to ensure type safety:
 

--- a/docs/component-adapter/how-the-component-adapter-works.md
+++ b/docs/component-adapter/how-the-component-adapter-works.md
@@ -10,11 +10,11 @@ order: 2
    - `GustoProviderCustomUIAdapter`: For complete UI control without React Aria dependencies
 3. Your custom components are used by the SDK instead of the default components
 
-### Choosing a Provider
+## Choosing a Provider
 
 The SDK offers two providers for different use cases:
 
-#### GustoProvider (Recommended)
+### GustoProvider (Recommended)
 
 ```tsx
 import { GustoProvider, type ButtonProps, type TextInputProps } from '@gusto/embedded-react-sdk'
@@ -60,7 +60,7 @@ function App() {
 - Best choice for most applications
 - Simpler to implement when you only need to customize some components
 
-#### GustoProviderCustomUIAdapter
+### GustoProviderCustomUIAdapter
 
 ```tsx
 import { GustoProviderCustomUIAdapter } from '@gusto/embedded-react-sdk'
@@ -82,14 +82,14 @@ function App() {
 - Better for tree-shaking and bundle size optimization
 - Ideal when you need complete control over the UI implementation
 
-### Default Components
+## Default Components
 
 The SDK provides a set of default components implemented with React Aria for accessibility. These are used when no custom components are provided. You can view the default implementations here:
 
 - [Default Component Adapter](https://github.com/Gusto/embedded-react-sdk/blob/main/src/contexts/ComponentAdapter/adapters/defaultComponentAdapter.tsx)
 - [UI Components Directory](https://github.com/Gusto/embedded-react-sdk/tree/main/src/components/Common/UI)
 
-### Benefits
+## Benefits
 
 This architecture provides several key benefits:
 

--- a/docs/component-adapter/setting-up-your-component-adapter.md
+++ b/docs/component-adapter/setting-up-your-component-adapter.md
@@ -6,7 +6,7 @@ order: 3
 
 This guide will walk you through the process of creating and implementing your own Component Adapter for the Gusto Embedded React SDK.
 
-### 1. Create Your Custom Component Implementations
+## 1. Create Your Custom Component Implementations
 
 Each component must implement the required props interface defined by the SDK. For example, if you're creating a custom TextInput, it must accept all the props defined in the `TextInputProps` interface ([View interface on GitHub](https://github.com/Gusto/embedded-react-sdk/blob/main/src/components/Common/UI/TextInput/TextInputTypes.ts)).
 
@@ -64,7 +64,7 @@ For a complete reference of all component types and their props, see the [Compon
 
 To learn more about how each component should be implemented, you can reference the default implementations in the SDK ([View on GitHub](https://github.com/Gusto/embedded-react-sdk/tree/main/src/components/Common/UI)).
 
-### 2. Create Your Component Adapter Object
+## 2. Create Your Component Adapter Object
 
 Create an object that implements the `ComponentsContextType` interface ([View interface on GitHub](https://github.com/Gusto/embedded-react-sdk/blob/main/src/contexts/ComponentAdapter/useComponentContext.ts)) with your custom components:
 
@@ -99,11 +99,11 @@ const myCustomComponents: ComponentsContextType = {
 }
 ```
 
-### 3. Choose Your Provider
+## 3. Choose Your Provider
 
 The SDK offers two ways to provide your custom components, each suited for different needs:
 
-#### Option A: Using GustoProvider (Recommended)
+### Option A: Using GustoProvider (Recommended)
 
 The `GustoProvider` is the recommended approach for most applications. Using the `GustoProvider`, you are able to supply only the components you want to override and then the rest fall back to default React Aria components:
 
@@ -134,7 +134,7 @@ Benefits of using `GustoProvider`:
 - Simpler integration path
 - Best choice for most applications
 
-#### Option B: Using GustoProviderCustomUIAdapter
+### Option B: Using GustoProviderCustomUIAdapter
 
 If you need complete control over the UI implementation or want to optimize bundle size through tree-shaking, use the `GustoProviderCustomUIAdapter`:
 
@@ -168,7 +168,7 @@ Choose this option when you:
 - Don't want React Aria as a dependency
 - Have a complete design system you want to use
 
-### 4. Testing Your Implementation
+## 4. Testing Your Implementation
 
 After implementing your Component Adapter, it's a good practice to:
 
@@ -177,7 +177,7 @@ After implementing your Component Adapter, it's a good practice to:
 3. Check accessibility features
 4. Test across different browsers and devices
 
-### Complete Example
+## Complete Example
 
 Here's an example showing how to customize a few common components using Material UI with `GustoProvider`. For a full list of customizable components and their props, see the [Component Inventory](./component-inventory.md).
 

--- a/docs/getting-started/authentication.mdx
+++ b/docs/getting-started/authentication.mdx
@@ -38,7 +38,7 @@ export default App
 
 The SDK provides two ways to add headers to API requests:
 
-#### 1. Static Headers via Config (Simple)
+### 1. Static Headers via Config (Simple)
 
 For static headers like API keys or simple authentication tokens, you can pass them directly in the config:
 
@@ -64,7 +64,7 @@ function App() {
 
 This approach automatically applies the headers to all API requests without requiring custom hooks.
 
-#### 2. Dynamic Headers via Hooks (Advanced)
+### 2. Dynamic Headers via Hooks (Advanced)
 
 For dynamic headers that need to be computed at request time (like refreshing tokens), use the hooks approach described in the [Request Interceptors guide](../integration-guide/request-interceptors.md).
 

--- a/docs/hooks/hooks.md
+++ b/docs/hooks/hooks.md
@@ -134,7 +134,7 @@ Fields inside an `SDKFormProvider` don't need the `formHookResult` prop — the 
 
 Both approaches produce identical validation, API payloads, and behavior. The difference is purely in how fields discover their form state.
 
-|                       | `formHookResult` prop                                               | `SDKFormProvider`                               |
+| Aspect                | `formHookResult` prop                                               | `SDKFormProvider`                               |
 | --------------------- | ------------------------------------------------------------------- | ----------------------------------------------- |
 | **Best for**          | Interleaving fields from multiple hooks; maximum layout flexibility | Grouping fields from a single hook together     |
 | **Boilerplate**       | Each field receives the prop                                        | One wrapper, fields are clean                   |

--- a/docs/integration-guide/composition.md
+++ b/docs/integration-guide/composition.md
@@ -6,7 +6,7 @@ order: 3
 
 The Gusto Embedded React SDK allows for flexible approaches when crafting experiences. You can use workflow components as needed to render complex user flows with a single component. You can also leverage the individual workflow steps in isolation, recompose them together in your desired order, and update them with your own content.
 
-### Building with workflow components
+## Building with workflow components
 
 Workflows are individual components that encapsulate complex, often multi step user interactions. Check out the `Workflows Overview` section to see the full list of available components.
 
@@ -30,7 +30,7 @@ function MyApp({ companyId }) {
 
 The benefits of this approach are simplicity and ease of development. Many times, however, we need more customization than is possible when using workflow components directly. For those scenarios, the React SDK offers methods of composition where you can leverage pieces of the flow individually and put them together as needed.
 
-### Using individual workflow pieces
+## Using individual workflow pieces
 
 Continuing with the previous example, say we wanted to render employee compensation UI (which is a step in the employee onboarding flow) in isolation. We could import that directly as follows:
 

--- a/docs/integration-guide/customizing-sdk-ui.md
+++ b/docs/integration-guide/customizing-sdk-ui.md
@@ -12,7 +12,7 @@ There are two mechanisms that can be used to customize the SDK UI:
 
 Theming sets the visual baseline for all of the SDK UI, and it is recommended to use theming as a first pass to match your brand with the SDK. Component adapters are more complex to configure and should be used for advanced use cases if theming falls short.
 
-### Theming
+## Theming
 
 > See [theming](../theming/theming.md) for a complete usage guide.
 
@@ -43,7 +43,7 @@ function MyApp({ children }) {
 
 The above code would change the primary colors (applied to elements like buttons and links) to red and white. It would also change the font family universally to 'Courier New'.
 
-### Component Adapters
+## Component Adapters
 
 > See [component adapters](../component-adapter/component-adapter.md) for a complete usage guide.
 

--- a/docs/integration-guide/event-handling.md
+++ b/docs/integration-guide/event-handling.md
@@ -6,7 +6,7 @@ order: 1
 
 The Gusto Embedded React SDK can communicate events with the parent application. An event can represent a user interaction (like selecting a CTA), a successful API response (like updating user information) or the completion of a step within a flow (like completing a form). Consumers of the React SDK can perform actions based on these events as needed. Some common use cases for events include implementing telemetry, performing navigation, or running side effects in your own application.
 
-### Using events
+## Using events
 
 Each of our React SDK components ships with an `onEvent` property. This is a function callback that is supplied with the event type and data associated with the user action. It takes the form:
 

--- a/docs/integration-guide/providing-your-own-data.md
+++ b/docs/integration-guide/providing-your-own-data.md
@@ -6,7 +6,7 @@ order: 4
 
 Where possible, the Gusto Embedded React SDK allows for providing your own data to SDK forms. You can do this by setting form default values with data from your application.
 
-### Providing your own application data using default values
+## Providing your own application data using default values
 
 If an SDK component contains a form and has a `defaultValues` property, the `defaultValues` can be set with values from your own data if needed. `defaultValues` is an object with keys corresponding to each of the form fields.
 

--- a/docs/integration-guide/routing.md
+++ b/docs/integration-guide/routing.md
@@ -6,11 +6,11 @@ order: 6
 
 Gusto Embedded React SDK is implemented to be flexible and seamlessly integrate with your application. Because of this, it does not have opinions on routing. Instead, React SDK aims to be easily integrated with whichever routing library you are using. This section will walk through an example of creating a workflow using [React Router](https://reactrouter.com/), but the same concepts should apply regardless of routing technology chosen.
 
-### Required knowledge
+## Required knowledge
 
 Before starting, you might consider familiarizing yourself with documentation around composition, workflows, and event handling.
 
-### Overview
+## Overview
 
 For this exercise we’ll be creating the Employee Self Onboarding flow in [React Router](https://reactrouter.com/).
 
@@ -34,7 +34,7 @@ import { EmployeeOnboarding } from '@gusto/embedded-react-sdk'
 
 For self onboarding to work, we’ll need to have access to the company id, and the employee id. Not all steps require the company id, but each will require the employee id.
 
-### Creating the routes
+## Creating the routes
 
 Let’s create a simple router. This router will take the employee id and company id as parameters. We will then create a route corresponding to each step outlined above. Note: we’ll add the actual elements in the next step.
 
@@ -82,7 +82,7 @@ const createEmployeeSelfOnboardingRouter = ({
   );
 ```
 
-### Creating components with navigation
+## Creating components with navigation
 
 Each component in the React SDK has an onEvent property. `onEvent` is fired when the users perform various actions for the SDK components (read more in the Event Handling documentation). When a component is ready for navigation, an event will be fired. We can hook into the event and configure our navigation.
 
@@ -112,7 +112,7 @@ function EmployeeLandingWrapper({ companyId, employeeId }: { companyId: string; 
 
 Note that each flow component is meant to be independent and usable in isolation. When a user saves data in a given step, the component for that step will make an API call and actually save the user data. That means you can rearrange steps as desired. In this example we are navigating the user to the profile form after landing, but you could navigate to whichever step is desired according to the order you want the steps to be in.
 
-### Putting it all together
+## Putting it all together
 
 Once we have our wrapper components configured with the correct navigation, we can supply them to our router that we configured in the first step. Here’s the full example with navigation configured for each step:
 

--- a/docs/integration-guide/translation.md
+++ b/docs/integration-guide/translation.md
@@ -6,11 +6,11 @@ order: 5
 
 The Gusto Embedded React SDK supports translation of all strings present in the UI. Translations can be used for internationalization. They can also be used to customize text according to the needs of your application.
 
-### i18Next
+## i18Next
 
 We use [i18next](https://www.i18next.com/) to implement translations. If you are also leveraging i18next, we create our own independent instance to avoid conflicting with the one already present in your application.
 
-### Supplying your own translations
+## Supplying your own translations
 
 You can use the `dictionary` prop on the `GustoProvider` to set translations. The top level key represents the language being used (“en” by default). Each string in the UI has a key and corresponding default text. Let’s go through an example updating the `Employee.PaymentMethod` component.
 
@@ -52,7 +52,7 @@ Which results in the following:
 
 We could provide custom text in a similar manner for any copy on the page.
 
-### Viewing available translations
+## Viewing available translations
 
 Documenting available translations is still a work in progress. Every entry in the dictionary, however, is typed. This means that if you can begin typing and get available options in your IDE:
 

--- a/docs/integration-guide/versioning.md
+++ b/docs/integration-guide/versioning.md
@@ -6,21 +6,21 @@ order: 0
 
 The Gusto Embedded React SDK is committed to following the principles of [Semantic Versioning 2.0.0](https://semver.org/). It should also be understood, however, that **we are still pre-1.0.0** and [the rules of SemVer are different while we work towards 1.0.0](https://semver.org/#spec-item-4).
 
-### Using events Pre-1.0 Versioning under SemVer
+## Using events Pre-1.0 Versioning under SemVer
 
 According to SemVer, versions in the 0.x.y range are considered experimental. This means that:
 
 - **Breaking Changes Are Allowed:** You may encounter breaking changes in versions labeled as 0.x.y without a major version bump. This flexibility allows us to iterate quickly and make necessary adjustments as we gather feedback and refine the SDK.
 - **Frequent Iteration:** We anticipate a more frequent release cycle during this stage, which may include breaking changes as we improve features and functionality.
 
-### Communication and Support
+## Communication and Support
 
 To ensure a smooth experience during this transitional phase, we are dedicated to the following practices:
 
 - **Advance Notice: **We will communicate any upcoming breaking changes well in advance, allowing you time to prepare for adjustments.
 - **Upgrade Guides: **Each breaking change will come with a comprehensive upgrade guide to help you transition your code with minimal friction.
 
-### Staying Informed
+## Staying Informed
 
 You can track all releases and their details in our [CHANGELOG](https://www.npmjs.com/package/@gusto/embedded-react-sdk?activeTab=code). We encourage you to stay updated and provide feedback as we work towards a stable 1.0 release. Your input is invaluable in shaping the SDK to better meet your needs.
 

--- a/docs/workflows-overview/company-onboarding.md
+++ b/docs/workflows-overview/company-onboarding.md
@@ -6,7 +6,7 @@ order: 1
 
 The Company Onboarding workflow provides components for managing company-related onboarding tasks. These components can be used individually or composed into a complete workflow.
 
-### Implementation
+## Implementation
 
 ```jsx title="App.tsx"
 import { CompanyOnboarding } from '@gusto/embedded-react-sdk'
@@ -21,7 +21,7 @@ function MyApp() {
 }
 ```
 
-#### Props
+### Props
 
 | Name               | Type   | Description                                                     |
 | ------------------ | ------ | --------------------------------------------------------------- |

--- a/docs/workflows-overview/contractor-onboarding.md
+++ b/docs/workflows-overview/contractor-onboarding.md
@@ -6,7 +6,7 @@ order: 2
 
 The Contractor Onboarding workflow provides components for managing contractor-related onboarding tasks. These components can be used individually or composed into a complete workflow.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { ContractorOnboarding } from '@gusto/embedded-react-sdk'
@@ -21,7 +21,7 @@ function MyApp() {
 }
 ```
 
-#### Props
+### Props
 
 | Name               | Type   | Description                                                                                           |
 | ------------------ | ------ | ----------------------------------------------------------------------------------------------------- |

--- a/docs/workflows-overview/contractor-payments.md
+++ b/docs/workflows-overview/contractor-payments.md
@@ -6,7 +6,7 @@ order: 3
 
 The Contractor Payments workflow provides components for creating, managing, and viewing contractor payment groups. These components can be used individually or composed into a complete payment workflow through the `Contractor.PaymentFlow` component.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { Contractor } from '@gusto/embedded-react-sdk'
@@ -18,7 +18,7 @@ function MyApp() {
 }
 ```
 
-#### Props
+### Props
 
 | Name               | Type   | Description                                                     |
 | ------------------ | ------ | --------------------------------------------------------------- |

--- a/docs/workflows-overview/dismissal-payroll.md
+++ b/docs/workflows-overview/dismissal-payroll.md
@@ -10,7 +10,7 @@ This workflow is typically launched from the [Employee Termination](./employee-t
 
 > **Important**: Make sure employees are paid on time by checking your [state's requirement guide](https://support.gusto.com/article/100895878100000/Final-paychecks). Some states require employees to receive their final wages within 24 hours (unless they consent otherwise), in which case running a dismissal payroll may be the only option.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { Payroll } from '@gusto/embedded-react-sdk'
@@ -26,7 +26,7 @@ function MyApp() {
 }
 ```
 
-#### Props
+### Props
 
 | Name                | Type     | Description                                                                                                               |
 | ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -35,7 +35,7 @@ function MyApp() {
 | onEvent Required    | function | See events table for available events.                                                                                    |
 | payrollId           | string   | Optional payroll identifier. When provided, the flow skips pay period selection and starts directly at payroll execution. |
 
-#### Events
+### Events
 
 Events emitted during the pay period selection phase:
 

--- a/docs/workflows-overview/employee-dashboard.md
+++ b/docs/workflows-overview/employee-dashboard.md
@@ -6,7 +6,7 @@ order: 5
 
 The Employee Dashboard provides a comprehensive view of employee information organized into four tabs: Basic details, Job and pay, Taxes, and Documents. This component serves as a central hub for viewing and managing employee data.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { EmployeeManagement } from '@gusto/embedded-react-sdk'
@@ -18,7 +18,7 @@ function MyApp() {
 
 > Legacy import via `Employee.DashboardFlow` continues to work.
 
-#### Props
+### Props
 
 | Name                | Type                | Description                                                     |
 | ------------------- | ------------------- | --------------------------------------------------------------- |
@@ -27,7 +27,7 @@ function MyApp() {
 | dictionary          | object              | Optional translations for component text.                       |
 | FallbackComponent   | React.ComponentType | Optional custom error fallback component.                       |
 
-#### Events
+### Events
 
 | Event type                                                   | Description                                                     | Data                                                     |
 | ------------------------------------------------------------ | --------------------------------------------------------------- | -------------------------------------------------------- |

--- a/docs/workflows-overview/employee-management/employee-management.md
+++ b/docs/workflows-overview/employee-management/employee-management.md
@@ -6,7 +6,7 @@ order: 0
 
 The Employee Management namespace provides components for viewing and editing an employee's information after onboarding is complete. The headline entry point is the Employee Dashboard — a tabbed read/edit surface that covers basic details, job & pay, taxes, and documents — but every section of that dashboard is also exported individually so it can be composed into a custom layout, rendered in isolation, or replaced with a custom UI built on top of the same data hooks.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { EmployeeManagement } from '@gusto/embedded-react-sdk'

--- a/docs/workflows-overview/employee-onboarding/employee-onboarding.md
+++ b/docs/workflows-overview/employee-onboarding/employee-onboarding.md
@@ -6,7 +6,7 @@ order: 0
 
 The Employee Onboarding workflow provides a complete experience for onboarding an employee to a company. It is used to collect all required information for an employee to be added to payroll.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { EmployeeOnboarding } from '@gusto/embedded-react-sdk'
@@ -22,7 +22,7 @@ function MyApp() {
 }
 ```
 
-#### Props
+### Props
 
 | Name                    | Type    | Default | Description                                                                                                                                                          |
 | ----------------------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/workflows-overview/employee-onboarding/employee-self-onboarding.md
+++ b/docs/workflows-overview/employee-onboarding/employee-self-onboarding.md
@@ -6,7 +6,7 @@ order: 0
 
 In the case an employer elects to allow the employee to self-onboard, they can be provided with the self-onboarding workflow. This workflow places the responsibility of submitting some required information on the employee.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { EmployeeOnboarding } from '@gusto/embedded-react-sdk'
@@ -23,7 +23,7 @@ function MyApp() {
 }
 ```
 
-#### Props
+### Props
 
 | Name                | Type    | Default | Description                                                                                                                                       |
 | ------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/workflows-overview/employee-termination.md
+++ b/docs/workflows-overview/employee-termination.md
@@ -8,7 +8,7 @@ The Employee Termination workflow provides a complete experience for terminating
 
 > **Important**: Make sure employees are paid on time by checking your [state's requirement guide](https://support.gusto.com/article/100895878100000/Final-paychecks). Some states require employees to receive their final wages within 24 hours (unless they consent otherwise), in which case running a dismissal payroll may be the only option.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { EmployeeManagement } from '@gusto/embedded-react-sdk'
@@ -26,7 +26,7 @@ function MyApp() {
 
 > Legacy import via `Employee.TerminationFlow` continues to work.
 
-#### Props
+### Props
 
 | Name                | Type     | Description                                                     |
 | ------------------- | -------- | --------------------------------------------------------------- |
@@ -35,7 +35,7 @@ function MyApp() {
 | onEvent Required    | function | See events table for each subcomponent to see available events. |
 | dictionary          | object   | Optional translations for component text.                       |
 
-#### Events
+### Events
 
 | Event type                                 | Description                                                | Data                                                                                                         |
 | ------------------------------------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
@@ -50,7 +50,7 @@ function MyApp() {
 | EMPLOYEE_TERMINATION_PAYROLL_CREATED       | Fired when an off-cycle payroll is created for termination | { employeeId: string, effectiveDate: string }                                                                |
 | EMPLOYEE_TERMINATION_PAYROLL_FAILED        | Fired when off-cycle payroll creation fails                | { employeeId: string }                                                                                       |
 
-#### Payroll Options
+### Payroll Options
 
 The workflow supports three payroll processing options for the employee's final paycheck:
 

--- a/docs/workflows-overview/information-requests.md
+++ b/docs/workflows-overview/information-requests.md
@@ -6,7 +6,7 @@ order: 8
 
 The Information Requests workflow surfaces outstanding information requests that Gusto has issued for a company (for example, a request for a missing tax document or identity verification artifact) and lets the user respond to them. Information requests can also block payroll processing, in which case they are surfaced inline within `Payroll.PayrollBlockerList`; this flow provides a dedicated, standalone surface for managing them.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { InformationRequests } from '@gusto/embedded-react-sdk'
@@ -21,7 +21,7 @@ function MyApp() {
 }
 ```
 
-#### Props
+### Props
 
 | Name               | Type     | Default | Description                                                                                                                                                                               |
 | ------------------ | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -30,7 +30,7 @@ function MyApp() {
 | withAlert          | boolean  | `true`  | When true, the submission success alert is rendered at the top of the flow. Set to false when embedding in a parent (e.g. `Payroll.PayrollBlockerList`) that renders the alert elsewhere. |
 | dictionary         | object   |         | Optional translations for component text.                                                                                                                                                 |
 
-#### Events
+### Events
 
 Events emitted by the flow (and by its subcomponents — they bubble up through `onEvent`):
 

--- a/docs/workflows-overview/off-cycle-payroll.md
+++ b/docs/workflows-overview/off-cycle-payroll.md
@@ -8,7 +8,7 @@ The Off-Cycle Payroll workflow provides a complete experience for running payrol
 
 After creation, the flow transitions into the standard [Payroll Processing](./run-payroll.md) execution experience (configuration, overview, submission, and receipts). All off-cycle payroll types share the same execution steps as regular payrolls — the only difference is how the payroll is created.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { Payroll } from '@gusto/embedded-react-sdk'
@@ -18,7 +18,7 @@ function MyApp() {
 }
 ```
 
-#### Props
+### Props
 
 | Name               | Type                        | Description                                                                                                |
 | ------------------ | --------------------------- | ---------------------------------------------------------------------------------------------------------- |
@@ -26,7 +26,7 @@ function MyApp() {
 | onEvent Required   | function                    | See events table for each subcomponent to see available events.                                            |
 | payrollType        | `'bonus'` \| `'correction'` | Optional pre-selected off-cycle reason. When provided, the creation form starts with this reason selected. |
 
-#### Events
+### Events
 
 Events emitted during the creation phase:
 

--- a/docs/workflows-overview/run-payroll.md
+++ b/docs/workflows-overview/run-payroll.md
@@ -6,7 +6,7 @@ order: 3
 
 The Run Payroll workflow provides a complete experience for running payroll for a company. It guides users through selecting a payroll, configuring employee compensation, reviewing payroll details, and submitting the payroll for processing.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { Payroll } from '@gusto/embedded-react-sdk'
@@ -16,7 +16,7 @@ function MyApp() {
 }
 ```
 
-#### Props
+### Props
 
 | Name                        | Type                                     | Description                                                                                                                             |
 | --------------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
@@ -27,7 +27,7 @@ function MyApp() {
 | dictionary                  | object                                   | Optional translations for component text.                                                                                               |
 | ConfirmWireDetailsComponent | `ComponentType<ConfirmWireDetailsProps>` | Optional custom component to replace the default wire details confirmation UI. See [ConfirmWireDetailsProps](#confirmwiredetailsprops). |
 
-#### ConfirmWireDetailsProps
+### ConfirmWireDetailsProps
 
 | Prop      | Type                                   | Required | Description                                                                                                          |
 | --------- | -------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
@@ -35,7 +35,7 @@ function MyApp() {
 | wireInId  | string                                 | No       | Specific wire-in request identifier. If not provided, your component should handle the first active wire-in request. |
 | onEvent   | (type: string, data?: unknown) => void | No       | Optional callback to emit events back to the parent flow.                                                            |
 
-#### Events
+### Events
 
 | Event type                     | Description                                               | Data                                                                                                                                                                                     |
 | ------------------------------ | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/workflows-overview/time-off.md
+++ b/docs/workflows-overview/time-off.md
@@ -8,7 +8,7 @@ The Time Off Policy Management workflow provides a complete experience for creat
 
 Sick and vacation policies share a common creation flow — configure details, set accrual settings, then add employees. Holiday policies follow a separate path — select observed federal holidays, then assign employees. All policy types can be viewed, edited, and managed from the unified policy list.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { TimeOff } from '@gusto/embedded-react-sdk'
@@ -18,14 +18,14 @@ function MyApp() {
 }
 ```
 
-#### Props
+### Props
 
 | Name               | Type     | Description                                                     |
 | ------------------ | -------- | --------------------------------------------------------------- |
 | companyId Required | string   | The associated company identifier.                              |
 | onEvent Required   | function | See events table for each subcomponent to see available events. |
 
-#### Events
+### Events
 
 The flow emits the following events as users navigate through the workflow:
 

--- a/docs/workflows-overview/transition-payroll.md
+++ b/docs/workflows-overview/transition-payroll.md
@@ -11,7 +11,7 @@ The SDK provides a flow component and an integrated alert for transition payroll
 - **`Payroll.TransitionFlow`**: A full creation-to-execution flow for running a specific transition payroll. After creation, the flow transitions into the standard [Payroll Processing](./run-payroll.md) execution experience — the same steps used by regular and other off-cycle payrolls.
 - **Transition Payroll Alert**: An alert automatically rendered within `Payroll.PayrollLanding` when there are unprocessed transition pay periods. It surfaces upcoming transition periods and allows users to run or skip them. This is not a standalone export — it is built into the landing page.
 
-### Implementation
+## Implementation
 
 ```jsx
 import { Payroll } from '@gusto/embedded-react-sdk'
@@ -29,7 +29,7 @@ function MyApp() {
 }
 ```
 
-#### Props
+### Props
 
 | Name                     | Type     | Description                                                      |
 | ------------------------ | -------- | ---------------------------------------------------------------- |
@@ -39,7 +39,7 @@ function MyApp() {
 | payScheduleUuid Required | string   | The UUID of the pay schedule this transition is associated with. |
 | onEvent Required         | function | See events table for each subcomponent to see available events.  |
 
-#### Events
+### Events
 
 Events emitted during the creation phase:
 


### PR DESCRIPTION
## Summary

Part of [SDK-767](https://gustohq.atlassian.net/browse/SDK-767). Site-wide accessibility pass against the built docs site (66 URLs from the sitemap), driven by `@axe-core/cli` against each page.

**Result: 5,502 → 286 violations (94.8% reduction), 5 → 3 rule types remaining.**

| Rule | Before | After | Action |
| --- | ---: | ---: | --- |
| `color-contrast` | 5,338 | 284 | Swapped Prism dark theme `dracula → nightOwl`. Remainder is nightOwl's comment/boolean token tints (~280) + 4 brand-orange edge cases — would need a custom Prism theme or design-system change. |
| `link-in-text-block` | 136 | **0** | Added `text-decoration: underline` to body links (scoped to `p, li, td, blockquote`). |
| `heading-order` | 26 | **0** | Bumped `h3 → h2` (and immediate `h4 → h3` descendants) in 26 .md/.mdx files where pages opened with `### …` directly under the frontmatter h1. |
| `landmark-one-main` | 1 | 1 | `/search` page (docusaurus-lunr-search); needs a swizzle — separate PR. |
| `region` | 1 | 1 | Same `/search` page. |
| `empty-table-header` | 1 | **0** | Filled the empty header cell in `docs/hooks/hooks.md`. |

## Commits

1. **Landing page + hooks-table structural fixes** — `<main>` wrap, `aria-label="Introduction"` on hero, `aria-labelledby` on features pointing at the existing visible h2, "Aspect" header in the hooks comparison table.
2. **Prism theme + body link underline** — `docs-site/docusaurus.config.ts` + `docs-site/src/css/custom.css`.
3. **Heading-level bumps** — 84 heading edits across 26 files; no body content moves.

## What this PR doesn't fix (and why)

- **~280 color-contrast nodes left**: nightOwl's `.token.comment` (#637777, 2.7:1) and `.token.boolean` (#ff5874, 4.2:1) tints are still below AA on the editor background. Fixable with custom Prism theme overrides — out of scope for this PR.
- **2 nodes on `/search`** (missing `<main>`/region): requires swizzling the `docusaurus-lunr-search` SearchPage component.
- **Brand-orange CTA contrast** on the landing-page "Get Started" button (3.26:1 white on #f15e49) — design-system decision.

## Verification

- `cd docs-site && npm run build` — clean
- `cd docs-site && npm run serve`
- `xargs -n 1 -P 4 /tmp/scan-one.sh < urls.txt` — counts match the table above

## Test plan

- [ ] CI's `docs-build` job passes
- [ ] Open a deploy preview; tab through the landing page with a keyboard
- [ ] Spot-check a workflows-overview page in dark mode — Prism colors look intentional, body links are underlined
- [ ] Open `/docs/workflows-overview/company-onboarding` and confirm the Implementation section now renders as h2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-767]: https://gustohq.atlassian.net/browse/SDK-767