### PR TITLE
feat: re-export onboarding status constants from public entry

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -665,7 +665,6 @@ interface CompensationAddAnotherJobFormProps extends CommonComponentInterface<'E
     // (undocumented)
     employeeId: string;
     // Warning: (ae-forgotten-export) The symbol "OnEventType" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "EventType" needs to be exported by the entry point index.d.ts
     onEvent: OnEventType<EventType, unknown>;
 }
 
@@ -1245,11 +1244,25 @@ declare namespace ContractorOnboarding {
     }
 }
 
+// @public
+export const ContractorOnboardingStatus: {
+    readonly ADMIN_ONBOARDING_INCOMPLETE: "admin_onboarding_incomplete";
+    readonly ADMIN_ONBOARDING_REVIEW: "admin_onboarding_review";
+    readonly SELF_ONBOARDING_NOT_INVITED: "self_onboarding_not_invited";
+    readonly SELF_ONBOARDING_INVITED: "self_onboarding_invited";
+    readonly SELF_ONBOARDING_STARTED: "self_onboarding_started";
+    readonly SELF_ONBOARDING_REVIEW: "self_onboarding_review";
+    readonly ONBOARDING_COMPLETED: "onboarding_completed";
+};
+
 // Warning: (ae-forgotten-export) The symbol "ContractorProfileProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "ContractorProfile" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 function ContractorProfile(props: ContractorProfileProps & BaseComponentInterface): JSX;
+
+// @public
+export const ContractorSelfOnboardingStatuses: Set<"self_onboarding_invited" | "self_onboarding_not_invited" | "self_onboarding_started" | "self_onboarding_review">;
 
 // Warning: (ae-forgotten-export) The symbol "ContractorSubmitProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "ContractorSubmit" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -2181,6 +2194,21 @@ declare namespace EmployeeOnboarding {
     }
 }
 
+// @public
+export const EmployeeOnboardingStatus: {
+    readonly ADMIN_ONBOARDING_INCOMPLETE: "admin_onboarding_incomplete";
+    readonly SELF_ONBOARDING_PENDING_INVITE: "self_onboarding_pending_invite";
+    readonly SELF_ONBOARDING_INVITED: "self_onboarding_invited";
+    readonly SELF_ONBOARDING_INVITED_STARTED: "self_onboarding_invited_started";
+    readonly SELF_ONBOARDING_INVITED_OVERDUE: "self_onboarding_invited_overdue";
+    readonly SELF_ONBOARDING_COMPLETED_BY_EMPLOYEE: "self_onboarding_completed_by_employee";
+    readonly SELF_ONBOARDING_AWAITING_ADMIN_REVIEW: "self_onboarding_awaiting_admin_review";
+    readonly ONBOARDING_COMPLETED: "onboarding_completed";
+};
+
+// @public
+export const EmployeeSelfOnboardingStatuses: Set<"self_onboarding_invited" | "self_onboarding_invited_started" | "self_onboarding_invited_overdue">;
+
 // Warning: (ae-missing-release-tag) "EmployeeStateTaxesErrorCode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -2268,6 +2296,9 @@ interface EmploymentEligibilityProps extends BaseComponentInterface<'Employee.Em
     // (undocumented)
     employeeId: string;
 }
+
+// @public
+export type EventType = (typeof componentEvents)[keyof typeof componentEvents];
 
 // Warning: (ae-missing-release-tag) "ExtraWithholdingFieldProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -3425,8 +3456,6 @@ interface OnboardingExecutionFlowProps {
     defaultValues?: OnboardingDefaultValues;
     // (undocumented)
     initialEmployeeId?: string;
-    // Warning: (ae-forgotten-export) The symbol "EmployeeOnboardingStatus" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     initialOnboardingStatus?: (typeof EmployeeOnboardingStatus)[keyof typeof EmployeeOnboardingStatus];
     // (undocumented)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
 export * from '@/components'
 export * from '@/contexts'
-export { componentEvents } from '@/shared/constants'
+export {
+  componentEvents,
+  EmployeeOnboardingStatus,
+  EmployeeSelfOnboardingStatuses,
+  ContractorOnboardingStatus,
+  ContractorSelfOnboardingStatuses,
+} from '@/shared/constants'
+export type { EventType } from '@/shared/constants'
 export type {
   BeforeCreateRequestHook,
   BeforeRequestHook,


### PR DESCRIPTION
## Summary

These constants are tagged `@public` in `src/shared/constants.ts` and are referenced by existing public component props (`OnboardingExecutionFlowProps#initialOnboardingStatus`, `OnboardingFlowProps#initialOnboardingStatus`), but they aren't actually re-exported from `src/index.ts`. The same is true for the `EventType` alias next to `componentEvents` — its own JSDoc already documents `import { componentEvents, type EventType } from '@gusto/embedded-react-sdk'`, which doesn't compile today.

This PR closes the gap by re-exporting them from the public entry, alongside the contractor equivalents for parity.

## Changes

- Add `EmployeeOnboardingStatus`, `EmployeeSelfOnboardingStatuses`, `ContractorOnboardingStatus`, `ContractorSelfOnboardingStatuses`, and `type EventType` to `src/index.ts`.
- Regenerate `.reports/embedded-react-sdk.api.md` — this also clears two of the existing `ae-forgotten-export` warnings (`EmployeeOnboardingStatus`, `EventType`) that the API report had been emitting for a while. `OnEventType` still warns; it lives in a different module and is left for a follow-up.

## Motivation

A partner reference demo (the embedded-react-sdk-demo-app router-driven employee onboarding work) wants to type its onboarding-status sets — e.g. *"skip federal/state taxes when employee is self-onboarding"* — against the SDK's own constants instead of hand-rolling string literals. Today there's no clean import path:

- Deep import into `@gusto/embedded-react-sdk/dist/shared/constants` — reaches into `dist/`, fragile.
- Import from `@gusto/embedded-api/models/operations/putv1employeesemployeeidonboardingstatus` — works but the path is a footgun for the partner reading the demo, and tightly coupled to a specific PUT operation's request body.

After this PR, the demo can simply do:

```ts
import { EmployeeOnboardingStatus } from '@gusto/embedded-react-sdk'

const SELF_ONBOARDING_STATUSES = new Set<
  (typeof EmployeeOnboardingStatus)[keyof typeof EmployeeOnboardingStatus]
>([
  EmployeeOnboardingStatus.SELF_ONBOARDING_PENDING_INVITE,
  EmployeeOnboardingStatus.SELF_ONBOARDING_INVITED,
  EmployeeOnboardingStatus.SELF_ONBOARDING_INVITED_STARTED,
  EmployeeOnboardingStatus.SELF_ONBOARDING_INVITED_OVERDUE,
])
```

## Testing

- `npm run lint:check` — clean (0 errors; 26 pre-existing warnings unchanged).
- `npm run test -- --run` — 3092 passed, 1 expected fail (unchanged).
- `npm run build` — clean.
- `npm run api-report:derive` — applied the additions; diff is the additions plus removal of two stale `ae-forgotten-export` warnings.

## Related

- Demo app PR consuming this: https://github.com/Gusto/embedded-react-sdk-demo-app/pull/19

Made with [Cursor](https://cursor.com)