### PR TITLE
fix(Form): disable native browser validation by default

### DIFF
--- a/src/components/Common/Form/Form.test.tsx
+++ b/src/components/Common/Form/Form.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, screen } from '@testing-library/react'
+import { Form } from './Form'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+
+describe('Form', () => {
+  it('disables native browser validation by default', () => {
+    renderWithProviders(
+      <Form data-testid="form">
+        <button type="submit">Submit</button>
+      </Form>,
+    )
+    expect(screen.getByTestId('form')).toHaveAttribute('novalidate')
+  })
+
+  it('allows native validation to be re-enabled via the noValidate prop', () => {
+    renderWithProviders(
+      <Form data-testid="form" noValidate={false}>
+        <button type="submit">Submit</button>
+      </Form>,
+    )
+    expect(screen.getByTestId('form')).not.toHaveAttribute('novalidate')
+  })
+
+  it('prevents default submission and forwards the event to onSubmit', () => {
+    const onSubmit = vi.fn()
+    renderWithProviders(
+      <Form data-testid="form" onSubmit={onSubmit}>
+        <button type="submit">Submit</button>
+      </Form>,
+    )
+
+    fireEvent.submit(screen.getByTestId('form'))
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit.mock.calls[0]![0]!.defaultPrevented).toBe(true)
+  })
+})

--- a/src/components/Common/Form/Form.tsx
+++ b/src/components/Common/Form/Form.tsx
@@ -5,10 +5,11 @@ import styles from './Form.module.scss'
 export type FormProps = React.FormHTMLAttributes<HTMLFormElement>
 
 /** @internal */
-export const Form = ({ children, className, onSubmit, ...props }: FormProps) => {
+export const Form = ({ children, className, onSubmit, noValidate = true, ...props }: FormProps) => {
   return (
     <form
       className={classNames(styles.form, className)}
+      noValidate={noValidate}
       onSubmit={e => {
         e.preventDefault()
         onSubmit?.(e)


### PR DESCRIPTION
## Summary

The SDK validates forms exclusively through react-hook-form + Zod, yet the shared `Form` component did not set `noValidate`. As a result, native HTML constraint validation (`type="email"`, `min`/`max`, `maxLength`, etc.) can fire browser-native validation bubbles that:

- bypass the SDK design system and look inconsistent across browsers, and
- can block `onSubmit` from firing, interfering with the SDK's own validation/submission.

This sets `noValidate` on the shared `Form` component (`src/components/Common/Form/Form.tsx`), which backs 50+ forms across the SDK. The existing `noValidate` prop still lets a caller opt back into native validation (`noValidate={false}`).

This does **not** remove validation — react-hook-form + Zod still enforce every constraint. Native `required` was never wired up (`isRequired` only drives the visual label + aria), so no form depends on native enforcement.

## Why it doesn't break forms

- All SDK forms route submission/validation through react-hook-form + Zod resolvers; native constraint validation was redundant.
- `isRequired` is not mapped to the native `required` attribute, so nothing relied on native blocking.
- jsdom doesn't run constraint validation, so existing tests are unaffected; targeted `Form` tests were added.

## Test plan

- [x] `npm run test -- --run src/components/Common/Form/Form.test.tsx` (3 passing: default `noValidate`, opt-out via prop, preventDefault + onSubmit forwarding)
- [x] ESLint clean on changed files
- [x] Pre-commit build passes
- [ ] CI green

Made with [Cursor](https://cursor.com)