### PR TITLE
fix(sdk-app): theme sidebar toggle, slim scrollbar, modernize icons

### DIFF
--- a/sdk-app/src/Sidebar.module.scss
+++ b/sdk-app/src/Sidebar.module.scss
@@ -86,7 +86,7 @@
   font-size: 0.75rem;
   font-weight: 600;
   color: var(--color-text-muted);
-  background: #fff;
+  background: var(--color-bg);
   user-select: none;
 
   &:hover {
@@ -104,6 +104,21 @@
   flex: 1;
   overflow-y: auto;
   padding: 0.5rem 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
+
+  &::-webkit-scrollbar {
+    width: 0.375rem;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--color-border);
+    border-radius: 0.1875rem;
+  }
 }
 
 .category {

--- a/sdk-app/src/Sidebar.tsx
+++ b/sdk-app/src/Sidebar.tsx
@@ -10,7 +10,65 @@ import {
 } from './design/registry'
 import type { AppMode } from './useAppMode'
 import styles from './Sidebar.module.scss'
-import CaretRightIcon from '@/assets/icons/caret-right.svg?react'
+
+function ChevronRightIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  )
+}
+
+function PanelLeftCloseIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect width="18" height="18" x="3" y="3" rx="2" />
+      <path d="M9 3v18" />
+      <path d="m16 15-3-3 3-3" />
+    </svg>
+  )
+}
+
+function PanelLeftOpenIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect width="18" height="18" x="3" y="3" rx="2" />
+      <path d="M9 3v18" />
+      <path d="m14 9 3 3-3 3" />
+    </svg>
+  )
+}
 
 interface SidebarProps {
   mode: AppMode
@@ -82,7 +140,7 @@ function CategorySection({
         }}
       >
         <div className={styles.categoryTitle}>
-          <CaretRightIcon
+          <ChevronRightIcon
             className={`${styles.categoryArrow} ${collapsed ? styles.categoryArrowCollapsed : ''}`}
           />
           {displayCategory}
@@ -153,7 +211,7 @@ export function Sidebar({ mode, searchQuery, onSearchChange, isOpen, onToggle }:
           aria-label="Show components sidebar"
           title="Show components sidebar"
         >
-          <span>▸</span>
+          <PanelLeftOpenIcon />
         </button>
       </aside>
     )
@@ -178,7 +236,7 @@ export function Sidebar({ mode, searchQuery, onSearchChange, isOpen, onToggle }:
             aria-label="Hide sidebar"
             title="Hide sidebar"
           >
-            <span>◂</span>
+            <PanelLeftCloseIcon />
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- The sidebar toggle button had a hardcoded white background, so it stayed white in dark mode — swapped for `var(--color-bg)`.
- Slimmed the sidebar's scroll experience: transparent track, thin themed thumb (via `scrollbar-color` and `::-webkit-scrollbar-thumb`).
- Replaced the unicode `▸`/`◂` arrows and chunky filled caret with inline Lucide-style SVGs (`ChevronRight`, `PanelLeftOpen`, `PanelLeftClose`). Drawn inline rather than adding a dependency, consistent with how the dev app handles icons today.

## Test plan
- [ ] In sdk-app, toggle between light and dark themes — confirm the sidebar hide button background tracks the theme.
- [ ] Scroll the sidebar list — confirm the scrollbar shows only a thumb, no track.
- [ ] Click category headers — chevron rotates between right (collapsed) and down (expanded).
- [ ] Toggle the sidebar open/closed — verify the panel icons render and inherit text color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)