### PR TITLE
chore: release 0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,133 @@
 # Changelog
 
+## [0.48.0](https://github.com/Gusto/embedded-react-sdk/compare/v0.47.1...v0.48.0) (2026-06-15)
+
+### Breaking Changes
+
+#### Removed deprecated namespace exports: `Company`, `Employee`, `Contractor`, `GustoApiProvider` ([#2120](https://github.com/Gusto/embedded-react-sdk/issues/2120))
+
+These umbrella exports have been removed in favor of the journey-based namespaces.
+
+**`GustoApiProvider` → `GustoProvider`** (an alias since 0.8.0)
+
+```tsx
+// Before
+import { GustoApiProvider } from '@gusto/embedded-react-sdk'
+;<GustoApiProvider {...props} />
+
+// After
+import { GustoProvider } from '@gusto/embedded-react-sdk'
+;<GustoProvider {...props} />
+```
+
+**`Company` → `CompanyOnboarding`**
+
+```tsx
+// Before
+import { Company } from '@gusto/embedded-react-sdk'
+;<Company.OnboardingFlow {...props} />
+
+// After
+import { CompanyOnboarding } from '@gusto/embedded-react-sdk'
+;<CompanyOnboarding.OnboardingFlow {...props} />
+```
+
+**`Employee` → `EmployeeOnboarding` / `EmployeeManagement`**
+
+Onboarding components live in `EmployeeOnboarding`; post-hire management components live in `EmployeeManagement`. Tax and address components exist in both namespaces — pick the one that matches your surface.
+
+```tsx
+// Before
+import { Employee } from '@gusto/embedded-react-sdk'
+;<Employee.Profile {...props} />
+;<Employee.FederalTaxes {...props} />
+
+// After
+import { EmployeeOnboarding, EmployeeManagement } from '@gusto/embedded-react-sdk'
+;<EmployeeManagement.Profile {...props} />
+;<EmployeeOnboarding.FederalTaxes {...props} />
+```
+
+**`Contractor` → `ContractorOnboarding` / `ContractorManagement`**
+
+Onboarding components (`OnboardingFlow`, `ContractorList`, `ContractorProfile`, `Address`, `PaymentMethod`, `NewHireReport`, `ContractorSubmit`) live in `ContractorOnboarding`. Payment components (`PaymentFlow`, `PaymentsList`, `CreatePayment`, `PaymentHistory`, `PaymentSummary`, `PaymentStatement`) live in the new `ContractorManagement` namespace.
+
+```tsx
+// Before
+import { Contractor } from '@gusto/embedded-react-sdk'
+;<Contractor.OnboardingFlow {...props} />
+;<Contractor.PaymentFlow {...props} />
+
+// After
+import { ContractorOnboarding, ContractorManagement } from '@gusto/embedded-react-sdk'
+;<ContractorOnboarding.OnboardingFlow {...props} />
+;<ContractorManagement.PaymentFlow {...props} />
+```
+
+#### Removed deprecated `Employee.Taxes` component and `EMPLOYEE_TAXES_DONE` event ([#2098](https://github.com/Gusto/embedded-react-sdk/issues/2098))
+
+Tax collection was split into separate federal and state components. The combined `Employee.Taxes` component, its i18n namespace, and the `EMPLOYEE_TAXES_DONE` event have been removed. The two components are now separate routing steps — `FederalTaxes` emits `EMPLOYEE_FEDERAL_TAXES_DONE`, and `StateTaxes` emits `EMPLOYEE_STATE_TAXES_DONE` when complete.
+
+```tsx
+// Before
+import { Employee } from '@gusto/embedded-react-sdk'
+;<Employee.Taxes employeeId={employeeId} onEvent={onEvent} />
+
+// After
+import { EmployeeOnboarding } from '@gusto/embedded-react-sdk'
+;<EmployeeOnboarding.FederalTaxes employeeId={employeeId} onEvent={onEvent} />
+;<EmployeeOnboarding.StateTaxes employeeId={employeeId} onEvent={onEvent} />
+```
+
+`EMPLOYEE_TAXES_DONE` → `EMPLOYEE_FEDERAL_TAXES_DONE` + `EMPLOYEE_STATE_TAXES_DONE`:
+
+```tsx
+// Before
+if (event.eventType === componentEvents.EMPLOYEE_TAXES_DONE) {
+  navigate('/next_step')
+}
+
+// After
+if (event.eventType === componentEvents.EMPLOYEE_FEDERAL_TAXES_DONE) {
+  navigate('/state_taxes')
+}
+// in the StateTaxes onEvent handler:
+if (event.eventType === componentEvents.EMPLOYEE_STATE_TAXES_DONE) {
+  navigate('/next_step')
+}
+```
+
+#### `TimeOff.PolicySettings` is now the data-connected component ([#2119](https://github.com/Gusto/embedded-react-sdk/issues/2119))
+
+`TimeOff.PolicySettings` now refers to the data-connected component, whose props are `{ policyId, mode?, onEvent }` (`PolicySettingsProps`). The presentational component is now exported as `TimeOff.PolicySettingsPresentation` with `PolicySettingsPresentationProps`.
+
+```tsx
+// Before — TimeOff.PolicySettings was the presentational component
+import { TimeOff, type PolicySettingsProps } from '@gusto/embedded-react-sdk'
+;<TimeOff.PolicySettings {...presentationalProps} />
+
+// After — the presentational component is renamed
+import { TimeOff, type PolicySettingsPresentationProps } from '@gusto/embedded-react-sdk'
+;<TimeOff.PolicySettingsPresentation {...presentationalProps} />
+
+// TimeOff.PolicySettings now fetches its own data
+;<TimeOff.PolicySettings policyId={policyId} onEvent={onEvent} />
+```
+
+### Features & Enhancements
+
+- Export the `useEmployeeList` hook for fetching and paginating a company's employees ([#2092](https://github.com/Gusto/embedded-react-sdk/issues/2092))
+- **TimeOff:** Export the data-connected `TimeOff.PolicySettings` and `TimeOff.TimeOffPolicyDetail` blocks, each rendering and fetching from just `policyId` + `onEvent` ([#2119](https://github.com/Gusto/embedded-react-sdk/issues/2119))
+- **Payroll:** Export the `DismissalPayPeriodSelection` block ([#2115](https://github.com/Gusto/embedded-react-sdk/issues/2115))
+- **Employee:** Surface `PayrollOption` on the `EmployeeManagement` namespace ([#2117](https://github.com/Gusto/embedded-react-sdk/issues/2117))
+- Render payroll reimbursements in a `DataView` with an empty-state CTA ([#2135](https://github.com/Gusto/embedded-react-sdk/issues/2135))
+
+### Chores & Maintenance
+
+- Bump `dompurify` (3.4.8 → 3.4.10) ([#2096](https://github.com/Gusto/embedded-react-sdk/issues/2096), [#2124](https://github.com/Gusto/embedded-react-sdk/issues/2124))
+- Bump `react-hook-form` (7.78.0 → 7.79.0) ([#2125](https://github.com/Gusto/embedded-react-sdk/issues/2125))
+- Bump dev and tooling dependencies (`storybook`, `@storybook/*`, `eslint-plugin-storybook`, `prettier`, `@types/react`, `@microsoft/api-extractor`, `axe-core`, `form-data`)
+
 ## [0.47.1](https://github.com/Gusto/embedded-react-sdk/compare/v0.47.0...v0.47.1) (2026-06-09)
 
 ### Features & Enhancements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.47.1",
+  "version": "0.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-react-sdk",
-      "version": "0.47.1",
+      "version": "0.48.0",
       "license": "MIT",
       "dependencies": {
         "@gusto/embedded-api-v-2025-11-15": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.47.1",
+  "version": "0.48.0",
   "homepage": "https://github.com/Gusto/embedded-react-sdk",
   "bugs": {
     "url": "https://github.com/Gusto/embedded-react-sdk/issues"


### PR DESCRIPTION
## Release 0.48.0

Prepared with `release-it`. Version auto-detected from conventional commits since `v0.47.1` (`feat!` → MINOR during 0.x). Merging this PR triggers the Publish to NPM workflow automatically.

### Breaking Changes

- **Removed deprecated namespace exports `Company`, `Employee`, `Contractor`, `GustoApiProvider`** (#2120). Migrate to the journey-based namespaces:
  - `GustoApiProvider` → `GustoProvider`
  - `Company` → `CompanyOnboarding`
  - `Employee` → `EmployeeOnboarding` / `EmployeeManagement`
  - `Contractor` → `ContractorOnboarding` / `ContractorManagement` (the new `ContractorManagement` holds the payment components: `PaymentFlow`, `PaymentsList`, `CreatePayment`, `PaymentHistory`, `PaymentSummary`, `PaymentStatement`)
- **Removed deprecated `Employee.Taxes` component and `EMPLOYEE_TAXES_DONE` event** (#2098). Use the separate `FederalTaxes` / `StateTaxes` components; the event splits into `EMPLOYEE_FEDERAL_TAXES_DONE` + `EMPLOYEE_STATE_TAXES_DONE`.
- **`TimeOff.PolicySettings` is now the data-connected component** (`{ policyId, mode?, onEvent }`); the presentational component is now `TimeOff.PolicySettingsPresentation` (#2119).

### Features & Enhancements

- Export the `useEmployeeList` hook (#2092)
- Export the data-connected `TimeOff.PolicySettings` and `TimeOff.TimeOffPolicyDetail` blocks (#2119)
- Export the `DismissalPayPeriodSelection` block (#2115)
- Surface `PayrollOption` on the `EmployeeManagement` namespace (#2117)
- Render payroll reimbursements in a `DataView` with an empty-state CTA (#2135)

### Chores & Maintenance

- Bump `dompurify` (3.4.8 → 3.4.10) and `react-hook-form` (7.78.0 → 7.79.0)
- Bump dev and tooling dependencies

See `CHANGELOG.md` for the full, consumer-facing entry with complete before/after migration examples for each breaking change.