### PR TITLE
fix(docs-site): mobile search improvements and dropdown persistence

### DIFF
--- a/docs-site/src/theme/SearchBar/index.tsx
+++ b/docs-site/src/theme/SearchBar/index.tsx
@@ -143,6 +143,24 @@ export default function SearchBar(): ReactNode {
     }
   }, [isOpen])
 
+  // The underlying autocomplete library closes and empties its dropdown on
+  // input blur. When the OS moves focus to another app (e.g. Terminal), the
+  // input blurs and the results vanish. Block the blur event from reaching the
+  // library's handler whenever the document itself is losing focus — the user
+  // blur (clicking elsewhere in the page) still closes as expected.
+  useEffect(() => {
+    if (!isOpen) return
+    const blockBlurOnWindowSwitch = (event: FocusEvent) => {
+      const target = event.target as HTMLElement | null
+      if (!target?.matches('input.navbar__search-input')) return
+      if (document.hasFocus()) return
+      event.stopImmediatePropagation()
+      event.stopPropagation()
+    }
+    document.addEventListener('blur', blockBlurOnWindowSwitch, true)
+    return () => document.removeEventListener('blur', blockBlurOnWindowSwitch, true)
+  }, [isOpen])
+
   return (
     <>
       <SearchTrigger onClick={open} triggerRef={triggerRef} />

--- a/docs-site/src/theme/SearchBar/styles.module.css
+++ b/docs-site/src/theme/SearchBar/styles.module.css
@@ -106,9 +106,9 @@
   -webkit-backdrop-filter: blur(4px);
   z-index: 1000;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
-  padding: 12vh 1rem 1rem;
+  padding: 1rem;
   animation: searchBackdropFadeIn 0.15s ease;
 }
 
@@ -131,12 +131,17 @@
 .searchModal {
   width: 100%;
   max-width: 640px;
+  max-height: 100%;
+  min-height: 0;
   padding: 1.25rem 1.25rem 0;
   background-color: #ffffff;
   border: 1px solid rgba(27, 27, 29, 0.08);
   border-radius: 14px;
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.18);
   animation: searchModalScaleIn 0.18s ease;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 
   --search-local-modal-width: 100%;
   --search-local-modal-width-sm: 100%;
@@ -169,6 +174,10 @@
 .searchInputArea {
   position: relative;
   margin: -1.25rem -1.25rem 0;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .searchInputIcon {
@@ -182,10 +191,13 @@
 }
 
 .searchModal :global(.navbar__search) {
-  display: block;
+  display: flex;
+  flex-direction: column;
   margin: 0;
   width: 100%;
   position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .searchModal :global(.navbar__search-input) {
@@ -198,6 +210,7 @@
   border: none;
   border-bottom: 1px solid var(--ifm-hr-background-color);
   border-radius: 0;
+  flex-shrink: 0;
 }
 
 .searchEscChip {
@@ -260,8 +273,11 @@
 }
 
 .searchModal :global([class*='searchBar_']) {
-  display: block !important;
+  display: flex !important;
+  flex-direction: column;
   width: 100% !important;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .searchModal :global([class*='dropdownMenu_']) {
@@ -271,6 +287,9 @@
   padding: 1.5rem 1.5rem;
   background: transparent;
   box-shadow: none;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .searchModal :global([class*='suggestion_']) {


### PR DESCRIPTION
## Summary
- Center the search modal vertically and constrain its height to the backdrop's available area so the results scroll inside the modal instead of overflowing the viewport on short / mobile screens.
- Keep the search input pinned while the dropdown becomes the scrollable region via flex layout.
- Block blur events from reaching the underlying autocomplete library when the OS window loses focus, so results stay visible (and populated) when alt-tabbing to another app.

## Test plan
- [ ] Open search on a small / mobile viewport, type a query that returns many results — modal stays centered and only the results region scrolls.
- [ ] Resize browser window to a short height while modal is open — modal stays bounded.
- [ ] Open search with results visible, then alt-tab to Terminal or another app — results remain visible behind the browser.
- [ ] Return to the browser window — input is focused, results unchanged.
- [ ] Click outside the input but still inside the page — dropdown closes as before (user-driven blur still works).
- [ ] Press Esc / click the backdrop — modal closes normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)