### PR TITLE
ci(SDK-839): throw on broken markdown links in docusaurus build

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -42,6 +42,9 @@ const config: Config = {
 
   markdown: {
     format: 'detect',
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
   },
 
   i18n: {


### PR DESCRIPTION
## Summary

Adds `onBrokenMarkdownLinks: 'throw'` to the Docusaurus config so a stale `[text](./missing.md)` reference fails the existing `docs-build` CI job at PR time instead of silently warning.

Lives under `markdown.hooks.*`, the location Docusaurus 4 expects — same migration the current build was emitting a deprecation warning about.

This is the first of four scoped PRs decomposing the original SDK-839 work.

## Changes

- `onBrokenMarkdownLinks: 'throw'` added next to the existing `onBrokenLinks` / `onBrokenAnchors` throws.

## Related

- [SDK-839](https://gustohq.atlassian.net/browse/SDK-839)
- Parent epic: [SDK-758](https://gustohq.atlassian.net/browse/SDK-758) — Modernize SDK Documentation

## Testing

\`\`\`bash
npm --prefix docs-site run build
\`\`\`

Builds clean on the current tree; no deprecation warning.

Synthetic violation check: appended \`[broken](./does-not-exist.md)\` to a doc → \`docs:build\` fails with the expected \`onBrokenMarkdownLinks\` MDX error. Reverted.

[SDK-839]: https://gustohq.atlassian.net/browse/SDK-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-758]: https://gustohq.atlassian.net/browse/SDK-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ