### PR TITLE
ci: skip derive job on Dependabot pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,6 +134,15 @@ jobs:
   # On main: fails if derived files are stale (they should always be up-to-date after PRs).
   derive:
     needs: [build]
+    # Dependabot pushes read from a separate Dependabot secrets store and
+    # cannot access `CI_TASKS_ID`/`CI_TASKS_SECRET` or the `ci-tasks`
+    # environment, so `create-github-app-token` fails with "appId option is
+    # required". Skip the job for Dependabot — derived files are produced
+    # from SDK source, not dep versions, so dep bumps can't make them stale.
+    # The merge_group event still runs derive with real secrets before the
+    # PR lands on main. Required status checks are satisfied by a skipped
+    # job, so branch protection is unaffected.
+    if: github.actor != 'dependabot[bot]'
     # Must use the self-hosted runner group — GitHub-hosted runners are blocked
     # by the org IP allow list and cannot push back to the repository.
     runs-on:


### PR DESCRIPTION
## Summary

- `derive` fails on every Dependabot push because Dependabot pushes read from a separate Dependabot secrets store — `CI_TASKS_ID`/`CI_TASKS_SECRET` resolve to empty and `create-github-app-token` errors with "appId option is required". The `environment: ci-tasks` gate compounds it (environment secrets aren't exposed to Dependabot events).
- Skip the job when `github.actor == 'dependabot[bot]'`. Derived files come from SDK source, not dep versions, so dep bumps can't make them stale. `merge_group` still runs `derive` with real secrets before a PR lands on main, providing the final guard.
- A skipped required status check satisfies branch protection, so no branch-protection changes are required.

## Test plan

- [ ] Confirm this PR's own `derive` check runs normally (this is a human-authored push, not a Dependabot one)
- [ ] After merge, verify the next Dependabot PR shows `derive` as **Skipped** and is no longer visibly blocked
- [ ] Inspect a Dependabot PR's `merge_group` run after merge to confirm `derive` mints the app token and succeeds with real secrets