### PR TITLE
feat(docs-site): restyle code blocks with icon-typed title bar

### DIFF
--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -541,7 +541,6 @@ pre code,
   word-break: break-word;
 }
 
-
 [data-theme='dark'] code {
   background-color: rgba(255, 255, 255, 0.13);
 }

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -485,19 +485,41 @@ aside.theme-doc-sidebar-container {
 
 .prism-code {
   font-size: 0.85rem;
-  border-radius: 8px;
+  background-color: #f7f7f8 !important;
 }
 
-div[class^='codeBlockContainer'] {
+[data-theme='dark'] .prism-code {
+  background-color: #0c0c0d !important;
+}
+
+div[class*='codeBlockContainer'] {
   border-radius: 8px;
   overflow: hidden;
   border: 1px solid #e5e7eb;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  box-shadow: none;
+  background: transparent;
 }
 
-[data-theme='dark'] div[class^='codeBlockContainer'] {
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
-  border: 1px solid #3a3a3d;
+[data-theme='dark'] div[class*='codeBlockContainer'] {
+  border-color: #3a3a3d;
+}
+
+div[class*='codeBlockContent'],
+div[class*='codeBlock_'],
+.prism-code {
+  border-radius: 0 !important;
+}
+
+div[class*='codeBlockTitle'] {
+  background: transparent;
+  border-bottom: 1px solid #e5e7eb;
+  color: rgba(27, 27, 29, 0.75);
+  font-weight: 500;
+}
+
+[data-theme='dark'] div[class*='codeBlockTitle'] {
+  border-bottom-color: #3a3a3d;
+  color: rgba(255, 255, 255, 0.75);
 }
 
 code {
@@ -506,8 +528,27 @@ code {
   font-size: 0.875em;
 }
 
+pre code,
+.prism-code code {
+  border-radius: 0;
+  background: none;
+}
+
+.prism-code,
+.prism-code code,
+[class*='codeBlockLines'] {
+  white-space: pre-wrap !important;
+  word-break: break-word;
+}
+
+
 [data-theme='dark'] code {
   background-color: rgba(255, 255, 255, 0.13);
+}
+
+[data-theme='dark'] pre code,
+[data-theme='dark'] .prism-code code {
+  background-color: transparent;
 }
 
 /* ── Table of contents (right sidebar) ── */

--- a/docs-site/src/theme/CodeBlock/Buttons/index.tsx
+++ b/docs-site/src/theme/CodeBlock/Buttons/index.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import clsx from 'clsx'
 import BrowserOnly from '@docusaurus/BrowserOnly'
 import CopyButton from '@theme/CodeBlock/Buttons/CopyButton'
-import styles from '@theme/CodeBlock/Buttons/styles.module.css'
+import styles from './styles.module.css'
 
 export default function CodeBlockButtons({ className }: { className?: string }): ReactNode {
   return (

--- a/docs-site/src/theme/CodeBlock/Buttons/index.tsx
+++ b/docs-site/src/theme/CodeBlock/Buttons/index.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react'
+import clsx from 'clsx'
+import BrowserOnly from '@docusaurus/BrowserOnly'
+import CopyButton from '@theme/CodeBlock/Buttons/CopyButton'
+import styles from '@theme/CodeBlock/Buttons/styles.module.css'
+
+export default function CodeBlockButtons({ className }: { className?: string }): ReactNode {
+  return (
+    <BrowserOnly>
+      {() => (
+        <div className={clsx(className, styles.buttonGroup)}>
+          <CopyButton />
+        </div>
+      )}
+    </BrowserOnly>
+  )
+}

--- a/docs-site/src/theme/CodeBlock/Buttons/styles.module.css
+++ b/docs-site/src/theme/CodeBlock/Buttons/styles.module.css
@@ -1,0 +1,30 @@
+.buttonGroup {
+  display: flex;
+  column-gap: 0.2rem;
+  position: absolute;
+  /* rtl:ignore */
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+}
+
+.buttonGroup button {
+  display: flex;
+  align-items: center;
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 0.4rem;
+  line-height: 0;
+  transition: opacity var(--ifm-transition-fast) ease-in-out;
+  opacity: 0;
+}
+
+.buttonGroup button:focus-visible,
+.buttonGroup button:hover {
+  opacity: 1 !important;
+}
+
+:global(.theme-code-block:hover) .buttonGroup button {
+  opacity: 0.4;
+}

--- a/docs-site/src/theme/CodeBlock/Layout/index.tsx
+++ b/docs-site/src/theme/CodeBlock/Layout/index.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react'
+import clsx from 'clsx'
+import { useCodeBlockContext } from '@docusaurus/theme-common/internal'
+import Container from '@theme/CodeBlock/Container'
+import Title from '@theme/CodeBlock/Title'
+import Content from '@theme/CodeBlock/Content'
+import Buttons from '@theme/CodeBlock/Buttons'
+import styles from './styles.module.css'
+
+export default function CodeBlockLayout({ className }: { className?: string }): ReactNode {
+  const { metadata } = useCodeBlockContext()
+  const hasTitle = Boolean(metadata.title)
+
+  return (
+    // @ts-expect-error - Container is polymorphic and not fully typed
+    <Container as="div" className={clsx(className, metadata.className)}>
+      {hasTitle && (
+        <div className={styles.codeBlockTitle}>
+          <Title>{metadata.title}</Title>
+          <Buttons />
+        </div>
+      )}
+      <div className={styles.codeBlockContent}>
+        <Content />
+        {!hasTitle && <Buttons />}
+      </div>
+    </Container>
+  )
+}

--- a/docs-site/src/theme/CodeBlock/Layout/styles.module.css
+++ b/docs-site/src/theme/CodeBlock/Layout/styles.module.css
@@ -1,0 +1,41 @@
+.codeBlockTitle {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem var(--ifm-pre-padding);
+  font-size: var(--ifm-code-font-size);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+
+.codeBlockContent {
+  position: relative;
+  direction: ltr;
+  border-radius: inherit;
+}
+
+.codeBlockTitle :global([class*='buttonGroup_']) {
+  position: static;
+}
+
+.codeBlockTitle :global([class*='buttonGroup_']) button {
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: inherit;
+  opacity: 0.6;
+  padding: 0.5rem 0.6rem;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.codeBlockTitle :global([class*='buttonGroup_']) button:hover {
+  background: rgba(27, 27, 29, 0.08);
+  opacity: 1;
+}
+
+[data-theme='dark'] .codeBlockTitle :global([class*='buttonGroup_']) button:hover {
+  background: rgba(255, 255, 255, 0.1);
+}

--- a/docs-site/src/theme/CodeBlock/Title/index.tsx
+++ b/docs-site/src/theme/CodeBlock/Title/index.tsx
@@ -1,0 +1,194 @@
+import type { ReactNode } from 'react'
+import { useCodeBlockContext } from '@docusaurus/theme-common/internal'
+import styles from './styles.module.css'
+
+type IconProps = { className?: string }
+
+function TerminalIcon({ className }: IconProps): ReactNode {
+  return (
+    <svg
+      className={className}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="4 17 10 11 4 5" />
+      <line x1="12" x2="20" y1="19" y2="19" />
+    </svg>
+  )
+}
+
+function CodeIcon({ className }: IconProps): ReactNode {
+  return (
+    <svg
+      className={className}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="16 18 22 12 16 6" />
+      <polyline points="8 6 2 12 8 18" />
+    </svg>
+  )
+}
+
+function PaletteIcon({ className }: IconProps): ReactNode {
+  return (
+    <svg
+      className={className}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
+      <circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
+      <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
+      <circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
+      <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
+    </svg>
+  )
+}
+
+function BracesIcon({ className }: IconProps): ReactNode {
+  return (
+    <svg
+      className={className}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5a2 2 0 0 0 2 2h1" />
+      <path d="M16 21h1a2 2 0 0 0 2-2v-5a2 2 0 0 1 2-2 2 2 0 0 1-2-2V5a2 2 0 0 0-2-2h-1" />
+    </svg>
+  )
+}
+
+function FileTextIcon({ className }: IconProps): ReactNode {
+  return (
+    <svg
+      className={className}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <path d="M14 2v6h6" />
+      <path d="M16 13H8" />
+      <path d="M16 17H8" />
+      <path d="M10 9H8" />
+    </svg>
+  )
+}
+
+function FileIcon({ className }: IconProps): ReactNode {
+  return (
+    <svg
+      className={className}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <path d="M14 2v6h6" />
+    </svg>
+  )
+}
+
+function pickIconByLanguage(language: string): ReactNode | null {
+  const lang = language.toLowerCase()
+  if (/^(bash|sh|shell|zsh|console|terminal|cli)$/.test(lang)) {
+    return <TerminalIcon className={styles.titleIcon} />
+  }
+  if (/^(tsx|ts|typescript|jsx|js|mjs|cjs|javascript)$/.test(lang)) {
+    return <CodeIcon className={styles.titleIcon} />
+  }
+  if (/^(css|scss|sass|less)$/.test(lang)) {
+    return <PaletteIcon className={styles.titleIcon} />
+  }
+  if (lang === 'json') {
+    return <BracesIcon className={styles.titleIcon} />
+  }
+  if (/^(md|mdx|markdown)$/.test(lang)) {
+    return <FileTextIcon className={styles.titleIcon} />
+  }
+  if (/^(yaml|yml)$/.test(lang)) {
+    return <FileIcon className={styles.titleIcon} />
+  }
+  return null
+}
+
+function pickIconByTitle(title: string): ReactNode | null {
+  if (/\b(command line|terminal|shell)\b/i.test(title)) {
+    return <TerminalIcon className={styles.titleIcon} />
+  }
+  if (/\.(tsx?|jsx?|mjs|cjs)$/i.test(title)) {
+    return <CodeIcon className={styles.titleIcon} />
+  }
+  if (/\.(css|scss|sass|less)$/i.test(title)) {
+    return <PaletteIcon className={styles.titleIcon} />
+  }
+  if (/\.json$/i.test(title)) {
+    return <BracesIcon className={styles.titleIcon} />
+  }
+  if (/\.(md|mdx)$/i.test(title)) {
+    return <FileTextIcon className={styles.titleIcon} />
+  }
+  if (/\.ya?ml$/i.test(title)) {
+    return <FileIcon className={styles.titleIcon} />
+  }
+  if (/\//.test(title)) {
+    return <FileIcon className={styles.titleIcon} />
+  }
+  return null
+}
+
+export default function CodeBlockTitle({ children }: { children: ReactNode }): ReactNode {
+  const { metadata } = useCodeBlockContext()
+  const text = typeof children === 'string' ? children : ''
+  const icon = pickIconByTitle(text) ?? pickIconByLanguage(metadata.language ?? '')
+  if (!icon) {
+    return children
+  }
+  return (
+    <span className={styles.titleWrapper}>
+      {icon}
+      <span>{children}</span>
+    </span>
+  )
+}

--- a/docs-site/src/theme/CodeBlock/Title/styles.module.css
+++ b/docs-site/src/theme/CodeBlock/Title/styles.module.css
@@ -1,0 +1,10 @@
+.titleWrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.titleIcon {
+  flex-shrink: 0;
+  opacity: 0.7;
+}

--- a/docs/workflows-overview/company-onboarding.md
+++ b/docs/workflows-overview/company-onboarding.md
@@ -60,7 +60,7 @@ A component allowing users to choose between creating a new signatory with full 
 
 For more granular control, you can use `Company.CreateSignatory` or `Company.InviteSignatory` directly.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -93,7 +93,7 @@ function MyComponent() {
 
 A standalone form for creating a new signatory with full personal details including name, contact information, SSN, and home address. Use this component when you want to provide only the create signatory flow without the invite option.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -124,7 +124,7 @@ function MyComponent() {
 
 A standalone form for inviting someone else to become the company signatory. The invited person will receive an email to complete their signatory information. Use this component when you want to provide only the invite signatory flow without the create option.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -153,7 +153,7 @@ function MyComponent() {
 
 A component for selecting and saving the company's industry classification (NAICS code). The selector presents a searchable list of industry options for the company.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -178,7 +178,7 @@ function MyComponent() {
 
 Provides an interface for company representatives to read and sign required company documents. The component handles document listing, signatory management, and document signing workflow.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -216,7 +216,7 @@ function MyComponent() {
 
 A standalone component that displays the list of company documents to be signed and lets the user manage signatories. This is the lower-level building block used internally by `Company.DocumentSigner` for its list view. Use this component directly when you need full control over navigation between the document list and the signature form.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -246,7 +246,7 @@ function MyComponent() {
 
 A standalone form for signing an individual company document. This is the lower-level building block used internally by `Company.DocumentSigner` for its signing view. Use this component directly when you need full control over navigation between the document list and the signature form (e.g. you are routing the user yourself after they select a form from `Company.DocumentList`).
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -280,7 +280,7 @@ function MyComponent() {
 
 A component for adding company federal tax information including EIN, tax payer type, filing form, and legal name.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -309,7 +309,7 @@ function MyComponent() {
 
 A component for managing company pay schedules, including creating, editing, and viewing pay schedules with preview functionality.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -336,7 +336,7 @@ function MyComponent() {
 
 An orchestrated component for managing company addresses, including mailing and filing address. Internally uses a state machine to switch between a list view and a create/edit form. For more granular control, you can use `Company.LocationForm` directly.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -368,7 +368,7 @@ A standalone form component for creating a new company location or editing an ex
 
 Pass a `locationId` to edit an existing location; omit it to create a new location.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -402,7 +402,7 @@ function MyComponent() {
 
 A component for managing company bank account
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -432,7 +432,7 @@ function MyComponent() {
 
 An orchestrated component for managing company state taxes setup. Internally uses a state machine to switch between a list view and an edit form. For more granular control, you can use `CompanyOnboarding.StateTaxesList` or `CompanyOnboarding.StateTaxesForm` directly.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -459,7 +459,7 @@ function MyComponent() {
 
 A standalone form component for editing state tax requirements for a specific state. This is the lower-level building block used internally by `Company.StateTaxes` for its edit view. Use this component directly when you need full control over navigation between the list and form views.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -492,7 +492,7 @@ function MyComponent() {
 
 A standalone component that displays the list of state tax requirements for a company. This is the lower-level building block used internally by `Company.StateTaxes` for its list view. Use this component directly when you need full control over navigation between the list and form views.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -520,7 +520,7 @@ function MyComponent() {
 
 Displays the company's overall onboarding status. Shows completed steps and remaining requirements, providing a high-level summary of where the company is in the onboarding process. Used as the landing/summary screen of the onboarding flow.
 
-```jsx title="MyComponent.jsx"
+```jsx title="MyComponent.tsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {

--- a/docs/workflows-overview/company-onboarding.md
+++ b/docs/workflows-overview/company-onboarding.md
@@ -8,7 +8,7 @@ The Company Onboarding workflow provides components for managing company-related
 
 ### Implementation
 
-```jsx
+```jsx title="App.tsx"
 import { CompanyOnboarding } from '@gusto/embedded-react-sdk'
 
 function MyApp() {
@@ -60,7 +60,7 @@ A component allowing users to choose between creating a new signatory with full 
 
 For more granular control, you can use `Company.CreateSignatory` or `Company.InviteSignatory` directly.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -93,7 +93,7 @@ function MyComponent() {
 
 A standalone form for creating a new signatory with full personal details including name, contact information, SSN, and home address. Use this component when you want to provide only the create signatory flow without the invite option.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -124,7 +124,7 @@ function MyComponent() {
 
 A standalone form for inviting someone else to become the company signatory. The invited person will receive an email to complete their signatory information. Use this component when you want to provide only the invite signatory flow without the create option.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -153,7 +153,7 @@ function MyComponent() {
 
 A component for selecting and saving the company's industry classification (NAICS code). The selector presents a searchable list of industry options for the company.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -178,7 +178,7 @@ function MyComponent() {
 
 Provides an interface for company representatives to read and sign required company documents. The component handles document listing, signatory management, and document signing workflow.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -216,7 +216,7 @@ function MyComponent() {
 
 A standalone component that displays the list of company documents to be signed and lets the user manage signatories. This is the lower-level building block used internally by `Company.DocumentSigner` for its list view. Use this component directly when you need full control over navigation between the document list and the signature form.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -246,7 +246,7 @@ function MyComponent() {
 
 A standalone form for signing an individual company document. This is the lower-level building block used internally by `Company.DocumentSigner` for its signing view. Use this component directly when you need full control over navigation between the document list and the signature form (e.g. you are routing the user yourself after they select a form from `Company.DocumentList`).
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -280,7 +280,7 @@ function MyComponent() {
 
 A component for adding company federal tax information including EIN, tax payer type, filing form, and legal name.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -309,7 +309,7 @@ function MyComponent() {
 
 A component for managing company pay schedules, including creating, editing, and viewing pay schedules with preview functionality.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -336,7 +336,7 @@ function MyComponent() {
 
 An orchestrated component for managing company addresses, including mailing and filing address. Internally uses a state machine to switch between a list view and a create/edit form. For more granular control, you can use `Company.LocationForm` directly.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -368,7 +368,7 @@ A standalone form component for creating a new company location or editing an ex
 
 Pass a `locationId` to edit an existing location; omit it to create a new location.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -402,7 +402,7 @@ function MyComponent() {
 
 A component for managing company bank account
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -432,7 +432,7 @@ function MyComponent() {
 
 An orchestrated component for managing company state taxes setup. Internally uses a state machine to switch between a list view and an edit form. For more granular control, you can use `CompanyOnboarding.StateTaxesList` or `CompanyOnboarding.StateTaxesForm` directly.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -459,7 +459,7 @@ function MyComponent() {
 
 A standalone form component for editing state tax requirements for a specific state. This is the lower-level building block used internally by `Company.StateTaxes` for its edit view. Use this component directly when you need full control over navigation between the list and form views.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -492,7 +492,7 @@ function MyComponent() {
 
 A standalone component that displays the list of state tax requirements for a company. This is the lower-level building block used internally by `Company.StateTaxes` for its list view. Use this component directly when you need full control over navigation between the list and form views.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {
@@ -520,7 +520,7 @@ function MyComponent() {
 
 Displays the company's overall onboarding status. Shows completed steps and remaining requirements, providing a high-level summary of where the company is in the onboarding process. Used as the landing/summary screen of the onboarding flow.
 
-```jsx
+```jsx title="MyComponent.jsx"
 import { Company } from '@gusto/embedded-react-sdk'
 
 function MyComponent() {


### PR DESCRIPTION
## Summary

Swizzles `@theme/CodeBlock/{Title,Layout,Buttons}` to give code blocks a refined look that matches the rest of the docs theme.

- **Title bar with icon** — picks a lucide-style icon by language (\`tsx\`/\`bash\`/\`json\`/...) or by filename pattern in the title:
  - code: `<>` brackets (JS/TS/JSX/TSX)
  - terminal: shell prompt (bash/sh/Command line)
  - palette (CSS/SCSS)
  - braces (JSON)
  - file-text (MD/MDX)
  - file (YAML, paths with `/`)
- **Copy button moved into the title bar** as a ghost button (no bg/border by default, subtle gray on hover)
- **Word-wrap toggle removed**; lines always wrap via `white-space: pre-wrap` so users never have to discover a hover-only toggle
- **Code body background** is now a subtle off-white (light) / off-black (dark) — just barely separated from the page background
- **Container** keeps rounded corners; inner code is flush (no double-radius)
- **Inline `<code>` in prose** keeps its rounded pill; `<code>` inside `<pre>` is flush with no background of its own
- Added `title="..."` metastrings to all code blocks in `company-onboarding.md` so the new icon picker has something to render

## Test plan

- [ ] Open any docs page with code blocks (e.g. `/docs/workflows-overview/company-onboarding`)
- [ ] Verify icons render correctly for different fence languages and file extensions
- [ ] Hover a code block → copy button appears in the title bar with ghost style; hover the button → subtle gray bg
- [ ] Long lines wrap automatically — no horizontal scroll, no wrap toggle visible
- [ ] Title bar background matches the page; code body is just barely darker/lighter
- [ ] Container has a single rounded border; inner code is flush, no double-rounded artifacts
- [ ] Light and dark modes both render correctly
- [ ] Code blocks without titles still render the copy button in its original top-right position

🤖 Generated with [Claude Code](https://claude.com/claude-code)