### PR TITLE
fix(sdk-app): stabilize EmployeeListDemo hooks order on states page

### DIFF
--- a/sdk-app/src/design/components/employee/management/EmployeeList/EmployeeListStates.tsx
+++ b/sdk-app/src/design/components/employee/management/EmployeeList/EmployeeListStates.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+import type { Employee } from '@gusto/embedded-api-v-2025-11-15/models/components/employee'
+import { EmployeeList, type EmployeeListTab } from './EmployeeList'
+
+export function EmployeeListDemo({
+  employees,
+  initialTab,
+}: {
+  employees: Employee[]
+  initialTab: EmployeeListTab
+}) {
+  const [tab, setTab] = useState<EmployeeListTab>(initialTab)
+  return (
+    <EmployeeList
+      employees={employees}
+      selectedTab={tab}
+      onSelectTab={setTab}
+      onAddEmployee={() => {}}
+      onEditEmployee={() => {}}
+      onDismissEmployee={() => {}}
+      onRehireEmployee={() => {}}
+    />
+  )
+}

--- a/sdk-app/src/design/prototypes/employee-management/EmployeeManagement/states.tsx
+++ b/sdk-app/src/design/prototypes/employee-management/EmployeeManagement/states.tsx
@@ -1,11 +1,7 @@
-import { useState } from 'react'
 import type { Employee } from '@gusto/embedded-api-v-2025-11-15/models/components/employee'
 import type { Location } from '@gusto/embedded-api-v-2025-11-15/models/components/location'
 import type { PrototypeComponent } from '../../prototypeTypes'
-import {
-  EmployeeList,
-  type EmployeeListTab,
-} from '../../../components/employee/management/EmployeeList/EmployeeList'
+import { EmployeeListDemo } from '../../../components/employee/management/EmployeeList/EmployeeListStates'
 import { RehireEmployeeForm } from '../../../components/employee/management/RehireEmployeeForm/RehireEmployeeForm'
 
 function buildEmployee(overrides: Partial<Employee>): Employee {
@@ -170,24 +166,6 @@ const workLocations: Location[] = [
   },
 ]
 
-function renderEmployeeList(employees: Employee[], initialTab: EmployeeListTab) {
-  function EmployeeListDemo() {
-    const [tab, setTab] = useState<EmployeeListTab>(initialTab)
-    return (
-      <EmployeeList
-        employees={employees}
-        selectedTab={tab}
-        onSelectTab={setTab}
-        onAddEmployee={() => {}}
-        onEditEmployee={() => {}}
-        onDismissEmployee={() => {}}
-        onRehireEmployee={() => {}}
-      />
-    )
-  }
-  return EmployeeListDemo
-}
-
 export const components: PrototypeComponent[] = [
   {
     slug: 'employee-list',
@@ -198,25 +176,25 @@ export const components: PrototypeComponent[] = [
         slug: 'active-populated',
         name: 'Active — populated',
         description: 'Three active employees with primary jobs.',
-        render: renderEmployeeList(activeEmployees, 'active'),
+        render: () => <EmployeeListDemo employees={activeEmployees} initialTab="active" />,
       },
       {
         slug: 'onboarding',
         name: 'Onboarding',
         description: 'Two employees mid-onboarding with status badges.',
-        render: renderEmployeeList(onboardingEmployees, 'onboarding'),
+        render: () => <EmployeeListDemo employees={onboardingEmployees} initialTab="onboarding" />,
       },
       {
         slug: 'dismissed',
         name: 'Dismissed',
         description: 'Dismissed employees with rehire action available.',
-        render: renderEmployeeList(dismissedEmployees, 'dismissed'),
+        render: () => <EmployeeListDemo employees={dismissedEmployees} initialTab="dismissed" />,
       },
       {
         slug: 'empty',
         name: 'Empty',
         description: 'No employees on the active tab.',
-        render: renderEmployeeList([], 'active'),
+        render: () => <EmployeeListDemo employees={[]} initialTab="active" />,
       },
     ],
   },


### PR DESCRIPTION
## Summary

- The employee-list configurations on the component states page were returning the `EmployeeListDemo` component function itself from `render()`. `ComponentStatesPage` invokes `render()` and renders its return as children, so `EmployeeListDemo` was called as a plain function — running `useState` inline in `ComponentStatesPage`'s render and tripping the Rules of Hooks ("Rendered more hooks than during the previous render").
- Extracted `EmployeeListDemo` next to `EmployeeList` as `EmployeeListStates.tsx`, matching the existing `ContractorListStates` pattern. Each prototype configuration's `render` now returns `<EmployeeListDemo .../>` JSX so hooks run inside the demo component where they belong.

## Test plan

- [ ] Open the employee-management prototype's component states page and switch through Employee List configurations (active, onboarding, dismissed, empty) — no console errors, tabs are clickable, state is preserved per configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)