### PR TITLE
docs: reframe "Deciding to build with the SDK" page

### DIFF
--- a/docs/deciding-to-build-with-the-sdk/deciding-to-build-with-the-sdk.md
+++ b/docs/deciding-to-build-with-the-sdk/deciding-to-build-with-the-sdk.md
@@ -4,27 +4,26 @@ description: Considerations for choosing the React SDK over Flows or a custom AP
 order: 1
 ---
 
-## How do I know if the GEP React SDK is right for me?
+## Is the GEP React SDK right for me?
 
-While it’s possible to mix and match the build approach _across_ the domain of your payroll application, you would still generally want to match your needs to the best approach out of the possible build options (SDK, Flows, or build your own UI) for any given domain within the payroll application. As our SDK components are still in an early phase of development, many components may not yet be available via SDK (discuss with your Gusto point of contact if you’d like to inquire about a specific component).
+If your application uses React — or can introduce React ([see how](https://react.dev/learn/add-react-to-an-existing-project)) — the SDK is the recommended build path for any [payroll workflow it covers](../workflows-overview/workflows-overview.md). You can mix and match approaches across workflows, choosing the right level of abstraction for each part of your application.
 
-Here are some considerations when deciding whether or not to use the React SDK for any given payroll workflow for your application:
+**Use the SDK if:**
 
-**You should use the React SDK if…**
+- Your app is built with React, or you can add React to it
+- You want pre-built, customizable UI — via [workflows](../workflows-overview/workflows-overview.md) or their sub-components — or to own your UI entirely while the SDK handles data fetching, validation, and API calls (via [hooks](../hooks/hooks.md))
+- You want to pre-fill forms with data your application already has
+- You need to match your design system via theming or custom components
 
-- If you already use React in your application, or are open to introducing React into your stack ([Learn how to add React to existing projects](https://react.dev/learn/add-react-to-an-existing-project))
-- You want to use pre-built components that abstract API endpoint complexity
-- You already capture info required for a particular workflow (e.g. company onboarding)
-- You want to customize components to your application’s theme and layout
-- You’re just starting out with building embedded payroll on GEP, or the components you want to use are currently available via the SDK library
+**Consider a different approach if:**
 
-**You may benefit from a different build approach if…**
+- The workflow or hook you need doesn't have SDK coverage yet — check the [Workflows Overview](../workflows-overview/workflows-overview.md) and [Hooks](../hooks/hooks.md) for what's available, and reach out to your Gusto Embedded contact to ask about coverage on your roadmap
+- Your customization requirements go beyond what hooks and component adapters can support — in that case a raw API build may be the right path, though we'd still recommend using SDK components where possible to reduce build scope
 
-- You need to deploy a proof of concept as soon as possible, even if the resulting application feels inconsistent in look and feel and non-integrated with the rest of your application (e.g. data that you already have may be requested again).
-  - If your number one priority is speed, you may need to use [Flows](https://docs.gusto.com/embedded-payroll/docs/flows-intro) instead, as it is still the fastest way to deploy any given workflow.
-- You have very deep customization needs that may not be met by the React SDK (if in doubt, ask your Gusto Embedded point of contact!). You may need to create a custom, API-only build to accommodate your requirements, but we would still highly recommend using SDK or Flow components where possible to reduce your build workload.
-- The SDK component you need currently does not yet exist: we are actively working on several components to cover the rest of our application - for what’s currently available, see the Workflows Overview section and reach out to your Gusto Embedded point of contact for more information!
+## Next steps
 
-### How can I learn more about React SDK?
+[**Getting Started →**](../getting-started/getting-started.md) Install the SDK and render your first component.
 
-As a Gusto Embedded partner, we will provide consultation with a GEP Solutions Architect to ensure we can find the right solution for you. We recommend starting with the documentation sections provided, and please reach out to your Gusto Embedded representative to learn more!
+[**Workflows Overview →**](../workflows-overview/workflows-overview.md) See what's available end-to-end.
+
+[**Hooks →**](../hooks/hooks.md) Explore the headless API surface.


### PR DESCRIPTION
## Summary

- Removes "early phase of development" framing and the hedged, comparison-heavy intro
- Rewrites the opening to lead with a clear recommendation: use the SDK if you're on React
- Adds hooks as an explicit consideration in the "Use the SDK if" bullets; merges the pre-built UI and headless hooks points into one to show the two paths cleanly
- Tightens "Consider a different approach" from three bullets to two — coverage gap and extreme customization only (removed the Flows POC speed bullet)
- Replaces the "talk to a Solutions Architect" CTA with direct Next steps links to Getting Started, Workflows Overview, and Hooks
- Swaps internal terminology: "domains" → "workflows", removes "Building Blocks" in favor of "sub-components"

## Context

Second PR in the `sdk.gusto.com` docs refresh series. Follows #2116 (What is the GEP React SDK?).

## Test plan

- [ ] Visit `/docs/deciding-to-build-with-the-sdk` on the deployed preview and confirm the reframed copy renders correctly
- [ ] Confirm all inline links (Workflows Overview, Hooks, Getting Started, react.dev) resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)