### PR TITLE
fix(ContractorPayments): move create CTA into empty state only

### DIFF
--- a/src/components/Contractor/Payments/PaymentsList/PaymentsListPresentation.tsx
+++ b/src/components/Contractor/Payments/PaymentsList/PaymentsListPresentation.tsx
@@ -7,6 +7,7 @@ import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentCon
 import { useI18n } from '@/i18n'
 import useNumberFormatter from '@/hooks/useNumberFormatter'
 import EyeIcon from '@/assets/icons/eye.svg?react'
+import PlusCircleIcon from '@/assets/icons/plus-circle.svg?react'
 import { useDateFormatter } from '@/hooks/useDateFormatter'
 import { ConfirmWireDetails } from '@/components/Payroll/ConfirmWireDetails'
 import type { EventType } from '@/shared/constants'
@@ -78,7 +79,11 @@ export const PaymentsListPresentation = ({
     emptyState: () => (
       <EmptyData title={t('noPaymentsFound')} description={t('noPaymentsDescription')}>
         <ActionsLayout justifyContent="center">
-          <Button variant="primary" onClick={onCreatePayment}>
+          <Button
+            variant="secondary"
+            icon={<PlusCircleIcon aria-hidden />}
+            onClick={onCreatePayment}
+          >
             {t('createPaymentCta')}
           </Button>
         </ActionsLayout>
@@ -133,7 +138,7 @@ export const PaymentsListPresentation = ({
         gap={16}
         alignItems={{
           base: 'stretch',
-          small: 'flex-end',
+          small: 'center',
         }}
         justifyContent="space-between"
       >
@@ -153,9 +158,6 @@ export const PaymentsListPresentation = ({
             placeholder=""
             shouldVisuallyHideLabel
           />
-          <Button onClick={onCreatePayment} variant="secondary" className={styles.nowrap}>
-            {t('createPaymentCta')}
-          </Button>
         </div>
       </Flex>
 


### PR DESCRIPTION
## Summary
- Remove the duplicate "New payment" button from the actions row above the contractor payments list; the date-range filter remains.
- Empty-state CTA is now the only create entry point and is restyled as a secondary button with a leading plus-circle icon.

## Test plan
- [ ] In Storybook, open the contractor payments list with no payments in range and confirm the empty state shows the secondary "Create payment" button with the plus-circle icon.
- [ ] Confirm the filter dropdown still renders above the table when the list is empty (so users can switch the date range back).
- [ ] With payments present, confirm the row above the table shows only the date-range filter (no duplicate create button) and the create CTA still works from inside the empty state when filters return zero rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)