### PR TITLE
chore(deps): override js-yaml to ^4.2.0 to clear security advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19634,10 +19634,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -172,7 +172,11 @@
     "typescript": "^5.8.3"
   },
   "overrides": {
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "js-yaml": "^4.2.0",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^3.13.1"
+    }
   },
   "dependencies": {
     "@gusto/embedded-api-v-2025-11-15": "^0.0.2",


### PR DESCRIPTION
## Summary

Force-resolves the hoisted `js-yaml` from 4.1.1 to 4.2.0 in `package-lock.json` (root) to clear:

| Alert | Severity | Advisory |
| --- | --- | --- |
| [#106](https://github.com/Gusto/embedded-react-sdk/security/dependabot/106) | Moderate | [GHSA-h67p-54hq-rp68](https://github.com/nodeca/js-yaml/security/advisories/GHSA-h67p-54hq-rp68) / CVE-2026-53550 — quadratic-complexity DoS in merge-key handling via repeated aliases |

## Changes

Added `overrides` to root `package.json`:

```json
"overrides": {
  "js-yaml": "^4.2.0",
  "@istanbuljs/load-nyc-config": {
    "js-yaml": "^3.13.1"
  }
}
```

## Why the scoped `@istanbuljs/load-nyc-config` override?

`@istanbuljs/load-nyc-config` (transitive via the coverage tooling) requires `js-yaml ^3.13.1` and calls `yaml.safeLoad`, which was removed in js-yaml 4. Forcing it onto 4.x breaks coverage runs. The scoped override lets the hoisted js-yaml move to 4.2.0 (what Dependabot flags) while Istanbul keeps its nested 3.x copy.

## Partner exposure

**None.** `js-yaml` here is dev tooling (ESLint, JSON schema utilities, Istanbul). It is not in the published SDK npm tarball.

## Testing

- `npm run build` passes
- CI runs the full lint/test/storybook/e2e suite

## Related

Triage doc: [Dependabot alerts — June 2026](https://app.notion.com/p/381ad673c6c281c3acd4c2453fb21fc7) (private)

Siblings: #2157 (esbuild override), #2159 (docs-site overrides)