### PR TITLE
ci: fix typedoc build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,9 @@ jobs:
       - name: Lint
         run: npm run lint:check
 
+      - name: Validate docs front matter
+        run: npm run docs:lint
+
   # Format job: Run Prettier check (parallel with other checks)
   format:
     needs: setup
@@ -171,8 +174,9 @@ jobs:
   # Docs build job: validates the Docusaurus site compiles, catching broken
   # links/anchors (onBrokenLinks: 'throw') at PR time rather than at release
   # time. Uses its own node_modules under docs-site/ — not the root cache.
+  # Mirrors the publish-docs.yaml sync job environment so a green CI build
+  # means the sync job will also pass.
   docs-build:
-    needs: setup
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -180,15 +184,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@v5
-        with:
-          path: node_modules
-          key: ${{ needs.setup.outputs.cache-key }}
-
-      - name: Validate docs front matter
-        run: npm run docs:lint
 
       - name: Install docs dependencies
         working-directory: docs-site

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,9 +88,6 @@ jobs:
       - name: Lint
         run: npm run lint:check
 
-      - name: Validate docs front matter
-        run: npm run docs:lint
-
   # Format job: Run Prettier check (parallel with other checks)
   format:
     needs: setup
@@ -174,9 +171,8 @@ jobs:
   # Docs build job: validates the Docusaurus site compiles, catching broken
   # links/anchors (onBrokenLinks: 'throw') at PR time rather than at release
   # time. Uses its own node_modules under docs-site/ — not the root cache.
-  # Mirrors the publish-docs.yaml sync job environment so a green CI build
-  # means the sync job will also pass.
   docs-build:
+    needs: setup
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -184,6 +180,15 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v5
+        with:
+          path: node_modules
+          key: ${{ needs.setup.outputs.cache-key }}
+
+      - name: Validate docs front matter
+        run: npm run docs:lint
 
       - name: Install docs dependencies
         working-directory: docs-site

--- a/docs-site/tsconfig.typedoc.json
+++ b/docs-site/tsconfig.typedoc.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "exclude": ["node_modules", "../src/**/*.test.*", "../src/**/*.spec.*"]
+  "exclude": ["node_modules", "../src/**/*.test.*", "../src/**/*.spec.*", "../.storybook/**"]
 }


### PR DESCRIPTION
## Summary

The docs sync job (`publish-docs.yaml`) was failing because TypeDoc picked up
`.storybook` files via the inherited root `tsconfig.json`. Storybook deps
(React, etc.) aren't installed in `docs-site/`, so TypeDoc's TypeScript
compilation errored on those files.

The CI `docs-build` job was accidentally passing because it restores root
`node_modules` first, making React types available and hiding the problem.

## Changes

- Exclude `../.storybook/**` from `tsconfig.typedoc.json` so TypeDoc never
  tries to compile storybook files

## Testing

Verified TypeDoc builds successfully locally:

```
cd docs-site && npm run typedoc
# → [info] markdown generated at .../docs/api
# → Found 0 errors and 126 warnings
```