### PR TITLE
fix(ContractorPayments): restore create CTA in header when payments exist

### DIFF
--- a/src/components/Contractor/Payments/PaymentsList/PaymentsListPresentation.tsx
+++ b/src/components/Contractor/Payments/PaymentsList/PaymentsListPresentation.tsx
@@ -158,6 +158,16 @@ export const PaymentsListPresentation = ({
             placeholder=""
             shouldVisuallyHideLabel
           />
+          {contractorPayments.length > 0 && (
+            <Button
+              onClick={onCreatePayment}
+              variant="secondary"
+              icon={<PlusCircleIcon aria-hidden />}
+              className={styles.nowrap}
+            >
+              {t('createPaymentCta')}
+            </Button>
+          )}
         </div>
       </Flex>
 


### PR DESCRIPTION
## Summary
- PR #2215 removed the header create button entirely; this restores it next to the date-range filter, but only when the list has payments.
- The empty state remains the sole CTA when there are zero payments, preserving the intent of #2215.

## Test plan
- [ ] In Storybook, view the payments list with payments present and confirm the secondary "Create payment" button appears next to the date-range filter.
- [ ] Confirm the empty state still shows its own create button when there are no payments and no duplicate appears in the header.
- [ ] Confirm clicking the header button triggers the create flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)