### PR TITLE
docs: add versioned documentation support (SDK-766)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -50,7 +50,7 @@ Do not make any file changes or git operations in dry-run mode.
    git push -u origin chore/release-<version>
    gh pr create --title "chore: release <version>"
    ```
-6. Once the PR is merged, publishing happens automatically — the [Publish to NPM](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish.yaml) workflow triggers when the `chore: release` commit lands on `main` and CI passes. No manual action needed unless something goes wrong.
+6. Once the PR is merged, publishing happens automatically — the [Publish to NPM](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish.yaml) workflow triggers when the `chore: release` commit lands on `main` and CI passes. The [Sync Docs Source](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish-docs.yaml) workflow then propagates the docs to `Gusto/embedded-sdk-docs` and creates or refreshes the versioned snapshot for the released minor automatically. No manual action needed unless something goes wrong.
 
 ## Changelog curation (step 4)
 

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -1,11 +1,42 @@
 name: Sync Docs Source
 
-# Fires after a successful NPM publish on main. Runs TypeDoc to generate
-# docs/api/ markdown, then pushes the Docusaurus source
-# (docs/ + docs-site/ + .nvmrc, including the generated docs/api/ files)
-# to the main branch of Gusto/embedded-sdk-docs. That repo's Buildkite
-# pipeline runs the Docusaurus build and publishes the result to its
-# gh-pages branch.
+# Builds docs source on this repo and pushes it to Gusto/embedded-sdk-docs.
+# The downstream repo's Buildkite pipeline then runs the Docusaurus build
+# and publishes the result to its gh-pages branch.
+#
+# Versioning lives entirely in the downstream repo, not here. This repo
+# only ever carries the live (current) docs in `docs/`. Versioned snapshots
+# (`docs-site/versioned_docs/`, `versions.json`, `versioned_sidebars/`)
+# accumulate in `embedded-sdk-docs` over time as releases land.
+#
+# Three triggers, all funnel through the same job:
+#   1. workflow_run after Publish to NPM — the release path. If the released
+#      minor isn't in downstream's versions.json, creates a new snapshot.
+#      If it is, refreshes the existing snapshot's content from the freshly
+#      synced docs (content-only; structural changes to versioned docs are
+#      explicit edits in the downstream repo).
+#   2. push to main on docs/** or docs-site/** — the live-content path.
+#      Syncs the latest docs source down so /docs/ refreshes. Does not touch
+#      versioned snapshots.
+#   3. workflow_dispatch — manual run. Always allowed; useful for recovery,
+#      end-to-end testing, or bootstrapping the first snapshot on a clean
+#      downstream (it will create the snapshot if missing for the current
+#      package.json minor).
+#
+# Snapshot mechanics:
+#   New minor / bootstrap: `npx docusaurus docs:version <X.Y>` runs inside the
+#   freshly-synced downstream working tree. Docusaurus copies the current
+#   docs/ into versioned_docs/version-<X.Y>/, captures the sidebar, and adds
+#   <X.Y> to versions.json. The conditional config in docs-site/docusaurus.config.ts
+#   then derives lastVersion from versions.json[0], so the unprefixed /docs/
+#   automatically points at the newest snapshot — no manual config change.
+#
+#   Patch refresh: walks versioned_docs/version-<X.Y>/ and refreshes the
+#   content of each file from the matching path in the freshly-synced docs/.
+#   Files in the snapshot that have no live counterpart are left as-is.
+#   Files in live docs/ that aren't already in the snapshot are NOT added —
+#   adding a doc to a released minor is an intentional change made directly
+#   in the downstream repo.
 #
 # Auth: a GitHub App installed on Gusto/embedded-sdk-docs with
 # Contents: write. Credentials live in this repo's `publish-docs`
@@ -18,17 +49,22 @@ name: Sync Docs Source
 #      DOCS_APP_ID and DOCS_APP_PRIVATE_KEY (paste the entire .pem
 #      contents for the private key).
 #   3. Once a manual workflow_dispatch run is green, set repo variable
-#      DOCS_PUBLISH_ENABLED=true to turn on auto-publish on release.
+#      DOCS_PUBLISH_ENABLED=true to turn on the workflow_run + push paths.
 #
 # Manual `workflow_dispatch` triggers fire any time (the gate below only
-# guards the auto-on-release path), so the pipeline can be exercised
-# end-to-end before flipping the variable.
+# guards the auto paths), so the pipeline can be exercised end-to-end
+# before flipping the variable.
 
 on:
   workflow_run:
     workflows: [Publish to NPM]
     types: [completed]
     branches: [main]
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'docs-site/**'
   workflow_dispatch:
 
 concurrency:
@@ -38,12 +74,15 @@ concurrency:
 jobs:
   sync:
     # workflow_dispatch always allowed (for manual testing). workflow_run
-    # only fires when DOCS_PUBLISH_ENABLED=true, so the next NPM release
-    # won't auto-publish docs until that variable is explicitly set.
+    # and push only fire when DOCS_PUBLISH_ENABLED=true, so neither an NPM
+    # release nor a docs push will auto-publish until that variable is
+    # explicitly set.
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (vars.DOCS_PUBLISH_ENABLED == 'true' &&
-       github.event.workflow_run.conclusion == 'success')
+      (vars.DOCS_PUBLISH_ENABLED == 'true' && (
+        github.event_name == 'push' ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      ))
     runs-on:
       group: gusto-ubuntu-default
     environment: publish-docs
@@ -60,7 +99,13 @@ jobs:
 
       - name: Read SDK version
         id: version
-        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+          {
+            echo "version=${VERSION}"
+            echo "minor=${MINOR}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Install SDK dependencies for TypeDoc
         run: npm ci
@@ -77,32 +122,29 @@ jobs:
           owner: Gusto
           repositories: embedded-sdk-docs
 
-      # Push docs source (markdown + Docusaurus config + Node pin) to
-      # embedded-sdk-docs/main. Its Buildkite pipeline then builds and
-      # publishes the result to gh-pages.
+      # Sync live source to downstream, then create or refresh the versioned
+      # snapshot if appropriate. Versioning is owned by the downstream repo —
+      # this is the only place that knows about versioned_docs/ etc.
       #
-      # docs/api/ contains a mix of tracked and generated files:
-      #   docs/api/index.md        — hand-authored, tracked in this repo
-      #   docs/api/reference.md    — generated by TypeDoc (step above)
-      #   docs/api/{domain}/...    — generated by TypeDoc (step above)
-      # All are copied and force-staged so the docs repo always has the
-      # full generated output regardless of its own .gitignore rules.
-      #
-      # Safety model: this workflow only touches paths it explicitly
-      # manages (docs/, docs-site/, .nvmrc). Everything else in the
-      # docs repo (.buildkite/, README.md, CODEOWNERS, CNAME, .github/,
-      # …) is left untouched, ever. A defense-in-depth check at the
-      # end fails the push if any staged change escapes the allowlist
-      # — so if someone later widens the cp/rm logic by accident, the
-      # push fails closed instead of silently wiping unrelated files.
-      #
-      # `concurrency: publish-docs` above prevents overlapping pushes,
-      # so a non-force push is safe.
-      - name: Push docs source to embedded-sdk-docs
+      # Sequencing:
+      #   1. Clone downstream (which may already have versioned_docs/, etc.)
+      #   2. Wipe the source-owned paths in downstream (docs/, .nvmrc, and
+      #      everything in docs-site/ EXCEPT the versioned files)
+      #   3. Copy fresh source into downstream
+      #   4. Run versioning logic (create new snapshot OR refresh existing
+      #      snapshot content), but only when the trigger calls for it
+      #   5. Defense-in-depth: refuse to push anything outside the managed
+      #      allowlist (docs/, docs-site/, .nvmrc)
+      #   6. Commit + push
+      - name: Sync source and update versioned snapshot in embedded-sdk-docs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SDK_VERSION: ${{ steps.version.outputs.version }}
+          MINOR: ${{ steps.version.outputs.minor }}
+          TRIGGER: ${{ github.event_name }}
         run: |
+          set -euo pipefail
+
           git clone --depth 50 \
             "https://x-access-token:$GH_TOKEN@github.com/Gusto/embedded-sdk-docs.git" \
             docs-repo
@@ -110,13 +152,22 @@ jobs:
           git config user.name "gusto-embedded-docs[bot]"
           git config user.email "gusto-embedded-docs[bot]@users.noreply.github.com"
 
-          # Remove only the paths this workflow owns. Anything else in
-          # the docs repo (.buildkite/, README.md, etc.) stays put.
-          # --ignore-unmatch so first-run (no prior docs/ on the repo)
-          # doesn't fail.
-          git rm -rf --quiet --ignore-unmatch docs docs-site .nvmrc
+          # ---- Step 2: wipe source-owned paths, preserve versioned files ----
+          # docs/ and .nvmrc are entirely source-owned.
+          git rm -rf --quiet --ignore-unmatch docs .nvmrc
 
-          # Copy fresh source in.
+          # docs-site/ is mostly source-owned, but versioned_docs/,
+          # versioned_sidebars/, versions.json belong to downstream.
+          # Move them aside so the wipe doesn't take them out.
+          mkdir -p /tmp/preserved
+          for v in versioned_docs versioned_sidebars versions.json; do
+            if [ -e "docs-site/$v" ]; then
+              mv "docs-site/$v" "/tmp/preserved/$v"
+            fi
+          done
+          git rm -rf --quiet --ignore-unmatch docs-site
+
+          # ---- Step 3: copy fresh source in ----
           cp -R ../docs .
           cp -R ../docs-site .
           cp ../.nvmrc .
@@ -124,16 +175,75 @@ jobs:
           # Strip anything that shouldn't ship with source.
           rm -rf docs-site/node_modules docs-site/build
 
-          # Stage only the paths we manage. NOT `git add -A` — that
-          # could pick up unrelated tree changes if anything went sideways.
+          # Restore the versioned files (or initialize empty placeholders if
+          # downstream was bare — the snapshot step below populates them).
+          for v in versioned_docs versioned_sidebars versions.json; do
+            if [ -e "/tmp/preserved/$v" ]; then
+              mv "/tmp/preserved/$v" "docs-site/$v"
+            fi
+          done
+
+          # ---- Step 4: snapshot creation or refresh ----
+          # Snapshot ACTION is determined by trigger + downstream state:
+          #   workflow_run, minor missing  -> create (new minor)
+          #   workflow_run, minor present  -> refresh (patch)
+          #   workflow_dispatch, missing   -> create (bootstrap / recover)
+          #   workflow_dispatch, present   -> none
+          #   push                         -> none
+          MINOR_IN_VERSIONS=false
+          if [ -f docs-site/versions.json ] \
+             && jq -e --arg key "${MINOR}" 'index($key) != null' docs-site/versions.json > /dev/null 2>&1; then
+            MINOR_IN_VERSIONS=true
+          fi
+
+          SNAPSHOT_ACTION=none
+          if [ "$TRIGGER" = "workflow_run" ] || [ "$TRIGGER" = "workflow_dispatch" ]; then
+            if [ "$MINOR_IN_VERSIONS" = "false" ]; then
+              SNAPSHOT_ACTION=create
+            elif [ "$TRIGGER" = "workflow_run" ]; then
+              SNAPSHOT_ACTION=refresh
+            fi
+          fi
+          echo "Snapshot action for SDK ${SDK_VERSION} (minor ${MINOR}, trigger ${TRIGGER}): ${SNAPSHOT_ACTION}"
+
+          if [ "$SNAPSHOT_ACTION" = "create" ]; then
+            # docusaurus docs:version copies docs/ -> versioned_docs/version-<minor>/,
+            # captures the sidebar, prepends <minor> to versions.json.
+            # The conditional config picks up versions.json[0] as lastVersion automatically.
+            (cd docs-site && npm ci && npx docusaurus docs:version "${MINOR}")
+            echo "Created snapshot version-${MINOR} in downstream."
+          elif [ "$SNAPSHOT_ACTION" = "refresh" ]; then
+            VERSIONED_DIR="docs-site/versioned_docs/version-${MINOR}"
+            if [ ! -d "$VERSIONED_DIR" ]; then
+              echo "::error::${MINOR} is in versions.json but ${VERSIONED_DIR}/ is missing in downstream."
+              exit 1
+            fi
+            updated=0
+            orphan=0
+            while IFS= read -r snap_file; do
+              rel="${snap_file#${VERSIONED_DIR}/}"
+              live="docs/${rel}"
+              if [ -f "$live" ]; then
+                cp "$live" "$snap_file"
+                updated=$((updated + 1))
+              else
+                orphan=$((orphan + 1))
+              fi
+            done < <(find "$VERSIONED_DIR" -type f)
+            echo "Refreshed ${updated} file(s) in version-${MINOR}; ${orphan} orphan(s) left as-is."
+          fi
+
+          # ---- Step 5: stage and validate ----
+          # Stage only the paths we manage. NOT `git add -A` — that could
+          # pick up unrelated tree changes if anything went sideways.
           # Force-add docs/api/ so the TypeDoc-generated files are staged
           # even if the docs repo's .gitignore excludes them.
           git add docs docs-site .nvmrc
           git add -f docs/api
 
-          # Defense in depth: refuse to push if any staged change
-          # escapes the managed allowlist. No-op when the workflow is
-          # correct; catches future drift.
+          # Defense in depth: refuse to push if any staged change escapes
+          # the managed allowlist. No-op when the workflow is correct;
+          # catches future drift.
           unexpected=$(git diff --cached --name-only | grep -vE '^(docs/|docs-site/|\.nvmrc$)' || true)
           if [[ -n "$unexpected" ]]; then
             echo "ERROR: refusing to push — staged changes outside managed paths:" >&2
@@ -141,8 +251,28 @@ jobs:
             exit 1
           fi
 
+          # ---- Step 6: commit and push ----
+          # Commit message records the trigger + snapshot action so the
+          # downstream history is traceable to whichever cause prompted it.
+          SHORT_SHA=$(git -C "${GITHUB_WORKSPACE}" rev-parse --short HEAD)
+          case "${TRIGGER}" in
+            workflow_run)
+              MSG="docs: sync source for SDK ${SDK_VERSION}"
+              ;;
+            push)
+              MSG="docs: sync docs source from ${SHORT_SHA} (SDK ${SDK_VERSION})"
+              ;;
+            *)
+              MSG="docs: sync source from ${SHORT_SHA} (SDK ${SDK_VERSION}, ${TRIGGER})"
+              ;;
+          esac
+          if [ "$SNAPSHOT_ACTION" = "create" ]; then
+            MSG="${MSG} — created version-${MINOR} snapshot"
+          elif [ "$SNAPSHOT_ACTION" = "refresh" ]; then
+            MSG="${MSG} — refreshed version-${MINOR} snapshot"
+          fi
+
           # Always commit (even with no file changes) so every sync run
-          # leaves a release-marker in the docs repo's history, matching
-          # 1:1 with the NPM releases that triggered it.
-          git commit -q --allow-empty -m "docs: sync source for SDK $SDK_VERSION"
+          # leaves a marker in the docs repo's history.
+          git commit -q --allow-empty -m "${MSG}"
           git push origin main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -371,9 +371,11 @@ Inside `docs/`, use relative links between files (e.g. `[link](../getting-starte
 
 ```md
 <!-- Good -->
+
 See the [Getting Started guide](../getting-started/index.md).
 
 <!-- Bad — breaks when served at /docs/0.47/... -->
+
 See the [Getting Started guide](/docs/getting-started/index.md).
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,6 +337,38 @@ gh pr create --title "chore: release <version>"
 
 Trigger the [Prepare Release](https://github.com/Gusto/embedded-react-sdk/actions/workflows/prepare-release.yaml) workflow from the Actions UI (`Run workflow`). It accepts an optional version override; if left blank it auto-detects from commits. The workflow creates the branch, commits the changes, and opens a PR automatically.
 
+### Documentation versioning
+
+The published docs site uses Docusaurus versioning so partners on older SDK versions can read the docs that match their installed version. **All versioned content lives in `Gusto/embedded-sdk-docs`, not this repo.** This repo only ever carries the live (current) docs in `docs/`; versioned snapshots (`versioned_docs/version-X.Y/`, `versions.json`, `versioned_sidebars/`) accumulate in the downstream repo as releases land.
+
+Snapshots are **keyed by minor**, not by patch. A new minor creates a new snapshot in downstream; patch releases refresh the existing minor's snapshot content. The dropdown stays clean (`0.47`, `0.48`, …).
+
+#### What happens automatically
+
+The [Sync Docs Source](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish-docs.yaml) workflow does all the work:
+
+- **After Publish to NPM completes** (release): if the released minor isn't in downstream's `versions.json` yet, the workflow runs `npx docusaurus docs:version <minor>` inside the freshly-synced downstream working tree — copying the new `docs/` into `versioned_docs/version-<minor>/`, capturing the sidebar, and prepending the minor to `versions.json`. If the minor is already there (patch release), the workflow refreshes the existing snapshot's file contents from the synced `docs/`.
+- **On any push to `docs/**`or`docs-site/**`** on `main`: source is synced to downstream so the live (`current`) docs refresh. Versioned snapshots are not touched.
+- **On manual workflow_dispatch**: same as push by default. If downstream's `versions.json` is missing the current `package.json` minor (e.g., bootstrapping a clean downstream), the snapshot is created.
+
+`docs-site/docusaurus.config.ts` is the same file in both places. It reads `versions.json` at config-load time: if absent (this repo), versioning is disabled and the build serves only the live docs; if present (downstream), versioning is active, `lastVersion` is derived from `versions.json[0]`, and the navbar dropdown appears.
+
+#### Editing docs in a released version
+
+To change content for a partner on an older minor:
+
+- For a typo / clarification that should propagate on the **next patch release** of that minor: edit `docs/` here. The next patch refresh will copy the change into the versioned snapshot in downstream.
+- To add, remove, or rename a doc in an already-released minor: edit `versioned_docs/version-X.Y/` directly in [Gusto/embedded-sdk-docs](https://github.com/Gusto/embedded-sdk-docs). The patch refresh is content-only — it won't add new files or remove orphaned ones from a versioned snapshot.
+- After any such manual edit downstream, also update `versioned_sidebars/version-X.Y-sidebars.json` there if the change affects navigation. Patch refresh does not regenerate the versioned sidebar.
+
+#### When does the variable matter
+
+When the repo variable `DOCS_PUBLISH_ENABLED=true` is set (the current default), the `workflow_run` and `push` triggers above fire automatically. If unset, only manual `workflow_dispatch` runs publish docs. `workflow_dispatch` is allowed any time, so the pipeline can be exercised end-to-end before flipping the variable.
+
+#### Markdown links
+
+Inside `docs/`, use relative links between files (e.g. `[link](../getting-started/index.md)`), not `/docs/...` absolute links. Absolute links don't resolve correctly when the same file is served at a versioned URL like `/docs/0.47/...`.
+
 ### After the PR is merged
 
 Publishing happens automatically. When a `chore: release` commit lands on `main` and all CI checks pass, the [Publish to NPM](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish.yaml) workflow runs automatically and publishes to NPM.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -369,6 +369,14 @@ When the repo variable `DOCS_PUBLISH_ENABLED=true` is set (the current default),
 
 Inside `docs/`, use relative links between files (e.g. `[link](../getting-started/index.md)`), not `/docs/...` absolute links. Absolute links don't resolve correctly when the same file is served at a versioned URL like `/docs/0.47/...`.
 
+```md
+<!-- Good -->
+See the [Getting Started guide](../getting-started/index.md).
+
+<!-- Bad — breaks when served at /docs/0.47/... -->
+See the [Getting Started guide](/docs/getting-started/index.md).
+```
+
 ### After the PR is merged
 
 Publishing happens automatically. When a `chore: release` commit lands on `main` and all CI checks pass, the [Publish to NPM](https://github.com/Gusto/embedded-react-sdk/actions/workflows/publish.yaml) workflow runs automatically and publishes to NPM.

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -9,9 +9,18 @@ import { themes as prismThemes } from 'prism-react-renderer'
 // builds locally on embedded-react-sdk it doesn't, and Docusaurus falls back to
 // a single-version site. The same config file works in both places — no fork.
 const versionsPath = resolve(__dirname, 'versions.json')
-const versions: string[] = existsSync(versionsPath)
-  ? (JSON.parse(readFileSync(versionsPath, 'utf8')) as string[])
+
+function isStringArray(val: unknown): val is string[] {
+  return Array.isArray(val) && val.every((v) => typeof v === 'string')
+}
+
+const rawVersions: unknown = existsSync(versionsPath)
+  ? JSON.parse(readFileSync(versionsPath, 'utf8'))
   : []
+if (!isStringArray(rawVersions)) {
+  throw new Error('docs-site/versions.json must be a string[]')
+}
+const versions: string[] = rawVersions
 const lastVersion = versions[0]
 const hasVersions = lastVersion !== undefined
 

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -1,6 +1,19 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import type { Config } from '@docusaurus/types'
 import type * as Preset from '@docusaurus/preset-classic'
 import { themes as prismThemes } from 'prism-react-renderer'
+
+// Versioning is owned by Gusto/embedded-sdk-docs, not this repo. When this
+// config builds there, `versions.json` exists and lists the cut minors; when it
+// builds locally on embedded-react-sdk it doesn't, and Docusaurus falls back to
+// a single-version site. The same config file works in both places — no fork.
+const versionsPath = resolve(__dirname, 'versions.json')
+const versions: string[] = existsSync(versionsPath)
+  ? (JSON.parse(readFileSync(versionsPath, 'utf8')) as string[])
+  : []
+const lastVersion = versions[0]
+const hasVersions = lastVersion !== undefined
 
 const config: Config = {
   title: 'Gusto Embedded',
@@ -54,6 +67,12 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           breadcrumbs: true,
           exclude: ['test-fests/**'],
+          ...(hasVersions && {
+            lastVersion,
+            versions: {
+              current: { label: 'Next (unreleased)', path: 'next' },
+            },
+          }),
         },
         blog: false,
         theme: {
@@ -95,6 +114,15 @@ const config: Config = {
           position: 'left',
           label: 'Docs',
         },
+        ...(hasVersions
+          ? [
+              {
+                type: 'docsVersionDropdown' as const,
+                position: 'right' as const,
+                dropdownActiveClassDisabled: true,
+              },
+            ]
+          : []),
         {
           href: 'https://github.com/Gusto/embedded-react-sdk',
           label: 'GitHub',

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -11,7 +11,7 @@ import { themes as prismThemes } from 'prism-react-renderer'
 const versionsPath = resolve(__dirname, 'versions.json')
 
 function isStringArray(val: unknown): val is string[] {
-  return Array.isArray(val) && val.every((v) => typeof v === 'string')
+  return Array.isArray(val) && val.every(v => typeof v === 'string')
 }
 
 const rawVersions: unknown = existsSync(versionsPath)

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -11,7 +11,8 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "typedoc": "typedoc --options typedoc.config.ts",
-    "test": "vitest run"
+    "test": "vitest run",
+    "docs:version": "docusaurus docs:version"
   },
   "dependencies": {
     "@docusaurus/core": "^3.7.0",


### PR DESCRIPTION
## What partners get

Docs versioning. Once the first snapshot is bootstrapped in `Gusto/embedded-sdk-docs`, `sdk.gusto.com` serves two flavors of every page:

| URL | Content |
|---|---|
| `/docs/<page>` | The latest released minor — `0.47` after first release post-merge |
| `/docs/next/<page>` | Live in-development content (the `docs/` directory at `main`) |

A version dropdown lives in the navbar between Docs and GitHub.

JIRA: [SDK-766](https://gustohq.atlassian.net/browse/SDK-766) · Epic: [SDK-758](https://gustohq.atlassian.net/browse/SDK-758) (Modernize SDK Documentation, Phase 3c)

## Where versioned content lives

**Not in this repo.** This was the key shift from earlier iterations of this PR, driven by [Marie's review](https://github.com/Gusto/embedded-react-sdk/pull/2076#discussion_r3406382132): keeping `versioned_docs/` here would (a) flood the source tree with stale copies of docs LLMs would happily index alongside current ones, and (b) make every patch release add 20k+ lines of "old docs" churn to PRs. So:

- **This repo** carries only `docs/` (live content). No `versioned_docs/`, no `versions.json`, no `versioned_sidebars/`, no snapshot script.
- **`Gusto/embedded-sdk-docs`** accumulates `versioned_docs/version-X.Y/`, `versions.json`, and `versioned_sidebars/` as releases land. The Sync Docs Source workflow creates and maintains them there.

### What docs in this repo look like

```
embedded-react-sdk/
├── docs/                      ← live, in-development docs (only)
│   ├── component-adapter/
│   ├── getting-started/
│   ├── hooks/
│   └── ...
├── docs-site/                 ← Docusaurus source: config, sidebars, theme
│   ├── docusaurus.config.ts   ← versioning conditional on versions.json
│   ├── sidebars.ts
│   ├── src/
│   └── package.json           ← NO versioned_docs/, NO versions.json
└── .github/workflows/publish-docs.yaml  ← does all versioning work downstream
```

No `versioned_docs/`, no snapshot script, no `docs:snapshot` / `docs:version` npm scripts. Locally:
- `npm run docs` → dev server, single version, no dropdown
- `npm run docs:build` → builds clean, single version

### What docs in `embedded-sdk-docs` look like

```
embedded-sdk-docs/
├── docs/                      ← synced from source on every workflow run
├── docs-site/                 ← synced from source EXCEPT for:
│   ├── versioned_docs/        ← accumulates downstream over releases
│   │   ├── version-0.47/      ← (created on first release post-merge)
│   │   ├── version-0.48/      ← (created when 0.48.0 ships)
│   │   └── ...
│   ├── versioned_sidebars/    ← accumulates downstream
│   └── versions.json          ← ["0.48", "0.47", ...] — accumulates
├── .buildkite/                ← downstream's own pipeline
└── .nvmrc                     ← synced from source
```

### Why the same `docusaurus.config.ts` works in both places

It reads `versions.json` at config-load time:
- **Absent** (this repo) → versioning disabled, no dropdown, no `/next/` route
- **Present** (downstream) → versioning active, `lastVersion = versions[0]` (so the unprefixed `/docs/` automatically points at the freshest minor), dropdown shown

No fork, no config drift, no manual `lastVersion` bumps.

## The four flow paths

### Path 1 — docs change between releases (push trigger)

```
PR with docs/** or docs-site/** changes merges to main on this repo
  → Sync Docs Source fires (push trigger)
  → workflow:
       - runs typedoc → docs/api/
       - clones embedded-sdk-docs
       - preserves downstream's versioned_docs/, versioned_sidebars/, versions.json
       - wipes + copies fresh docs/ + docs-site/ + .nvmrc in
       - snapshot action = NONE
  → commits + pushes to embedded-sdk-docs/main
  → downstream Buildkite builds + publishes to gh-pages
  → sdk.gusto.com /docs/next/* updated; /docs/0.47/* unchanged
```

### Path 2 — patch release (e.g. 0.47.2)

```
chore: release 0.47.2 merges → Publish to NPM publishes
  → Sync Docs Source fires (workflow_run trigger)
  → workflow:
       - runs typedoc; clones downstream; preserves versioned_*;
         copies fresh source in
       - versions.json has "0.47" → snapshot action = REFRESH
       - walks versioned_docs/version-0.47/, refreshes content of each file
         from the matching path in the freshly-synced docs/
       - files in the snapshot with no live counterpart left as-is
       - files in live docs/ that aren't in the snapshot are NOT added
  → commits + pushes
  → /docs/0.47/* now reflects 0.47.2 content; new docs landed on main since
    0.47.0 (e.g. useEmployeeList) do not propagate to the 0.47 snapshot
```

### Path 3 — minor release (e.g. 0.48.0)

```
chore: release 0.48.0 merges → Publish to NPM publishes
  → Sync Docs Source fires
  → workflow:
       - runs typedoc; clones downstream; preserves any existing versioned_*
         (none for 0.48 yet); copies fresh source in
       - versions.json doesn't have "0.48" → snapshot action = CREATE
       - runs `npx docusaurus docs:version 0.48`:
           - copies current docs/ → versioned_docs/version-0.48/
           - captures sidebar to versioned_sidebars/version-0.48-sidebars.json
           - prepends "0.48" to versions.json
       - lastVersion = versions[0] = "0.48" (config-derived, automatic)
  → commits + pushes
  → /docs/ now resolves to 0.48; /docs/0.47/ still works;
    dropdown shows 0.48, 0.47, Next
```

### Path 4 — bootstrap (first time after this PR merges)

```
This PR merges; downstream's versions.json is empty / missing
Either: the next release fires the workflow,
Or: a maintainer manually triggers Sync Docs Source via workflow_dispatch
  → workflow: same prep as Path 1
       - versions.json doesn't have current minor → snapshot action = CREATE
       - runs `npx docusaurus docs:version <current-minor>`
       - downstream now has versioned_docs/version-X.Y/, versions.json=[X.Y]
  → /docs/ → X.Y; /docs/next/ → main; dropdown active
```

## Workflow safety properties

| Trigger | Snapshot policy |
|---|---|
| `workflow_run` after Publish to NPM | Create if minor is new; refresh content if patch |
| `push` to `docs/**` or `docs-site/**` on `main` | Never touch versioned files; only sync live source |
| `workflow_dispatch` | Create if minor missing in downstream (bootstrap / recover); otherwise none |

- **Doc fixes don't wait for a release.** Push trigger redeploys `/docs/next/` automatically.
- **Manual dispatch is safe.** Only creates a snapshot when one is missing; never overwrites.
- **Defense-in-depth allowlist.** The workflow refuses to push anything outside `^(docs/|docs-site/|\.nvmrc$)` to downstream — guards against future edits accidentally widening the touch radius.

## Editing docs in a released version

- **Typo / clarification that should reach a previous minor**: edit `docs/` here. The next patch release of that minor refreshes the file's content in the downstream snapshot.
- **Add / remove / rename a doc in an already-released minor**: edit `versioned_docs/version-X.Y/` directly in `Gusto/embedded-sdk-docs`. Patch refresh is content-only — never adds new files to a versioned snapshot, never removes orphaned ones. Update `versioned_sidebars/version-X.Y-sidebars.json` downstream too if navigation changes.

This split keeps released-minor structure stable: a new live doc for a future feature can't accidentally appear in a partner's `0.47` view.

## Files to focus on while reviewing

**The actual versioning wiring:**
- `docs-site/docusaurus.config.ts` — conditional on `versions.json` presence. Same file works in both repos.
- `.github/workflows/publish-docs.yaml` — adds `push` trigger; rewrites the sync step to preserve downstream's versioned files and handle snapshot create/refresh in shell.

**Cleanup:**
- `package.json` — removed `docs:snapshot` and `docs:version` scripts (workflow does this in downstream now).
- `.gitignore`, `eslint.config.ts` — removed entries that referenced source-side versioned dirs / snapshot script.
- `.claude/commands/release.md` — release flow no longer touches docs; workflow handles everything post-merge.

**Process docs:**
- `CONTRIBUTING.md` — new "Documentation versioning" section.

## Design choices worth scrutiny

**Why conditional config instead of two files.** Same `docusaurus.config.ts` deployed to both repos avoids drift. `existsSync('./versions.json')` is a one-line gate at config-load time; `lastVersion` derived from `versions[0]` is auto-correct.

**Why content-only patch refresh.** Adding / removing / renaming a doc in a released minor is an intentional, version-scoped decision; it shouldn't be a side effect of editing live `docs/`. Content-only keeps released-minor structure stable while still letting fixes and regenerated reference data flow into older versions.

**Why workflow-driven instead of release-skill-driven.** Earlier iterations of this PR ran `npm run docs:snapshot` locally as part of `chore: release`. That created two failure modes: (a) the snapshot could go stale or be forgotten, and (b) the source tree carried committed copies of every released minor's docs. Moving the work into the workflow eliminates both.

**Bootstrap on dispatch.** A manual `workflow_dispatch` will create the snapshot if it's missing for the current minor. We can bootstrap the first 0.47 snapshot in downstream without waiting for the next release.

## Verified locally

- [x] `npm run docs:build` — clean (single-version build since `versions.json` is absent in this repo)
- [x] `npm run lint:check`, `npm run format:check`, `npm run tsc` — all clean
- [x] Workflow YAML parses; trigger semantics, snapshot-decision branching, and allowlist defense traced through manually for every event type
- [x] `versions.json` conditional in `docusaurus.config.ts` — verified the disabled path renders correctly (no dropdown, no `/next/` route, no `lastVersion`)

Two items can only be confirmed end-to-end on the next release or via manual dispatch post-merge:
- [ ] Sync Docs Source bootstraps the first snapshot in `embedded-sdk-docs`
- [ ] Subsequent patch releases refresh the snapshot content correctly downstream

## Heads-up for reviewers

`npm run lint:check` shows 26 pre-existing warnings — all `react-hooks/exhaustive-deps` warnings in `src/components/Payroll/*`, `src/hooks/*`, etc. These exist on `main` and are not introduced by this PR. CI doesn't gate on warnings.

## Acceptance criteria (SDK-766)

- [x] Versioned snapshots exist alongside "Next" — bootstrapped downstream by the workflow on first release post-merge or manual dispatch
- [x] Version switcher dropdown works in the navbar — wired in `docusaurus.config.ts`, active when `versions.json` is present
- [x] Team documentation exists — `CONTRIBUTING.md` "Documentation versioning" section
- [x] Integration with release CI — Sync Docs Source workflow handles snapshot creation and content refresh automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SDK-766]: https://gustohq.atlassian.net/browse/SDK-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-758]: https://gustohq.atlassian.net/browse/SDK-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ