### PR TITLE
fix(sdk-app): match code panel background to panel bg in dark mode

### DIFF
--- a/sdk-app/src/CodePanel.tsx
+++ b/sdk-app/src/CodePanel.tsx
@@ -64,23 +64,32 @@ export function CodePanel({ onClose }: CodePanelProps) {
             </div>
           </div>
           <Highlight code={snippet} language="tsx" theme={prismTheme}>
-            {({ className, style, tokens, getLineProps, getTokenProps }) => (
-              <pre className={`${styles.code} ${className}`} style={style}>
-                {tokens.map((line, i) => {
-                  const lineProps = getLineProps({ line })
-                  return (
-                    <div key={i} {...lineProps} className={`${styles.line} ${lineProps.className}`}>
-                      <span className={styles.lineNumber}>{i + 1}</span>
-                      <span className={styles.lineContent}>
-                        {line.map((token, key) => (
-                          <span key={key} {...getTokenProps({ token })} />
-                        ))}
-                      </span>
-                    </div>
-                  )
-                })}
-              </pre>
-            )}
+            {({ className, style, tokens, getLineProps, getTokenProps }) => {
+              const { background, backgroundColor, ...codeStyle } = style
+              void background
+              void backgroundColor
+              return (
+                <pre className={`${styles.code} ${className}`} style={codeStyle}>
+                  {tokens.map((line, i) => {
+                    const lineProps = getLineProps({ line })
+                    return (
+                      <div
+                        key={i}
+                        {...lineProps}
+                        className={`${styles.line} ${lineProps.className}`}
+                      >
+                        <span className={styles.lineNumber}>{i + 1}</span>
+                        <span className={styles.lineContent}>
+                          {line.map((token, key) => (
+                            <span key={key} {...getTokenProps({ token })} />
+                          ))}
+                        </span>
+                      </div>
+                    )
+                  })}
+                </pre>
+              )
+            }}
           </Highlight>
         </>
       )}


### PR DESCRIPTION
## Summary
- Strip Prism's hard-coded `background` / `backgroundColor` from the inline theme style applied to the code `<pre>`, so the code panel inherits `--color-bg` instead of vsDark's gray.

## Test plan
- [ ] Open sdk-app, toggle dark mode, open the Code panel — background matches the surrounding panel.
- [ ] Toggle back to light mode — syntax colors still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)