### PR TITLE
feat(docs-site): restyle Markdown tables with horizontal rules

### DIFF
--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -460,12 +460,19 @@ aside.theme-doc-sidebar-container {
 
 /* ── Tables ── */
 
+.markdownTableWrapper {
+  width: 100%;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
 .markdown table {
   display: table;
   width: 100%;
+  min-width: max-content;
   border-collapse: collapse;
   font-size: 0.9rem;
-  margin: 1.5rem 0;
+  margin: 0;
 }
 
 .markdown table thead {
@@ -498,7 +505,7 @@ aside.theme-doc-sidebar-container {
   border-top: 1px solid var(--ifm-table-border-color);
   vertical-align: top;
   line-height: 1.55;
-  overflow-wrap: anywhere;
+  max-width: 28rem;
 }
 
 .markdown table th:last-child,

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -461,10 +461,8 @@ aside.theme-doc-sidebar-container {
 /* ── Tables ── */
 
 .markdown table {
-  display: block;
-  width: max-content;
-  max-width: 100%;
-  overflow-x: auto;
+  display: table;
+  width: 100%;
   border-collapse: collapse;
   font-size: 0.9rem;
   margin: 1.5rem 0;
@@ -500,6 +498,7 @@ aside.theme-doc-sidebar-container {
   border-top: 1px solid var(--ifm-table-border-color);
   vertical-align: top;
   line-height: 1.55;
+  overflow-wrap: anywhere;
 }
 
 .markdown table th:last-child,

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -461,8 +461,10 @@ aside.theme-doc-sidebar-container {
 /* ── Tables ── */
 
 .markdown table {
-  display: table;
-  width: 100%;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
   border-collapse: collapse;
   font-size: 0.9rem;
   margin: 1.5rem 0;

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -465,24 +465,48 @@ aside.theme-doc-sidebar-container {
   width: 100%;
   border-collapse: collapse;
   font-size: 0.9rem;
+  margin: 1.5rem 0;
+}
+
+.markdown table thead {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--ifm-table-border-color);
+}
+
+.markdown table thead tr {
+  background: transparent;
+  border: none;
 }
 
 .markdown table th {
-  background-color: var(--gusto-table-header-bg);
+  background: transparent;
   font-weight: 600;
   text-align: left;
-  padding: 12px 16px;
-  border: 1px solid var(--ifm-table-border-color);
+  padding: 10px 32px 10px 0;
+  border: none;
+  color: rgba(27, 27, 29, 0.6);
+}
+
+[data-theme='dark'] .markdown table th {
+  color: rgba(255, 255, 255, 0.55);
 }
 
 .markdown table td {
-  padding: 12px 16px;
-  border: 1px solid var(--ifm-table-border-color);
+  padding: 14px 32px 14px 0;
+  border: none;
+  border-top: 1px solid var(--ifm-table-border-color);
   vertical-align: top;
+  line-height: 1.55;
+}
+
+.markdown table th:last-child,
+.markdown table td:last-child {
+  padding-right: 0;
 }
 
 .markdown table tr:nth-child(even) {
-  background-color: var(--ifm-table-stripe-background);
+  background: transparent;
 }
 
 /* ── Code blocks ── */

--- a/docs-site/src/theme/MDXComponents/index.tsx
+++ b/docs-site/src/theme/MDXComponents/index.tsx
@@ -1,0 +1,13 @@
+import React, { type ComponentProps } from 'react'
+import MDXComponents from '@theme-original/MDXComponents'
+
+const Table = (props: ComponentProps<'table'>) => (
+  <div className="markdownTableWrapper">
+    <table {...props} />
+  </div>
+)
+
+export default {
+  ...MDXComponents,
+  table: Table,
+}

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -14,7 +14,7 @@ To get started with the Gusto Embedded React SDK, first install it from NPM via 
 
 In this case, installing via NPM:
 
-```
+```bash title="Command line"
 npm i @gusto/embedded-react-sdk
 ```
 
@@ -22,7 +22,7 @@ npm i @gusto/embedded-react-sdk
 
 The `GustoProvider` is used to configure the SDK at the application level. It must wrap the top-level component tree (typically at the root of the application) to ensure SDK components have access to the necessary configurations.
 
-```jsx
+```jsx title="App.tsx"
 import { GustoProvider } from '@gusto/embedded-react-sdk'
 
 function App() {


### PR DESCRIPTION
## Summary
- Replaces the bordered + zebra-striped Markdown table style with a quieter look: no cell borders, just hairlines between rows.
- Header text is muted gray (matches the muted-text treatment used elsewhere in the site) with a single hairline beneath; row text uses the default body color.
- Column gutters bumped to 32px so columns read as separate without vertical borders. First column stays flush-left with prose; last column flush-right.

Before / after applies to every Markdown table across `docs-site/docs/**`.

## Test plan
- [ ] `cd docs-site && npm run start` and visit a table-heavy page (e.g. `docs/hooks/hooks.md`).
- [ ] Confirm light mode: header reads as muted gray, no fills or vertical borders, rows separated by single hairlines.
- [ ] Toggle dark mode and confirm header gray + row hairlines stay legible.
- [ ] Open a page where a table sits next to a code block — table should read as quieter than the code block, not louder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)