### PR TITLE
feat(docs-site): refine sidebar styling and Workflows structure

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -62,14 +62,13 @@ const config: Config = {
     },
     navbar: {
       logo: {
-        alt: 'Gusto Ember',
+        alt: 'Gusto Embedded',
         src: 'img/gdev-logo-light.svg',
         srcDark: 'img/gdev-logo-dark.svg',
       },
       items: [
         {
-          type: 'docSidebar',
-          sidebarId: 'docs',
+          to: '/docs/',
           position: 'left',
           label: 'Docs',
         },
@@ -108,7 +107,7 @@ const config: Config = {
         {
           title: 'Get Started',
           items: [
-            { label: 'What is the SDK?', to: '/docs/what-is-the-gep-react-sdk' },
+            { label: 'What is the SDK?', to: '/docs/' },
             { label: 'Getting Started', to: '/docs/getting-started' },
             { label: 'Authentication', to: '/docs/getting-started/authentication' },
           ],

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -2,7 +2,13 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs'
 
 const sidebars: SidebarsConfig = {
   docs: [
-    'what-is-the-gep-react-sdk',
+    {
+      type: 'category',
+      label: 'Getting Started',
+      link: { type: 'doc', id: 'getting-started/getting-started' },
+      collapsible: false,
+      items: ['getting-started/authentication', 'getting-started/proxy-security-partner-guidance'],
+    },
     {
       type: 'category',
       label: 'Deciding to build with the SDK',
@@ -14,31 +20,84 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
-      label: 'Getting Started',
-      link: { type: 'doc', id: 'getting-started/getting-started' },
-      items: ['getting-started/authentication', 'getting-started/proxy-security-partner-guidance'],
-    },
-    {
-      type: 'category',
-      label: 'Workflows Overview',
+      label: 'Workflows',
       link: { type: 'doc', id: 'workflows-overview/workflows-overview' },
+      collapsible: false,
       items: [
-        'workflows-overview/company-onboarding',
         {
           type: 'category',
-          label: 'Employee Onboarding',
-          link: { type: 'doc', id: 'workflows-overview/employee-onboarding/employee-onboarding' },
-          items: ['workflows-overview/employee-onboarding/employee-self-onboarding'],
+          label: 'Companies',
+          items: [
+            {
+              type: 'doc',
+              id: 'workflows-overview/company-onboarding',
+              label: 'Company onboarding',
+            },
+            {
+              type: 'doc',
+              id: 'workflows-overview/information-requests',
+              label: 'Information requests',
+            },
+          ],
         },
-        'workflows-overview/employee-dashboard',
-        'workflows-overview/employee-termination',
-        'workflows-overview/run-payroll',
-        'workflows-overview/off-cycle-payroll',
-        'workflows-overview/dismissal-payroll',
-        'workflows-overview/transition-payroll',
-        'workflows-overview/contractor-onboarding',
-        'workflows-overview/contractor-payments',
-        'workflows-overview/information-requests',
+        {
+          type: 'category',
+          label: 'Employees',
+          items: [
+            {
+              type: 'doc',
+              id: 'workflows-overview/employee-onboarding/employee-onboarding',
+              label: 'Employee onboarding',
+            },
+            {
+              type: 'doc',
+              id: 'workflows-overview/employee-onboarding/employee-self-onboarding',
+              label: 'Employee self-onboarding',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Contractors',
+          items: [
+            {
+              type: 'doc',
+              id: 'workflows-overview/contractor-onboarding',
+              label: 'Conractor onboarding',
+            },
+            {
+              type: 'doc',
+              id: 'workflows-overview/contractor-payments',
+              label: 'Contractor payments',
+            },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Payroll',
+          items: [
+            {
+              type: 'doc',
+              id: 'workflows-overview/run-payroll',
+              label: 'Payroll processing',
+            },
+            {
+              type: 'doc',
+              id: 'workflows-overview/off-cycle-payroll',
+              label: 'Off-cycle payroll',
+            },
+            {
+              type: 'doc',
+              id: 'workflows-overview/dismissal-payroll',
+              label: 'Dismissal payroll',
+            },
+            {
+              type: 'doc',
+              id: 'workflows-overview/transition-payroll',
+              label: 'Transition payroll',
+            },
+          ],
+        },
       ],
     },
     {

--- a/docs-site/src/components/AuthFlowDiagram/index.tsx
+++ b/docs-site/src/components/AuthFlowDiagram/index.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react'
+import styles from './styles.module.css'
+
+function Node({
+  label,
+  title,
+  detail,
+  accent = false,
+}: {
+  label: string
+  title: string
+  detail: string
+  accent?: boolean
+}): ReactNode {
+  return (
+    <div className={`${styles.node} ${accent ? styles.nodeAccent : ''}`}>
+      <span className={styles.label}>{label}</span>
+      <span className={styles.title}>{title}</span>
+      <span className={styles.detail}>{detail}</span>
+    </div>
+  )
+}
+
+function Connector({ caption }: { caption: string }): ReactNode {
+  return (
+    <div className={styles.connector}>
+      <span className={styles.connectorCaption}>{caption}</span>
+      <div className={styles.arrow} />
+    </div>
+  )
+}
+
+export function AuthFlowDiagram(): ReactNode {
+  return (
+    <div className={styles.diagram} role="img" aria-label="Authentication flow diagram">
+      <Node
+        label="Client"
+        title="Partner App"
+        detail="Renders SDK components and calls the proxy"
+      />
+      <Connector caption="SDK request" />
+      <Node
+        label="Backend"
+        title="Partner Proxy"
+        detail="Authenticates, fetches OAuth2 token, forwards"
+        accent
+      />
+      <Connector caption="OAuth2 token" />
+      <Node label="API" title="Gusto Embedded API" detail="Returns payroll data and resources" />
+    </div>
+  )
+}

--- a/docs-site/src/components/AuthFlowDiagram/styles.module.css
+++ b/docs-site/src/components/AuthFlowDiagram/styles.module.css
@@ -1,0 +1,149 @@
+.diagram {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto 1fr;
+  align-items: stretch;
+  gap: 0.5rem;
+  margin: 2rem 0;
+  padding: 1.5rem;
+  background-color: var(--ifm-background-surface-color, #ffffff);
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 12px;
+}
+
+[data-theme='dark'] .diagram {
+  background-color: rgba(255, 255, 255, 0.02);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.node {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 1rem 1.25rem;
+  background-color: #ffffff;
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 10px;
+  text-align: center;
+}
+
+[data-theme='dark'] .node {
+  background-color: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.nodeAccent {
+  border-color: rgba(241, 94, 73, 0.4);
+  background-color: rgba(241, 94, 73, 0.04);
+}
+
+[data-theme='dark'] .nodeAccent {
+  border-color: rgba(241, 94, 73, 0.45);
+  background-color: rgba(241, 94, 73, 0.06);
+}
+
+.label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(27, 27, 29, 0.55);
+}
+
+[data-theme='dark'] .label {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1b1b1d;
+}
+
+[data-theme='dark'] .title {
+  color: #ffffff;
+}
+
+.detail {
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: #525860;
+}
+
+[data-theme='dark'] .detail {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.connector {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  min-width: 88px;
+}
+
+.connectorCaption {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: rgba(27, 27, 29, 0.55);
+  white-space: nowrap;
+}
+
+[data-theme='dark'] .connectorCaption {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.arrow {
+  position: relative;
+  width: 100%;
+  height: 1px;
+  background-color: rgba(27, 27, 29, 0.2);
+}
+
+[data-theme='dark'] .arrow {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.arrow::after {
+  content: '';
+  position: absolute;
+  right: -1px;
+  top: 50%;
+  width: 7px;
+  height: 7px;
+  border-top: 1px solid rgba(27, 27, 29, 0.4);
+  border-right: 1px solid rgba(27, 27, 29, 0.4);
+  transform: translateY(-50%) rotate(45deg);
+}
+
+[data-theme='dark'] .arrow::after {
+  border-top-color: rgba(255, 255, 255, 0.4);
+  border-right-color: rgba(255, 255, 255, 0.4);
+}
+
+@media (max-width: 768px) {
+  .diagram {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+  }
+
+  .connector {
+    min-width: 0;
+    flex-direction: row;
+    padding: 0.25rem 0;
+  }
+
+  .arrow {
+    width: 1px;
+    height: 24px;
+    margin: 0 auto;
+  }
+
+  .arrow::after {
+    right: 50%;
+    top: auto;
+    bottom: -1px;
+    transform: translate(50%, 0) rotate(135deg);
+  }
+}

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -29,6 +29,9 @@ html {
   --ifm-navbar-search-input-placeholder-color: rgba(82, 88, 96, 0.7);
   --ifm-navbar-search-input-icon: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%23525860" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>');
 
+  --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%23525860" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m6 15 6-6 6 6"/></svg>');
+  --ifm-menu-link-sublist-icon-filter: none;
+
   --ifm-link-color: #f15e49;
   --ifm-link-hover-color: #d91f0c;
   --ifm-breadcrumb-color-active: #f15e49;
@@ -42,7 +45,6 @@ html {
   --gusto-table-header-bg: #eef0f2;
   --gusto-pagination-border: #ebedf0;
   --gusto-code-block-bg: #f7f7f8;
-  --gusto-sidebar-active-border: #f15e49;
 
   --docusaurus-highlighted-code-line-bg: rgba(241, 94, 73, 0.1);
 }
@@ -66,6 +68,9 @@ html {
   --ifm-navbar-search-input-placeholder-color: rgba(255, 255, 255, 0.55);
   --ifm-navbar-search-input-icon: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%23ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.7"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>');
 
+  --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%239a9da3" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m6 15 6-6 6 6"/></svg>');
+  --ifm-menu-link-sublist-icon-filter: none;
+
   --ifm-link-color: #f15e49;
   --ifm-link-hover-color: #ff998c;
   --ifm-breadcrumb-color-active: #f15e49;
@@ -79,7 +84,6 @@ html {
   --gusto-table-header-bg: #2a2a2d;
   --gusto-pagination-border: #3a3a3d;
   --gusto-code-block-bg: #2a2a2d;
-  --gusto-sidebar-active-border: #f15e49;
 
   --docusaurus-highlighted-code-line-bg: rgba(241, 94, 73, 0.15);
 }
@@ -363,51 +367,100 @@ html {
 .menu__link {
   font-size: 0.875rem;
   font-weight: 400;
-  border-radius: 0;
+  border-radius: 0.25rem;
   padding: 7px 12px;
-  border-left: 3px solid transparent;
   transition:
     background-color 0.15s ease,
-    color 0.15s ease,
-    border-color 0.15s ease;
+    color 0.15s ease;
 }
 
 .menu__link--active:not(.menu__link--sublist) {
   background-color: transparent;
   color: var(--ifm-color-primary);
   font-weight: 500;
-  border-left-color: var(--gusto-sidebar-active-border);
+}
+
+.menu__list .menu__list .menu__link--active:not(.menu__link--sublist) {
+  position: relative;
+}
+
+.menu__list .menu__list .menu__link--active:not(.menu__link--sublist)::before {
+  content: '';
+  position: absolute;
+  left: calc(-0.5rem - 1px);
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background-color: var(--ifm-color-primary);
 }
 
 [data-theme='dark'] .menu__link--active:not(.menu__link--sublist) {
   background-color: transparent;
 }
 
-.menu__link:hover {
-  color: var(--ifm-color-primary);
-  background-color: rgba(241, 94, 73, 0.04);
+.menu__link:hover,
+.menu__list-item-collapsible:hover {
+  background: transparent;
 }
 
-[data-theme='dark'] .menu__link:hover {
-  background-color: rgba(241, 94, 73, 0.06);
-}
-
-.menu__list-item-collapsible .menu__link--sublist {
-  font-weight: 600;
-
-  font-size: 0.875rem;
-
+.menu__list-item > .menu__link:not(.menu__link--active),
+.menu__list .menu__list .menu__list-item-collapsible > .menu__link:not(.menu__link--active) {
   color: var(--gusto-sidebar-category-color);
-  margin-top: 1.25rem;
-  border-left: none;
 }
 
-.menu__list-item-collapsible:first-child .menu__link--sublist {
-  margin-top: 0;
+.menu__list-item > .menu__link:hover:not(.menu__link--active),
+.menu__list .menu__list .menu__list-item-collapsible > .menu__link:hover:not(.menu__link--active) {
+  color: var(--ifm-menu-color);
+}
+
+.menu > .menu__list > .menu__list-item > .menu__list-item-collapsible > .menu__link {
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+.menu > .menu__list > .menu__list-item + .menu__list-item {
+  margin-top: 1rem;
+}
+
+.menu__list-item-collapsible > .menu__link--active {
+  background-color: transparent;
+  color: inherit;
+}
+
+.menu__list-item-collapsible--active > .menu__link {
+  color: var(--ifm-color-primary);
+}
+
+.menu__list-item-collapsible > .menu__link--sublist.menu__link--active {
+  color: var(--ifm-color-primary);
+  font-weight: 500;
 }
 
 .menu__list .menu__list {
-  padding-left: 0.75rem;
+  padding-left: 0.5rem;
+  margin-left: 1.5rem;
+  border-left: 1px solid var(--ifm-toc-border-color);
+}
+
+.theme-doc-sidebar-item-category:not(:has(> .menu__list-item-collapsible > .menu__link--sublist)) > .menu__list {
+  padding-left: 0;
+  margin-left: 0;
+  border-left: none;
+}
+
+.menu__link--sublist-caret::after,
+.menu__caret::before {
+  background-size: 1.25rem 1.25rem;
+}
+
+.menu__caret:hover {
+  background-color: transparent;
+}
+
+.menu__list-item-collapsible:has(> .menu__link--sublist.menu__link--active),
+.menu__list-item-collapsible--active {
+  --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%23f15e49" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m6 15 6-6 6 6"/></svg>');
+  --ifm-menu-link-sublist-icon-filter: none;
 }
 
 /* ── Content ── */

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -386,11 +386,23 @@ aside.theme-doc-sidebar-container {
   align-self: flex-start;
 }
 
+.theme-doc-sidebar-container > div > div {
+  padding-top: 0;
+}
+
+.theme-doc-sidebar-container .menu {
+  padding-top: 3rem;
+}
+
 .theme-doc-toc-desktop {
   position: sticky;
-  top: calc(var(--ifm-navbar-height) + 1rem);
+  top: calc(var(--ifm-navbar-height) + 3rem);
   max-height: calc(100vh - var(--ifm-navbar-height) - 2rem);
   overflow-y: auto;
+}
+
+.docs-doc-page main[class*='docMainContainer_'] {
+  padding-top: 2rem;
 }
 
 .col.docItemCol_VOVn .table-of-contents,
@@ -448,9 +460,47 @@ aside.theme-doc-sidebar-container {
   color: var(--ifm-menu-color);
 }
 
+.menu__list .menu__list .menu__list-item > .menu__link:hover:not(.menu__link--active),
+.menu__list
+  .menu__list
+  .menu__list-item-collapsible
+  > .menu__link:hover:not(.menu__link--active) {
+  color: #000000;
+}
+
+[data-theme='dark']
+  .menu__list
+  .menu__list
+  .menu__list-item
+  > .menu__link:hover:not(.menu__link--active),
+[data-theme='dark']
+  .menu__list
+  .menu__list
+  .menu__list-item-collapsible
+  > .menu__link:hover:not(.menu__link--active) {
+  color: #ffffff;
+}
+
 .menu > .menu__list > .menu__list-item > .menu__list-item-collapsible > .menu__link {
   font-weight: 600;
   font-size: 0.875rem;
+}
+
+.menu
+  > .menu__list
+  > .menu__list-item
+  > .menu__list-item-collapsible
+  > .menu__link:not(.menu__link--active) {
+  color: #000000;
+}
+
+[data-theme='dark']
+  .menu
+  > .menu__list
+  > .menu__list-item
+  > .menu__list-item-collapsible
+  > .menu__link:not(.menu__link--active) {
+  color: #ffffff;
 }
 
 .menu > .menu__list > .menu__list-item + .menu__list-item {
@@ -585,6 +635,10 @@ code {
 
 /* ── Table of contents (right sidebar) ── */
 
+.table-of-contents__link:not(.table-of-contents__link--active) {
+  color: var(--gusto-sidebar-category-color);
+}
+
 .table-of-contents__link--active {
   color: var(--ifm-color-primary);
   font-weight: 500;
@@ -618,6 +672,7 @@ code {
 
 .footer {
   background-color: transparent;
+  margin-top: 3rem;
 }
 
 .footer__links {

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -399,7 +399,8 @@ html {
 }
 
 .menu__link:hover,
-.menu__list-item-collapsible:hover {
+.menu__list-item-collapsible:hover,
+.menu__list-item-collapsible--active {
   background: transparent;
 }
 

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -39,7 +39,8 @@ html {
   --ifm-toc-border-color: #ebedf0;
   --ifm-table-stripe-background: #f9f9fa;
   --ifm-table-border-color: #e0e0e0;
-  --ifm-hr-border-color: #ebedf0;
+  --ifm-hr-border-color: #d4d7dc;
+  --ifm-hr-background-color: #d4d7dc;
 
   --gusto-sidebar-category-color: #525860;
   --gusto-table-header-bg: #eef0f2;
@@ -79,6 +80,7 @@ html {
   --ifm-table-stripe-background: #2a2a2d;
   --ifm-table-border-color: #3a3a3d;
   --ifm-hr-border-color: #3a3a3d;
+  --ifm-hr-background-color: rgba(255, 255, 255, 0.12);
 
   --gusto-sidebar-category-color: #9a9da3;
   --gusto-table-header-bg: #2a2a2d;
@@ -380,18 +382,14 @@ html {
 
 aside.theme-doc-sidebar-container {
   border-right: none;
-  position: sticky;
-  top: var(--ifm-navbar-height);
-  height: calc(100vh - var(--ifm-navbar-height));
-  align-self: flex-start;
 }
 
 .theme-doc-sidebar-container > div > div {
-  padding-top: 0;
+  padding-top: calc(var(--ifm-navbar-height) + 3rem);
 }
 
 .theme-doc-sidebar-container .menu {
-  padding-top: 3rem;
+  padding-top: 0;
 }
 
 .theme-doc-toc-desktop {
@@ -552,6 +550,10 @@ aside.theme-doc-sidebar-container {
   padding: 0 1.5rem;
 }
 
+.markdown hr {
+  margin: 4.5rem 0;
+}
+
 .markdown h1:first-child {
   font-size: 2rem;
   font-weight: 700;
@@ -661,6 +663,10 @@ nav.theme-doc-breadcrumbs {
 }
 
 .theme-doc-breadcrumbs .breadcrumbs__item:first-child {
+  display: none;
+}
+
+nav.theme-doc-breadcrumbs:not(:has(.breadcrumbs__item + .breadcrumbs__item)) {
   display: none;
 }
 

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -443,7 +443,8 @@ html {
   border-left: 1px solid var(--ifm-toc-border-color);
 }
 
-.theme-doc-sidebar-item-category:not(:has(> .menu__list-item-collapsible > .menu__link--sublist)) > .menu__list {
+.theme-doc-sidebar-item-category:not(:has(> .menu__list-item-collapsible > .menu__link--sublist))
+  > .menu__list {
   padding-left: 0;
   margin-left: 0;
   border-left: none;

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -461,10 +461,7 @@ aside.theme-doc-sidebar-container {
 }
 
 .menu__list .menu__list .menu__list-item > .menu__link:hover:not(.menu__link--active),
-.menu__list
-  .menu__list
-  .menu__list-item-collapsible
-  > .menu__link:hover:not(.menu__link--active) {
+.menu__list .menu__list .menu__list-item-collapsible > .menu__link:hover:not(.menu__link--active) {
   color: #000000;
 }
 
@@ -653,6 +650,19 @@ code {
 }
 
 /* ── Breadcrumbs ── */
+
+nav.theme-doc-breadcrumbs {
+  padding-left: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.theme-doc-breadcrumbs .breadcrumbs__item:nth-child(2) .breadcrumbs__link {
+  padding-left: 0;
+}
+
+.theme-doc-breadcrumbs .breadcrumbs__item:first-child {
+  display: none;
+}
 
 .breadcrumbs__link {
   font-size: 0.8rem;

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -58,10 +58,10 @@ html {
   --ifm-color-primary-lighter: #ffa89b;
   --ifm-color-primary-lightest: #ffd6cf;
 
-  --ifm-background-color: #1b1b1d;
-  --ifm-background-surface-color: #242427;
+  --ifm-background-color: #000000;
+  --ifm-background-surface-color: #000000;
 
-  --ifm-navbar-background-color: #18181a;
+  --ifm-navbar-background-color: #000000;
   --ifm-navbar-link-color: #ffffff;
   --ifm-navbar-search-input-background-color: rgba(255, 255, 255, 0.08);
   --ifm-navbar-search-input-color: #ffffff;
@@ -88,10 +88,28 @@ html {
   --docusaurus-highlighted-code-line-bg: rgba(241, 94, 73, 0.15);
 }
 
+[data-theme='dark'] html,
+[data-theme='dark'] body,
+[data-theme='dark'] #__docusaurus,
+[data-theme='dark'] .main-wrapper {
+  background-color: #000000;
+}
+
+.main-wrapper {
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
 /* ── Navbar ── */
 
 .navbar {
   border-bottom: 1px solid #ebedf0;
+}
+
+.navbar__inner {
+  max-width: 1400px;
+  margin: 0 auto;
 }
 
 [data-theme='dark'] .navbar {
@@ -360,8 +378,24 @@ html {
 
 /* ── Sidebar ── */
 
-.theme-doc-sidebar-container {
-  border-right: 1px solid var(--ifm-toc-border-color);
+aside.theme-doc-sidebar-container {
+  border-right: none;
+  position: sticky;
+  top: var(--ifm-navbar-height);
+  height: calc(100vh - var(--ifm-navbar-height));
+  align-self: flex-start;
+}
+
+.theme-doc-toc-desktop {
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + 1rem);
+  max-height: calc(100vh - var(--ifm-navbar-height) - 2rem);
+  overflow-y: auto;
+}
+
+.col.docItemCol_VOVn .table-of-contents,
+.theme-doc-toc-desktop .table-of-contents {
+  border-left: none;
 }
 
 .menu__link {
@@ -466,6 +500,10 @@ html {
 }
 
 /* ── Content ── */
+
+.theme-doc-markdown {
+  padding: 0 1.5rem;
+}
 
 .markdown h1:first-child {
   font-size: 2rem;
@@ -703,22 +741,15 @@ code {
   --ifm-alert-border-color: rgba(250, 56, 56, 0.3);
 }
 
-/* ── Scrollbar (dark mode) ── */
+/* ── Sidebar scrollbars ── */
 
-[data-theme='dark'] ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+.theme-doc-sidebar-container .menu,
+.theme-doc-toc-desktop {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(27, 27, 29, 0.25) transparent;
 }
 
-[data-theme='dark'] ::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-[data-theme='dark'] ::-webkit-scrollbar-thumb {
-  background: #4a4a4d;
-  border-radius: 4px;
-}
-
-[data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
-  background: #5a5a5d;
+[data-theme='dark'] .theme-doc-sidebar-container .menu,
+[data-theme='dark'] .theme-doc-toc-desktop {
+  scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
 }

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -303,7 +303,7 @@ function HeroSection() {
             <Link className={styles.heroPrimary} to="/docs/getting-started">
               Get Started
             </Link>
-            <Link className={styles.heroSecondary} to="/docs/what-is-the-gep-react-sdk">
+            <Link className={styles.heroSecondary} to="/docs/">
               Learn More
             </Link>
           </div>

--- a/docs-site/src/theme/NotFound/Content/index.tsx
+++ b/docs-site/src/theme/NotFound/Content/index.tsx
@@ -20,7 +20,7 @@ export default function NotFoundContent(): ReactNode {
           <Link to={homeUrl} className={styles.homeLink}>
             Go to Home
           </Link>
-          <Link to="/docs/what-is-the-gep-react-sdk" className={styles.docsLink}>
+          <Link to="/docs/" className={styles.docsLink}>
             Browse Docs
           </Link>
         </div>

--- a/docs/component-adapter/component-adapter-faq.md
+++ b/docs/component-adapter/component-adapter-faq.md
@@ -3,8 +3,6 @@ title: Component Adapter FAQ
 order: 1
 ---
 
-## Component Adapter FAQ
-
 This FAQ addresses common questions and potential issues when working with the Component Adapter system in the Gusto Embedded React SDK.
 
 ### General Questions

--- a/docs/component-adapter/component-adapter-types.md
+++ b/docs/component-adapter/component-adapter-types.md
@@ -3,8 +3,6 @@ title: Component Adapter Types
 order: 4
 ---
 
-## Component Adapter Types
-
 The Component Adapter system uses TypeScript interfaces to ensure type safety and consistent behavior. This document provides links to the type definitions you'll need when implementing custom components.
 
 ### Core Types

--- a/docs/component-adapter/component-adapter.md
+++ b/docs/component-adapter/component-adapter.md
@@ -3,8 +3,6 @@ title: Component Adapter
 order: 5
 ---
 
-## Component Adapter
-
 The Component Adapter system provides a powerful way to customize the UI components used throughout the Gusto Embedded React SDK. This feature allows you to replace the default SDK UI components with your own UI components while maintaining all the SDK's functionality.
 
 > Component adapters are powerful but can be complicated to set up and involve higher maintenance overhead. It is recommended to start with [theming](../theming/theming-guide.md) and then only use component adapters as needed.

--- a/docs/component-adapter/how-the-component-adapter-works.md
+++ b/docs/component-adapter/how-the-component-adapter-works.md
@@ -3,8 +3,6 @@ title: How the Component Adapter Works
 order: 2
 ---
 
-## How the Component Adapter Works
-
 1. You create mappings that connect the SDK props to your UI components
 2. You provide these mappings to either:
    - `GustoProvider` (recommended): Includes default React Aria components and allows overriding specific ones

--- a/docs/component-adapter/setting-up-your-component-adapter.md
+++ b/docs/component-adapter/setting-up-your-component-adapter.md
@@ -3,8 +3,6 @@ title: Setting Up Your Component Adapter
 order: 3
 ---
 
-## Setting Up Your Component Adapter
-
 This guide will walk you through the process of creating and implementing your own Component Adapter for the Gusto Embedded React SDK.
 
 ### 1. Create Your Custom Component Implementations

--- a/docs/getting-started/authentication.md
+++ b/docs/getting-started/authentication.md
@@ -3,8 +3,6 @@ title: Authentication
 order: 0
 ---
 
-## Authentication
-
 To get started, you'll need to create a way to properly create and retrieve access tokens on behalf of your authenticated user from your application.
 
 Since there are a vast number of ways this might work for a partner, what we can suggest to get up and running is to implement a proxy server that handles translating requests from the SDK to the Gusto Embedded API.

--- a/docs/getting-started/authentication.mdx
+++ b/docs/getting-started/authentication.mdx
@@ -3,17 +3,21 @@ title: Authentication
 order: 0
 ---
 
+import { AuthFlowDiagram } from '@site/src/components/AuthFlowDiagram'
+
 To get started, you'll need to create a way to properly create and retrieve access tokens on behalf of your authenticated user from your application.
 
 Since there are a vast number of ways this might work for a partner, what we can suggest to get up and running is to implement a proxy server that handles translating requests from the SDK to the Gusto Embedded API.
 
-### How access tokens work
+---
+
+## How access tokens work
 
 To maximize compatibility with a wide range of partner security postures and implementations, the Gusto Embedded React SDK does not include built-in OAuth2 token acquisition and refresh flows but instead is built to fit into a partner's existing flows.
 
 The most simple implementation is one where a partner has a backend service that acquires OAuth2 tokens from the Gusto Embedded API on behalf of an authenticated user and then proxies calls to the Gusto Embedded API using those tokens. The following provides a high level graphical representation of how that configuration would look:
 
-![](https://files.readme.io/161c4c0c0952486a811a18c71d959a8bd74ca4884f2fc1abe39737c988f3a05f-image.png)
+<AuthFlowDiagram />
 
 The `<GustoProvider>` can receive a `baseUrl` that can be configured with the address of your backend proxy service and can also be used if necessary to pass along vendor authentication credentials.
 
@@ -27,7 +31,9 @@ function App() {
 export default App
 ```
 
-### Adding Headers to Requests
+---
+
+## Adding Headers to Requests
 
 The SDK provides two ways to add headers to API requests:
 
@@ -61,11 +67,15 @@ This approach automatically applies the headers to all API requests without requ
 
 For dynamic headers that need to be computed at request time (like refreshing tokens), use the hooks approach described in the [Request Interceptors guide](../integration-guide/request-interceptors.md).
 
-### Securing your proxy
+---
+
+## Securing your proxy
 
 Beyond authentication, your proxy server should also enforce authorization -- controlling which users can perform which actions through the Gusto API. For detailed guidance on implementing endpoint allowlisting, role-based access control, and other proxy security practices, see the [Securing your proxy](./getting-started.md#securing-your-proxy) section in the Getting Started guide and the [Proxy Security: Partner Guidance](./proxy-security-partner-guidance.md).
 
-### How components utilize the API
+---
+
+## How components utilize the API
 
 Components which are part of the Gusto Embedded SDK utilize the `baseUrl` to call the appropriate public Gusto API endpoint. These components are custom built in order to abstract complicated API interactions. The baseUrl serves as a foundational element within the Embedded SDK framework, directing its components to the correct public Gusto API endpoint.
 

--- a/docs/theming/theming.md
+++ b/docs/theming/theming.md
@@ -2,8 +2,6 @@
 title: Theming
 ---
 
-## Theming
-
 Theming provides a simple and powerful way to customize the visual appearance of the Gusto Embedded React SDK UI components. This feature allows you to change colors, typography, shadows, and other design variables to globally update the SDK visuals to match your application.
 
 > Theming is the recommended approach for customizing your UI. It provides the best balance of customization power and maintenance simplicity. For advanced customization, consider using [component adapters](../component-adapter/component-adapter.md).

--- a/docs/what-is-the-gep-react-sdk.md
+++ b/docs/what-is-the-gep-react-sdk.md
@@ -1,5 +1,7 @@
 ---
 title: What is the GEP React SDK?
+slug: /
+displayed_sidebar: docs
 order: 0
 ---
 

--- a/docs/workflows-overview/company-onboarding.md
+++ b/docs/workflows-overview/company-onboarding.md
@@ -3,8 +3,6 @@ title: Company Onboarding
 order: 1
 ---
 
-## Overview
-
 The Company Onboarding workflow provides components for managing company-related onboarding tasks. These components can be used individually or composed into a complete workflow.
 
 ### Implementation

--- a/docs/workflows-overview/contractor-onboarding.md
+++ b/docs/workflows-overview/contractor-onboarding.md
@@ -3,8 +3,6 @@ title: Contractor Onboarding
 order: 2
 ---
 
-## Overview
-
 The Contractor Onboarding workflow provides components for managing contractor-related onboarding tasks. These components can be used individually or composed into a complete workflow.
 
 ### Implementation

--- a/docs/workflows-overview/contractor-payments.md
+++ b/docs/workflows-overview/contractor-payments.md
@@ -3,8 +3,6 @@ title: Contractor Payments
 order: 3
 ---
 
-## Overview
-
 The Contractor Payments workflow provides components for creating, managing, and viewing contractor payment groups. These components can be used individually or composed into a complete payment workflow through the `Contractor.PaymentFlow` component.
 
 ### Implementation

--- a/docs/workflows-overview/dismissal-payroll.md
+++ b/docs/workflows-overview/dismissal-payroll.md
@@ -3,8 +3,6 @@ title: Dismissal Payroll
 order: 6
 ---
 
-## Overview
-
 The Dismissal Payroll workflow provides a guided experience for running a terminated employee's final payroll. It presents unprocessed termination pay periods for the employee, creates an off-cycle payroll for the selected period, and then transitions into the standard [Payroll Processing](./run-payroll.md) flow for configuration, review, and submission. Like all off-cycle payroll types, the dismissal flow shares the same execution steps as regular payrolls — the only difference is how the payroll is created.
 
 This workflow is typically launched from the [Employee Termination](./employee-termination.md) flow when the user selects the "Dismissal payroll" option for the employee's final paycheck.

--- a/docs/workflows-overview/employee-dashboard.md
+++ b/docs/workflows-overview/employee-dashboard.md
@@ -3,8 +3,6 @@ title: Employee Dashboard
 order: 5
 ---
 
-## Overview
-
 The Employee Dashboard provides a comprehensive view of employee information organized into four tabs: Basic details, Job and pay, Taxes, and Documents. This component serves as a central hub for viewing and managing employee data.
 
 ### Implementation

--- a/docs/workflows-overview/employee-management/employee-management.md
+++ b/docs/workflows-overview/employee-management/employee-management.md
@@ -3,8 +3,6 @@ title: Employee Management
 order: 0
 ---
 
-## Overview
-
 The Employee Management namespace provides components for viewing and editing an employee's information after onboarding is complete. The headline entry point is the Employee Dashboard — a tabbed read/edit surface that covers basic details, job & pay, taxes, and documents — but every section of that dashboard is also exported individually so it can be composed into a custom layout, rendered in isolation, or replaced with a custom UI built on top of the same data hooks.
 
 ### Implementation

--- a/docs/workflows-overview/employee-onboarding/employee-onboarding.md
+++ b/docs/workflows-overview/employee-onboarding/employee-onboarding.md
@@ -3,8 +3,6 @@ title: Employee Onboarding
 order: 0
 ---
 
-## Overview
-
 The Employee Onboarding workflow provides a complete experience for onboarding an employee to a company. It is used to collect all required information for an employee to be added to payroll.
 
 ### Implementation

--- a/docs/workflows-overview/employee-onboarding/employee-self-onboarding.md
+++ b/docs/workflows-overview/employee-onboarding/employee-self-onboarding.md
@@ -3,8 +3,6 @@ title: Employee Self-Onboarding
 order: 0
 ---
 
-## Overview
-
 In the case an employer elects to allow the employee to self-onboard, they can be provided with the self-onboarding workflow. This workflow places the responsibility of submitting some required information on the employee.
 
 ### Implementation

--- a/docs/workflows-overview/employee-termination.md
+++ b/docs/workflows-overview/employee-termination.md
@@ -3,8 +3,6 @@ title: Employee Termination
 order: 4
 ---
 
-## Overview
-
 The Employee Termination workflow provides a complete experience for terminating employees. It guides users through selecting a termination date, choosing how to process final payroll, reviewing termination details, and managing the offboarding process.
 
 > **Important**: Make sure employees are paid on time by checking your [state's requirement guide](https://support.gusto.com/article/100895878100000/Final-paychecks). Some states require employees to receive their final wages within 24 hours (unless they consent otherwise), in which case running a dismissal payroll may be the only option.

--- a/docs/workflows-overview/information-requests.md
+++ b/docs/workflows-overview/information-requests.md
@@ -3,8 +3,6 @@ title: Information Requests
 order: 8
 ---
 
-## Overview
-
 The Information Requests workflow surfaces outstanding information requests that Gusto has issued for a company (for example, a request for a missing tax document or identity verification artifact) and lets the user respond to them. Information requests can also block payroll processing, in which case they are surfaced inline within `Payroll.PayrollBlockerList`; this flow provides a dedicated, standalone surface for managing them.
 
 ### Implementation

--- a/docs/workflows-overview/off-cycle-payroll.md
+++ b/docs/workflows-overview/off-cycle-payroll.md
@@ -3,8 +3,6 @@ title: Off-Cycle Payroll (Bonus & Correction)
 order: 5
 ---
 
-## Overview
-
 The Off-Cycle Payroll workflow provides a complete experience for running payrolls outside of a company's regular pay schedule. It supports two off-cycle reasons: **Bonus** (paying a bonus, gift, or commission) and **Correction** (running a correction payment). The flow guides users through configuring pay period dates, selecting a reason, choosing employees, setting deduction and tax withholding preferences, and then executing the payroll.
 
 After creation, the flow transitions into the standard [Payroll Processing](./run-payroll.md) execution experience (configuration, overview, submission, and receipts). All off-cycle payroll types share the same execution steps as regular payrolls — the only difference is how the payroll is created.

--- a/docs/workflows-overview/run-payroll.md
+++ b/docs/workflows-overview/run-payroll.md
@@ -3,8 +3,6 @@ title: Payroll Processing
 order: 3
 ---
 
-## Overview
-
 The Run Payroll workflow provides a complete experience for running payroll for a company. It guides users through selecting a payroll, configuring employee compensation, reviewing payroll details, and submitting the payroll for processing.
 
 ### Implementation

--- a/docs/workflows-overview/time-off.md
+++ b/docs/workflows-overview/time-off.md
@@ -3,8 +3,6 @@ title: Time Off Policy Management
 order: 6
 ---
 
-## Overview
-
 The Time Off Policy Management workflow provides a complete experience for creating and managing time off policies for a company. It supports three policy types: **Sick**, **Vacation**, and **Holiday**. The flow guides users through selecting a policy type, configuring accrual rules, setting policy limits, and assigning employees.
 
 Sick and vacation policies share a common creation flow — configure details, set accrual settings, then add employees. Holiday policies follow a separate path — select observed federal holidays, then assign employees. All policy types can be viewed, edited, and managed from the unified policy list.

--- a/docs/workflows-overview/transition-payroll.md
+++ b/docs/workflows-overview/transition-payroll.md
@@ -3,8 +3,6 @@ title: Transition Payroll
 order: 7
 ---
 
-## Overview
-
 The Transition Payroll workflow handles payrolls that cover gaps between old and new pay schedules. When a company changes its pay schedule, there may be workdays that fall between the end of the old schedule and the start of the new one. Transition payrolls ensure employees are paid for those days.
 
 The SDK provides a flow component and an integrated alert for transition payrolls:


### PR DESCRIPTION
## Summary
- Restructured the Workflows sidebar section into an always-open group with four dropdown subsections (Companies, Employees, Contractors, Payroll).
- Reworked sidebar active/hover styling: only the actual current page highlights as coral; collapsible dropdown parents (with or without their own page) follow suit; non-collapsible categories highlight only when their own page is current.
- Added a coral vertical-line indicator next to active items inside nested lists, sized and offset to overlap the existing gray group line.
- Removed all sidebar hover backgrounds; nested labels and leaves go gray by default and brighten on hover, with no background.
- Made dropdown chevrons thinner and switched them to coral when their parent is active.

## Test plan
- [ ] Run `npm --prefix docs-site start` and verify each section in the sidebar.
- [ ] Confirm only the current page shows coral; parents only highlight when applicable.
- [ ] Verify dropdown indicators (vertical lines, chevrons) behave correctly across collapsible and non-collapsible groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)