### PR TITLE
docs: hide Next from version dropdown and remove version banner

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -78,9 +78,10 @@ const config: Config = {
           exclude: ['test-fests/**'],
           ...(hasVersions && {
             lastVersion,
-            versions: {
-              current: { label: 'Next (unreleased)', path: 'next' },
-            },
+            includeCurrentVersion: false,
+            versions: Object.fromEntries(
+              versions.map(version => [version, { banner: 'none' as const }]),
+            ),
           }),
         },
         blog: false,

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -80,7 +80,7 @@ const config: Config = {
             lastVersion,
             includeCurrentVersion: false,
             versions: Object.fromEntries(
-              versions.map(version => [version, { banner: 'none' as const }]),
+              versions.map(version => [version, { banner: 'none' as const, badge: false }]),
             ),
           }),
         },


### PR DESCRIPTION
## Summary

Follow-up visual cleanup on the versioned docs site shipped in #2076. Three tweaks:

1. **No more "Next" in the dropdown.** The "Next (unreleased)" entry is dropped from the navbar version dropdown — only numbered minor versions (`0.47`, `0.48`, …) appear.
2. **No per-page version banner.** The "This is documentation for…" banner above each page's content is removed.
3. **No per-page Version badge.** The "Version: 0.47" pill that Docusaurus' default `DocVersionBadge` renders above each page title is removed.

The selected version is already visible in the navbar dropdown — the banner + badge were design noise.

All three behaviors only activate downstream (`Gusto/embedded-sdk-docs`) where `versions.json` is present; the in-repo single-version preview is unchanged.

## Changes

- `docs-site/docusaurus.config.ts` — under the `hasVersions` branch:
  - `includeCurrentVersion: false` removes the `Next` dropdown entry and the `/docs/next/` route entirely.
  - `versions` is generated from `versions.json` so every released minor gets `{ banner: 'none', badge: false }`. Suppresses both the per-page banner and the `Version: X.Y` badge.

## Related

- Jira: [SDK-766](https://gustohq.atlassian.net/browse/SDK-766)
- Original versioning PR: #2076

## Testing

Locally simulated the downstream environment to verify all three fixes:

```bash
cd docs-site
npx docusaurus docs:version 0.47    # stages versions.json + versioned_docs/0.47 snapshot
npm run typedoc && npm run build    # builds successfully
ls build/docs/next/                 # → No such file or directory ✅
grep -oE '(Next|0\.47)' build/docs/index.html | sort -u
                                    # → only "0.47" in navbar ✅
grep -l 'This is documentation for' build/docs/**/*.html
                                    # → no matches (banner suppressed) ✅
grep -l 'theme-doc-version-badge\|Version:' build/docs/**/*.html
                                    # → no matches (badge suppressed) ✅
rm -rf versions.json versioned_docs versioned_sidebars build
```

Also ran `npm run tsc` clean. The in-repo single-version preview (no `versions.json`) still builds as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-766]: https://gustohq.atlassian.net/browse/SDK-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ