### PR TITLE
feat(sdk-app): employee management design prototype

### DIFF
--- a/sdk-app/src/design/components/employee/management/EmployeeList/EmployeeList.tsx
+++ b/sdk-app/src/design/components/employee/management/EmployeeList/EmployeeList.tsx
@@ -1,0 +1,354 @@
+import type { Employee } from '@gusto/embedded-api-v-2025-11-15/models/components/employee'
+import type { Job } from '@gusto/embedded-api-v-2025-11-15/models/components/job'
+import { useEmployeeEmploymentsGetRehire } from '@gusto/embedded-api-v-2025-11-15/react-query/employeeEmploymentsGetRehire'
+import { Skeleton } from '../../../common/Skeleton'
+import { DataView, EmptyData, Flex, useDataView } from '@/components/Common'
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu/HamburgerMenu'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import PencilSvg from '@/assets/icons/pencil.svg?react'
+import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
+import PlusCircleIcon from '@/assets/icons/plus-circle.svg?react'
+
+export type EmployeeListTab = 'active' | 'onboarding' | 'dismissed'
+
+export interface EmployeeListProps {
+  employees: Employee[]
+  isFetching?: boolean
+  selectedTab: EmployeeListTab
+  onSelectTab: (tab: EmployeeListTab) => void
+  successMessage?: string | null
+  onDismissSuccess?: () => void
+  onAddEmployee?: () => void
+  onEditEmployee?: (employee: Employee) => void
+  onDismissEmployee?: (employee: Employee) => void
+  onRehireEmployee?: (employee: Employee) => void
+  onViewEmployeeDetails?: (employee: Employee) => void
+  onEditRehire?: (employee: Employee) => void
+  onCancelRehire?: (employee: Employee) => void
+}
+
+const TABS: Array<{ id: EmployeeListTab; label: string }> = [
+  { id: 'active', label: 'Active' },
+  { id: 'onboarding', label: 'Onboarding' },
+  { id: 'dismissed', label: 'Dismissed' },
+]
+
+function getPrimaryJob(employee: Employee): Job | undefined {
+  return employee.jobs?.find(job => job.primary === true) ?? employee.jobs?.[0]
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) return '-'
+  const date = new Date(`${value}T00:00:00`)
+  if (Number.isNaN(date.getTime())) return '-'
+  return date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+}
+
+function formatShortDate(dateStr: string): string {
+  const date = new Date(`${dateStr}T00:00:00`)
+  const now = new Date()
+  const sameYear = date.getFullYear() === now.getFullYear()
+  const month = date.toLocaleDateString('en-US', { month: 'long' })
+  const day = date.getDate()
+  return sameYear ? `${month} ${day}` : `${month} ${day}, ${date.getFullYear()}`
+}
+
+function pendingDismissalDate(employee: Employee): string | null {
+  const pending = employee.terminations?.find(termination => {
+    if (!termination.effectiveDate) return false
+    if (termination.active === true) return false
+    const effective = new Date(`${termination.effectiveDate}T00:00:00`)
+    if (Number.isNaN(effective.getTime())) return false
+    return effective.getTime() > Date.now()
+  })
+  return pending?.effectiveDate ?? null
+}
+
+function employeeName(employee: Employee): string {
+  return [employee.firstName, employee.lastName].filter(Boolean).join(' ') || '-'
+}
+
+const ONBOARDING_STATUS_LABELS: Record<string, string> = {
+  admin_onboarding_incomplete: 'Admin-onboarding Incomplete',
+  onboarding_completed: 'Completed',
+  self_onboarding_pending_invite: 'Self-onboarding: Pending Invite',
+  self_onboarding_invited: 'Self-onboarding: Invited',
+  self_onboarding_invited_started: 'Self-onboarding started',
+  self_onboarding_invited_overdue: 'Self-onboarding: Overdue',
+  self_onboarding_completed_by_employee: 'Self-onboarding: Completed',
+  self_onboarding_awaiting_admin_review: 'Self-onboarding: Admin review',
+}
+
+function usePendingRehireEffectiveDate(employeeId: string): string | null {
+  const { data } = useEmployeeEmploymentsGetRehire(
+    { employeeId },
+    { throwOnError: () => false, retry: false },
+  )
+  const effectiveDate = data?.rehire?.effectiveDate
+  if (!effectiveDate) return null
+  const effective = new Date(`${effectiveDate}T00:00:00`)
+  if (Number.isNaN(effective.getTime()) || effective.getTime() <= Date.now()) return null
+  return effectiveDate
+}
+
+function PendingRehireBadge({ employeeId }: { employeeId: string }) {
+  const Components = useComponentContext()
+  const effectiveDate = usePendingRehireEffectiveDate(employeeId)
+  if (!effectiveDate) return null
+  return <Components.Badge status="info">Rehire {formatShortDate(effectiveDate)}</Components.Badge>
+}
+
+function DismissedRowMenu({
+  employee,
+  onViewDetails,
+  onRehire,
+  onEditRehire,
+  onCancelRehire,
+}: {
+  employee: Employee
+  onViewDetails?: (employee: Employee) => void
+  onRehire?: (employee: Employee) => void
+  onEditRehire?: (employee: Employee) => void
+  onCancelRehire?: (employee: Employee) => void
+}) {
+  const hasPendingRehire = usePendingRehireEffectiveDate(employee.uuid) !== null
+
+  const items: Array<{ label: string; onClick: () => void; icon?: React.ReactNode }> = []
+
+  if (onViewDetails) {
+    items.push({
+      label: 'View details',
+      onClick: () => {
+        onViewDetails(employee)
+      },
+    })
+  }
+
+  if (hasPendingRehire) {
+    if (onEditRehire) {
+      items.push({
+        label: 'Edit rehire details',
+        onClick: () => {
+          onEditRehire(employee)
+        },
+        icon: <PencilSvg aria-hidden />,
+      })
+    }
+    if (onCancelRehire) {
+      items.push({
+        label: 'Cancel rehire',
+        onClick: () => {
+          onCancelRehire(employee)
+        },
+        icon: <TrashCanSvg aria-hidden />,
+      })
+    }
+  } else if (onRehire) {
+    items.push({
+      label: 'Rehire',
+      onClick: () => {
+        onRehire(employee)
+      },
+    })
+  }
+
+  if (items.length === 0) return null
+  return <HamburgerMenu items={items} triggerLabel="Open actions" />
+}
+
+function onboardingStatusLabel(employee: Employee): string {
+  if (employee.onboarded) return 'Onboarded'
+  if (!employee.onboardingStatus) return 'N/A'
+  return ONBOARDING_STATUS_LABELS[employee.onboardingStatus] ?? employee.onboardingStatus
+}
+
+export function EmployeeList({
+  employees,
+  isFetching,
+  selectedTab,
+  onSelectTab,
+  onAddEmployee,
+  onEditEmployee,
+  onDismissEmployee,
+  onRehireEmployee,
+  onViewEmployeeDetails,
+  onEditRehire,
+  onCancelRehire,
+  successMessage,
+  onDismissSuccess,
+}: EmployeeListProps) {
+  const Components = useComponentContext()
+
+  const nameColumn = {
+    key: 'name',
+    title: 'Name',
+    render: (employee: Employee) => employeeName(employee),
+  }
+
+  const jobTitleColumn = {
+    key: 'jobTitle',
+    title: 'Job title',
+    render: (employee: Employee) => getPrimaryJob(employee)?.title ?? '-',
+  }
+
+  const startDateColumn = {
+    key: 'startDate',
+    title: 'Start date',
+    render: (employee: Employee) => formatDate(getPrimaryJob(employee)?.hireDate),
+  }
+
+  const statusColumn = {
+    key: 'status',
+    title: 'Status',
+    render: (employee: Employee) => (
+      <Components.Badge status={employee.onboarded ? 'success' : 'warning'}>
+        {onboardingStatusLabel(employee)}
+      </Components.Badge>
+    ),
+  }
+
+  const lastDayColumn = {
+    key: 'lastDay',
+    title: 'Last day',
+    render: (employee: Employee) => formatDate(employee.terminations?.[0]?.effectiveDate),
+  }
+
+  const pendingRehireColumn = {
+    key: 'pendingRehire',
+    title: '',
+    render: (employee: Employee) => <PendingRehireBadge employeeId={employee.uuid} />,
+  }
+
+  const pendingDismissalColumn = {
+    key: 'pendingDismissal',
+    title: '',
+    render: (employee: Employee) => {
+      const date = pendingDismissalDate(employee)
+      if (!date) return null
+      return <Components.Badge status="info">Last day {formatShortDate(date)}</Components.Badge>
+    },
+  }
+
+  const realColumns = (() => {
+    switch (selectedTab) {
+      case 'active':
+        return [nameColumn, jobTitleColumn, pendingDismissalColumn]
+      case 'onboarding':
+        return [nameColumn, startDateColumn, jobTitleColumn, statusColumn]
+      case 'dismissed':
+        return [nameColumn, jobTitleColumn, lastDayColumn, pendingRehireColumn]
+    }
+  })()
+
+  const skeletonColumns = realColumns.map(col => ({
+    key: col.key,
+    title: col.title ? <Skeleton width={60} height={16} /> : '',
+    render: () => <Skeleton width={120} height={16} />,
+  }))
+
+  const placeholders = Array.from({ length: 3 }) as Employee[]
+  const columns = isFetching ? skeletonColumns : realColumns
+  const data = isFetching ? placeholders : employees
+
+  const emptyState = (() => {
+    switch (selectedTab) {
+      case 'active':
+        return {
+          title: 'No active employees',
+          description: 'Once an employee finishes onboarding, they will appear here.',
+        }
+      case 'onboarding':
+        return {
+          title: 'No employees in onboarding',
+          description: 'Add an employee to start their onboarding.',
+        }
+      case 'dismissed':
+        return {
+          title: 'No dismissed employees',
+          description: 'Dismissed employees appear here and can be rehired.',
+        }
+    }
+  })()
+
+  const dataViewProps = useDataView<Employee>({
+    data,
+    columns,
+    isFetching,
+    itemMenu: isFetching
+      ? undefined
+      : employee => {
+          if (selectedTab === 'dismissed') {
+            return (
+              <DismissedRowMenu
+                employee={employee}
+                onViewDetails={onViewEmployeeDetails}
+                onRehire={onRehireEmployee}
+                onEditRehire={onEditRehire}
+                onCancelRehire={onCancelRehire}
+              />
+            )
+          }
+
+          const items: Array<{ label: string; onClick: () => void; icon?: React.ReactNode }> = []
+
+          if (onEditEmployee) {
+            items.push({
+              label: 'Edit',
+              onClick: () => {
+                onEditEmployee(employee)
+              },
+              icon: <PencilSvg aria-hidden />,
+            })
+          }
+
+          if (selectedTab === 'active' && onDismissEmployee) {
+            items.push({
+              label: 'Dismiss',
+              onClick: () => {
+                onDismissEmployee(employee)
+              },
+              icon: <TrashCanSvg aria-hidden />,
+            })
+          }
+
+          if (items.length === 0) return null
+          return <HamburgerMenu items={items} triggerLabel="Open actions" />
+        },
+    emptyState: () => <EmptyData title={emptyState.title} description={emptyState.description} />,
+  })
+
+  return (
+    <Flex flexDirection="column" gap={32}>
+      {successMessage && (
+        <Components.Alert
+          label={successMessage}
+          status="success"
+          onDismiss={onDismissSuccess}
+          disableScrollIntoView
+        />
+      )}
+
+      <Flex justifyContent="space-between" alignItems="center">
+        <Components.Heading as="h2">Employees</Components.Heading>
+        {onAddEmployee && (
+          <Components.Button variant="secondary" onClick={onAddEmployee} icon={<PlusCircleIcon />}>
+            Add employee
+          </Components.Button>
+        )}
+      </Flex>
+
+      <Flex flexDirection="column" gap={0}>
+        <Components.Tabs
+          tabs={TABS.map(tab => ({ id: tab.id, label: tab.label, content: null }))}
+          selectedId={selectedTab}
+          onSelectionChange={id => {
+            onSelectTab(id as EmployeeListTab)
+          }}
+          aria-label="Employee filter"
+        />
+
+        <DataView label="Employees" {...dataViewProps} />
+      </Flex>
+    </Flex>
+  )
+}

--- a/sdk-app/src/design/components/employee/management/EmployeeList/EmployeeList.tsx
+++ b/sdk-app/src/design/components/employee/management/EmployeeList/EmployeeList.tsx
@@ -79,21 +79,27 @@ const ONBOARDING_STATUS_LABELS: Record<string, string> = {
   self_onboarding_awaiting_admin_review: 'Self-onboarding: Admin review',
 }
 
-function usePendingRehireEffectiveDate(employeeId: string): string | null {
-  const { data } = useEmployeeEmploymentsGetRehire(
+function usePendingRehire(employeeId: string): {
+  effectiveDate: string | null
+  isPending: boolean
+} {
+  const { data, isPending } = useEmployeeEmploymentsGetRehire(
     { employeeId },
     { throwOnError: () => false, retry: false },
   )
   const effectiveDate = data?.rehire?.effectiveDate
-  if (!effectiveDate) return null
+  if (!effectiveDate) return { effectiveDate: null, isPending }
   const effective = new Date(`${effectiveDate}T00:00:00`)
-  if (Number.isNaN(effective.getTime()) || effective.getTime() <= Date.now()) return null
-  return effectiveDate
+  if (Number.isNaN(effective.getTime()) || effective.getTime() <= Date.now()) {
+    return { effectiveDate: null, isPending }
+  }
+  return { effectiveDate, isPending }
 }
 
 function PendingRehireBadge({ employeeId }: { employeeId: string }) {
   const Components = useComponentContext()
-  const effectiveDate = usePendingRehireEffectiveDate(employeeId)
+  const { effectiveDate, isPending } = usePendingRehire(employeeId)
+  if (isPending) return <Skeleton width={120} height={16} />
   if (!effectiveDate) return null
   return <Components.Badge status="info">Rehire {formatShortDate(effectiveDate)}</Components.Badge>
 }
@@ -111,7 +117,7 @@ function DismissedRowMenu({
   onEditRehire?: (employee: Employee) => void
   onCancelRehire?: (employee: Employee) => void
 }) {
-  const hasPendingRehire = usePendingRehireEffectiveDate(employee.uuid) !== null
+  const hasPendingRehire = usePendingRehire(employee.uuid).effectiveDate !== null
 
   const items: Array<{ label: string; onClick: () => void; icon?: React.ReactNode }> = []
 

--- a/sdk-app/src/design/components/employee/management/RehireEmployeeForm/RehireEmployeeForm.tsx
+++ b/sdk-app/src/design/components/employee/management/RehireEmployeeForm/RehireEmployeeForm.tsx
@@ -1,0 +1,188 @@
+import { useEffect } from 'react'
+import { FormProvider, useForm, useWatch } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import type { Employee } from '@gusto/embedded-api-v-2025-11-15/models/components/employee'
+import type { Location } from '@gusto/embedded-api-v-2025-11-15/models/components/location'
+import type { Rehire } from '@gusto/embedded-api-v-2025-11-15/models/components/rehire'
+import { Flex } from '@/components/Common/Flex'
+import { Form } from '@/components/Common/Form'
+import { Grid } from '@/components/Common/Grid/Grid'
+import { DatePickerField } from '@/components/Common/Fields/DatePickerField'
+import { SelectField } from '@/components/Common/Fields/SelectField'
+import { RadioGroupField } from '@/components/Common/Fields/RadioGroupField'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { formatDateToStringDate } from '@/helpers/dateFormatting'
+
+const RehireEmployeeSchema = z.object({
+  effectiveDate: z.date(),
+  workLocationUuid: z.string().min(1, 'Select a work address'),
+  fileNewHireReport: z.enum(['yes', 'no']),
+})
+
+type RehireEmployeeFormData = z.infer<typeof RehireEmployeeSchema>
+
+export interface RehireEmployeeFormValues {
+  effectiveDate: string
+  workLocationUuid: string
+  fileNewHireReport: boolean
+}
+
+export interface RehireEmployeeFormProps {
+  employee: Pick<Employee, 'firstName' | 'lastName' | 'uuid'>
+  workLocations: Location[]
+  isPending?: boolean
+  defaultWorkLocationUuid?: string
+  existingRehire?: Pick<
+    Rehire,
+    'effectiveDate' | 'workLocationUuid' | 'fileNewHireReport' | 'version'
+  > | null
+  submitError?: string | null
+  onDismissSubmitError?: () => void
+  effectiveDateError?: string | null
+  onDismissEffectiveDateError?: () => void
+  onCancel?: () => void
+  onSubmit: (values: RehireEmployeeFormValues) => Promise<void> | void
+}
+
+function locationLabel(location: Location): string {
+  const lines = [location.street1, location.city, location.state, location.zip].filter(Boolean)
+  return lines.join(', ')
+}
+
+function employeeName(employee: Pick<Employee, 'firstName' | 'lastName'>): string {
+  return [employee.firstName, employee.lastName].filter(Boolean).join(' ') || 'employee'
+}
+
+export function RehireEmployeeForm({
+  employee,
+  workLocations,
+  isPending,
+  defaultWorkLocationUuid,
+  existingRehire,
+  submitError,
+  onDismissSubmitError,
+  effectiveDateError,
+  onDismissEffectiveDateError,
+  onCancel,
+  onSubmit,
+}: RehireEmployeeFormProps) {
+  const Components = useComponentContext()
+
+  const isEditing = !!existingRehire
+
+  const initialEffectiveDate = existingRehire?.effectiveDate
+    ? new Date(`${existingRehire.effectiveDate}T00:00:00`)
+    : new Date()
+
+  const initialWorkLocationUuid =
+    existingRehire?.workLocationUuid ?? defaultWorkLocationUuid ?? workLocations[0]?.uuid ?? ''
+
+  const initialFileNewHireReport: 'yes' | 'no' =
+    existingRehire?.fileNewHireReport === false ? 'no' : 'yes'
+
+  const formMethods = useForm<RehireEmployeeFormData>({
+    resolver: zodResolver(RehireEmployeeSchema),
+    defaultValues: {
+      effectiveDate: initialEffectiveDate,
+      workLocationUuid: initialWorkLocationUuid,
+      fileNewHireReport: initialFileNewHireReport,
+    },
+  })
+
+  useEffect(() => {
+    if (effectiveDateError) {
+      formMethods.setError('effectiveDate', { type: 'server', message: effectiveDateError })
+    } else {
+      formMethods.clearErrors('effectiveDate')
+    }
+  }, [effectiveDateError, formMethods])
+
+  const watchedEffectiveDate = useWatch({ control: formMethods.control, name: 'effectiveDate' })
+  useEffect(() => {
+    if (effectiveDateError) {
+      onDismissEffectiveDateError?.()
+    }
+  }, [watchedEffectiveDate]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const workLocationOptions = workLocations.map(location => ({
+    label: locationLabel(location),
+    value: location.uuid,
+  }))
+
+  const handleSubmit = formMethods.handleSubmit(async data => {
+    await onSubmit({
+      effectiveDate: formatDateToStringDate(data.effectiveDate) || '',
+      workLocationUuid: data.workLocationUuid,
+      fileNewHireReport: data.fileNewHireReport === 'yes',
+    })
+  })
+
+  return (
+    <FormProvider {...formMethods}>
+      <Form onSubmit={handleSubmit}>
+        <Grid gridTemplateColumns="1fr" gap={24}>
+          {submitError && (
+            <Components.Alert label={submitError} status="error" onDismiss={onDismissSubmitError} />
+          )}
+
+          <Flex flexDirection="column" gap={4}>
+            <Components.Heading as="h2">
+              {isEditing
+                ? `Edit rehire for ${employeeName(employee)}`
+                : `Rehire ${employeeName(employee)}`}
+            </Components.Heading>
+            <Components.Text variant="supporting">
+              {isEditing
+                ? 'Update the return to work date or work address for this scheduled rehire.'
+                : 'Schedule a return to work date and confirm where this employee will work.'}
+            </Components.Text>
+          </Flex>
+
+          <DatePickerField
+            name="effectiveDate"
+            label="Start date"
+            description="The day the employee returns to work."
+            isRequired
+          />
+
+          <SelectField
+            name="workLocationUuid"
+            label="Work address"
+            description="The address where this employee will report to work."
+            options={workLocationOptions}
+            isRequired
+          />
+
+          <RadioGroupField
+            name="fileNewHireReport"
+            label="File a new hire report"
+            description="Required in most states when rehiring after a separation of 60 days or more."
+            isRequired
+            options={[
+              { label: 'Yes, file a new hire report', value: 'yes' },
+              { label: 'No, do not file', value: 'no' },
+            ]}
+          />
+
+          <Flex gap={12} justifyContent="flex-end">
+            {onCancel && (
+              <Components.Button variant="secondary" onClick={onCancel} isDisabled={isPending}>
+                Cancel
+              </Components.Button>
+            )}
+            <Components.Button type="submit" variant="primary" isDisabled={isPending}>
+              {isPending
+                ? isEditing
+                  ? 'Saving...'
+                  : 'Scheduling rehire...'
+                : isEditing
+                  ? 'Save rehire'
+                  : 'Schedule rehire'}
+            </Components.Button>
+          </Flex>
+        </Grid>
+      </Form>
+    </FormProvider>
+  )
+}

--- a/sdk-app/src/design/prototypes/employee-management/EmployeeManagement/EmployeeList.tsx
+++ b/sdk-app/src/design/prototypes/employee-management/EmployeeManagement/EmployeeList.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useOutletContext, useSearchParams } from 'react-router-dom'
+import { useEmployeesList } from '@gusto/embedded-api-v-2025-11-15/react-query/employeesList'
+import { useEmployeeEmploymentsDeleteRehireMutation } from '@gusto/embedded-api-v-2025-11-15/react-query/employeeEmploymentsDeleteRehire'
+import type { EntityIds } from '../../../../useEntities'
+import {
+  EmployeeList as EmployeeListView,
+  type EmployeeListTab,
+} from '../../../components/employee/management/EmployeeList/EmployeeList'
+import { BaseComponent } from '@/components/Base'
+
+function tabToQueryParams(tab: EmployeeListTab, companyId: string) {
+  const base = { companyId, page: 1, per: 25 }
+  switch (tab) {
+    case 'active':
+      return { ...base, onboardedActive: true }
+    case 'onboarding':
+      return { ...base, onboarded: false }
+    case 'dismissed':
+      return { ...base, terminatedToday: true }
+  }
+}
+
+function EmployeeListContent() {
+  const { entities } = useOutletContext<{ entities: EntityIds }>()
+  const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [selectedTab, setSelectedTab] = useState<EmployeeListTab>('active')
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    const msg = searchParams.get('success')
+    if (msg) {
+      setSuccessMessage(msg)
+      setSearchParams({}, { replace: true })
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const queryParams = useMemo(
+    () => tabToQueryParams(selectedTab, entities.companyId),
+    [selectedTab, entities.companyId],
+  )
+
+  const { data, isPending } = useEmployeesList(queryParams)
+
+  const { mutateAsync: deleteRehire } = useEmployeeEmploymentsDeleteRehireMutation()
+
+  const { data: terminatedData } = useEmployeesList(
+    { companyId: entities.companyId, page: 1, per: 25, terminated: true },
+    { enabled: selectedTab === 'active' },
+  )
+
+  const pendingDismissals = useMemo(() => {
+    if (selectedTab !== 'active') return []
+    return (terminatedData?.showEmployees ?? []).filter(employee =>
+      employee.terminations?.some(termination => {
+        if (!termination.effectiveDate || termination.active === true) return false
+        const effective = new Date(`${termination.effectiveDate}T00:00:00`)
+        if (Number.isNaN(effective.getTime())) return false
+        return effective.getTime() > Date.now()
+      }),
+    )
+  }, [selectedTab, terminatedData])
+
+  const employees = useMemo(() => {
+    const primary = data?.showEmployees ?? []
+    if (selectedTab !== 'active') return primary
+    const seen = new Set(primary.map(e => e.uuid))
+    return [...primary, ...pendingDismissals.filter(e => !seen.has(e.uuid))]
+  }, [data, pendingDismissals, selectedTab])
+
+  return (
+    <EmployeeListView
+      employees={employees}
+      isFetching={isPending}
+      selectedTab={selectedTab}
+      onSelectTab={setSelectedTab}
+      successMessage={successMessage}
+      onDismissSuccess={() => {
+        setSuccessMessage(null)
+      }}
+      onAddEmployee={() => {}}
+      onEditEmployee={() => {}}
+      onDismissEmployee={() => {}}
+      onRehireEmployee={employee => {
+        void navigate(`${employee.uuid}/rehire`)
+      }}
+      onViewEmployeeDetails={() => {}}
+      onEditRehire={employee => {
+        void navigate(`${employee.uuid}/rehire`)
+      }}
+      onCancelRehire={async employee => {
+        await deleteRehire({ request: { employeeId: employee.uuid } })
+        const name = [employee.firstName, employee.lastName].filter(Boolean).join(' ') || 'employee'
+        setSuccessMessage(`Rehire cancelled for ${name}`)
+      }}
+    />
+  )
+}
+
+export function EmployeeList() {
+  return (
+    <BaseComponent onEvent={() => {}}>
+      <EmployeeListContent />
+    </BaseComponent>
+  )
+}

--- a/sdk-app/src/design/prototypes/employee-management/EmployeeManagement/EmployeeManagementFlow.tsx
+++ b/sdk-app/src/design/prototypes/employee-management/EmployeeManagement/EmployeeManagementFlow.tsx
@@ -1,0 +1,22 @@
+import { Outlet, useOutletContext } from 'react-router-dom'
+import type { EntityIds } from '../../../../useEntities'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common'
+
+export function EmployeeManagementFlow() {
+  const { entities } = useOutletContext<{ entities: EntityIds }>()
+  const Components = useComponentContext()
+
+  if (!entities.companyId) {
+    return (
+      <Flex flexDirection="column" gap={16} alignItems="stretch">
+        <Components.Heading as="h2">Employee Management</Components.Heading>
+        <Components.Alert label="Missing company ID" status="warning">
+          Set a company ID in Settings (top right) to load real data.
+        </Components.Alert>
+      </Flex>
+    )
+  }
+
+  return <Outlet context={{ entities }} />
+}

--- a/sdk-app/src/design/prototypes/employee-management/EmployeeManagement/RehireEmployee.tsx
+++ b/sdk-app/src/design/prototypes/employee-management/EmployeeManagement/RehireEmployee.tsx
@@ -1,0 +1,179 @@
+import { Suspense, useState } from 'react'
+import { useNavigate, useOutletContext, useParams } from 'react-router-dom'
+import { UnprocessableEntityError } from '@gusto/embedded-api-v-2025-11-15/models/errors/unprocessableentityerror'
+import type { EntityErrorObject } from '@gusto/embedded-api-v-2025-11-15/models/components/entityerrorobject'
+import { useEmployeesGetSuspense } from '@gusto/embedded-api-v-2025-11-15/react-query/employeesGet'
+import { useLocationsGetSuspense } from '@gusto/embedded-api-v-2025-11-15/react-query/locationsGet'
+import { useEmployeeEmploymentsGetRehire } from '@gusto/embedded-api-v-2025-11-15/react-query/employeeEmploymentsGetRehire'
+import { useEmployeeEmploymentsCreateRehireMutation } from '@gusto/embedded-api-v-2025-11-15/react-query/employeeEmploymentsCreateRehire'
+import { useEmployeeEmploymentsRehireMutation } from '@gusto/embedded-api-v-2025-11-15/react-query/employeeEmploymentsRehire'
+import { RehireBodyEmploymentStatus } from '@gusto/embedded-api-v-2025-11-15/models/components/rehirebody'
+import type { EntityIds } from '../../../../useEntities'
+import {
+  RehireEmployeeForm,
+  type RehireEmployeeFormValues,
+} from '../../../components/employee/management/RehireEmployeeForm/RehireEmployeeForm'
+import { BaseComponent } from '@/components/Base'
+import { Flex } from '@/components/Common'
+
+function flattenErrors(errors: EntityErrorObject[]): EntityErrorObject[] {
+  const flat: EntityErrorObject[] = []
+  for (const error of errors) {
+    if (error.category === 'nested_errors' && Array.isArray(error.errors)) {
+      flat.push(...flattenErrors(error.errors))
+    } else {
+      flat.push(error)
+    }
+  }
+  return flat
+}
+
+interface SubmitError {
+  effectiveDateError?: string
+  generalError?: string
+}
+
+function classifySubmitError(error: unknown): SubmitError {
+  if (error instanceof UnprocessableEntityError) {
+    const flat = flattenErrors(error.errors)
+    const result: SubmitError = {}
+    const generalMessages: string[] = []
+
+    for (const entry of flat) {
+      const message = entry.message ?? ''
+      const isHireDateRule =
+        (entry.errorKey === 'hired_at' || entry.errorKey === 'effective_date') &&
+        /work employee addresses history/i.test(message)
+
+      if (isHireDateRule) {
+        const dateMatch = message.match(/(\d{2}\/\d{2}\/\d{4})/)
+        result.effectiveDateError = dateMatch
+          ? `This rehire date isn't compatible with this employee's employment history. Try a date on or before ${dateMatch[1]}.`
+          : "This rehire date isn't compatible with this employee's employment history."
+      } else if (message) {
+        generalMessages.push(message)
+      }
+    }
+
+    if (generalMessages.length > 0) result.generalError = generalMessages.join(' ')
+    if (result.effectiveDateError || result.generalError) return result
+  }
+  if (error instanceof Error && error.message) return { generalError: error.message }
+  return { generalError: 'Something went wrong. Please try again.' }
+}
+
+function RehireEmployeeContent() {
+  const { entities } = useOutletContext<{ entities: EntityIds }>()
+  const { employeeId } = useParams<{ employeeId: string }>()
+  const navigate = useNavigate()
+  const [generalError, setGeneralError] = useState<string | null>(null)
+  const [effectiveDateError, setEffectiveDateError] = useState<string | null>(null)
+
+  const { data: employeeData } = useEmployeesGetSuspense({ employeeId: employeeId! })
+  const employee = employeeData.employee
+
+  const { data: locationsData } = useLocationsGetSuspense({ companyId: entities.companyId })
+  const workLocations = (locationsData.companyLocationsList ?? []).filter(
+    location => location.active !== false,
+  )
+
+  const { data: rehireData, isPending: isLoadingRehire } = useEmployeeEmploymentsGetRehire(
+    { employeeId: employeeId! },
+    { throwOnError: () => false, retry: false },
+  )
+
+  const rehire = rehireData?.rehire
+  const isPendingRehire = (() => {
+    if (!rehire?.version || !rehire.effectiveDate) return false
+    const effective = new Date(`${rehire.effectiveDate}T00:00:00`)
+    if (Number.isNaN(effective.getTime())) return false
+    return effective.getTime() > Date.now()
+  })()
+  const existingRehire = isPendingRehire ? rehire : null
+
+  const { mutateAsync: createRehire, isPending: isCreating } =
+    useEmployeeEmploymentsCreateRehireMutation()
+  const { mutateAsync: updateRehire, isPending: isUpdating } =
+    useEmployeeEmploymentsRehireMutation()
+
+  if (!employee) return null
+  if (isLoadingRehire) return null
+
+  const handleSubmit = async (values: RehireEmployeeFormValues) => {
+    setGeneralError(null)
+    setEffectiveDateError(null)
+    const isUpdate = !!existingRehire?.version
+    try {
+      if (existingRehire?.version) {
+        await updateRehire({
+          request: {
+            employeeId: employee.uuid,
+            rehireUpdateRequestBody: {
+              version: existingRehire.version,
+              effectiveDate: values.effectiveDate,
+              workLocationUuid: values.workLocationUuid,
+              fileNewHireReport: values.fileNewHireReport,
+            },
+          },
+        })
+      } else {
+        await createRehire({
+          request: {
+            employeeId: employee.uuid,
+            rehireBody: {
+              effectiveDate: values.effectiveDate,
+              workLocationUuid: values.workLocationUuid,
+              fileNewHireReport: values.fileNewHireReport,
+              employmentStatus: RehireBodyEmploymentStatus.FullTime,
+            },
+          },
+        })
+      }
+    } catch (error) {
+      const classified = classifySubmitError(error)
+      if (classified.effectiveDateError) setEffectiveDateError(classified.effectiveDateError)
+      if (classified.generalError) setGeneralError(classified.generalError)
+      return
+    }
+    const name = [employee.firstName, employee.lastName].filter(Boolean).join(' ') || 'employee'
+    const message = isUpdate ? `Rehire updated for ${name}` : `Rehire scheduled for ${name}`
+    void navigate(`..?success=${encodeURIComponent(message)}`, { replace: true })
+  }
+
+  return (
+    <RehireEmployeeForm
+      employee={employee}
+      workLocations={workLocations}
+      isPending={isCreating || isUpdating}
+      existingRehire={existingRehire}
+      submitError={generalError}
+      effectiveDateError={effectiveDateError}
+      onDismissSubmitError={() => {
+        setGeneralError(null)
+      }}
+      onDismissEffectiveDateError={() => {
+        setEffectiveDateError(null)
+      }}
+      onCancel={() => {
+        void navigate('..')
+      }}
+      onSubmit={handleSubmit}
+    />
+  )
+}
+
+export function RehireEmployee() {
+  return (
+    <BaseComponent onEvent={() => {}}>
+      <Suspense
+        fallback={
+          <Flex flexDirection="column" gap={24}>
+            Loading…
+          </Flex>
+        }
+      >
+        <RehireEmployeeContent />
+      </Suspense>
+    </BaseComponent>
+  )
+}

--- a/sdk-app/src/design/prototypes/employee-management/EmployeeManagement/index.tsx
+++ b/sdk-app/src/design/prototypes/employee-management/EmployeeManagement/index.tsx
@@ -1,0 +1,12 @@
+import { ComponentStatesPage } from '../../ComponentStatesPage'
+import { components } from './states'
+
+const BASE_PATH = '/design/employee-management'
+
+export { EmployeeManagementFlow } from './EmployeeManagementFlow'
+export { EmployeeList } from './EmployeeList'
+export { RehireEmployee } from './RehireEmployee'
+
+export function EmployeeManagementStates() {
+  return <ComponentStatesPage basePath={`${BASE_PATH}/component-states`} components={components} />
+}

--- a/sdk-app/src/design/prototypes/employee-management/EmployeeManagement/states.tsx
+++ b/sdk-app/src/design/prototypes/employee-management/EmployeeManagement/states.tsx
@@ -1,0 +1,270 @@
+import { useState } from 'react'
+import type { Employee } from '@gusto/embedded-api-v-2025-11-15/models/components/employee'
+import type { Location } from '@gusto/embedded-api-v-2025-11-15/models/components/location'
+import type { PrototypeComponent } from '../../prototypeTypes'
+import {
+  EmployeeList,
+  type EmployeeListTab,
+} from '../../../components/employee/management/EmployeeList/EmployeeList'
+import { RehireEmployeeForm } from '../../../components/employee/management/RehireEmployeeForm/RehireEmployeeForm'
+
+function buildEmployee(overrides: Partial<Employee>): Employee {
+  return {
+    uuid: 'employee-uuid',
+    firstName: 'Avery',
+    lastName: 'Lin',
+    onboarded: true,
+    onboardingStatus: 'onboarding_completed',
+    jobs: [
+      {
+        uuid: 'job-uuid',
+        version: 'job-version',
+        employeeUuid: 'employee-uuid',
+        currentCompensationUuid: 'comp-uuid',
+        paymentUnit: 'Year',
+        primary: true,
+        twoPercentShareholder: false,
+        title: 'Software Engineer',
+        rate: '95000',
+        hireDate: '2023-04-10',
+      },
+    ],
+    ...overrides,
+  } as Employee
+}
+
+const activeEmployees: Employee[] = [
+  buildEmployee({ uuid: 'e-1', firstName: 'Avery', lastName: 'Lin' }),
+  buildEmployee({
+    uuid: 'e-2',
+    firstName: 'Jordan',
+    lastName: 'Park',
+    jobs: [
+      {
+        uuid: 'job-2',
+        version: 'job-version',
+        employeeUuid: 'e-2',
+        currentCompensationUuid: 'comp-2',
+        paymentUnit: 'Hour',
+        primary: true,
+        twoPercentShareholder: false,
+        title: 'Barista',
+        rate: '22',
+        hireDate: '2024-02-01',
+      },
+    ],
+  }),
+  buildEmployee({
+    uuid: 'e-3',
+    firstName: 'Sam',
+    lastName: 'Rivera',
+    jobs: [
+      {
+        uuid: 'job-3',
+        version: 'job-version',
+        employeeUuid: 'e-3',
+        currentCompensationUuid: 'comp-3',
+        paymentUnit: 'Year',
+        primary: true,
+        twoPercentShareholder: false,
+        title: 'Design Lead',
+        rate: '140000',
+        hireDate: '2022-08-15',
+      },
+    ],
+  }),
+]
+
+const onboardingEmployees: Employee[] = [
+  buildEmployee({
+    uuid: 'o-1',
+    firstName: 'Riley',
+    lastName: 'Nguyen',
+    onboarded: false,
+    onboardingStatus: 'admin_onboarding_incomplete',
+    jobs: [
+      {
+        uuid: 'o-job-1',
+        version: 'job-version',
+        employeeUuid: 'o-1',
+        currentCompensationUuid: 'o-comp-1',
+        paymentUnit: 'Year',
+        primary: true,
+        twoPercentShareholder: false,
+        title: 'Account Manager',
+        rate: '72000',
+        hireDate: '2026-07-01',
+      },
+    ],
+  }),
+  buildEmployee({
+    uuid: 'o-2',
+    firstName: 'Casey',
+    lastName: 'Brooks',
+    onboarded: false,
+    onboardingStatus: 'self_onboarding_pending_invite',
+    jobs: [
+      {
+        uuid: 'o-job-2',
+        version: 'job-version',
+        employeeUuid: 'o-2',
+        currentCompensationUuid: 'o-comp-2',
+        paymentUnit: 'Hour',
+        primary: true,
+        twoPercentShareholder: false,
+        title: 'Line Cook',
+        rate: '24',
+        hireDate: '2026-06-22',
+      },
+    ],
+  }),
+]
+
+const dismissedEmployees: Employee[] = [
+  buildEmployee({
+    uuid: 'd-1',
+    firstName: 'Morgan',
+    lastName: 'Diaz',
+    terminations: [{ uuid: 'term-1', effectiveDate: '2026-02-14' }],
+  }),
+  buildEmployee({
+    uuid: 'd-2',
+    firstName: 'Taylor',
+    lastName: 'Singh',
+    jobs: [
+      {
+        uuid: 'd-job-2',
+        version: 'job-version',
+        employeeUuid: 'd-2',
+        currentCompensationUuid: 'd-comp-2',
+        paymentUnit: 'Hour',
+        primary: true,
+        twoPercentShareholder: false,
+        title: 'Server',
+        rate: '18',
+        hireDate: '2023-11-01',
+      },
+    ],
+    terminations: [{ uuid: 'term-2', effectiveDate: '2025-12-30' }],
+  }),
+] as Employee[]
+
+const workLocations: Location[] = [
+  {
+    uuid: 'loc-1',
+    country: 'US',
+    street1: '123 Market St',
+    city: 'San Francisco',
+    state: 'CA',
+    zip: '94103',
+    active: true,
+  },
+  {
+    uuid: 'loc-2',
+    country: 'US',
+    street1: '500 5th Ave',
+    city: 'New York',
+    state: 'NY',
+    zip: '10110',
+    active: true,
+  },
+]
+
+function renderEmployeeList(employees: Employee[], initialTab: EmployeeListTab) {
+  function EmployeeListDemo() {
+    const [tab, setTab] = useState<EmployeeListTab>(initialTab)
+    return (
+      <EmployeeList
+        employees={employees}
+        selectedTab={tab}
+        onSelectTab={setTab}
+        onAddEmployee={() => {}}
+        onEditEmployee={() => {}}
+        onDismissEmployee={() => {}}
+        onRehireEmployee={() => {}}
+      />
+    )
+  }
+  return EmployeeListDemo
+}
+
+export const components: PrototypeComponent[] = [
+  {
+    slug: 'employee-list',
+    name: 'Employee List',
+    description: 'Tabbed list of a company\u2019s employees with per-row actions.',
+    configurations: [
+      {
+        slug: 'active-populated',
+        name: 'Active — populated',
+        description: 'Three active employees with primary jobs.',
+        render: renderEmployeeList(activeEmployees, 'active'),
+      },
+      {
+        slug: 'onboarding',
+        name: 'Onboarding',
+        description: 'Two employees mid-onboarding with status badges.',
+        render: renderEmployeeList(onboardingEmployees, 'onboarding'),
+      },
+      {
+        slug: 'dismissed',
+        name: 'Dismissed',
+        description: 'Dismissed employees with rehire action available.',
+        render: renderEmployeeList(dismissedEmployees, 'dismissed'),
+      },
+      {
+        slug: 'empty',
+        name: 'Empty',
+        description: 'No employees on the active tab.',
+        render: renderEmployeeList([], 'active'),
+      },
+    ],
+  },
+  {
+    slug: 'rehire-form',
+    name: 'Rehire Employee Form',
+    description: 'Form to schedule a rehire for a dismissed employee.',
+    configurations: [
+      {
+        slug: 'default',
+        name: 'Default',
+        description: 'Two work addresses to choose from.',
+        render: () => (
+          <RehireEmployeeForm
+            employee={{ uuid: 'd-1', firstName: 'Morgan', lastName: 'Diaz' }}
+            workLocations={workLocations}
+            onCancel={() => {}}
+            onSubmit={() => {}}
+          />
+        ),
+      },
+      {
+        slug: 'single-location',
+        name: 'Single work address',
+        description: 'Only one work address available — preselected.',
+        render: () => (
+          <RehireEmployeeForm
+            employee={{ uuid: 'd-2', firstName: 'Taylor', lastName: 'Singh' }}
+            workLocations={[workLocations[0]!]}
+            onCancel={() => {}}
+            onSubmit={() => {}}
+          />
+        ),
+      },
+      {
+        slug: 'submitting',
+        name: 'Submitting',
+        description: 'Form in its submitting state.',
+        render: () => (
+          <RehireEmployeeForm
+            employee={{ uuid: 'd-1', firstName: 'Morgan', lastName: 'Diaz' }}
+            workLocations={workLocations}
+            isPending
+            onCancel={() => {}}
+            onSubmit={() => {}}
+          />
+        ),
+      },
+    ],
+  },
+]

--- a/sdk-app/src/design/registry.ts
+++ b/sdk-app/src/design/registry.ts
@@ -60,6 +60,24 @@ export const categorizedRegistry: CategorizedRegistry = {
   ],
   Employees: [
     {
+      name: 'Employee Management',
+      path: '/design/employee-management',
+      description:
+        'A prototype for managing employees — list active, onboarding, and dismissed employees, and rehire dismissed employees.',
+      children: [
+        {
+          name: 'Prototype',
+          path: '/design/employee-management',
+          description: 'Live prototype against the real API.',
+        },
+        {
+          name: 'Component states',
+          path: '/design/employee-management/component-states',
+          description: 'Browse individual components and configurations with mock data.',
+        },
+      ],
+    },
+    {
       name: 'Compensation History',
       path: '/design/employee-compensation-history',
       description:

--- a/sdk-app/src/main.tsx
+++ b/sdk-app/src/main.tsx
@@ -22,6 +22,12 @@ import {
   CompensationHistoryPrototype,
   CompensationHistoryStates,
 } from './design/prototypes/employee-management/CompensationHistory'
+import {
+  EmployeeManagementFlow,
+  EmployeeList as EmployeeManagementList,
+  RehireEmployee as EmployeeManagementRehire,
+  EmployeeManagementStates,
+} from './design/prototypes/employee-management/EmployeeManagement'
 import './app.scss'
 import '@/styles/sdk.scss'
 
@@ -71,6 +77,24 @@ const router = createBrowserRouter([
                   {
                     path: ':componentSlug/:configSlug',
                     element: <ContractorSelfOnboardingStates />,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            path: 'employee-management',
+            element: <EmployeeManagementFlow />,
+            children: [
+              { index: true, element: <EmployeeManagementList /> },
+              { path: ':employeeId/rehire', element: <EmployeeManagementRehire /> },
+              {
+                path: 'component-states',
+                children: [
+                  { index: true, element: <EmployeeManagementStates /> },
+                  {
+                    path: ':componentSlug/:configSlug',
+                    element: <EmployeeManagementStates />,
                   },
                 ],
               },


### PR DESCRIPTION
## Summary

Scaffolds a new **Employee Management** design prototype under [sdk-app/src/design](sdk-app/src/design) with two views:

- **Employee list** — tabbed (active / onboarding / dismissed) view mirroring the production `ManagementEmployeeList` UI. Adds inline status badges:
  - On **active**: "Last day {date}" when a future dismissal is scheduled.
  - On **dismissed**: "Rehire {date}" when a future rehire is scheduled.
- **Rehire form** — date picker, work-address select, and "file new hire report" radio. Detects whether a pending rehire already exists and routes to PUT vs POST accordingly; cancel calls DELETE.

## Notable decisions

- The rehire badge fetches per-row via `useEmployeeEmploymentsGetRehire` (N+1) — there's no batched rehire-list endpoint and `Employee` doesn't carry rehire data inline like `Contractor` does. Acceptable for a prototype; would want a server change before production. Each cell shows a small skeleton while the per-row fetch is in flight to avoid badge pop-in.
- Dismissed tab uses `terminatedToday: true` (not `terminated: true`) so employees with a scheduled rehire still appear until their rehire effective date.
- Tab switches use `isPending` + skeleton placeholder rows (matches contractor-list pattern) to avoid the empty-state flash.
- The `Start date cannot be later than {date} based on work employee addresses history` 422 from the rehire endpoint is rewritten to a friendlier message and surfaced as a field-level error on the Start date input, not a page alert. Per the [Jan 2025 Lattice thread](https://gustohq.slack.com/archives/C06A8UEDL58/p1736184696232019), the validator name references address history but the real meaning is hire-date compatibility.

## Test plan

- [ ] \`npm run sdk-app\` → visit http://localhost:5200/design → Employee Management card appears under Employees
- [ ] Active / Onboarding / Dismissed tabs each render their own column set and switch cleanly (no empty-state flash)
- [ ] Dismiss an active employee → row stays on active with "Last day {date}" badge
- [ ] Click Rehire on a dismissed row → form loads, submit → returns to list with success alert; row now shows "Rehire {date}" badge after the badge skeleton resolves
- [ ] Open dismissed menu for a row with pending rehire → "View details" / "Edit rehire details" / "Cancel rehire" appear
- [ ] Edit rehire details → form prefills, submit → success alert "Rehire updated for {name}"
- [ ] Cancel rehire → success alert "Rehire cancelled for {name}", badge disappears
- [ ] Set a rehire date that violates the address-history rule → field-level error appears under Start date; changing the date clears it
- [ ] Component states gallery (\`/component-states\`) renders all variations

🤖 Generated with [Claude Code](https://claude.com/claude-code)