### PR TITLE
feat(docs-site): docs search as a centered modal

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -33,6 +33,8 @@ const config: Config = {
         indexBlog: false,
         docsRouteBasePath: '/docs',
         docsDir: '../docs',
+        searchBarShortcut: false,
+        searchBarShortcutHint: false,
       },
     ],
   ],

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -256,7 +256,6 @@ html {
   transform: translateY(1.5px);
 }
 
-
 /* ── Sidebar ── */
 
 aside.theme-doc-sidebar-container {

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -237,24 +237,6 @@ html {
   .navbar__link.navbarGithub {
     display: none;
   }
-
-  .navbar__search-input:not(:focus) {
-    width: 2rem;
-    height: 2rem;
-    padding: 0;
-    background-position: center;
-    color: transparent;
-    cursor: pointer;
-  }
-
-  .navbar__search-input:not(:focus)::placeholder {
-    color: transparent;
-  }
-
-  .navbar:has(.navbar__search-input:focus) .navbar__logo,
-  .navbar:has(.navbar__search-input:focus) .navbar__title {
-    display: none;
-  }
 }
 
 .navbar__link,
@@ -274,109 +256,6 @@ html {
   transform: translateY(1.5px);
 }
 
-.navbar__search-input {
-  width: 14rem;
-  height: 2.25rem;
-  padding-left: 2.5rem;
-  padding-right: 4rem;
-  border-radius: 10px;
-  border: 1px solid rgba(27, 27, 29, 0.1);
-  background-position: 0.85rem center;
-  background-size: 16px 16px;
-  font-size: 0.875rem;
-  font-weight: 400;
-  transition:
-    background-color 0.15s ease,
-    border-color 0.15s ease,
-    box-shadow 0.15s ease;
-}
-
-[data-theme='dark'] .navbar__search-input {
-  border-color: #ffffff1a;
-}
-
-.navbar__search-input:hover {
-  background-color: rgba(27, 27, 29, 0.06);
-  border-color: rgba(27, 27, 29, 0.16);
-}
-
-[data-theme='dark'] .navbar__search-input:hover {
-  background-color: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.18);
-}
-
-.navbar__search-input:focus {
-  background-color: rgba(27, 27, 29, 0.02);
-  border-color: var(--ifm-color-primary);
-  box-shadow: 0 0 0 3px rgba(241, 94, 73, 0.15);
-}
-
-[data-theme='dark'] .navbar__search-input:focus {
-  background-color: rgba(255, 255, 255, 0.06);
-  border-color: var(--ifm-color-primary);
-  box-shadow: 0 0 0 3px rgba(241, 94, 73, 0.18);
-}
-
-.navbar__search div:has(> kbd) {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.2rem;
-  padding: 0.15rem 0.5rem;
-  background: rgba(27, 27, 29, 0.05);
-  border: 1px solid rgba(27, 27, 29, 0.1);
-  border-radius: 6px;
-  height: auto;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
-[data-theme='dark'] .navbar__search div:has(> kbd) {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(255, 255, 255, 0.14);
-}
-
-.navbar__search kbd {
-  display: inline-flex;
-  align-items: center;
-  min-width: 0;
-  height: auto;
-  padding: 0;
-  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, Consolas, monospace;
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: rgba(82, 88, 96, 0.9);
-  background: transparent;
-  border: none;
-  border-radius: 0;
-  box-shadow: none;
-}
-
-.navbar__search kbd:first-child {
-  font-size: 0.95rem;
-  line-height: 1;
-  font-weight: 500;
-  transform: translateY(0.04em);
-}
-
-[data-theme='dark'] .navbar__search kbd {
-  color: rgba(255, 255, 255, 0.78);
-}
-
-@media (max-width: 1200px) {
-  .navbar__search div:has(> kbd) {
-    display: none;
-  }
-}
-
-@media (hover: none) and (pointer: coarse) {
-  .navbar__search div:has(> kbd) {
-    display: none;
-  }
-
-  .navbar__search-input {
-    padding-right: 1rem;
-  }
-}
 
 /* ── Sidebar ── */
 

--- a/docs-site/src/theme/SearchBar/easyops-search-bar.d.ts
+++ b/docs-site/src/theme/SearchBar/easyops-search-bar.d.ts
@@ -1,0 +1,5 @@
+declare module '@easyops-cn/docusaurus-search-local/dist/client/client/theme/SearchBar' {
+  import type { ComponentType } from 'react'
+  const SearchBar: ComponentType
+  export default SearchBar
+}

--- a/docs-site/src/theme/SearchBar/index.tsx
+++ b/docs-site/src/theme/SearchBar/index.tsx
@@ -1,0 +1,186 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { useLocation } from '@docusaurus/router'
+import useIsBrowser from '@docusaurus/useIsBrowser'
+import OriginalSearchBar from '@easyops-cn/docusaurus-search-local/dist/client/client/theme/SearchBar'
+import styles from './styles.module.css'
+
+function SearchIcon({ className, size = 16 }: { className?: string; size?: number }): ReactNode {
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  )
+}
+
+const SearchTrigger = ({
+  onClick,
+  triggerRef,
+}: {
+  onClick: () => void
+  triggerRef: React.Ref<HTMLButtonElement>
+}): ReactNode => (
+  <button
+    ref={triggerRef}
+    type="button"
+    className={styles.searchTrigger}
+    onClick={onClick}
+    aria-label="Search docs"
+  >
+    <SearchIcon className={styles.searchTriggerIcon} />
+    <span className={styles.searchTriggerText}>Search docs</span>
+    <span className={styles.searchTriggerKbd}>
+      <kbd>⌘</kbd>
+      <kbd>K</kbd>
+    </span>
+  </button>
+)
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+export default function SearchBar(): ReactNode {
+  const isBrowser = useIsBrowser()
+  const [isOpen, setIsOpen] = useState(false)
+  const modalRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const location = useLocation()
+
+  const open = useCallback(() => setIsOpen(true), [])
+  const close = useCallback(() => setIsOpen(false), [])
+
+  useEffect(() => {
+    if (!isBrowser) return
+    const handleKey = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault()
+        setIsOpen(prev => !prev)
+      } else if (event.key === 'Escape') {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [isBrowser])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const trapTab = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return
+      const modal = modalRef.current
+      if (!modal) return
+      const focusable = modal.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      if (focusable.length === 0) return
+      const first = focusable[0]!
+      const last = focusable[focusable.length - 1]!
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('keydown', trapTab)
+    return () => document.removeEventListener('keydown', trapTab)
+  }, [isOpen])
+
+  const wasOpenRef = useRef(false)
+  useEffect(() => {
+    if (!isOpen && wasOpenRef.current) {
+      triggerRef.current?.focus()
+    }
+    wasOpenRef.current = isOpen
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const id = window.requestAnimationFrame(() => {
+      const input = modalRef.current?.querySelector<HTMLInputElement>('input.navbar__search-input')
+      input?.focus()
+    })
+    return () => window.cancelAnimationFrame(id)
+  }, [isOpen])
+
+  useEffect(() => {
+    setIsOpen(false)
+  }, [location.pathname, location.search, location.hash])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const { body } = document
+    const previousOverflow = body.style.overflow
+    body.style.overflow = 'hidden'
+    return () => {
+      body.style.overflow = previousOverflow
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleVisibility = () => {
+      if (document.visibilityState !== 'visible') return
+      const input = modalRef.current?.querySelector<HTMLInputElement>('input.navbar__search-input')
+      input?.focus()
+    }
+    document.addEventListener('visibilitychange', handleVisibility)
+    window.addEventListener('focus', handleVisibility)
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility)
+      window.removeEventListener('focus', handleVisibility)
+    }
+  }, [isOpen])
+
+  return (
+    <>
+      <SearchTrigger onClick={open} triggerRef={triggerRef} />
+      {isBrowser &&
+        isOpen &&
+        createPortal(
+          <div className={styles.searchModalBackdrop} onClick={close} role="presentation">
+            <div
+              ref={modalRef}
+              className={styles.searchModal}
+              role="dialog"
+              aria-modal="true"
+              aria-label="Search docs"
+              onClick={event => event.stopPropagation()}
+            >
+              <div className={styles.searchInputArea}>
+                <SearchIcon className={styles.searchInputIcon} size={20} />
+                <OriginalSearchBar />
+                <button
+                  type="button"
+                  className={styles.searchEscChip}
+                  onClick={close}
+                  aria-label="Close search"
+                >
+                  <kbd>esc</kbd>
+                </button>
+              </div>
+              <div className={styles.searchEmptyState}>
+                <SearchIcon className={styles.searchEmptyIcon} size={32} />
+                <p className={styles.searchEmptyTitle}>Start typing to search</p>
+                <p className={styles.searchEmptyHint}>
+                  Look up components, hooks, guides, and more.
+                </p>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
+  )
+}

--- a/docs-site/src/theme/SearchBar/styles.module.css
+++ b/docs-site/src/theme/SearchBar/styles.module.css
@@ -1,0 +1,468 @@
+.searchTrigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 2.25rem;
+  width: 14rem;
+  padding: 0 0.5rem 0 0.85rem;
+  background-color: var(--ifm-navbar-search-input-background-color);
+  color: var(--ifm-navbar-search-input-placeholder-color);
+  border: 1px solid rgba(27, 27, 29, 0.1);
+  border-radius: 10px;
+  font: inherit;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+[data-theme='dark'] .searchTrigger {
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.searchTrigger:hover {
+  background-color: rgba(27, 27, 29, 0.06);
+  border-color: rgba(27, 27, 29, 0.16);
+}
+
+[data-theme='dark'] .searchTrigger:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.searchTriggerIcon {
+  flex-shrink: 0;
+  opacity: 0.75;
+}
+
+.searchTriggerText {
+  flex: 1;
+  text-align: left;
+}
+
+.searchTriggerKbd {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.15rem 0.5rem;
+  background: rgba(27, 27, 29, 0.05);
+  border: 1px solid rgba(27, 27, 29, 0.1);
+  border-radius: 6px;
+}
+
+[data-theme='dark'] .searchTriggerKbd {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.searchTriggerKbd kbd {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, Consolas, monospace;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: rgba(82, 88, 96, 0.9);
+}
+
+.searchTriggerKbd kbd:first-child {
+  font-size: 0.95rem;
+  line-height: 1;
+  font-weight: 500;
+  transform: translateY(0.04em);
+}
+
+[data-theme='dark'] .searchTriggerKbd kbd {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+@media (max-width: 1200px) {
+  .searchTriggerKbd {
+    display: none;
+  }
+}
+
+@media (max-width: 996px) {
+  .searchTriggerText {
+    display: none;
+  }
+
+  .searchTrigger {
+    width: 2.25rem;
+    padding: 0;
+    justify-content: center;
+  }
+}
+
+.searchModalBackdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 1000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 12vh 1rem 1rem;
+  animation: searchBackdropFadeIn 0.15s ease;
+}
+
+@keyframes searchBackdropFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .searchModalBackdrop,
+  .searchModal {
+    animation: none;
+  }
+}
+
+.searchModal {
+  width: 100%;
+  max-width: 640px;
+  padding: 1.25rem 1.25rem 0;
+  background-color: #ffffff;
+  border: 1px solid rgba(27, 27, 29, 0.08);
+  border-radius: 14px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.18);
+  animation: searchModalScaleIn 0.18s ease;
+
+  --search-local-modal-width: 100%;
+  --search-local-modal-width-sm: 100%;
+  --search-local-modal-background: transparent;
+  --search-local-modal-shadow: none;
+  --search-local-spacing: 0px;
+  --search-local-hit-background: rgba(27, 27, 29, 0.04);
+  --search-local-hit-shadow: none;
+}
+
+[data-theme='dark'] .searchModal {
+  background-color: #18181a;
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
+
+  --search-local-hit-background: rgba(255, 255, 255, 0.04);
+}
+
+@keyframes searchModalScaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.searchInputArea {
+  position: relative;
+  margin: -1.25rem -1.25rem 0;
+}
+
+.searchInputIcon {
+  position: absolute;
+  left: 1.25rem;
+  top: 1.75rem;
+  transform: translateY(-50%);
+  opacity: 0.5;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.searchModal :global(.navbar__search) {
+  display: block;
+  margin: 0;
+  width: 100%;
+  position: relative;
+}
+
+.searchModal :global(.navbar__search-input) {
+  width: 100%;
+  height: 3.5rem;
+  font-size: 1rem;
+  padding: 0 4rem 0 3rem;
+  background: none;
+  background-image: none;
+  border: none;
+  border-bottom: 1px solid var(--ifm-hr-background-color);
+  border-radius: 0;
+}
+
+.searchEscChip {
+  position: absolute;
+  top: 1.75rem;
+  right: 1.25rem;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.55rem;
+  background: rgba(27, 27, 29, 0.05);
+  border: 1px solid rgba(27, 27, 29, 0.1);
+  border-radius: 6px;
+  cursor: pointer;
+  z-index: 1;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+[data-theme='dark'] .searchEscChip {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.searchEscChip:hover {
+  background: rgba(27, 27, 29, 0.09);
+  border-color: rgba(27, 27, 29, 0.16);
+}
+
+[data-theme='dark'] .searchEscChip:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.searchEscChip kbd {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, Consolas, monospace;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: rgba(82, 88, 96, 0.9);
+  text-transform: lowercase;
+}
+
+[data-theme='dark'] .searchEscChip kbd {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.searchModal :global(.navbar__search-input):focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.searchModal :global([class*='searchHintContainer_']) {
+  display: none;
+}
+
+.searchModal :global([class*='searchBar_']) {
+  display: block !important;
+  width: 100% !important;
+}
+
+.searchModal :global([class*='dropdownMenu_']) {
+  position: static !important;
+  width: 100% !important;
+  margin-top: 0;
+  padding: 1.5rem 1.5rem;
+  background: transparent;
+  box-shadow: none;
+}
+
+.searchModal :global([class*='suggestion_']) {
+  padding: 0 1rem !important;
+  margin-bottom: 0.5rem !important;
+}
+
+.searchModal :global([class*='suggestion_']:last-child) {
+  margin-bottom: 0 !important;
+}
+
+.searchModal :global([class*='hitIcon_']) svg,
+.searchModal :global([class*='hitAction_']) svg {
+  display: none;
+}
+
+.searchModal :global([class*='hitIcon_']),
+.searchModal :global([class*='hitAction_']) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+}
+
+.searchModal :global([class*='hitIcon_'])::before,
+.searchModal :global([class*='hitAction_'])::before {
+  content: '';
+  display: block;
+  width: 18px;
+  height: 18px;
+  background-color: currentColor;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+}
+
+.searchModal :global([class*='hitIcon_'])::before {
+  -webkit-mask-image: url("data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z'/><path d='M14 2v6h6'/><path d='M16 13H8'/><path d='M16 17H8'/><path d='M10 9H8'/></svg>");
+  mask-image: url("data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z'/><path d='M14 2v6h6'/><path d='M16 13H8'/><path d='M16 17H8'/><path d='M10 9H8'/></svg>");
+}
+
+.searchModal :global([class*='hitIcon_']:has(path[d^='M13 13']))::before {
+  -webkit-mask-image: url("data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><line x1='4' x2='20' y1='9' y2='9'/><line x1='4' x2='20' y1='15' y2='15'/><line x1='10' x2='8' y1='3' y2='21'/><line x1='16' x2='14' y1='3' y2='21'/></svg>");
+  mask-image: url("data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><line x1='4' x2='20' y1='9' y2='9'/><line x1='4' x2='20' y1='15' y2='15'/><line x1='10' x2='8' y1='3' y2='21'/><line x1='16' x2='14' y1='3' y2='21'/></svg>");
+}
+
+.searchModal :global([class*='hitIcon_']:has(path[d^='M17 5H3']))::before {
+  -webkit-mask-image: url("data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><line x1='17' x2='3' y1='6' y2='6'/><line x1='21' x2='3' y1='12' y2='12'/><line x1='17' x2='3' y1='18' y2='18'/></svg>");
+  mask-image: url("data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><line x1='17' x2='3' y1='6' y2='6'/><line x1='21' x2='3' y1='12' y2='12'/><line x1='17' x2='3' y1='18' y2='18'/></svg>");
+}
+
+.searchModal :global([class*='hitAction_'])::before {
+  -webkit-mask-image: url("data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='9 10 4 15 9 20'/><path d='M20 4v7a4 4 0 0 1-4 4H4'/></svg>");
+  mask-image: url("data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='9 10 4 15 9 20'/><path d='M20 4v7a4 4 0 0 1-4 4H4'/></svg>");
+}
+
+.searchModal :global([class*='noResults_']) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 3rem 1.25rem;
+  gap: 0.5rem;
+  color: rgba(27, 27, 29, 0.75);
+}
+
+[data-theme='dark'] .searchModal :global([class*='noResults_']) {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.searchModal :global([class*='noResultsIcon_']) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin-bottom: 0.25rem;
+  opacity: 0.5;
+}
+
+.searchModal :global([class*='noResultsIcon_']) svg {
+  display: none;
+}
+
+.searchModal :global([class*='noResultsIcon_'])::before {
+  content: '';
+  display: block;
+  width: 32px;
+  height: 32px;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m13.5 8.5-5 5'/><path d='m8.5 8.5 5 5'/><circle cx='11' cy='11' r='8'/><path d='m21 21-4.3-4.3'/></svg>")
+    no-repeat center / contain;
+  mask: url("data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m13.5 8.5-5 5'/><path d='m8.5 8.5 5 5'/><circle cx='11' cy='11' r='8'/><path d='m21 21-4.3-4.3'/></svg>")
+    no-repeat center / contain;
+}
+
+.searchModal :global([class*='hitFooter_']) {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.searchModal :global([class*='hitFooter_']) a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  background: rgba(27, 27, 29, 0.04);
+  border: 1px solid rgba(27, 27, 29, 0.1);
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: rgba(27, 27, 29, 0.8);
+  text-decoration: none;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+[data-theme='dark'] .searchModal :global([class*='hitFooter_']) a {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.searchModal :global([class*='hitFooter_']) a:hover {
+  background: rgba(27, 27, 29, 0.07);
+  border-color: rgba(27, 27, 29, 0.16);
+  color: #1b1b1d;
+  text-decoration: none;
+}
+
+[data-theme='dark'] .searchModal :global([class*='hitFooter_']) a:hover {
+  background: rgba(255, 255, 255, 0.09);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+}
+
+.searchModal :global([class*='hitFooter_']) a::after {
+  content: '';
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M5 12h14'/><path d='m12 5 7 7-7 7'/></svg>")
+    no-repeat center / contain;
+  mask: url("data:image/svg+xml;utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M5 12h14'/><path d='m12 5 7 7-7 7'/></svg>")
+    no-repeat center / contain;
+}
+
+.searchEmptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 3rem 1.25rem;
+  gap: 0.5rem;
+}
+
+.searchModal:has(:global(.navbar__search-input):not(:placeholder-shown)) .searchEmptyState {
+  display: none;
+}
+
+.searchEmptyIcon {
+  opacity: 0.35;
+  margin-bottom: 0.25rem;
+}
+
+.searchEmptyTitle {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(27, 27, 29, 0.75);
+}
+
+[data-theme='dark'] .searchEmptyTitle {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.searchEmptyHint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(27, 27, 29, 0.5);
+}
+
+[data-theme='dark'] .searchEmptyHint {
+  color: rgba(255, 255, 255, 0.5);
+}


### PR DESCRIPTION
## Summary

- Swizzles `@easyops-cn/docusaurus-search-local`'s `SearchBar` and replaces the inline navbar input with a click-or-`⌘K` triggered centered modal (Tailwind/DocSearch style)
- Reuses the plugin's local search index — no new dependency, no API key, works offline
- Modern lucide-style icons across results, no-results, "See all results" button, and empty state
- Accessibility: focus trap inside the modal, focus restoration to trigger on close, body scroll lock while open, `prefers-reduced-motion`, `aria-modal` + `aria-label`, keyboard nav via the underlying autocomplete

## Test plan

- [ ] Click navbar search button → modal opens centered with backdrop
- [ ] `⌘K` / `Ctrl+K` toggles the modal
- [ ] Empty state shows when input is blank
- [ ] Results populate as you type and are clickable
- [ ] "No results" state shows with modern icon when query has no matches
- [ ] "See all results" footer button styled as a real button with arrow
- [ ] `esc` chip on the right of the input closes the modal
- [ ] Backdrop click closes the modal
- [ ] `Esc` key closes the modal
- [ ] Focus returns to navbar trigger after close
- [ ] `Tab` / `Shift+Tab` stays inside the modal while open
- [ ] Light and dark themes both render correctly
- [ ] Mobile / narrow viewport collapses the trigger to icon-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)