### PR TITLE
fix(docs-site): unify mobile nav around the docs sidebar tree

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -49,7 +49,7 @@ const config: Config = {
     locales: ['en'],
   },
 
-  plugins: [],
+  plugins: [require.resolve('./plugins/global-docs-sidebar')],
 
   themes: [
     [

--- a/docs-site/plugins/global-docs-sidebar/index.ts
+++ b/docs-site/plugins/global-docs-sidebar/index.ts
@@ -1,0 +1,27 @@
+import type { LoadContext, Plugin } from '@docusaurus/types'
+import type { LoadedContent, LoadedVersion } from '@docusaurus/plugin-content-docs'
+// Internal but stable utility: same fn the docs plugin uses to build the
+// `docsSidebars` prop passed to each docs route. Re-exposing the result via
+// globalData lets us render the docs sidebar tree on non-docs routes too
+// (e.g. inside the mobile navbar on the landing page).
+import { toSidebarsProp } from '@docusaurus/plugin-content-docs/lib/props.js'
+
+export default function globalDocsSidebarPlugin(_context: LoadContext): Plugin<void> {
+  return {
+    name: 'global-docs-sidebar',
+    async allContentLoaded({ allContent, actions }) {
+      const docsContent = allContent['docusaurus-plugin-content-docs'] as
+        | Record<string, LoadedContent>
+        | undefined
+      const defaultInstance = docsContent?.default
+      if (!defaultInstance) return
+
+      const versions = defaultInstance.loadedVersions
+      const activeVersion: LoadedVersion | undefined = versions.find(v => v.isLast) ?? versions[0]
+      if (!activeVersion) return
+
+      const sidebars = toSidebarsProp(activeVersion)
+      actions.setGlobalData({ items: sidebars.docs ?? [] })
+    },
+  }
+}

--- a/docs-site/src/theme/Navbar/MobileSidebar/Layout/index.tsx
+++ b/docs-site/src/theme/Navbar/MobileSidebar/Layout/index.tsx
@@ -1,6 +1,5 @@
 import React, { version, type ReactNode } from 'react'
 import clsx from 'clsx'
-import { useNavbarSecondaryMenu } from '@docusaurus/theme-common/internal'
 import { ThemeClassNames } from '@docusaurus/theme-common'
 import NavbarColorModeToggle from '@theme/Navbar/ColorModeToggle'
 import type { Props } from '@theme/Navbar/MobileSidebar/Layout'
@@ -28,12 +27,7 @@ function NavbarMobileSidebarPanel({ children, inert }: { children: ReactNode; in
   )
 }
 
-export default function NavbarMobileSidebarLayout({
-  header,
-  primaryMenu,
-  secondaryMenu,
-}: Props): ReactNode {
-  const { shown: secondaryMenuShown } = useNavbarSecondaryMenu()
+export default function NavbarMobileSidebarLayout({ header, primaryMenu }: Props): ReactNode {
   return (
     <div
       className={clsx(
@@ -43,17 +37,8 @@ export default function NavbarMobileSidebarLayout({
       )}
     >
       {header}
-      <div
-        className={clsx('navbar-sidebar__items', styles.mobileSidebarItems, {
-          'navbar-sidebar__items--show-secondary': secondaryMenuShown,
-        })}
-      >
-        <NavbarMobileSidebarPanel inert={secondaryMenuShown}>
-          {primaryMenu}
-        </NavbarMobileSidebarPanel>
-        <NavbarMobileSidebarPanel inert={!secondaryMenuShown}>
-          {secondaryMenu}
-        </NavbarMobileSidebarPanel>
+      <div className={clsx('navbar-sidebar__items', styles.mobileSidebarItems)}>
+        <NavbarMobileSidebarPanel inert={false}>{primaryMenu}</NavbarMobileSidebarPanel>
       </div>
       <div className={styles.mobileSidebarFooter}>
         <NavbarColorModeToggle />

--- a/docs-site/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.tsx
+++ b/docs-site/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.tsx
@@ -1,0 +1,32 @@
+import React, { type ReactNode } from 'react'
+import { useLocation } from '@docusaurus/router'
+import { usePluginData } from '@docusaurus/useGlobalData'
+import { useNavbarMobileSidebar } from '@docusaurus/theme-common/internal'
+import { DocSidebarItemsExpandedStateProvider } from '@docusaurus/plugin-content-docs/client'
+import DocSidebarItems from '@theme/DocSidebarItems'
+import type { PropSidebar } from '@docusaurus/plugin-content-docs'
+
+export default function NavbarMobilePrimaryMenu(): ReactNode {
+  const { items } = usePluginData('global-docs-sidebar') as { items: PropSidebar }
+  const { pathname } = useLocation()
+  const mobileSidebar = useNavbarMobileSidebar()
+  return (
+    <DocSidebarItemsExpandedStateProvider>
+      <ul className="menu__list">
+        <DocSidebarItems
+          items={items}
+          activePath={pathname}
+          onItemClick={item => {
+            if (item.type === 'category' && item.href) {
+              mobileSidebar.toggle()
+            }
+            if (item.type === 'link') {
+              mobileSidebar.toggle()
+            }
+          }}
+          level={1}
+        />
+      </ul>
+    </DocSidebarItemsExpandedStateProvider>
+  )
+}


### PR DESCRIPTION
## Summary

- Single mobile menu on every route: the full parsed docs sidebar tree from `sidebars.ts`, on landing and docs pages alike. No more `Docs` / `GitHub` primary panel, no `Back to main menu` toggle.
- New local Docusaurus plugin `global-docs-sidebar` re-exposes the docs plugin's parsed `PropSidebar` via `globalData` so the swizzled `Navbar/MobileSidebar/PrimaryMenu` can render `DocSidebarItems` on non-docs routes too (`useLayoutDocsSidebar` only returns `{link}`, not items).
- `Navbar/MobileSidebar/Layout` swizzle simplified to render a single panel.

## Test plan

- [ ] `cd docs-site && npm run start`, mobile width — open hamburger on `/` (landing); confirm the full docs sidebar tree renders, no `Back to main menu`, no `Docs`/`GitHub` items.
- [ ] Same on `/docs/` and on a deep page like `/docs/workflows-overview/employee-onboarding`; current page is highlighted; tapping a leaf closes the menu and navigates; tapping a category header expands/collapses without closing.
- [ ] Desktop navbar unchanged: logo, `Docs`, `GitHub`, color toggle, search.
- [ ] `npm run build` inside `docs-site/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)