### PR TITLE
refactor(DocumentList): unify empty and error states via EmptyData

### DIFF
--- a/src/components/Common/DocumentList/DocumentList.stories.tsx
+++ b/src/components/Common/DocumentList/DocumentList.stories.tsx
@@ -1,0 +1,46 @@
+import { DocumentList, type FormData } from './DocumentList'
+
+export default {
+  title: 'Common/DocumentList',
+}
+
+const labels = {
+  label: 'Documents to sign',
+  columnLabels: { form: 'Form', action: 'Status' },
+  statusLabels: {
+    signCta: 'Sign',
+    notSigned: 'Awaiting signature',
+    complete: 'Signed',
+  },
+  emptyStateLabel: 'No documents to sign',
+  errorLabel: 'We couldn’t load your documents. Try again later.',
+}
+
+const forms: FormData[] = [
+  {
+    uuid: 'form-1',
+    title: 'Form W-4',
+    description: 'Employee’s withholding certificate',
+    requires_signing: true,
+  },
+  {
+    uuid: 'form-2',
+    title: 'Form I-9',
+    description: 'Employment eligibility verification',
+    requires_signing: false,
+  },
+  {
+    uuid: 'form-3',
+    title: 'Direct Deposit Authorization',
+    description: 'Authorize payroll direct deposit',
+    requires_signing: true,
+  },
+]
+
+export const Populated = () => <DocumentList forms={forms} {...labels} />
+
+export const ReadOnly = () => <DocumentList forms={forms} canSign={false} {...labels} />
+
+export const Empty = () => <DocumentList forms={[]} {...labels} />
+
+export const Error = () => <DocumentList forms={[]} withError {...labels} />

--- a/src/components/Common/DocumentList/DocumentList.tsx
+++ b/src/components/Common/DocumentList/DocumentList.tsx
@@ -82,12 +82,7 @@ function DocumentList({
         ),
       },
     ],
-    emptyState: () =>
-      withError ? (
-        <Components.Text className={styles.documentListError}>{errorLabel}</Components.Text>
-      ) : (
-        <EmptyData title={emptyStateLabel} />
-      ),
+    emptyState: () => <EmptyData title={withError ? errorLabel : emptyStateLabel} />,
   })
 
   return (


### PR DESCRIPTION
## Summary
- Render both the empty and error branches through `EmptyData` so they share the same layout instead of one being a centered `Text` and the other an `EmptyData` block.
- Add a `Common/DocumentList` Storybook story with Populated, ReadOnly, Empty, and Error variants.

## Test plan
- [ ] Open Storybook and verify the four `Common/DocumentList` stories render as expected.
- [ ] Confirm existing flows using `DocumentList` still render the empty state correctly when no forms are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)