### PR TITLE
style(docs-site): soften body copy color for heading contrast

### DIFF
--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -46,6 +46,7 @@ html {
   --gusto-table-header-bg: #eef0f2;
   --gusto-pagination-border: #ebedf0;
   --gusto-code-block-bg: #f7f7f8;
+  --gusto-body-text-color: rgba(27, 27, 29, 0.82);
 
   --docusaurus-highlighted-code-line-bg: rgba(241, 94, 73, 0.1);
 }
@@ -86,6 +87,7 @@ html {
   --gusto-table-header-bg: #2a2a2d;
   --gusto-pagination-border: #3a3a3d;
   --gusto-code-block-bg: #2a2a2d;
+  --gusto-body-text-color: rgba(255, 255, 255, 0.72);
 
   --docusaurus-highlighted-code-line-bg: rgba(241, 94, 73, 0.15);
 }
@@ -457,6 +459,18 @@ aside.theme-doc-sidebar-container {
 
 .markdown > p {
   line-height: 1.7;
+}
+
+.markdown p,
+.markdown li {
+  color: var(--gusto-body-text-color);
+}
+
+.markdown table p,
+.markdown table li,
+.markdown blockquote p,
+.markdown blockquote li {
+  color: inherit;
 }
 
 /* ── Tables ── */


### PR DESCRIPTION
## Summary
- Adds a `--gusto-body-text-color` variable (light and dark mode) and applies it to markdown paragraphs and list items so body copy contrasts with headings
- Table cells and blockquote contents keep the default text color via an `inherit` reset

## Test plan
- [ ] Visit the docs site and verify body copy reads as a subtle gray against the headings in light mode
- [ ] Switch to dark mode and confirm body copy remains readable
- [ ] Confirm table cell text and blockquote text are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)