### PR TITLE
fix(sdk-app): use CompanyOnboarding namespace

### DIFF
--- a/sdk-app/scripts/analyze-component-props.ts
+++ b/sdk-app/scripts/analyze-component-props.ts
@@ -25,7 +25,7 @@ const OUTPUT = resolve(import.meta.dirname, '../src/generated-registry-data.ts')
 const ENTITY_ID_PATTERN = /^(company|employee|contractor|payroll|request)Id$/
 
 const NAMESPACES: Record<string, string[]> = {
-  Company: ['src/components/Company/index.tsx'],
+  CompanyOnboarding: ['src/components/Company/exports/companyOnboarding.ts'],
   EmployeeManagement: ['src/components/Employee/exports/employeeManagement.ts'],
   EmployeeOnboarding: ['src/components/Employee/exports/employeeOnboarding.ts'],
   ContractorOnboarding: ['src/components/Contractor/exports/contractorOnboarding.ts'],

--- a/sdk-app/src/CommandPalette/componentMetadata.ts
+++ b/sdk-app/src/CommandPalette/componentMetadata.ts
@@ -18,8 +18,8 @@ export interface ComponentMetadata {
 }
 
 export const componentMetadata: Record<string, ComponentMetadata> = {
-  // ─── Company ─────────────────────────────────────────────────────────
-  'Company.OnboardingFlow': {
+  // ─── CompanyOnboarding ───────────────────────────────────────────────
+  'CompanyOnboarding.OnboardingFlow': {
     description: 'Onboard a company end-to-end (industry, signatory, taxes, bank, pay schedule).',
     keywords: [
       'onboard company',
@@ -29,7 +29,7 @@ export const componentMetadata: Record<string, ComponentMetadata> = {
       'start company',
     ],
   },
-  'Company.OnboardingOverview': {
+  'CompanyOnboarding.OnboardingOverview': {
     description: 'Overview of remaining company onboarding steps.',
     keywords: ['company onboarding status', 'company progress', 'company checklist'],
   },

--- a/sdk-app/src/Sidebar.tsx
+++ b/sdk-app/src/Sidebar.tsx
@@ -91,6 +91,7 @@ function isUnder(pathname: string, target: string): boolean {
 
 const PREVIEW_CATEGORY_LABELS: Record<string, string> = {
   InformationRequests: 'Info Requests',
+  CompanyOnboarding: 'Company Onboarding',
   ContractorManagement: 'Contractor Management',
   ContractorOnboarding: 'Contractor Onboarding',
   EmployeeManagement: 'Employee Management',

--- a/sdk-app/src/generated-registry-data.ts
+++ b/sdk-app/src/generated-registry-data.ts
@@ -2,6 +2,24 @@
 // Run: npx tsx sdk-app/scripts/analyze-component-props.ts
 
 export const ENTITY_REQUIREMENTS: Record<string, string[]> = {
+  'CompanyOnboarding.AssignSignatory': ['companyId'],
+  'CompanyOnboarding.BankAccount': ['companyId'],
+  'CompanyOnboarding.CreateSignatory': ['companyId'],
+  'CompanyOnboarding.DocumentList': ['companyId'],
+  'CompanyOnboarding.DocumentSigner': ['companyId'],
+  'CompanyOnboarding.FederalTaxes': ['companyId'],
+  'CompanyOnboarding.Industry': ['companyId'],
+  'CompanyOnboarding.InviteSignatory': ['companyId'],
+  'CompanyOnboarding.LocationForm': ['companyId'],
+  'CompanyOnboarding.Locations': ['companyId'],
+  'CompanyOnboarding.LocationsList': ['companyId'],
+  'CompanyOnboarding.OnboardingFlow': ['companyId'],
+  'CompanyOnboarding.OnboardingOverview': ['companyId'],
+  'CompanyOnboarding.PaySchedule': ['companyId'],
+  'CompanyOnboarding.SignatureForm': ['companyId'],
+  'CompanyOnboarding.StateTaxes': ['companyId'],
+  'CompanyOnboarding.StateTaxesForm': ['companyId'],
+  'CompanyOnboarding.StateTaxesList': ['companyId'],
   'ContractorManagement.CreatePayment': ['companyId'],
   'ContractorManagement.PaymentFlow': ['companyId'],
   'ContractorManagement.PaymentHistory': ['companyId'],
@@ -113,6 +131,8 @@ export const ENTITY_REQUIREMENTS: Record<string, string[]> = {
 }
 
 export const ADDITIONAL_REQUIRED_PROPS: Record<string, string[]> = {
+  'CompanyOnboarding.SignatureForm': ['formId'],
+  'CompanyOnboarding.StateTaxesForm': ['state'],
   'ContractorManagement.PaymentHistory': ['paymentId'],
   'ContractorManagement.PaymentStatement': ['paymentGroupId', 'contractorUuid'],
   'ContractorManagement.PaymentSummary': ['paymentGroupId'],

--- a/sdk-app/src/registry.ts
+++ b/sdk-app/src/registry.ts
@@ -1,5 +1,5 @@
 import { ENTITY_REQUIREMENTS, ADDITIONAL_REQUIRED_PROPS } from './generated-registry-data'
-import * as Company from '@/components/Company'
+import * as CompanyOnboarding from '@/components/Company/exports/companyOnboarding'
 import * as ContractorManagement from '@/components/Contractor/exports/contractorManagement'
 import * as ContractorOnboarding from '@/components/Contractor/exports/contractorOnboarding'
 import * as EmployeeManagement from '@/components/Employee/exports/employeeManagement'
@@ -9,7 +9,7 @@ import * as InformationRequests from '@/components/InformationRequests'
 import * as TimeOff from '@/components/TimeOff'
 
 export type Category =
-  | 'Company'
+  | 'CompanyOnboarding'
   | 'ContractorManagement'
   | 'ContractorOnboarding'
   | 'EmployeeManagement'
@@ -27,7 +27,7 @@ export interface ComponentEntry {
 }
 
 const namespaces: Record<Category, Record<string, unknown>> = {
-  Company,
+  CompanyOnboarding,
   ContractorManagement,
   ContractorOnboarding,
   EmployeeManagement,
@@ -73,7 +73,7 @@ function buildRegistry(): ComponentEntry[] {
 export const componentRegistry = buildRegistry()
 
 export const categorizedRegistry: Record<Category, ComponentEntry[]> = {
-  Company: [],
+  CompanyOnboarding: [],
   ContractorManagement: [],
   ContractorOnboarding: [],
   EmployeeManagement: [],
@@ -88,7 +88,7 @@ for (const entry of componentRegistry) {
 }
 
 export const CATEGORIES: Category[] = [
-  'Company',
+  'CompanyOnboarding',
   'EmployeeManagement',
   'EmployeeOnboarding',
   'ContractorOnboarding',


### PR DESCRIPTION
## Summary

- The Company section in the sdk-app sidebar was blank because [sdk-app/src/registry.ts](sdk-app/src/registry.ts) was importing from the deprecated `Company` barrel ([src/components/Company/index.tsx](src/components/Company/index.tsx)), which was reduced to `export {}` in #2187.
- Mirrors the Contractor split done in #2170: switch sdk-app to consume the published `CompanyOnboarding` namespace from [src/components/Company/exports/companyOnboarding.ts](src/components/Company/exports/companyOnboarding.ts) instead of restoring the deprecated barrel.
- Touches sdk-app only — no SDK surface changes.

## Changes

- [sdk-app/src/registry.ts](sdk-app/src/registry.ts) — import `* as CompanyOnboarding from '@/components/Company/exports/companyOnboarding'`, rename `Company` → `CompanyOnboarding` in `Category`, `namespaces`, `categorizedRegistry`, and `CATEGORIES`.
- [sdk-app/src/Sidebar.tsx](sdk-app/src/Sidebar.tsx) — add `CompanyOnboarding: 'Company Onboarding'` label.
- [sdk-app/scripts/analyze-component-props.ts](sdk-app/scripts/analyze-component-props.ts) — rename `Company` namespace entry to `CompanyOnboarding`, point at the exports barrel.
- [sdk-app/src/generated-registry-data.ts](sdk-app/src/generated-registry-data.ts) — regenerated via `npx tsx sdk-app/scripts/analyze-component-props.ts`. Keys move from `Company.*` → `CompanyOnboarding.*` and the full Company surface (Industry, AssignSignatory, BankAccount, DocumentSigner, FederalTaxes, Locations, OnboardingFlow, OnboardingOverview, PaySchedule, StateTaxes*, etc.) is back.
- [sdk-app/src/CommandPalette/componentMetadata.ts](sdk-app/src/CommandPalette/componentMetadata.ts) — rename `Company.OnboardingFlow` / `Company.OnboardingOverview` keys to match.

## Test plan

- [ ] `npm run sdk-app` — Company Onboarding section appears in the sidebar with the full set of components
- [ ] Command palette still finds `OnboardingFlow` / `OnboardingOverview` via their keywords
- [ ] `npx tsx sdk-app/scripts/analyze-component-props.ts` reproduces `sdk-app/src/generated-registry-data.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)