### PR TITLE
feat(docs-site): move version switcher into the docs sidebar

### DIFF
--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -2,3 +2,9 @@ node_modules/
 .docusaurus/
 build/
 .cache-loader/
+
+# Version snapshots are owned by Gusto/embedded-sdk-docs; only created locally
+# to develop the version-dropdown UI.
+versions.json
+versioned_docs/
+versioned_sidebars/

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -127,15 +127,6 @@ const config: Config = {
           position: 'left',
           label: 'Docs',
         },
-        ...(hasVersions
-          ? [
-              {
-                type: 'docsVersionDropdown' as const,
-                position: 'right' as const,
-                dropdownActiveClassDisabled: true,
-              },
-            ]
-          : []),
         {
           href: 'https://github.com/Gusto/embedded-react-sdk',
           label: 'GitHub',

--- a/docs-site/plugins/global-docs-sidebar/index.ts
+++ b/docs-site/plugins/global-docs-sidebar/index.ts
@@ -1,10 +1,15 @@
 import type { LoadContext, Plugin } from '@docusaurus/types'
-import type { LoadedContent, LoadedVersion } from '@docusaurus/plugin-content-docs'
+import type { LoadedContent, PropSidebarItem } from '@docusaurus/plugin-content-docs'
 // Internal but stable utility: same fn the docs plugin uses to build the
 // `docsSidebars` prop passed to each docs route. Re-exposing the result via
 // globalData lets us render the docs sidebar tree on non-docs routes too
 // (e.g. inside the mobile navbar on the landing page).
 import { toSidebarsProp } from '@docusaurus/plugin-content-docs/lib/props.js'
+
+export type GlobalDocsSidebarData = {
+  versions: { [versionName: string]: PropSidebarItem[] }
+  latestVersionName: string | null
+}
 
 export default function globalDocsSidebarPlugin(_context: LoadContext): Plugin<void> {
   return {
@@ -14,14 +19,20 @@ export default function globalDocsSidebarPlugin(_context: LoadContext): Plugin<v
         | Record<string, LoadedContent>
         | undefined
       const defaultInstance = docsContent?.default
-      if (!defaultInstance) return
+      if (!defaultInstance) {
+        actions.setGlobalData({ versions: {}, latestVersionName: null })
+        return
+      }
 
-      const versions = defaultInstance.loadedVersions
-      const activeVersion: LoadedVersion | undefined = versions.find(v => v.isLast) ?? versions[0]
-      if (!activeVersion) return
-
-      const sidebars = toSidebarsProp(activeVersion)
-      actions.setGlobalData({ items: sidebars.docs ?? [] })
+      const loadedVersions = defaultInstance.loadedVersions
+      const versions: { [versionName: string]: PropSidebarItem[] } = {}
+      for (const version of loadedVersions) {
+        const sidebars = toSidebarsProp(version)
+        versions[version.versionName] = sidebars.docs ?? []
+      }
+      const latestVersionName =
+        loadedVersions.find(v => v.isLast)?.versionName ?? loadedVersions[0]?.versionName ?? null
+      actions.setGlobalData({ versions, latestVersionName } satisfies GlobalDocsSidebarData)
     },
   }
 }

--- a/docs-site/src/components/SidebarVersionSelect/index.tsx
+++ b/docs-site/src/components/SidebarVersionSelect/index.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useRef, useState, type ReactNode } from 'react'
+import clsx from 'clsx'
+import { useHistory } from '@docusaurus/router'
+import {
+  useActiveDocContext,
+  useDocsPreferredVersion,
+  useDocsVersionCandidates,
+  useVersions,
+} from '@docusaurus/plugin-content-docs/client'
+import type { GlobalDoc, GlobalVersion } from '@docusaurus/plugin-content-docs/client'
+import styles from './styles.module.css'
+
+function getVersionMainDoc(version: GlobalVersion): GlobalDoc {
+  return version.docs.find(doc => doc.id === version.mainDocId)!
+}
+
+export default function SidebarVersionSelect(): ReactNode {
+  const versions = useVersions(undefined)
+  const activeDocContext = useActiveDocContext(undefined)
+  const candidates = useDocsVersionCandidates(undefined)
+  const { savePreferredVersionName } = useDocsPreferredVersion(undefined)
+  const history = useHistory()
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onPointerDown(event: PointerEvent) {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  if (versions.length <= 1) {
+    return null
+  }
+
+  const activeVersion = activeDocContext.activeVersion ?? candidates[0] ?? versions[0]!
+
+  function selectVersion(version: GlobalVersion) {
+    savePreferredVersionName(version.name)
+    const targetDoc =
+      activeDocContext.alternateDocVersions[version.name] ?? getVersionMainDoc(version)
+    setOpen(false)
+    history.push(targetDoc.path)
+  }
+
+  return (
+    <div ref={rootRef} className={styles.versionSelect}>
+      <button
+        type="button"
+        className={styles.trigger}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen(prev => !prev)}
+      >
+        <span className={styles.label}>Version</span>
+        <span className={styles.value}>{activeVersion.label}</span>
+        <span className={styles.chevron} aria-hidden="true" />
+      </button>
+      {open && (
+        <ul className={styles.menu} role="listbox" aria-label="Documentation versions">
+          {versions.map(version => {
+            const isActive = version.name === activeVersion.name
+            return (
+              <li key={version.name} className={styles.menuItem}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={isActive}
+                  className={clsx(styles.menuButton, isActive && styles.menuButtonActive)}
+                  onClick={() => selectVersion(version)}
+                >
+                  {version.label}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/docs-site/src/components/SidebarVersionSelect/styles.module.css
+++ b/docs-site/src/components/SidebarVersionSelect/styles.module.css
@@ -1,0 +1,112 @@
+.versionSelect {
+  position: relative;
+  margin: 0.5rem 0.75rem 1.25rem;
+}
+
+.trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  height: 2.25rem;
+  padding: 0 0.75rem;
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 0.375rem;
+  background-color: transparent;
+  color: var(--ifm-navbar-link-color);
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.trigger:hover,
+.trigger[aria-expanded='true'] {
+  border-color: var(--ifm-color-emphasis-400);
+}
+
+.label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--gusto-sidebar-category-color);
+}
+
+.value {
+  margin-left: auto;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.chevron {
+  width: 0.875rem;
+  height: 0.875rem;
+  flex-shrink: 0;
+  background-color: var(--gusto-sidebar-category-color);
+  -webkit-mask-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>');
+  mask-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>');
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  transition: transform 0.15s ease;
+}
+
+.trigger[aria-expanded='true'] .chevron {
+  transform: rotate(180deg);
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  right: 0;
+  z-index: 50;
+  margin: 0;
+  padding: 0.25rem;
+  list-style: none;
+  background-color: var(--ifm-background-surface-color, var(--ifm-background-color));
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 0.375rem;
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.08),
+    0 2px 4px rgba(0, 0, 0, 0.04);
+}
+
+[data-theme='dark'] .menu {
+  background-color: #161618;
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.5),
+    0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.menuItem {
+  margin: 0;
+}
+
+.menuButton {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  border: none;
+  border-radius: 0.25rem;
+  background-color: transparent;
+  color: var(--ifm-navbar-link-color);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.1s ease;
+}
+
+.menuButton:hover {
+  background-color: var(--ifm-color-emphasis-100);
+}
+
+.menuButtonActive {
+  color: var(--ifm-color-primary);
+  font-weight: 500;
+}

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -237,7 +237,7 @@ html {
 }
 
 @media (max-width: 996px) {
-  .navbar__link.navbarGithub {
+  .navbar__items .navbar__link.navbarGithub {
     display: none;
   }
 }
@@ -790,12 +790,14 @@ nav.theme-doc-breadcrumbs:not(:has(.breadcrumbs__item + .breadcrumbs__item)) {
 /* ── Sidebar scrollbars ── */
 
 .theme-doc-sidebar-container .menu,
-.theme-doc-toc-desktop {
+.theme-doc-toc-desktop,
+.navbar-sidebar__item {
   scrollbar-width: thin;
   scrollbar-color: rgba(27, 27, 29, 0.25) transparent;
 }
 
 [data-theme='dark'] .theme-doc-sidebar-container .menu,
-[data-theme='dark'] .theme-doc-toc-desktop {
+[data-theme='dark'] .theme-doc-toc-desktop,
+[data-theme='dark'] .navbar-sidebar__item {
   scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
 }

--- a/docs-site/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/docs-site/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -1,0 +1,51 @@
+import React, { useState, type ComponentProps } from 'react'
+import clsx from 'clsx'
+import { ThemeClassNames } from '@docusaurus/theme-common'
+import { useAnnouncementBar, useScrollPosition } from '@docusaurus/theme-common/internal'
+import { translate } from '@docusaurus/Translate'
+import DocSidebarItems from '@theme/DocSidebarItems'
+import SidebarVersionSelect from '@site/src/components/SidebarVersionSelect'
+import type DocSidebarDesktopContent from '@theme/DocSidebar/Desktop/Content'
+import styles from './styles.module.css'
+
+function useShowAnnouncementBar() {
+  const { isActive } = useAnnouncementBar()
+  const [showAnnouncementBar, setShowAnnouncementBar] = useState(isActive)
+  useScrollPosition(
+    ({ scrollY }) => {
+      if (isActive) {
+        setShowAnnouncementBar(scrollY === 0)
+      }
+    },
+    [isActive],
+  )
+  return isActive && showAnnouncementBar
+}
+
+export default function DocSidebarDesktopContentSwizzled({
+  path,
+  sidebar,
+  className,
+}: ComponentProps<typeof DocSidebarDesktopContent>) {
+  const showAnnouncementBar = useShowAnnouncementBar()
+  return (
+    <nav
+      aria-label={translate({
+        id: 'theme.docs.sidebar.navAriaLabel',
+        message: 'Docs sidebar',
+        description: 'The ARIA label for the sidebar navigation',
+      })}
+      className={clsx(
+        'menu thin-scrollbar',
+        styles.menu,
+        showAnnouncementBar && styles.menuWithAnnouncementBar,
+        className,
+      )}
+    >
+      <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
+        <SidebarVersionSelect />
+        <DocSidebarItems items={sidebar} activePath={path} level={1} />
+      </ul>
+    </nav>
+  )
+}

--- a/docs-site/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/docs-site/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -1,0 +1,16 @@
+@media (min-width: 997px) {
+  .menu {
+    flex-grow: 1;
+    padding: 0.5rem;
+  }
+  @supports (scrollbar-gutter: stable) {
+    .menu {
+      padding: 0.5rem 0 0.5rem 0.5rem;
+      scrollbar-gutter: stable;
+    }
+  }
+
+  .menuWithAnnouncementBar {
+    margin-bottom: var(--docusaurus-announcement-bar-height);
+  }
+}

--- a/docs-site/src/theme/Navbar/MobileSidebar/Layout/index.tsx
+++ b/docs-site/src/theme/Navbar/MobileSidebar/Layout/index.tsx
@@ -41,6 +41,14 @@ export default function NavbarMobileSidebarLayout({ header, primaryMenu }: Props
         <NavbarMobileSidebarPanel inert={false}>{primaryMenu}</NavbarMobileSidebarPanel>
       </div>
       <div className={styles.mobileSidebarFooter}>
+        <a
+          href="https://github.com/Gusto/embedded-react-sdk"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="navbar__link navbarGithub"
+        >
+          GitHub
+        </a>
         <NavbarColorModeToggle />
       </div>
     </div>

--- a/docs-site/src/theme/Navbar/MobileSidebar/Layout/styles.module.css
+++ b/docs-site/src/theme/Navbar/MobileSidebar/Layout/styles.module.css
@@ -11,7 +11,7 @@
 .mobileSidebarFooter {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   padding: 1rem;
   border-top: 1px solid var(--ifm-toc-border-color);
   flex-shrink: 0;

--- a/docs-site/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.tsx
+++ b/docs-site/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.tsx
@@ -2,17 +2,30 @@ import React, { type ReactNode } from 'react'
 import { useLocation } from '@docusaurus/router'
 import { usePluginData } from '@docusaurus/useGlobalData'
 import { useNavbarMobileSidebar } from '@docusaurus/theme-common/internal'
-import { DocSidebarItemsExpandedStateProvider } from '@docusaurus/plugin-content-docs/client'
+import {
+  DocSidebarItemsExpandedStateProvider,
+  useActiveDocContext,
+  useDocsPreferredVersion,
+} from '@docusaurus/plugin-content-docs/client'
 import DocSidebarItems from '@theme/DocSidebarItems'
-import type { PropSidebar } from '@docusaurus/plugin-content-docs'
+import SidebarVersionSelect from '@site/src/components/SidebarVersionSelect'
+import type { GlobalDocsSidebarData } from '@site/plugins/global-docs-sidebar'
 
 export default function NavbarMobilePrimaryMenu(): ReactNode {
-  const { items } = usePluginData('global-docs-sidebar') as { items: PropSidebar }
+  const data = usePluginData('global-docs-sidebar') as GlobalDocsSidebarData
   const { pathname } = useLocation()
   const mobileSidebar = useNavbarMobileSidebar()
+  const activeDocContext = useActiveDocContext(undefined)
+  const { preferredVersion } = useDocsPreferredVersion(undefined)
+
+  const selectedVersionName =
+    activeDocContext.activeVersion?.name ?? preferredVersion?.name ?? data.latestVersionName
+  const items = (selectedVersionName && data.versions[selectedVersionName]) ?? []
+
   return (
     <DocSidebarItemsExpandedStateProvider>
       <ul className="menu__list">
+        <SidebarVersionSelect />
         <DocSidebarItems
           items={items}
           activePath={pathname}


### PR DESCRIPTION
## Summary
- Replaces the navbar version dropdown with a custom **Version selector** at the top of the docs sidebar (desktop + mobile primary menu) so the active version is always visible alongside the sidebar tree.
- `global-docs-sidebar` plugin now exposes per-version sidebar items. On non-docs routes (e.g. landing), mobile menu links route into the user's preferred version instead of always pointing at latest.
- Mobile sidebar footer is now a flex row with **GitHub on the left** and the **color-mode toggle on the right**; the navbar-only hide rule for the GitHub pill is scoped to `.navbar__items` so it doesn't hit the footer.
- Mobile menu scrollbar picks up the same thin styling as the desktop sidebar/TOC.

### About `SidebarVersionSelect`
Custom button + popover (not a native `<select>`) so the trigger is clickable across its full width and the menu can be styled. Closes on outside click / Escape, saves the preferred version via Docusaurus's `useDocsPreferredVersion`, and routes to the equivalent doc in the chosen version (falls back to the version's main doc).

### Why the `.gitignore` change
Versioning snapshots (`versions.json`, `versioned_docs/`, `versioned_sidebars/`) are owned by `Gusto/embedded-sdk-docs`, not this repo. To develop the version-dropdown UI you need a couple of cut versions locally — gitignoring those paths lets contributors do that without accidentally committing snapshots.

## Test plan
- [ ] Locally cut at least two doc versions (`npm --prefix docs-site run docusaurus -- docs:version 0.47.0`, then bump and repeat) so the selector has something to show
- [ ] Desktop: open `/docs/` and confirm the Version selector renders above "Getting Started"; switch versions; verify URL + persisted preference
- [ ] Mobile: open hamburger on a docs page; selector at top, footer has GitHub + theme toggle; switching versions navigates to the equivalent doc
- [ ] Landing page on mobile: switch version, confirm the docs sidebar links in the menu now point at `/docs/<version>/...`
- [ ] Light + dark mode visual check for trigger, popover, and scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)