### PR TITLE
chore(sdk-app): include unprocessed payrolls in entity catalog

### DIFF
--- a/sdk-app/src/DemoSettingsPanel.module.scss
+++ b/sdk-app/src/DemoSettingsPanel.module.scss
@@ -306,12 +306,42 @@
   background: var(--color-hover-bg);
 }
 
+.optionPrimaryRow {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
 .optionPrimary {
   font-size: 0.8125rem;
   color: var(--color-text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.optionBadge {
+  flex: 0 0 auto;
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03125rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.625rem;
+  line-height: 1;
+}
+
+.optionBadgeProcessed {
+  background: var(--color-badge-build-bg);
+  color: var(--color-badge-build-text);
+}
+
+.optionBadgeUnprocessed {
+  background: var(--color-badge-demo-bg);
+  color: var(--color-badge-demo-text);
 }
 
 .optionSecondary {

--- a/sdk-app/src/DemoSettingsPanel.tsx
+++ b/sdk-app/src/DemoSettingsPanel.tsx
@@ -331,7 +331,20 @@ function EntityCombobox({
                           handleSelect(option)
                         }}
                       >
-                        <span className={styles.optionPrimary}>{option.primary}</span>
+                        <span className={styles.optionPrimaryRow}>
+                          <span className={styles.optionPrimary}>{option.primary}</span>
+                          {option.badge && (
+                            <span
+                              className={`${styles.optionBadge} ${
+                                option.badge.tone === 'processed'
+                                  ? styles.optionBadgeProcessed
+                                  : styles.optionBadgeUnprocessed
+                              }`}
+                            >
+                              {option.badge.label}
+                            </span>
+                          )}
+                        </span>
                         <span className={styles.optionSecondary}>{option.secondary}</span>
                       </button>
                     </li>

--- a/sdk-app/src/entityFormatters.ts
+++ b/sdk-app/src/entityFormatters.ts
@@ -17,12 +17,14 @@ export interface RawPayroll {
   payroll_uuid?: string
   check_date?: string
   pay_period?: { start_date?: string; end_date?: string }
+  processed?: boolean
 }
 
 export interface EntityOption {
   value: string
   primary: string
   secondary: string
+  badge?: { label: string; tone: 'processed' | 'unprocessed' }
 }
 
 export function formatPayPeriod(payroll: RawPayroll): string {

--- a/sdk-app/src/useEntityCatalog.ts
+++ b/sdk-app/src/useEntityCatalog.ts
@@ -51,10 +51,22 @@ export function useEntityCatalog(companyId: string): EntityCatalog {
 
     const load = async () => {
       const base = `/api/v1/companies/${companyId}`
+      const today = new Date()
+      const startDate = new Date(today)
+      startDate.setMonth(startDate.getMonth() - 6)
+      const endDate = new Date(today)
+      endDate.setMonth(endDate.getMonth() + 3)
+      const toIso = (d: Date) => d.toISOString().slice(0, 10)
+      const payrollsQuery = new URLSearchParams({
+        processing_statuses: 'processed,unprocessed',
+        start_date: toIso(startDate),
+        end_date: toIso(endDate),
+        per: '100',
+      })
       const [employees, contractors, payrolls] = await Promise.all([
         fetchList<RawEmployee>(`${base}/employees`, controller.signal),
         fetchList<RawContractor>(`${base}/contractors`, controller.signal),
-        fetchList<RawPayroll>(`${base}/payrolls`, controller.signal),
+        fetchList<RawPayroll>(`${base}/payrolls?${payrollsQuery.toString()}`, controller.signal),
       ])
 
       if (controller.signal.aborted) return
@@ -78,10 +90,15 @@ export function useEntityCatalog(companyId: string): EntityCatalog {
           .filter(p => !!(p.payroll_uuid || p.uuid))
           .map(p => {
             const id = (p.payroll_uuid || p.uuid) as string
+            const isProcessed = p.processed === true
             return {
               value: id,
               primary: formatPayPeriod(p),
               secondary: id,
+              badge: {
+                label: isProcessed ? 'Processed' : 'Unprocessed',
+                tone: isProcessed ? ('processed' as const) : ('unprocessed' as const),
+              },
             }
           }),
         isLoading: false,


### PR DESCRIPTION
## Summary

- The settings-panel Payroll picker was calling `/v1/companies/:id/payrolls` with no params and silently inheriting the API default (`processed + regular + past 6 months`), so upcoming unprocessed payrolls weren't pickable.
- Pass `processing_statuses=processed,unprocessed` plus a 6mo-past → 3mo-future window and `per=100` so both states show up.
- Each payroll option now renders a `Processed` / `Unprocessed` badge so the state is visible at a glance.

## Test plan

- [ ] Run `npm run sdk-app`, open Demo Settings → Entity IDs, expand the Payroll combobox, confirm both processed and unprocessed payrolls appear with the correct badge color.
- [ ] Pick an unprocessed payroll and confirm the ID propagates to the rest of the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)