### PR TITLE
fix(Deductions): show cancel before deduction type is selected

### DIFF
--- a/src/components/Employee/Deductions/shared/DeductionsForm/DeductionsForm.tsx
+++ b/src/components/Employee/Deductions/shared/DeductionsForm/DeductionsForm.tsx
@@ -9,6 +9,7 @@ import { ChildSupportFormView } from './ChildSupportFormView'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { Grid } from '@/components/Common/Grid/Grid'
 import { Flex } from '@/components/Common/Flex/Flex'
+import { ActionsLayout } from '@/components/Common'
 import { useComponentDictionary, useI18n } from '@/i18n'
 import type { ResourceDictionary } from '@/types/Helpers'
 
@@ -138,6 +139,14 @@ export function DeductionsForm({
             </Flex>
 
             {variant !== null && <hr />}
+
+            {variant === null && (
+              <ActionsLayout>
+                <Components.Button variant="secondary" type="button" onClick={onCancel}>
+                  {t('actions.cancel')}
+                </Components.Button>
+              </ActionsLayout>
+            )}
           </>
         )}
 


### PR DESCRIPTION
## Summary
- The add-mode DeductionsForm no longer pre-selects a radio variant, so neither child form (which owns Cancel/Save) renders until the user picks one — leaving no way to back out.
- Render a Cancel-only `ActionsLayout` in the interim state so users can cancel before choosing a deduction type.

## Test plan
- [ ] Open the add deduction form; verify a Cancel button appears immediately and dismisses the form.
- [ ] Select "Garnishment" or "Custom"; verify the child form's own Cancel/Save buttons take over and the interim Cancel is gone.
- [ ] Edit an existing deduction; verify the interim Cancel does not appear (radio group is hidden in edit mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)