### PR TITLE
feat(Company): export LocationsList from CompanyOnboarding namespace

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -569,6 +569,7 @@ declare namespace CompanyOnboarding {
         BankAccount,
         Locations,
         LocationForm,
+        LocationsList,
         PaySchedule,
         PayScheduleProps,
         PayScheduleDefaultValues,
@@ -3098,6 +3099,11 @@ function LocationForm(input: LocationFormProps & BaseComponentInterface): JSX;
 //
 // @public
 function Locations(input: LocationsProps): JSX;
+
+// Warning: (ae-forgotten-export) The symbol "LocationsListProps" needs to be exported by the entry point index.d.ts
+//
+// @public
+function LocationsList(props: LocationsListProps): JSX;
 
 // @public
 function ManagementEmployeeList(input: ManagementEmployeeListProps & BaseComponentInterface): JSX;

--- a/docs/api/Company/CompanyOnboarding/blocks.md
+++ b/docs/api/Company/CompanyOnboarding/blocks.md
@@ -289,6 +289,30 @@ use the standalone `LocationForm` component directly.
 
 ***
 
+<a id="locationslist"></a>
+
+### LocationsList
+
+Displays the list of work locations for a company.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `props` | `LocationsListProps` | Component props including the `companyId` whose locations should be listed. |
+
+#### Remarks
+
+Standalone building block used internally by the orchestrated `Locations` component for its list view. Use this directly when you need full control over navigation between the list and form views.
+
+| Event | Description | Data |
+| ----- | ----------- | ---- |
+| `company/location/add` | A user chose to add a new location | — |
+| `company/location/edit` | A user chose to edit a specific location | `{ uuid: string }` |
+| `company/location/done` | The user chose to proceed to the next step | — |
+
+***
+
 <a id="onboardingoverview"></a>
 
 ### OnboardingOverview

--- a/docs/reference/endpoint-inventory.json
+++ b/docs/reference/endpoint-inventory.json
@@ -1489,6 +1489,17 @@
         "locationId"
       ]
     },
+    "CompanyOnboarding.LocationsList": {
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/v1/companies/:companyId/locations"
+        }
+      ],
+      "variables": [
+        "companyId"
+      ]
+    },
     "CompanyOnboarding.PaySchedule": {
       "endpoints": [
         {

--- a/docs/reference/endpoint-reference.md
+++ b/docs/reference/endpoint-reference.md
@@ -278,6 +278,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 | **CompanyOnboarding.LocationForm** | POST | `/v1/companies/:companyId/locations` |
 |  | GET | `/v1/locations/:locationId` |
 |  | PUT | `/v1/locations/:locationId` |
+| **CompanyOnboarding.LocationsList** | GET | `/v1/companies/:companyId/locations` |
 | **CompanyOnboarding.PaySchedule** | GET | `/v1/companies/:companyId/pay_schedules` |
 |  | POST | `/v1/companies/:companyId/pay_schedules` |
 |  | GET | `/v1/companies/:companyId/pay_schedules/:payScheduleId` |

--- a/src/components/Company/Locations/LocationsList/LocationsList.tsx
+++ b/src/components/Company/Locations/LocationsList/LocationsList.tsx
@@ -11,10 +11,26 @@ import { companyEvents } from '@/shared/constants'
 import { usePagination } from '@/hooks/usePagination/usePagination'
 
 interface LocationsListProps extends BaseComponentInterface {
+  /** The associated company identifier. */
   companyId: string
 }
 
-/** @internal */
+/**
+ * Displays the list of work locations for a company.
+ *
+ * @remarks
+ * Standalone building block used internally by the orchestrated `Locations` component for its list view. Use this directly when you need full control over navigation between the list and form views.
+ *
+ * | Event | Description | Data |
+ * | ----- | ----------- | ---- |
+ * | `company/location/add` | A user chose to add a new location | — |
+ * | `company/location/edit` | A user chose to edit a specific location | `{ uuid: string }` |
+ * | `company/location/done` | The user chose to proceed to the next step | — |
+ *
+ * @param props - Component props including the `companyId` whose locations should be listed.
+ * @returns The rendered locations list section.
+ * @public
+ */
 export function LocationsList(props: LocationsListProps) {
   return (
     <BaseComponent {...props}>

--- a/src/components/Company/exports/companyOnboarding.ts
+++ b/src/components/Company/exports/companyOnboarding.ts
@@ -8,6 +8,7 @@ export { Industry, type IndustryProps } from '../Industry'
 export { BankAccount } from '../BankAccount/BankAccount'
 export { Locations } from '../Locations/Locations'
 export { LocationForm } from '../Locations/LocationForm'
+export { LocationsList } from '../Locations/LocationsList'
 export {
   PaySchedule,
   type PayScheduleProps,


### PR DESCRIPTION
## Summary

- Re-export the standalone `LocationsList` building block from the `CompanyOnboarding` namespace barrel (`src/components/Company/exports/companyOnboarding.ts`), grouped with the other `Locations` exports.
- Mirrors its structurally-identical sibling `StateTaxesList` (same `companyId`-only props, same `company/location/*` events): promote `LocationsList`'s TSDoc from `@internal` to a `@public` block documenting its events.
- Regenerate `.reports/embedded-react-sdk.api.md` to reflect the newly public surface.

Consumers can now render `<CompanyOnboarding.LocationsList companyId={...} onEvent={...} />`.

## Test plan

- [x] `npm run tsc`
- [x] `eslint` on changed files
- [x] `npm run test -- --run src/components/Company/Locations` (11 passed)
- [x] `npm run build` + `npm run api-report:derive` (report regenerated)

Made with [Cursor](https://cursor.com)