### PR TITLE
ci: fix typedoc sync

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -25,8 +25,6 @@ name: Sync Docs Source
 # end-to-end before flipping the variable.
 
 on:
-  push:
-    branches: [marie/actually-fix-it]
   workflow_run:
     workflows: [Publish to NPM]
     types: [completed]
@@ -34,26 +32,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Runs on branch push to verify TypeDoc compiles before opening a PR.
-  test-typedoc:
-    if: github.event_name == 'push'
-    runs-on:
-      group: gusto-ubuntu-default
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Install SDK dependencies for TypeDoc
-        run: npm ci
-
-      - name: Generate TypeDoc markdown
-        run: cd docs-site && npm ci && npm run typedoc
-
   sync:
     # workflow_dispatch always allowed (for manual testing). workflow_run
     # only fires when DOCS_PUBLISH_ENABLED=true, so the next NPM release

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -25,17 +25,35 @@ name: Sync Docs Source
 # end-to-end before flipping the variable.
 
 on:
+  push:
+    branches: [marie/actually-fix-it]
   workflow_run:
     workflows: [Publish to NPM]
     types: [completed]
     branches: [main]
   workflow_dispatch:
 
-concurrency:
-  group: publish-docs
-  cancel-in-progress: false
-
 jobs:
+  # Runs on branch push to verify TypeDoc compiles before opening a PR.
+  test-typedoc:
+    if: github.event_name == 'push'
+    runs-on:
+      group: gusto-ubuntu-default
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install SDK dependencies for TypeDoc
+        run: npm ci
+
+      - name: Generate TypeDoc markdown
+        run: cd docs-site && npm ci && npm run typedoc
+
   sync:
     # workflow_dispatch always allowed (for manual testing). workflow_run
     # only fires when DOCS_PUBLISH_ENABLED=true, so the next NPM release
@@ -47,6 +65,9 @@ jobs:
     runs-on:
       group: gusto-ubuntu-default
     environment: publish-docs
+    concurrency:
+      group: publish-docs
+      cancel-in-progress: false
     permissions:
       contents: read
     steps:
@@ -61,6 +82,9 @@ jobs:
       - name: Read SDK version
         id: version
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Install SDK dependencies for TypeDoc
+        run: npm ci
 
       - name: Generate TypeDoc markdown
         run: cd docs-site && npm ci && npm run typedoc

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -31,6 +31,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: publish-docs
+  cancel-in-progress: false
+
 jobs:
   sync:
     # workflow_dispatch always allowed (for manual testing). workflow_run
@@ -43,9 +47,6 @@ jobs:
     runs-on:
       group: gusto-ubuntu-default
     environment: publish-docs
-    concurrency:
-      group: publish-docs
-      cancel-in-progress: false
     permissions:
       contents: read
     steps:

--- a/docs-site/tsconfig.typedoc.json
+++ b/docs-site/tsconfig.typedoc.json
@@ -1,4 +1,5 @@
 {
   "extends": "../tsconfig.json",
-  "exclude": ["node_modules", "../src/**/*.test.*", "../src/**/*.spec.*", "../.storybook/**"]
+  "include": ["../src", "../types"],
+  "exclude": ["node_modules", "../src/**/*.test.*", "../src/**/*.spec.*", "../src/**/*.stories.*"]
 }


### PR DESCRIPTION
## Summary

- **Root cause**: The sync job only ran \`cd docs-site && npm ci\`, so root \`node_modules\` was never installed. TypeDoc compiles \`../src/\` which imports \`react\`, \`react-aria\`, \`react-aria-components\`, etc. — all in root \`node_modules\` — so TypeDoc couldn't resolve SDK deps.
- **Also**: \`.stories.tsx\` files were not excluded from the TypeDoc tsconfig and have type errors from new required props added in the a11y pass.
- **Also**: The inherited \`include: [".storybook/*"]\` from the root tsconfig was pulling in storybook files; overriding \`include\` in \`tsconfig.typedoc.json\` to only \`["../src", "../types"]\` drops them cleanly.

Changes:
- \`publish-docs.yaml\`: Add \`npm ci\` at root before TypeDoc in the \`sync\` job.
- \`tsconfig.typedoc.json\`: Override \`include\` to \`["../src", "../types"]\` (removes \`.storybook/*\` inheritance). Replace \`.storybook/**\` exclude with \`*.stories.*\` exclude.

## Test plan

- [x] \`test-typedoc\` job passed on branch push: https://github.com/Gusto/embedded-react-sdk/actions/runs/27379759247/job/80913156822
- [x] Full \`sync\` job (TypeDoc + push to embedded-sdk-docs) passed via \`workflow_dispatch\` on branch: https://github.com/Gusto/embedded-react-sdk/actions/runs/27379951336/job/80913843264

🤖 Generated with [Claude Code](https://claude.com/claude-code)