### PR TITLE
fix(SDK-839): skip generated docs/api in frontmatter linter

### DIFF
--- a/build/lintDocsFrontmatter.ts
+++ b/build/lintDocsFrontmatter.ts
@@ -10,6 +10,11 @@ const ROOT = join(__dirname, '..')
 const DOCS_DIR = join(ROOT, 'docs')
 const REQUIRED_FIELDS = ['title', 'description'] as const
 
+// Generated content lives here (gitignored, rebuilt by TypeDoc on each
+// build). It legitimately has no frontmatter — skip the directory so a
+// local lint after a prior typedoc run doesn't see stale generated files.
+const SKIP_DIRS = new Set(['api'])
+
 interface Violation {
   file: string
   reason: string
@@ -20,6 +25,7 @@ function collectMarkdownFiles(dir: string): string[] {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry)
     if (statSync(full).isDirectory()) {
+      if (dir === DOCS_DIR && SKIP_DIRS.has(entry)) continue
       out.push(...collectMarkdownFiles(full))
     } else if (entry.endsWith('.md')) {
       out.push(full)


### PR DESCRIPTION
## Summary

Pre-existing latent bug surfaced while wiring up the rest of the SDK-839 quality gates. `build/lintDocsFrontmatter.ts` walks `docs/` recursively, but `docs/api/` is gitignored TypeDoc output with no frontmatter — locally a developer who has run `typedoc` previously sees the linter false-fail on stale generated files.

CI doesn't hit this because the lint step runs before TypeDoc generates the directory. Local runs do.

Second of four scoped PRs decomposing the original SDK-839 work.

## Changes

- `build/lintDocsFrontmatter.ts` now skips `docs/api/` to match the gitignore intent.

## Related

- [SDK-839](https://gustohq.atlassian.net/browse/SDK-839)
- Parent epic: [SDK-758](https://gustohq.atlassian.net/browse/SDK-758) — Modernize SDK Documentation

## Testing

\`\`\`bash
# Generate api/ first so the directory exists locally
cd docs-site && npx typedoc --options typedoc.config.ts && cd ..

# Now confirm the linter passes (without this fix it would fail on docs/api/**)
npm run docs:lint
\`\`\`

Output: \`✓ Front matter valid: 63 files checked\` — generated `docs/api/` files are no longer walked.

[SDK-839]: https://gustohq.atlassian.net/browse/SDK-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-758]: https://gustohq.atlassian.net/browse/SDK-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ