### PR TITLE
fix(docs-site): remove navbar shadow and tune dark border

### DIFF
--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -107,6 +107,7 @@ html {
 
 .navbar {
   border-bottom: 1px solid #ebedf0;
+  box-shadow: none;
 }
 
 .navbar__inner {
@@ -115,7 +116,7 @@ html {
 }
 
 [data-theme='dark'] .navbar {
-  border-bottom-color: rgba(255, 255, 255, 0.06);
+  border-bottom-color: rgba(255, 255, 255, 0.12);
 }
 
 .navbar__title {


### PR DESCRIPTION
## Summary
- Removes Infima's default `box-shadow` on the docs navbar in light mode so the existing border-bottom carries the separator on its own.
- Bumps the dark-mode navbar border from `rgba(255,255,255,0.06)` to `rgba(255,255,255,0.12)` so it's actually visible against the black background.

## Test plan
- [ ] `npm run start` in `docs-site/` — confirm light mode shows a clean 1px border with no drop shadow under the navbar.
- [ ] Toggle to dark mode and confirm the navbar bottom border is subtly visible (not invisible, not heavy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)