### PR TITLE
docs: refresh "What is the GEP React SDK?" landing page

### DIFF
--- a/docs/what-is-the-gep-react-sdk.md
+++ b/docs/what-is-the-gep-react-sdk.md
@@ -8,14 +8,30 @@ order: 0
 
 ## Introduction
 
-The Gusto Embedded Payroll React SDK offers component libraries with built-in business logic that helps our developers with the complexity of building with payroll APIs. The SDK represents a deeply customizable and yet quick-to-deploy option that complements our existing iframes components (“Flows”) and our underlying APIs. While the latter two methods are still valuable tools (and can be used in conjunction with each other or the SDK), the SDK was built in order to add another compelling option in the spectrum between customization and build velocity that partners may face in establishing a full-fledged payroll application.
+The Gusto Embedded Payroll React SDK is a React component library for building embedded payroll experiences on top of the Gusto Embedded API. It offers three levels of abstraction — workflows, sub-components, and hooks — so you can choose the right balance of speed and customization for each part of your application.
 
-## Benefits of the SDK
+## What you get
 
-Below are three demo videos that help illustrate the capabilities of our SDK components:
+- **Workflows** — embed a complete multi-step payroll experience (company onboarding, running payroll, employee management) with a single React component.
+- **Sub-components** — compose exactly the UI your application needs using individual form and data components, with full control over layout and sequencing.
+- **Hooks** — headless form and data utilities that let you own your UI entirely while the SDK handles data fetching, validation, and API calls.
+- **Theming and component adapters** — make the SDK match your design system, from CSS variable overrides to fully replacing individual UI components.
 
-### [Custom theming, translations, and data integration for a better payroll product](https://drive.google.com/file/d/1lV7o0hbzTVwVost9MV5wgxGO__D-B2Gq/preview)
+## Quick example
 
-### [Modularity and flexibility to shape your application's user experience](https://drive.google.com/file/d/12rfU6cSUfPVCaeWG3tvSZ7ARyVdGPQ9n/preview)
+The following renders a complete, multi-step employee onboarding experience:
 
-### [Enabling event modeling to integrate with your systems](https://drive.google.com/file/d/1RaJdgN2g8yXOx03tjet2HUcBlvPtkvBI/preview)
+```jsx
+import { EmployeeOnboarding, GustoProvider } from '@gusto/embedded-react-sdk'
+import '@gusto/embedded-react-sdk/style.css'
+
+function App({ companyId }) {
+  return (
+    <GustoProvider config={{ baseUrl: '/proxy-url/' }}>
+      <EmployeeOnboarding.OnboardingFlow companyId={companyId} onEvent={() => {}} />
+    </GustoProvider>
+  )
+}
+```
+
+See [Getting Started](./getting-started/getting-started.md) to install and configure the SDK for your application.


### PR DESCRIPTION
## Summary

- Replaces the intro paragraph, which framed the SDK as a complement to Flows/API rather than leading with what it is
- Removes three broken Google Drive demo video links under "Benefits of the SDK"
- Adds a "What you get" section surfacing all three abstraction levels: workflows, sub-components, and hooks
- Adds a minimal "Quick example" code snippet as an immediate on-ramp for new visitors
- Updates terminology to use "sub-components" (public-facing term) instead of "building blocks"

## Context

Part of a broader docs refresh pass on `sdk.gusto.com`. This is the first PR in that series — testing the process before continuing with the remaining pages.

## Test plan

- [ ] Visit `/docs/` on the deployed preview and confirm the new intro, bullets, and code snippet render correctly
- [ ] Confirm the "See Getting Started" link resolves to `/docs/getting-started/`
- [ ] Confirm no broken links or images

🤖 Generated with [Claude Code](https://claude.com/claude-code)