### PR TITLE
fix(TimeOff): use empty data component for empty states

### DIFF
--- a/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
+++ b/src/components/TimeOff/TimeOffManagement/SelectEmployees/SelectEmployeesPresentation.tsx
@@ -6,7 +6,7 @@ import type {
   SelectEmployeesPresentationProps,
 } from './SelectEmployeesPresentationTypes'
 import styles from './SelectEmployeesPresentation.module.scss'
-import { ActionsLayout, Flex } from '@/components/Common'
+import { ActionsLayout, Flex, EmptyData } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
 
@@ -58,13 +58,7 @@ export function SelectEmployeesPresentation({
         getIsItemSelected={item => selectedUuids.has(item.uuid)}
         isFetching={isFetching}
         pagination={pagination}
-        emptyState={() => (
-          <Flex flexDirection="column" alignItems="center" gap={8}>
-            <Text size="sm" textAlign="center">
-              {t('emptyState')}
-            </Text>
-          </Flex>
-        )}
+        emptyState={() => <EmptyData title={t('emptyState')} />}
         additionalColumns={[
           {
             key: 'department' as keyof EmployeeItem,

--- a/src/components/TimeOff/shared/EmployeeTable/EmployeeTable.tsx
+++ b/src/components/TimeOff/shared/EmployeeTable/EmployeeTable.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { EmployeeTableItem, EmployeeTableProps } from './EmployeeTableTypes'
 import styles from './EmployeeTable.module.scss'
-import { DataView, Flex, useDataView } from '@/components/Common'
+import { DataView, EmptyData, useDataView } from '@/components/Common'
 import type { useDataViewProp } from '@/components/Common/DataView/useDataView'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n/I18n'
@@ -120,10 +120,5 @@ export function EmployeeTable<T extends EmployeeTableItem>({
 }
 
 function DefaultEmptySearchState({ message }: { message: string }) {
-  const { Text } = useComponentContext()
-  return (
-    <Flex flexDirection="column" alignItems="center" gap={8}>
-      <Text size="sm">{message}</Text>
-    </Flex>
-  )
+  return <EmptyData title={message} />
 }


### PR DESCRIPTION
## Summary
- Replace custom `Flex` + `Text` empty-state markup in `SelectEmployeesPresentation` with the shared `EmptyData` component
- Same swap inside `EmployeeTable`'s `DefaultEmptySearchState` so empty/no-results states render consistently across the TimeOff surface

## Test plan
- [ ] Storybook: confirm SelectEmployees and EmployeeTable empty states render with the standard `EmptyData` styling
- [ ] Verify search-with-no-results in EmployeeTable still shows the localized message

🤖 Generated with [Claude Code](https://claude.com/claude-code)