### PR TITLE
feat(sdk-app): make dismissed contractor profile read-only

### DIFF
--- a/sdk-app/src/design/prototypes/contractor-management/ContractorProfile/ContractorProfileComponents.tsx
+++ b/sdk-app/src/design/prototypes/contractor-management/ContractorProfile/ContractorProfileComponents.tsx
@@ -125,10 +125,14 @@ function ProfileViewContent({ contractor }: { contractor: Contractor }) {
     isSubmitting ||
     contractor.onboardingStatus === ContractorOnboardingStatus.ADMIN_ONBOARDING_REVIEW ||
     contractor.onboardingStatus === ContractorOnboardingStatus.SELF_ONBOARDING_REVIEW
+  const isDismissedInPast = Boolean(
+    contractor.dismissalDate && new Date(contractor.dismissalDate) <= new Date(),
+  )
   const isEditable =
-    contractor.isActive ||
-    isReviewState ||
-    contractor.onboardingStatus === ContractorOnboardingStatus.ONBOARDING_COMPLETED
+    !isDismissedInPast &&
+    (contractor.isActive ||
+      isReviewState ||
+      contractor.onboardingStatus === ContractorOnboardingStatus.ONBOARDING_COMPLETED)
 
   const [isSubmitModalOpen, setIsSubmitModalOpen] = useState(false)
   const [fileNewHireReport, setFileNewHireReport] = useState('no')


### PR DESCRIPTION
## Summary
- When a contractor has a dismissal date on or before today, the prototype profile hides all edit/add/remove callbacks on Details, Address, Pay, and Payment Method sections.

## Test plan
- [ ] Open a dismissed contractor (dismissal date in the past) — verify no edit affordances appear on any tab.
- [ ] Open an active contractor — verify edit controls still render.
- [ ] Open a contractor in admin/self-onboarding review — verify the review state still allows edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)