### PR TITLE
docs: remove Hooks experimental label and fix sidebar typo

### DIFF
--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -63,7 +63,7 @@ const sidebars: SidebarsConfig = {
             {
               type: 'doc',
               id: 'workflows-overview/contractor-onboarding',
-              label: 'Conractor onboarding',
+              label: 'Contractor onboarding',
             },
             {
               type: 'doc',
@@ -139,7 +139,7 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
-      label: 'Hooks (Experimental)',
+      label: 'Hooks',
       link: { type: 'doc', id: 'hooks/hooks' },
       items: [
         'hooks/useEmployeeDetailsForm',

--- a/docs/hooks/hooks.md
+++ b/docs/hooks/hooks.md
@@ -8,8 +8,6 @@ order: 1
 
 Hooks let you own the layout while the SDK manages data fetching, validation, submission, and error handling. **Form hooks** return pre-bound field components, metadata, and actions for rendering a form — you supply the layout and labels. **Data hooks** return fetched, decorated data plus the actions valid for it — you supply the presentation. Both share the same loading/error/`HookErrorHandling` conventions.
 
-> Hooks are an experimental feature. APIs may change between minor versions during 0.x.x releases.
-
 ## Available Form Hooks
 
 | Hook                             | Description                                                                                        | Reference                                                             |


### PR DESCRIPTION
## Summary

- Removes `(Experimental)` from the Hooks sidebar nav label — hooks are a permanent and expanding part of the SDK portfolio, and the label was creating unnecessary hesitation for partners evaluating the surface
- Removes the redundant experimental callout from `hooks/hooks.md` (the opening paragraph already describes what hooks are)
- Fixes a typo in the Contractors sidebar entry: "Conractor onboarding" → "Contractor onboarding"

## Context

Fifth (and final) PR in the `sdk.gusto.com` docs refresh series. Follows #2116, #2118, #2127, #2128.

## Test plan

- [ ] Confirm sidebar shows "Hooks" (not "Hooks (Experimental)") on the deployed preview
- [ ] Confirm "Contractors > Contractor onboarding" is spelled correctly in the sidebar
- [ ] Confirm `hooks/hooks.md` opens directly to the intro paragraph with no callout block

🤖 Generated with [Claude Code](https://claude.com/claude-code)