### PR TITLE
feat(PayrollReceipts): show formatted licensee phone number

### DIFF
--- a/src/components/Payroll/PayrollReceipts/PayrollReceiptsPresentation.tsx
+++ b/src/components/Payroll/PayrollReceipts/PayrollReceiptsPresentation.tsx
@@ -10,7 +10,7 @@ import styles from './PayrollReceiptsPresentation.module.scss'
 import { DataView, DataTable, Flex } from '@/components/Common'
 import type { DescriptionListItem } from '@/components/Common/UI/DescriptionList/DescriptionListTypes'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
-import { formatNumberAsCurrency } from '@/helpers/formattedStrings'
+import { formatNumberAsCurrency, formatPhoneNumber } from '@/helpers/formattedStrings'
 import { useI18n } from '@/i18n'
 import { useContainerBreakpoints } from '@/hooks/useContainerBreakpoints/useContainerBreakpoints'
 import ReceiptCheck from '@/assets/icons/receipt-check.svg?react'
@@ -157,7 +157,8 @@ export const PayrollReceiptsPresentation = ({
             className={classNames(styles.address, isMobile && styles.textMobile)}
           >
             {receiptData.licensee &&
-              `${receiptData.licensee.address || ''}, ${receiptData.licensee.city || ''}, ${receiptData.licensee.state || ''} ${receiptData.licensee.postalCode || ''}`}
+              `${receiptData.licensee.address || ''}, ${receiptData.licensee.city || ''}, ${receiptData.licensee.state || ''} ${receiptData.licensee.postalCode || ''}`}{' '}
+            | {formatPhoneNumber(receiptData.licensee?.phoneNumber)}
           </Text>
         </Flex>
       </Flex>


### PR DESCRIPTION
## Summary
- Display the licensee phone number alongside the address on the payroll receipt
- Format via the shared `formatPhoneNumber` helper so it renders as `NNN-NNN-NNNN`

## Demo

<img width="734" height="572" alt="Screenshot 2026-06-17 at 3 53 26 PM" src="https://github.com/user-attachments/assets/d1964eb7-337f-4cd2-a374-461a055bb4bd" />


## Test plan
- [ ] Open the PayrollReceipts story in Storybook and confirm the phone number renders formatted next to the address
- [ ] Verify behavior when `licensee.phoneNumber` is missing (helper returns `''`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)