### PR TITLE
fix(sdk-app): polish sidebar styles and theme background

### DIFF
--- a/sdk-app/src/Sidebar.module.scss
+++ b/sdk-app/src/Sidebar.module.scss
@@ -169,6 +169,8 @@
 
 .items {
   list-style: none;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .item > a {
@@ -176,8 +178,13 @@
   padding: 0.375rem 1rem 0.375rem 1.5rem;
   color: var(--color-text);
   text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 0.8125rem;
   font-weight: 500;
+  border-radius: 0.4rem;
+  margin-bottom: 0.2rem;
   transition:
     background 0.1s,
     color 0.1s;
@@ -188,6 +195,7 @@
 
   &:global(.active) {
     color: var(--color-active);
+    background: var(--color-active-bg);
   }
 }
 
@@ -203,6 +211,7 @@
   color: var(--color-text-muted);
   text-decoration: none;
   font-size: 0.75rem;
+  border-radius: 0.4rem;
   transition:
     background 0.1s,
     color 0.1s;

--- a/sdk-app/src/app.scss
+++ b/sdk-app/src/app.scss
@@ -92,6 +92,8 @@ body {
   flex-direction: column;
   min-height: 100vh;
   overflow: clip;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .app-body {

--- a/sdk-app/src/design/prototypes/ComponentStatesSidebar.module.scss
+++ b/sdk-app/src/design/prototypes/ComponentStatesSidebar.module.scss
@@ -41,6 +41,9 @@
   font-size: 0.8125rem;
   border-radius: 0.4rem;
   font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   line-height: 1.4;
   margin-bottom: 0.2rem;

--- a/sdk-app/src/design/prototypes/ComponentStatesSidebar.module.scss
+++ b/sdk-app/src/design/prototypes/ComponentStatesSidebar.module.scss
@@ -1,5 +1,5 @@
 .root {
-  width: 14rem;
+  width: 16rem;
   flex-shrink: 0;
   background: var(--color-bg-sidebar);
   border-left: 0.0625rem solid var(--color-border);
@@ -18,7 +18,7 @@
 
 .componentHeading {
   margin: 0 0 0.375rem;
-  padding: 0 1rem;
+  padding: 0 2.2rem;
   font-size: 0.7rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -29,7 +29,8 @@
 .list {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .item a {
@@ -38,7 +39,12 @@
   color: var(--color-text);
   text-decoration: none;
   font-size: 0.8125rem;
-  border-left: 0.1875rem solid transparent;
+  border-radius: 0.4rem;
+  font-weight: 500;
+
+  line-height: 1.4;
+  margin-bottom: 0.2rem;
+
   transition:
     background 0.1s,
     border-color 0.1s;
@@ -51,6 +57,5 @@
     background: var(--color-active-bg);
     border-left-color: var(--color-active);
     color: var(--color-active);
-    font-weight: 500;
   }
 }

--- a/sdk-app/src/design/prototypes/ComponentStatesSidebar.module.scss
+++ b/sdk-app/src/design/prototypes/ComponentStatesSidebar.module.scss
@@ -44,7 +44,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-
   line-height: 1.4;
   margin-bottom: 0.2rem;
 


### PR DESCRIPTION
## Summary
- Restore `var(--color-bg-sidebar)` on the component-states right-rail sidebar so dark mode applies (was hardcoded to `#ffffff`)
- Align main-sidebar active-state styling (active background, border-radius, ellipsis, margin) with the component-states sidebar
- Apply `-webkit-font-smoothing: antialiased` / `-moz-osx-font-smoothing: grayscale` on `.app-layout` so sdk-app chrome renders at the same visual weight as SDK content inside `.GSDK`

## Test plan
- [ ] Toggle light/dark theme and confirm the component-states right-rail sidebar background matches the main sidebar in both modes
- [ ] Verify active item styling matches between the main sidebar and the component-states sidebar
- [ ] Confirm sidebar/topbar text no longer renders heavier than SDK content

🤖 Generated with [Claude Code](https://claude.com/claude-code)