### PR TITLE
feat(TimeOff)!: expose data-connected PolicySettings and TimeOffPolicyDetail blocks

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -3985,6 +3985,11 @@ interface PolicyListProps extends BaseComponentInterface<'Company.TimeOff.TimeOf
     companyId: string;
 }
 
+// Warning: (ae-missing-release-tag) "PolicySettings" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+function PolicySettings(props: PolicySettingsProps): JSX;
+
 // Warning: (ae-missing-release-tag) "PolicySettingsDisplay" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -4028,6 +4033,16 @@ interface PolicySettingsPresentationProps {
     //
     // (undocumented)
     onContinue: (data: PolicySettingsFormData) => void;
+}
+
+// Warning: (ae-missing-release-tag) "PolicySettingsProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface PolicySettingsProps extends BaseComponentInterface {
+    // (undocumented)
+    mode?: 'create' | 'edit';
+    // (undocumented)
+    policyId: string;
 }
 
 // Warning: (ae-missing-release-tag) "PolicyTypeSelector" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -4973,8 +4988,10 @@ declare namespace TimeOff {
         PolicyTypeSelectorProps,
         PolicyConfigurationForm,
         PolicyConfigurationFormProps,
-        PolicySettingsPresentation as PolicySettings,
-        PolicySettingsPresentationProps as PolicySettingsProps,
+        PolicySettings,
+        PolicySettingsProps,
+        PolicySettingsPresentation,
+        PolicySettingsPresentationProps,
         AddEmployeesToPolicy,
         AddEmployeesToPolicyProps,
         HolidaySelectionForm,
@@ -4989,6 +5006,8 @@ declare namespace TimeOff {
         ViewHolidayScheduleProps,
         HolidayPolicyDetailPresentationProps,
         HolidayPolicyDetailEmployee,
+        TimeOffPolicyDetail,
+        TimeOffPolicyDetailProps,
         TimeOffPolicyDetailPresentation,
         TimeOffPolicyDetailPresentationProps,
         TimeOffPolicyDetailEmployee,
@@ -5011,6 +5030,11 @@ interface TimeOffFlowProps extends BaseComponentInterface {
     // (undocumented)
     companyId: string;
 }
+
+// Warning: (ae-missing-release-tag) "TimeOffPolicyDetail" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+function TimeOffPolicyDetail(props: TimeOffPolicyDetailProps): JSX;
 
 // Warning: (ae-missing-release-tag) "TimeOffPolicyDetailEmployee" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -5040,6 +5064,14 @@ type TimeOffPolicyDetailPresentationProps = TimeOffPolicyDetailPresentationBaseP
     policySettings: PolicySettingsDisplay;
     onChangeSettings?: () => void;
 });
+
+// Warning: (ae-missing-release-tag) "TimeOffPolicyDetailProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+interface TimeOffPolicyDetailProps extends BaseComponentInterface {
+    // (undocumented)
+    policyId: string;
+}
 
 // Warning: (ae-missing-release-tag) "TotalAmountFieldProps" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/docs/reference/endpoint-inventory.json
+++ b/docs/reference/endpoint-inventory.json
@@ -1445,6 +1445,21 @@
         "timeOffPolicyUuid"
       ]
     },
+    "TimeOff.PolicySettingsPresentation": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        }
+      ],
+      "variables": [
+        "timeOffPolicyUuid"
+      ]
+    },
     "TimeOff.AddEmployeesToPolicy": {
       "endpoints": [
         {
@@ -1566,6 +1581,30 @@
       "variables": [
         "companyId",
         "companyUuid"
+      ]
+    },
+    "TimeOff.TimeOffPolicyDetail": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/employees"
+        },
+        {
+          "method": "GET",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/balance"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/time_off_policies/:timeOffPolicyUuid/remove_employees"
+        }
+      ],
+      "variables": [
+        "companyId",
+        "timeOffPolicyUuid"
       ]
     },
     "TimeOff.TimeOffPolicyDetailPresentation": {
@@ -2697,7 +2736,7 @@
         "TimeOff.PolicyList",
         "TimeOff.PolicySettings",
         "TimeOff.PolicyTypeSelector",
-        "TimeOff.TimeOffPolicyDetailPresentation",
+        "TimeOff.TimeOffPolicyDetail",
         "TimeOff.ViewHolidayEmployees",
         "TimeOff.ViewHolidaySchedule"
       ]

--- a/docs/reference/endpoint-reference.md
+++ b/docs/reference/endpoint-reference.md
@@ -272,6 +272,8 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 | **TimeOff.PolicySettings** | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
+| **TimeOff.PolicySettingsPresentation** | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
 | **TimeOff.AddEmployeesToPolicy** | GET | `/v1/companies/:companyId/employees` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid` |
@@ -291,6 +293,10 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 | **TimeOff.ViewHolidaySchedule** | GET | `/v1/companies/:companyId/employees` |
 |  | GET | `/v1/companies/:companyUuid/holiday_pay_policy` |
 |  | PUT | `/v1/companies/:companyUuid/holiday_pay_policy/remove` |
+| **TimeOff.TimeOffPolicyDetail** | GET | `/v1/companies/:companyId/employees` |
+|  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
+|  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/remove_employees` |
 | **TimeOff.TimeOffPolicyDetailPresentation** | GET | `/v1/companies/:companyId/employees` |
 |  | GET | `/v1/time_off_policies/:timeOffPolicyUuid` |
 |  | PUT | `/v1/time_off_policies/:timeOffPolicyUuid/balance` |
@@ -486,4 +492,4 @@ Flows compose multiple blocks into a single workflow. The endpoint list for a fl
 | **Payroll.PayrollExecutionFlow** | Payroll.PayrollFlow |
 | **Payroll.PayrollFlow** | Payroll.OffCycleFlow, Payroll.PayrollBlockerList, Payroll.PayrollConfiguration, Payroll.PayrollEditEmployee, Payroll.PayrollExecutionFlow, Payroll.PayrollLanding, Payroll.PayrollOverview, Payroll.PayrollReceipts, Payroll.TransitionFlow |
 | **Payroll.TransitionFlow** | Payroll.PayrollExecutionFlow, Payroll.TransitionCreation |
-| **TimeOff.TimeOffFlow** | TimeOff.AddEmployeesHoliday, TimeOff.AddEmployeesToPolicy, TimeOff.HolidaySelectionForm, TimeOff.PolicyConfigurationForm, TimeOff.PolicyList, TimeOff.PolicySettings, TimeOff.PolicyTypeSelector, TimeOff.TimeOffPolicyDetailPresentation, TimeOff.ViewHolidayEmployees, TimeOff.ViewHolidaySchedule |
+| **TimeOff.TimeOffFlow** | TimeOff.AddEmployeesHoliday, TimeOff.AddEmployeesToPolicy, TimeOff.HolidaySelectionForm, TimeOff.PolicyConfigurationForm, TimeOff.PolicyList, TimeOff.PolicySettings, TimeOff.PolicyTypeSelector, TimeOff.TimeOffPolicyDetail, TimeOff.ViewHolidayEmployees, TimeOff.ViewHolidaySchedule |

--- a/src/components/TimeOff/index.ts
+++ b/src/components/TimeOff/index.ts
@@ -4,8 +4,10 @@ export { PolicyTypeSelector } from './PolicyTypeSelector/PolicyTypeSelector'
 export type { PolicyTypeSelectorProps } from './PolicyTypeSelector/PolicyTypeSelector'
 export { PolicyConfigurationForm } from './TimeOffManagement/PolicyConfigurationForm'
 export type { PolicyConfigurationFormProps } from './TimeOffManagement/PolicyConfigurationForm'
-export { PolicySettingsPresentation as PolicySettings } from './PolicySettings/PolicySettingsPresentation'
-export type { PolicySettingsPresentationProps as PolicySettingsProps } from './PolicySettings/PolicySettingsTypes'
+export { PolicySettings } from './PolicySettings/PolicySettings'
+export type { PolicySettingsProps } from './PolicySettings/PolicySettings'
+export { PolicySettingsPresentation } from './PolicySettings/PolicySettingsPresentation'
+export type { PolicySettingsPresentationProps } from './PolicySettings/PolicySettingsTypes'
 export { AddEmployeesToPolicy } from './AddEmployeesToPolicy/AddEmployeesToPolicy'
 export type { AddEmployeesToPolicyProps } from './AddEmployeesToPolicy/AddEmployeesToPolicy'
 export { HolidaySelectionForm } from './HolidaySelectionForm/HolidaySelectionForm'
@@ -22,6 +24,8 @@ export type {
   HolidayPolicyDetailPresentationProps,
   HolidayPolicyDetailEmployee,
 } from './HolidayPolicyDetail'
+export { TimeOffPolicyDetail } from './TimeOffPolicyDetail/TimeOffPolicyDetail'
+export type { TimeOffPolicyDetailProps } from './TimeOffPolicyDetail/TimeOffPolicyDetail'
 export { TimeOffPolicyDetailPresentation } from './TimeOffPolicyDetail'
 export type {
   TimeOffPolicyDetailPresentationProps,


### PR DESCRIPTION
## Summary

The `TimeOff` public namespace only exported the **presentational** variants of `PolicySettings` and `TimeOffPolicyDetail`, while every other TimeOff block (`PolicyList`, `PolicyConfigurationForm`, `AddEmployeesToPolicy`, the holiday blocks) is exported in its **data-connected** form. That forced integrators to fall back to the all-in-one `TimeOffFlow` for the sick/vacation path instead of composing blocks behind their own router.

The data-connected components already existed and were used internally by `TimeOffFlow` (via `PolicySettingsContextual` / `TimeOffPolicyDetailContextual`); they were simply not part of the public surface. This PR wires them into the public barrel.

- `TimeOff.PolicySettings` / `PolicySettingsProps` now resolve to the data-connected component (`{ policyId, mode?, onEvent }`).
- Added `TimeOff.TimeOffPolicyDetail` / `TimeOffPolicyDetailProps` (data-connected, `{ policyId, onEvent }`).
- Presentational variants are now exported as `TimeOff.PolicySettingsPresentation` / `TimeOff.TimeOffPolicyDetailPresentation` with their `*PresentationProps`.

No component code changed — this is purely export wiring in `src/components/TimeOff/index.ts`. Internal consumers import the data-connected components directly from their files, so `TimeOffFlow` and the state machine are unaffected.

## Breaking change

`TimeOff.PolicySettings` now refers to the **data-connected** component, whose props are `{ policyId, mode?, onEvent }` (`PolicySettingsProps`), not the presentational props. Imports of the presentational component/props should move to `TimeOff.PolicySettingsPresentation` / `PolicySettingsPresentationProps`.

## Test plan

- [x] `npm run build` (declaration generation = type check) passes
- [x] `npm run api-report:derive` regenerated `.reports/embedded-react-sdk.api.md`; diff confirms new public surface
- [x] `npm run test -- --run src/components/TimeOff` — all 392 tests pass
- [x] Confirm `import { TimeOff } from '@gusto/embedded-react-sdk'` resolves `TimeOff.PolicySettings` / `TimeOff.TimeOffPolicyDetail` to the data-connected components, each rendering and fetching from just `policyId` + `onEvent`

Made with [Cursor](https://cursor.com)