### PR TITLE
feat(design): historical contractor payment prototype

### DIFF
--- a/sdk-app/src/design/components/contractor/payments/HistoricalPaymentConfiguration/EditContractorPaymentModal.tsx
+++ b/sdk-app/src/design/components/contractor/payments/HistoricalPaymentConfiguration/EditContractorPaymentModal.tsx
@@ -1,0 +1,151 @@
+import { useId } from 'react'
+import { FormProvider, useForm, useWatch } from 'react-hook-form'
+import type { ContractorOption, HistoricalContractorPayment } from '../types'
+import { ActionsLayout, Flex, Grid, NumberInputField } from '@/components/Common'
+import { Form } from '@/components/Common/Form'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+interface EditContractorPaymentModalProps {
+  isOpen: boolean
+  contractor: ContractorOption | null
+  initialPayment: HistoricalContractorPayment | null
+  onClose: () => void
+  onSave: (payment: HistoricalContractorPayment) => void
+}
+
+interface EditFormValues {
+  hours: number
+  wage: number
+  bonus: number
+  reimbursement: number
+}
+
+function toFormValues(payment: HistoricalContractorPayment | null): EditFormValues {
+  return {
+    hours: Number(payment?.hours || '0'),
+    wage: Number(payment?.wage || '0'),
+    bonus: Number(payment?.bonus || '0'),
+    reimbursement: Number(payment?.reimbursement || '0'),
+  }
+}
+
+export function EditContractorPaymentModal({
+  isOpen,
+  contractor,
+  initialPayment,
+  onClose,
+  onSave,
+}: EditContractorPaymentModalProps) {
+  const formId = useId()
+  const Components = useComponentContext()
+
+  const formMethods = useForm<EditFormValues>({
+    values: toFormValues(initialPayment),
+  })
+
+  const wageType = contractor?.wageType ?? 'Fixed'
+  const hourlyRate = Number(contractor?.hourlyRate || '0')
+
+  const handleSubmit = (values: EditFormValues) => {
+    if (!contractor) return
+    onSave({
+      contractorId: contractor.id,
+      hours: wageType === 'Hourly' ? String(values.hours) : '0',
+      wage: wageType === 'Fixed' ? String(values.wage) : '0',
+      bonus: wageType === 'Hourly' ? String(values.bonus) : '0',
+      reimbursement: String(values.reimbursement),
+    })
+    onClose()
+  }
+
+  return (
+    <Components.Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      footer={
+        <ActionsLayout>
+          <Components.Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Components.Button>
+          <Components.Button
+            variant="primary"
+            type="submit"
+            form={formId}
+            onClick={() => formMethods.handleSubmit(handleSubmit)}
+          >
+            Save
+          </Components.Button>
+        </ActionsLayout>
+      }
+    >
+      <FormProvider {...formMethods}>
+        <Form id={formId} onSubmit={formMethods.handleSubmit(handleSubmit)}>
+          <Flex flexDirection="column" gap={32}>
+            <Flex flexDirection="column" gap={4}>
+              <Components.Heading as="h2">Edit contractor payment</Components.Heading>
+              <Components.Text variant="supporting">
+                Update {contractor?.name ?? 'this contractor'}&apos;s historical payment details.
+              </Components.Text>
+              <RunningTotal wageType={wageType} hourlyRate={hourlyRate} />
+            </Flex>
+
+            {wageType === 'Hourly' && (
+              <Flex flexDirection="column" gap={16}>
+                <Components.Heading as="h3">Hours worked</Components.Heading>
+                <NumberInputField
+                  min={0}
+                  name="hours"
+                  isRequired
+                  label="Hours"
+                  adornmentEnd="hrs"
+                />
+              </Flex>
+            )}
+
+            {wageType === 'Fixed' && (
+              <Flex flexDirection="column" gap={16}>
+                <Components.Heading as="h3">Fixed pay</Components.Heading>
+                <NumberInputField min={0} name="wage" isRequired label="Wage" format="currency" />
+              </Flex>
+            )}
+
+            <Flex flexDirection="column" gap={16}>
+              <Components.Heading as="h3">Additional earnings</Components.Heading>
+              <Grid gridTemplateColumns={{ base: '1fr', small: [200, 200] }} gap={16}>
+                {wageType === 'Hourly' && (
+                  <NumberInputField min={0} name="bonus" label="Bonus" format="currency" />
+                )}
+                <NumberInputField
+                  min={0}
+                  name="reimbursement"
+                  label="Reimbursement"
+                  format="currency"
+                />
+              </Grid>
+            </Flex>
+          </Flex>
+        </Form>
+      </FormProvider>
+    </Components.Modal>
+  )
+}
+
+function RunningTotal({
+  wageType,
+  hourlyRate,
+}: {
+  wageType: 'Hourly' | 'Fixed'
+  hourlyRate: number
+}) {
+  const Components = useComponentContext()
+  const { hours, wage, bonus, reimbursement } = useWatch<EditFormValues>() as EditFormValues
+  const total =
+    (wageType === 'Fixed' ? wage : hours * hourlyRate) +
+    (wageType === 'Hourly' ? bonus : 0) +
+    reimbursement
+  return <Components.Text weight="bold">Total pay: {formatCurrency(total)}</Components.Text>
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value)
+}

--- a/sdk-app/src/design/components/contractor/payments/HistoricalPaymentConfiguration/HistoricalPaymentConfiguration.tsx
+++ b/sdk-app/src/design/components/contractor/payments/HistoricalPaymentConfiguration/HistoricalPaymentConfiguration.tsx
@@ -63,7 +63,7 @@ export function HistoricalPaymentConfiguration({
 
   return (
     <Flex flexDirection="column" gap={32}>
-      <Flex justifyContent="space-between" alignItems="flex-start" gap={16}>
+      <Flex justifyContent="space-between" alignItems="center" gap={16}>
         <Flex flexDirection="column" gap={4}>
           <Components.Heading as="h2">Hours and payments</Components.Heading>
           <Components.Text variant="supporting">
@@ -71,15 +71,14 @@ export function HistoricalPaymentConfiguration({
             reimbursements.
           </Components.Text>
         </Flex>
-        <Flex gap={8}>
+        <Flex gap={8} justifyContent="flex-end">
           {onBack && (
             <Components.Button variant="secondary" onClick={onBack}>
               Back
             </Components.Button>
           )}
-          <FlexItem>
-            <Components.Button onClick={onContinue}>Continue</Components.Button>
-          </FlexItem>
+
+          <Components.Button onClick={onContinue}>Continue</Components.Button>
         </Flex>
       </Flex>
 
@@ -127,7 +126,9 @@ export function HistoricalPaymentConfiguration({
             items={[
               {
                 label: 'Edit contractor payment',
-                onClick: () => { setEditingContractorId(contractor.id); },
+                onClick: () => {
+                  setEditingContractorId(contractor.id)
+                },
               },
             ]}
             triggerLabel="Edit contractor payment"
@@ -156,7 +157,9 @@ export function HistoricalPaymentConfiguration({
         isOpen={editingRow !== null}
         contractor={editingRow?.contractor ?? null}
         initialPayment={editingRow?.payment ?? null}
-        onClose={() => { setEditingContractorId(null); }}
+        onClose={() => {
+          setEditingContractorId(null)
+        }}
         onSave={onUpdatePayment}
       />
     </Flex>

--- a/sdk-app/src/design/components/contractor/payments/HistoricalPaymentConfiguration/HistoricalPaymentConfiguration.tsx
+++ b/sdk-app/src/design/components/contractor/payments/HistoricalPaymentConfiguration/HistoricalPaymentConfiguration.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import type { ContractorOption, HistoricalContractorPayment } from '../types'
 import { computePaymentTotal } from '../types'
 import { EditContractorPaymentModal } from './EditContractorPaymentModal'
-import { DataView, EmptyData, Flex, FlexItem } from '@/components/Common'
+import { DataView, EmptyData, Flex } from '@/components/Common'
 import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 
@@ -11,7 +11,6 @@ interface HistoricalPaymentConfigurationProps {
   payments: HistoricalContractorPayment[]
   onUpdatePayment: (payment: HistoricalContractorPayment) => void
   onContinue: () => void
-  onBack?: () => void
 }
 
 interface TableRow {
@@ -26,7 +25,6 @@ export function HistoricalPaymentConfiguration({
   payments,
   onUpdatePayment,
   onContinue,
-  onBack,
 }: HistoricalPaymentConfigurationProps) {
   const Components = useComponentContext()
   const [editingContractorId, setEditingContractorId] = useState<string | null>(null)
@@ -71,15 +69,7 @@ export function HistoricalPaymentConfiguration({
             reimbursements.
           </Components.Text>
         </Flex>
-        <Flex gap={8} justifyContent="flex-end">
-          {onBack && (
-            <Components.Button variant="secondary" onClick={onBack}>
-              Back
-            </Components.Button>
-          )}
-
-          <Components.Button onClick={onContinue}>Continue</Components.Button>
-        </Flex>
+        <Components.Button onClick={onContinue}>Continue</Components.Button>
       </Flex>
 
       <DataView

--- a/sdk-app/src/design/components/contractor/payments/HistoricalPaymentConfiguration/HistoricalPaymentConfiguration.tsx
+++ b/sdk-app/src/design/components/contractor/payments/HistoricalPaymentConfiguration/HistoricalPaymentConfiguration.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from 'react'
+import type { ContractorOption, HistoricalContractorPayment } from '../types'
+import { computePaymentTotal } from '../types'
+import { EditContractorPaymentModal } from './EditContractorPaymentModal'
+import { DataView, EmptyData, Flex, FlexItem } from '@/components/Common'
+import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+interface HistoricalPaymentConfigurationProps {
+  contractors: ContractorOption[]
+  payments: HistoricalContractorPayment[]
+  onUpdatePayment: (payment: HistoricalContractorPayment) => void
+  onContinue: () => void
+  onBack?: () => void
+}
+
+interface TableRow {
+  payment: HistoricalContractorPayment
+  contractor: ContractorOption
+}
+
+const ZERO_HOURS_DISPLAY = '0.000'
+
+export function HistoricalPaymentConfiguration({
+  contractors,
+  payments,
+  onUpdatePayment,
+  onContinue,
+  onBack,
+}: HistoricalPaymentConfigurationProps) {
+  const Components = useComponentContext()
+  const [editingContractorId, setEditingContractorId] = useState<string | null>(null)
+
+  const rows = useMemo<TableRow[]>(() => {
+    return payments
+      .map(payment => {
+        const contractor = contractors.find(c => c.id === payment.contractorId)
+        return contractor ? { payment, contractor } : null
+      })
+      .filter((row): row is TableRow => row !== null)
+  }, [payments, contractors])
+
+  const totals = useMemo(() => {
+    return rows.reduce(
+      (acc, { payment, contractor }) => {
+        const wage =
+          contractor.wageType === 'Hourly'
+            ? Number(payment.hours || '0') * Number(contractor.hourlyRate || '0')
+            : Number(payment.wage || '0')
+        acc.wage += wage
+        acc.bonus += Number(payment.bonus || '0')
+        acc.reimbursement += Number(payment.reimbursement || '0')
+        acc.total += computePaymentTotal(payment, contractor)
+        return acc
+      },
+      { wage: 0, bonus: 0, reimbursement: 0, total: 0 },
+    )
+  }, [rows])
+
+  const editingRow = editingContractorId
+    ? (rows.find(row => row.contractor.id === editingContractorId) ?? null)
+    : null
+
+  return (
+    <Flex flexDirection="column" gap={32}>
+      <Flex justifyContent="space-between" alignItems="flex-start" gap={16}>
+        <Flex flexDirection="column" gap={4}>
+          <Components.Heading as="h2">Hours and payments</Components.Heading>
+          <Components.Text variant="supporting">
+            Enter the hours or wage paid to each contractor along with any bonuses and
+            reimbursements.
+          </Components.Text>
+        </Flex>
+        <Flex gap={8}>
+          {onBack && (
+            <Components.Button variant="secondary" onClick={onBack}>
+              Back
+            </Components.Button>
+          )}
+          <FlexItem>
+            <Components.Button onClick={onContinue}>Continue</Components.Button>
+          </FlexItem>
+        </Flex>
+      </Flex>
+
+      <DataView
+        label="Hours and payments"
+        data={rows}
+        columns={[
+          { title: 'Contractor', render: ({ contractor }) => contractor.name },
+          {
+            title: 'Wage type',
+            render: ({ contractor }) =>
+              contractor.wageType === 'Hourly' && contractor.hourlyRate
+                ? `Hourly $${contractor.hourlyRate}/hr`
+                : contractor.wageType,
+          },
+          { title: 'Payment method', render: () => 'Historical Payment' },
+          {
+            title: 'Hours',
+            render: ({ payment, contractor }) =>
+              contractor.wageType === 'Hourly' && Number(payment.hours || '0') > 0
+                ? formatHours(Number(payment.hours))
+                : ZERO_HOURS_DISPLAY,
+          },
+          {
+            title: 'Wage',
+            render: ({ payment, contractor }) =>
+              formatCurrency(contractor.wageType === 'Fixed' ? Number(payment.wage || '0') : 0),
+          },
+          {
+            title: 'Bonus',
+            render: ({ payment }) => formatCurrency(Number(payment.bonus || '0')),
+          },
+          {
+            title: 'Reimbursement',
+            render: ({ payment }) => formatCurrency(Number(payment.reimbursement || '0')),
+          },
+          {
+            title: 'Total',
+            render: ({ payment, contractor }) =>
+              formatCurrency(computePaymentTotal(payment, contractor)),
+          },
+        ]}
+        itemMenu={({ contractor }) => (
+          <HamburgerMenu
+            items={[
+              {
+                label: 'Edit contractor payment',
+                onClick: () => { setEditingContractorId(contractor.id); },
+              },
+            ]}
+            triggerLabel="Edit contractor payment"
+          />
+        )}
+        footer={
+          rows.length > 0
+            ? () => ({
+                'column-0': 'Totals',
+                'column-4': formatCurrency(totals.wage),
+                'column-5': formatCurrency(totals.bonus),
+                'column-6': formatCurrency(totals.reimbursement),
+                'column-7': formatCurrency(totals.total),
+              })
+            : undefined
+        }
+        emptyState={() => (
+          <EmptyData
+            title="No contractors selected"
+            description="Go back and select at least one contractor."
+          />
+        )}
+      />
+
+      <EditContractorPaymentModal
+        isOpen={editingRow !== null}
+        contractor={editingRow?.contractor ?? null}
+        initialPayment={editingRow?.payment ?? null}
+        onClose={() => { setEditingContractorId(null); }}
+        onSave={onUpdatePayment}
+      />
+    </Flex>
+  )
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value)
+}
+
+function formatHours(value: number) {
+  return value.toFixed(3)
+}

--- a/sdk-app/src/design/components/contractor/payments/HistoricalPaymentSummary/HistoricalPaymentSummary.tsx
+++ b/sdk-app/src/design/components/contractor/payments/HistoricalPaymentSummary/HistoricalPaymentSummary.tsx
@@ -1,0 +1,166 @@
+import { useMemo } from 'react'
+import { computePaymentTotal } from '../types'
+import type { ContractorOption, HistoricalContractorPayment } from '../types'
+import { DataView, EmptyData, Flex } from '@/components/Common'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+interface HistoricalPaymentSummaryProps {
+  contractors: ContractorOption[]
+  payments: HistoricalContractorPayment[]
+  paidDate: string
+  isSubmitting?: boolean
+  onSubmit: () => void
+  onBack?: () => void
+}
+
+interface TableRow {
+  payment: HistoricalContractorPayment
+  contractor: ContractorOption
+}
+
+const ZERO_HOURS_DISPLAY = '0.000'
+
+export function HistoricalPaymentSummary({
+  contractors,
+  payments,
+  paidDate,
+  isSubmitting,
+  onSubmit,
+  onBack,
+}: HistoricalPaymentSummaryProps) {
+  const Components = useComponentContext()
+
+  const rows = useMemo<TableRow[]>(() => {
+    return payments
+      .map(payment => {
+        const contractor = contractors.find(c => c.id === payment.contractorId)
+        return contractor ? { payment, contractor } : null
+      })
+      .filter((row): row is TableRow => row !== null)
+  }, [payments, contractors])
+
+  const totals = useMemo(() => {
+    return rows.reduce(
+      (acc, { payment, contractor }) => {
+        const wage =
+          contractor.wageType === 'Hourly'
+            ? Number(payment.hours || '0') * Number(contractor.hourlyRate || '0')
+            : Number(payment.wage || '0')
+        acc.wage += wage
+        acc.bonus += Number(payment.bonus || '0')
+        acc.reimbursement += Number(payment.reimbursement || '0')
+        acc.total += computePaymentTotal(payment, contractor)
+        return acc
+      },
+      { wage: 0, bonus: 0, reimbursement: 0, total: 0 },
+    )
+  }, [rows])
+
+  return (
+    <Flex flexDirection="column" gap={32}>
+      <Flex justifyContent="space-between" alignItems="flex-start" gap={16}>
+        <Flex flexDirection="column" gap={4}>
+          <Components.Heading as="h2">Review and submit</Components.Heading>
+          <Components.Text variant="supporting">
+            Historical payment for {formatDate(paidDate)}
+          </Components.Text>
+        </Flex>
+        <Flex gap={8}>
+          {onBack && (
+            <Components.Button variant="secondary" onClick={onBack}>
+              Back
+            </Components.Button>
+          )}
+          <Components.Button onClick={onSubmit} isLoading={isSubmitting}>
+            Submit historical payment
+          </Components.Button>
+        </Flex>
+      </Flex>
+
+      <DataView
+        label="Contractor payments"
+        data={rows}
+        columns={[
+          { title: 'Contractor', render: ({ contractor }) => contractor.name },
+          {
+            title: 'Wage type',
+            render: ({ contractor }) =>
+              contractor.wageType === 'Hourly' && contractor.hourlyRate
+                ? `Hourly $${contractor.hourlyRate}/hr`
+                : contractor.wageType,
+          },
+          { title: 'Payment method', render: () => 'Historical Payment' },
+          {
+            title: 'Hours',
+            render: ({ payment, contractor }) =>
+              contractor.wageType === 'Hourly' && Number(payment.hours || '0') > 0
+                ? formatHours(Number(payment.hours))
+                : ZERO_HOURS_DISPLAY,
+          },
+          {
+            title: 'Wage',
+            render: ({ payment, contractor }) =>
+              formatCurrency(contractor.wageType === 'Fixed' ? Number(payment.wage || '0') : 0),
+          },
+          {
+            title: 'Bonus',
+            render: ({ payment }) => formatCurrency(Number(payment.bonus || '0')),
+          },
+          {
+            title: 'Reimbursement',
+            render: ({ payment }) => formatCurrency(Number(payment.reimbursement || '0')),
+          },
+          {
+            title: 'Total',
+            render: ({ payment, contractor }) =>
+              formatCurrency(computePaymentTotal(payment, contractor)),
+          },
+        ]}
+        footer={
+          rows.length > 0
+            ? () => ({
+                'column-0': 'Totals',
+                'column-4': formatCurrency(totals.wage),
+                'column-5': formatCurrency(totals.bonus),
+                'column-6': formatCurrency(totals.reimbursement),
+                'column-7': formatCurrency(totals.total),
+              })
+            : undefined
+        }
+        emptyState={() => (
+          <EmptyData
+            title="Nothing to submit"
+            description="Go back and configure at least one contractor payment."
+          />
+        )}
+      />
+
+      <Flex flexDirection="column" gap={4}>
+        <Components.Heading as="h3">Breakdown</Components.Heading>
+        <Components.Text>Wages: {formatCurrency(totals.wage)}</Components.Text>
+        <Components.Text>Bonuses: {formatCurrency(totals.bonus)}</Components.Text>
+        <Components.Text>Reimbursements: {formatCurrency(totals.reimbursement)}</Components.Text>
+        <Components.Text weight="bold">Total: {formatCurrency(totals.total)}</Components.Text>
+      </Flex>
+    </Flex>
+  )
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value)
+}
+
+function formatHours(value: number) {
+  return value.toFixed(3)
+}
+
+function formatDate(isoDate: string) {
+  if (!isoDate) return '—'
+  const [year, month, day] = isoDate.split('-').map(Number)
+  if (!year || !month || !day) return isoDate
+  return new Date(year, month - 1, day).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}

--- a/sdk-app/src/design/components/contractor/payments/HistoricalPaymentSummary/HistoricalPaymentSummary.tsx
+++ b/sdk-app/src/design/components/contractor/payments/HistoricalPaymentSummary/HistoricalPaymentSummary.tsx
@@ -10,7 +10,6 @@ interface HistoricalPaymentSummaryProps {
   paidDate: string
   isSubmitting?: boolean
   onSubmit: () => void
-  onBack?: () => void
 }
 
 interface TableRow {
@@ -26,7 +25,6 @@ export function HistoricalPaymentSummary({
   paidDate,
   isSubmitting,
   onSubmit,
-  onBack,
 }: HistoricalPaymentSummaryProps) {
   const Components = useComponentContext()
 
@@ -65,16 +63,9 @@ export function HistoricalPaymentSummary({
             Historical payment for {formatDate(paidDate)}
           </Components.Text>
         </Flex>
-        <Flex gap={8} justifyContent="flex-end">
-          {onBack && (
-            <Components.Button variant="secondary" onClick={onBack}>
-              Back
-            </Components.Button>
-          )}
-          <Components.Button onClick={onSubmit} isLoading={isSubmitting}>
-            Submit historical payment
-          </Components.Button>
-        </Flex>
+        <Components.Button onClick={onSubmit} isLoading={isSubmitting}>
+          Submit historical payment
+        </Components.Button>
       </Flex>
 
       <DataView

--- a/sdk-app/src/design/components/contractor/payments/HistoricalPaymentSummary/HistoricalPaymentSummary.tsx
+++ b/sdk-app/src/design/components/contractor/payments/HistoricalPaymentSummary/HistoricalPaymentSummary.tsx
@@ -58,14 +58,14 @@ export function HistoricalPaymentSummary({
 
   return (
     <Flex flexDirection="column" gap={32}>
-      <Flex justifyContent="space-between" alignItems="flex-start" gap={16}>
+      <Flex justifyContent="space-between" alignItems="center" gap={16}>
         <Flex flexDirection="column" gap={4}>
           <Components.Heading as="h2">Review and submit</Components.Heading>
           <Components.Text variant="supporting">
             Historical payment for {formatDate(paidDate)}
           </Components.Text>
         </Flex>
-        <Flex gap={8}>
+        <Flex gap={8} justifyContent="flex-end">
           {onBack && (
             <Components.Button variant="secondary" onClick={onBack}>
               Back
@@ -134,14 +134,6 @@ export function HistoricalPaymentSummary({
           />
         )}
       />
-
-      <Flex flexDirection="column" gap={4}>
-        <Components.Heading as="h3">Breakdown</Components.Heading>
-        <Components.Text>Wages: {formatCurrency(totals.wage)}</Components.Text>
-        <Components.Text>Bonuses: {formatCurrency(totals.bonus)}</Components.Text>
-        <Components.Text>Reimbursements: {formatCurrency(totals.reimbursement)}</Components.Text>
-        <Components.Text weight="bold">Total: {formatCurrency(totals.total)}</Components.Text>
-      </Flex>
     </Flex>
   )
 }

--- a/sdk-app/src/design/components/contractor/payments/SelectContractors/SelectContractors.tsx
+++ b/sdk-app/src/design/components/contractor/payments/SelectContractors/SelectContractors.tsx
@@ -1,6 +1,20 @@
 import type { ContractorOption } from '../types'
-import { ActionsLayout, EmptyData, Flex } from '@/components/Common'
+import { ActionsLayout, DataView, EmptyData, Flex, useDataView } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+function parseIsoDate(iso: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso)
+  if (!match) return null
+  const [, year, month, day] = match
+  return new Date(Number(year), Number(month) - 1, Number(day))
+}
+
+function toIsoDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
 
 interface SelectContractorsProps {
   contractors: ContractorOption[]
@@ -8,6 +22,7 @@ interface SelectContractorsProps {
   selectedContractorIds: string[]
   onPaidDateChange: (date: string) => void
   onToggleContractor: (contractorId: string) => void
+  onSelectAllContractors: (checked: boolean, visibleContractors: ContractorOption[]) => void
   onContinue: () => void
   onCancel?: () => void
 }
@@ -18,13 +33,53 @@ export function SelectContractors({
   selectedContractorIds,
   onPaidDateChange,
   onToggleContractor,
+  onSelectAllContractors,
   onContinue,
   onCancel,
 }: SelectContractorsProps) {
   const Components = useComponentContext()
 
   const canContinue = Boolean(paidDate) && selectedContractorIds.length > 0
-  const today = new Date().toISOString().slice(0, 10)
+  const today = new Date()
+  const paidDateValue = paidDate ? parseIsoDate(paidDate) : null
+
+  const dataViewProps = useDataView<ContractorOption>({
+    data: contractors,
+    columns: [
+      {
+        key: 'name',
+        title: 'Contractor',
+        render: contractor => (
+          <>
+            {contractor.name}
+            <Components.Text variant="supporting" size="sm">
+              {contractor.type}
+            </Components.Text>
+          </>
+        ),
+      },
+      {
+        key: 'wage',
+        title: 'Wage',
+        render: contractor =>
+          contractor.wageType === 'Hourly' && contractor.hourlyRate
+            ? `Hourly · $${contractor.hourlyRate}/hr`
+            : contractor.wageType,
+      },
+    ],
+    selectionMode: 'multiple',
+    onSelect: (contractor, _checked) => {
+      onToggleContractor(contractor.id)
+    },
+    onSelectAll: onSelectAllContractors,
+    getIsItemSelected: contractor => selectedContractorIds.includes(contractor.id),
+    emptyState: () => (
+      <EmptyData
+        title="No active contractors"
+        description="Activate at least one contractor before recording a historical payment."
+      />
+    ),
+  })
 
   return (
     <Flex flexDirection="column" gap={32}>
@@ -36,52 +91,17 @@ export function SelectContractors({
         </Components.Text>
       </Flex>
 
-      <div style={{ maxWidth: 280 }}>
-        <Components.TextInput
-          type="date"
-          label="Paid date"
-          isRequired
-          value={paidDate}
-          onChange={onPaidDateChange}
-          max={today}
-        />
-      </div>
+      <Components.DatePicker
+        label="Payment date"
+        isRequired
+        value={paidDateValue}
+        onChange={date => {
+          onPaidDateChange(date ? toIsoDate(date) : '')
+        }}
+        maxDate={today}
+      />
 
-      <Flex flexDirection="column" gap={16}>
-        <Components.Heading as="h3">Contractors</Components.Heading>
-        {contractors.length === 0 ? (
-          <EmptyData
-            title="No active contractors"
-            description="Activate at least one contractor before recording a historical payment."
-          />
-        ) : (
-          <Flex flexDirection="column" gap={12}>
-            {contractors.map(contractor => {
-              const isSelected = selectedContractorIds.includes(contractor.id)
-              const wageLabel =
-                contractor.wageType === 'Hourly' && contractor.hourlyRate
-                  ? `Hourly · $${contractor.hourlyRate}/hr`
-                  : contractor.wageType
-              return (
-                <Flex
-                  key={contractor.id}
-                  flexDirection="row"
-                  gap={12}
-                  alignItems="center"
-                  justifyContent="space-between"
-                >
-                  <Components.Checkbox
-                    label={contractor.name}
-                    value={isSelected}
-                    onChange={() => { onToggleContractor(contractor.id); }}
-                  />
-                  <Components.Text variant="supporting">{wageLabel}</Components.Text>
-                </Flex>
-              )
-            })}
-          </Flex>
-        )}
-      </Flex>
+      <DataView label="Select contractors" {...dataViewProps} />
 
       <ActionsLayout>
         {onCancel && (

--- a/sdk-app/src/design/components/contractor/payments/SelectContractors/SelectContractors.tsx
+++ b/sdk-app/src/design/components/contractor/payments/SelectContractors/SelectContractors.tsx
@@ -1,0 +1,98 @@
+import type { ContractorOption } from '../types'
+import { ActionsLayout, EmptyData, Flex } from '@/components/Common'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+interface SelectContractorsProps {
+  contractors: ContractorOption[]
+  paidDate: string
+  selectedContractorIds: string[]
+  onPaidDateChange: (date: string) => void
+  onToggleContractor: (contractorId: string) => void
+  onContinue: () => void
+  onCancel?: () => void
+}
+
+export function SelectContractors({
+  contractors,
+  paidDate,
+  selectedContractorIds,
+  onPaidDateChange,
+  onToggleContractor,
+  onContinue,
+  onCancel,
+}: SelectContractorsProps) {
+  const Components = useComponentContext()
+
+  const canContinue = Boolean(paidDate) && selectedContractorIds.length > 0
+  const today = new Date().toISOString().slice(0, 10)
+
+  return (
+    <Flex flexDirection="column" gap={32}>
+      <Flex flexDirection="column" gap={4}>
+        <Components.Heading as="h2">Record a historical payment</Components.Heading>
+        <Components.Text variant="supporting">
+          Log a contractor payment that already happened outside Gusto. Pick a paid date and the
+          contractors you paid.
+        </Components.Text>
+      </Flex>
+
+      <div style={{ maxWidth: 280 }}>
+        <Components.TextInput
+          type="date"
+          label="Paid date"
+          isRequired
+          value={paidDate}
+          onChange={onPaidDateChange}
+          max={today}
+        />
+      </div>
+
+      <Flex flexDirection="column" gap={16}>
+        <Components.Heading as="h3">Contractors</Components.Heading>
+        {contractors.length === 0 ? (
+          <EmptyData
+            title="No active contractors"
+            description="Activate at least one contractor before recording a historical payment."
+          />
+        ) : (
+          <Flex flexDirection="column" gap={12}>
+            {contractors.map(contractor => {
+              const isSelected = selectedContractorIds.includes(contractor.id)
+              const wageLabel =
+                contractor.wageType === 'Hourly' && contractor.hourlyRate
+                  ? `Hourly · $${contractor.hourlyRate}/hr`
+                  : contractor.wageType
+              return (
+                <Flex
+                  key={contractor.id}
+                  flexDirection="row"
+                  gap={12}
+                  alignItems="center"
+                  justifyContent="space-between"
+                >
+                  <Components.Checkbox
+                    label={contractor.name}
+                    value={isSelected}
+                    onChange={() => { onToggleContractor(contractor.id); }}
+                  />
+                  <Components.Text variant="supporting">{wageLabel}</Components.Text>
+                </Flex>
+              )
+            })}
+          </Flex>
+        )}
+      </Flex>
+
+      <ActionsLayout>
+        {onCancel && (
+          <Components.Button variant="secondary" onClick={onCancel}>
+            Cancel
+          </Components.Button>
+        )}
+        <Components.Button onClick={onContinue} isDisabled={!canContinue}>
+          Continue
+        </Components.Button>
+      </ActionsLayout>
+    </Flex>
+  )
+}

--- a/sdk-app/src/design/components/contractor/payments/types.ts
+++ b/sdk-app/src/design/components/contractor/payments/types.ts
@@ -1,8 +1,10 @@
 export type WageType = 'Hourly' | 'Fixed'
+export type ContractorType = 'Individual' | 'Business'
 
 export interface ContractorOption {
   id: string
   name: string
+  type: ContractorType
   wageType: WageType
   hourlyRate?: string
 }

--- a/sdk-app/src/design/components/contractor/payments/types.ts
+++ b/sdk-app/src/design/components/contractor/payments/types.ts
@@ -1,0 +1,37 @@
+export type WageType = 'Hourly' | 'Fixed'
+
+export interface ContractorOption {
+  id: string
+  name: string
+  wageType: WageType
+  hourlyRate?: string
+}
+
+export interface HistoricalContractorPayment {
+  contractorId: string
+  hours: string
+  wage: string
+  bonus: string
+  reimbursement: string
+}
+
+export function computePaymentTotal(
+  payment: HistoricalContractorPayment,
+  contractor: ContractorOption,
+): number {
+  const wages =
+    contractor.wageType === 'Hourly'
+      ? Number(payment.hours || '0') * Number(contractor.hourlyRate || '0')
+      : Number(payment.wage || '0')
+  return wages + Number(payment.bonus || '0') + Number(payment.reimbursement || '0')
+}
+
+export function emptyPaymentFor(contractor: ContractorOption): HistoricalContractorPayment {
+  return {
+    contractorId: contractor.id,
+    hours: '',
+    wage: '',
+    bonus: '',
+    reimbursement: '',
+  }
+}

--- a/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/CreateHistoricalPayment.tsx
+++ b/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/CreateHistoricalPayment.tsx
@@ -1,0 +1,159 @@
+import { Suspense, useMemo, useState } from 'react'
+import { useContractorsListSuspense } from '@gusto/embedded-api-v-2025-11-15/react-query/contractorsList'
+import { useContractorPaymentGroupsCreateMutation } from '@gusto/embedded-api-v-2025-11-15/react-query/contractorPaymentGroupsCreate'
+import { RFCDate } from '@gusto/embedded-api-v-2025-11-15/types/rfcdate'
+import { SelectContractors } from '../../../components/contractor/payments/SelectContractors/SelectContractors'
+import { HistoricalPaymentConfiguration } from '../../../components/contractor/payments/HistoricalPaymentConfiguration/HistoricalPaymentConfiguration'
+import { HistoricalPaymentSummary } from '../../../components/contractor/payments/HistoricalPaymentSummary/HistoricalPaymentSummary'
+import {
+  emptyPaymentFor,
+  type ContractorOption,
+  type HistoricalContractorPayment,
+} from '../../../components/contractor/payments/types'
+import { toContractorOptions } from './states'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common'
+import { BaseComponent } from '@/components/Base'
+
+export interface CreateHistoricalPaymentProps {
+  companyId: string
+  onDone?: () => void
+}
+
+type Step = 'select' | 'configure' | 'review'
+
+function Root({ companyId, onDone }: CreateHistoricalPaymentProps) {
+  const Components = useComponentContext()
+  const { data } = useContractorsListSuspense({ companyUuid: companyId })
+  const createMutation = useContractorPaymentGroupsCreateMutation()
+
+  const contractors = useMemo(() => toContractorOptions(data.contractors ?? []), [data.contractors])
+
+  const [step, setStep] = useState<Step>('select')
+  const [paidDate, setPaidDate] = useState('')
+  const [selectedIds, setSelectedIds] = useState<string[]>([])
+  const [payments, setPayments] = useState<HistoricalContractorPayment[]>([])
+  const [submittedCount, setSubmittedCount] = useState<number | null>(null)
+
+  const selectedContractors = useMemo(
+    () => contractors.filter(c => selectedIds.includes(c.id)),
+    [contractors, selectedIds],
+  )
+
+  const toggleContractor = (id: string) => {
+    setSelectedIds(prev => (prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]))
+  }
+
+  const handleSelectContinue = () => {
+    setPayments(
+      selectedContractors.map(c => {
+        const existing = payments.find(p => p.contractorId === c.id)
+        return existing ?? emptyPaymentFor(c)
+      }),
+    )
+    setStep('configure')
+  }
+
+  const handleUpdatePayment = (updated: HistoricalContractorPayment) => {
+    setPayments(prev => prev.map(p => (p.contractorId === updated.contractorId ? updated : p)))
+  }
+
+  const handleSubmit = async () => {
+    const touched = payments.filter(p => {
+      const contractor = contractors.find(c => c.id === p.contractorId)
+      if (!contractor) return false
+      const wage =
+        contractor.wageType === 'Hourly'
+          ? Number(p.hours || '0') * Number(contractor.hourlyRate || '0')
+          : Number(p.wage || '0')
+      return wage + Number(p.bonus || '0') + Number(p.reimbursement || '0') > 0
+    })
+
+    if (touched.length === 0 || !paidDate) return
+
+    await createMutation.mutateAsync({
+      request: {
+        companyId,
+        requestBody: {
+          checkDate: new RFCDate(paidDate),
+          creationToken: crypto.randomUUID(),
+          contractorPayments: touched.map(payment => {
+            const contractor = contractors.find(c => c.id === payment.contractorId)!
+            return {
+              contractorUuid: payment.contractorId,
+              paymentMethod: 'Historical Payment',
+              ...(contractor.wageType === 'Hourly'
+                ? { hours: payment.hours || '0', bonus: payment.bonus || '0' }
+                : { wage: payment.wage || '0' }),
+              reimbursement: payment.reimbursement || '0',
+            }
+          }),
+        },
+      },
+    })
+
+    setSubmittedCount(touched.length)
+    onDone?.()
+  }
+
+  if (submittedCount !== null) {
+    return (
+      <Components.Alert label="Historical payment recorded" status="success">
+        Submitted {submittedCount} payment(s) for {paidDate}.
+      </Components.Alert>
+    )
+  }
+
+  if (step === 'select') {
+    return (
+      <SelectContractors
+        contractors={contractors}
+        paidDate={paidDate}
+        selectedContractorIds={selectedIds}
+        onPaidDateChange={setPaidDate}
+        onToggleContractor={toggleContractor}
+        onContinue={handleSelectContinue}
+      />
+    )
+  }
+
+  if (step === 'configure') {
+    const selected = contractorsByIds(contractors, selectedIds)
+    return (
+      <HistoricalPaymentConfiguration
+        contractors={selected}
+        payments={payments}
+        onUpdatePayment={handleUpdatePayment}
+        onContinue={() => { setStep('review'); }}
+        onBack={() => { setStep('select'); }}
+      />
+    )
+  }
+
+  return (
+    <HistoricalPaymentSummary
+      contractors={contractorsByIds(contractors, selectedIds)}
+      payments={payments}
+      paidDate={paidDate}
+      isSubmitting={createMutation.isPending}
+      onSubmit={handleSubmit}
+      onBack={() => { setStep('configure'); }}
+    />
+  )
+}
+
+function contractorsByIds(contractors: ContractorOption[], ids: string[]) {
+  return contractors.filter(c => ids.includes(c.id))
+}
+
+export function CreateHistoricalPayment(props: CreateHistoricalPaymentProps) {
+  return (
+    <BaseComponent onEvent={() => {}}>
+      <Flex flexDirection="column" gap={32} alignItems="stretch">
+        <Suspense fallback={<div>Loading contractors…</div>}>
+          <Root {...props} />
+        </Suspense>
+      </Flex>
+    </BaseComponent>
+  )
+}

--- a/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/CreateHistoricalPayment.tsx
+++ b/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/CreateHistoricalPayment.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useMemo, useState } from 'react'
 import { useContractorsListSuspense } from '@gusto/embedded-api-v-2025-11-15/react-query/contractorsList'
 import { useContractorPaymentGroupsCreateMutation } from '@gusto/embedded-api-v-2025-11-15/react-query/contractorPaymentGroupsCreate'
+import { useContractorPaymentGroupsPreviewMutation } from '@gusto/embedded-api-v-2025-11-15/react-query/contractorPaymentGroupsPreview'
 import { RFCDate } from '@gusto/embedded-api-v-2025-11-15/types/rfcdate'
 import { SelectContractors } from '../../../components/contractor/payments/SelectContractors/SelectContractors'
 import { HistoricalPaymentConfiguration } from '../../../components/contractor/payments/HistoricalPaymentConfiguration/HistoricalPaymentConfiguration'
@@ -25,6 +26,7 @@ type Step = 'select' | 'configure' | 'review'
 function Root({ companyId, onDone }: CreateHistoricalPaymentProps) {
   const Components = useComponentContext()
   const { data } = useContractorsListSuspense({ companyUuid: companyId })
+  const previewMutation = useContractorPaymentGroupsPreviewMutation()
   const createMutation = useContractorPaymentGroupsCreateMutation()
 
   const contractors = useMemo(() => toContractorOptions(data.contractors ?? []), [data.contractors])
@@ -42,6 +44,15 @@ function Root({ companyId, onDone }: CreateHistoricalPaymentProps) {
 
   const toggleContractor = (id: string) => {
     setSelectedIds(prev => (prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]))
+  }
+
+  const selectAllContractors = (checked: boolean, visibleContractors: ContractorOption[]) => {
+    const visibleIds = visibleContractors.map(c => c.id)
+    setSelectedIds(prev =>
+      checked
+        ? Array.from(new Set([...prev, ...visibleIds]))
+        : prev.filter(id => !visibleIds.includes(id)),
+    )
   }
 
   const handleSelectContinue = () => {
@@ -71,23 +82,38 @@ function Root({ companyId, onDone }: CreateHistoricalPaymentProps) {
 
     if (touched.length === 0 || !paidDate) return
 
+    const contractorPayments = touched.map(payment => {
+      const contractor = contractors.find(c => c.id === payment.contractorId)!
+      return {
+        contractorUuid: payment.contractorId,
+        paymentMethod: 'Historical Payment' as const,
+        ...(contractor.wageType === 'Hourly'
+          ? { hours: payment.hours || '0', bonus: payment.bonus || '0' }
+          : { wage: payment.wage || '0' }),
+        reimbursement: payment.reimbursement || '0',
+      }
+    })
+
+    const previewResult = await previewMutation.mutateAsync({
+      request: {
+        companyId,
+        requestBody: {
+          checkDate: new RFCDate(paidDate),
+          contractorPayments,
+        },
+      },
+    })
+
+    const creationToken = previewResult.contractorPaymentGroupPreview?.creationToken
+    if (!creationToken) return
+
     await createMutation.mutateAsync({
       request: {
         companyId,
         requestBody: {
           checkDate: new RFCDate(paidDate),
-          creationToken: crypto.randomUUID(),
-          contractorPayments: touched.map(payment => {
-            const contractor = contractors.find(c => c.id === payment.contractorId)!
-            return {
-              contractorUuid: payment.contractorId,
-              paymentMethod: 'Historical Payment',
-              ...(contractor.wageType === 'Hourly'
-                ? { hours: payment.hours || '0', bonus: payment.bonus || '0' }
-                : { wage: payment.wage || '0' }),
-              reimbursement: payment.reimbursement || '0',
-            }
-          }),
+          creationToken,
+          contractorPayments,
         },
       },
     })
@@ -112,6 +138,7 @@ function Root({ companyId, onDone }: CreateHistoricalPaymentProps) {
         selectedContractorIds={selectedIds}
         onPaidDateChange={setPaidDate}
         onToggleContractor={toggleContractor}
+        onSelectAllContractors={selectAllContractors}
         onContinue={handleSelectContinue}
       />
     )
@@ -124,8 +151,12 @@ function Root({ companyId, onDone }: CreateHistoricalPaymentProps) {
         contractors={selected}
         payments={payments}
         onUpdatePayment={handleUpdatePayment}
-        onContinue={() => { setStep('review'); }}
-        onBack={() => { setStep('select'); }}
+        onContinue={() => {
+          setStep('review')
+        }}
+        onBack={() => {
+          setStep('select')
+        }}
       />
     )
   }
@@ -135,9 +166,11 @@ function Root({ companyId, onDone }: CreateHistoricalPaymentProps) {
       contractors={contractorsByIds(contractors, selectedIds)}
       payments={payments}
       paidDate={paidDate}
-      isSubmitting={createMutation.isPending}
+      isSubmitting={previewMutation.isPending || createMutation.isPending}
       onSubmit={handleSubmit}
-      onBack={() => { setStep('configure'); }}
+      onBack={() => {
+        setStep('configure')
+      }}
     />
   )
 }

--- a/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/CreateHistoricalPayment.tsx
+++ b/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/CreateHistoricalPayment.tsx
@@ -15,6 +15,7 @@ import { toContractorOptions } from './states'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { Flex } from '@/components/Common'
 import { BaseComponent } from '@/components/Base'
+import CaretLeftIcon from '@/assets/icons/caret-left.svg?react'
 
 export interface CreateHistoricalPaymentProps {
   companyId: string
@@ -124,7 +125,7 @@ function Root({ companyId, onDone }: CreateHistoricalPaymentProps) {
 
   if (submittedCount !== null) {
     return (
-      <Components.Alert label="Historical payment recorded" status="success">
+      <Components.Alert label="Historical payment recorded" status="success" disableScrollIntoView>
         Submitted {submittedCount} payment(s) for {paidDate}.
       </Components.Alert>
     )
@@ -144,34 +145,41 @@ function Root({ companyId, onDone }: CreateHistoricalPaymentProps) {
     )
   }
 
-  if (step === 'configure') {
-    const selected = contractorsByIds(contractors, selectedIds)
-    return (
-      <HistoricalPaymentConfiguration
-        contractors={selected}
-        payments={payments}
-        onUpdatePayment={handleUpdatePayment}
-        onContinue={() => {
-          setStep('review')
-        }}
-        onBack={() => {
-          setStep('select')
-        }}
-      />
-    )
-  }
+  const backStep: Step = step === 'review' ? 'configure' : 'select'
 
   return (
-    <HistoricalPaymentSummary
-      contractors={contractorsByIds(contractors, selectedIds)}
-      payments={payments}
-      paidDate={paidDate}
-      isSubmitting={previewMutation.isPending || createMutation.isPending}
-      onSubmit={handleSubmit}
-      onBack={() => {
-        setStep('configure')
-      }}
-    />
+    <Flex flexDirection="column" gap={16}>
+      <div>
+        <Components.Button
+          variant="secondary"
+          icon={<CaretLeftIcon aria-hidden="true" />}
+          onClick={() => {
+            setStep(backStep)
+          }}
+        >
+          Back
+        </Components.Button>
+      </div>
+
+      {step === 'configure' ? (
+        <HistoricalPaymentConfiguration
+          contractors={contractorsByIds(contractors, selectedIds)}
+          payments={payments}
+          onUpdatePayment={handleUpdatePayment}
+          onContinue={() => {
+            setStep('review')
+          }}
+        />
+      ) : (
+        <HistoricalPaymentSummary
+          contractors={contractorsByIds(contractors, selectedIds)}
+          payments={payments}
+          paidDate={paidDate}
+          isSubmitting={previewMutation.isPending || createMutation.isPending}
+          onSubmit={handleSubmit}
+        />
+      )}
+    </Flex>
   )
 }
 

--- a/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/StateHarnesses.tsx
+++ b/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/StateHarnesses.tsx
@@ -24,10 +24,20 @@ export function SelectContractorsHarness({
       paidDate={paidDate}
       selectedContractorIds={selected}
       onPaidDateChange={setPaidDate}
-      onToggleContractor={id =>
-        { setSelected(prev => (prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id])); }
-      }
-      onContinue={() => { console.log('continue', { paidDate, selected }); }}
+      onToggleContractor={id => {
+        setSelected(prev => (prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]))
+      }}
+      onSelectAllContractors={(checked, visibleContractors) => {
+        const visibleIds = visibleContractors.map(c => c.id)
+        setSelected(prev =>
+          checked
+            ? Array.from(new Set([...prev, ...visibleIds]))
+            : prev.filter(id => !visibleIds.includes(id)),
+        )
+      }}
+      onContinue={() => {
+        console.log('continue', { paidDate, selected })
+      }}
     />
   )
 }
@@ -43,11 +53,15 @@ export function ConfigurationHarness({ contractors, initialPayments }: Configura
     <HistoricalPaymentConfiguration
       contractors={contractors}
       payments={payments}
-      onUpdatePayment={updated =>
-        { setPayments(prev => prev.map(p => (p.contractorId === updated.contractorId ? updated : p))); }
-      }
-      onContinue={() => { console.log('continue to review'); }}
-      onBack={() => { console.log('back to select'); }}
+      onUpdatePayment={updated => {
+        setPayments(prev => prev.map(p => (p.contractorId === updated.contractorId ? updated : p)))
+      }}
+      onContinue={() => {
+        console.log('continue to review')
+      }}
+      onBack={() => {
+        console.log('back to select')
+      }}
     />
   )
 }

--- a/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/StateHarnesses.tsx
+++ b/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/StateHarnesses.tsx
@@ -59,9 +59,6 @@ export function ConfigurationHarness({ contractors, initialPayments }: Configura
       onContinue={() => {
         console.log('continue to review')
       }}
-      onBack={() => {
-        console.log('back to select')
-      }}
     />
   )
 }

--- a/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/StateHarnesses.tsx
+++ b/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/StateHarnesses.tsx
@@ -1,0 +1,53 @@
+/* eslint-disable no-console */
+import { useState } from 'react'
+import { SelectContractors } from '../../../components/contractor/payments/SelectContractors/SelectContractors'
+import { HistoricalPaymentConfiguration } from '../../../components/contractor/payments/HistoricalPaymentConfiguration/HistoricalPaymentConfiguration'
+import type {
+  ContractorOption,
+  HistoricalContractorPayment,
+} from '../../../components/contractor/payments/types'
+
+interface SelectContractorsHarnessProps {
+  initialContractors: ContractorOption[]
+  initialDate?: string
+}
+
+export function SelectContractorsHarness({
+  initialContractors,
+  initialDate = '',
+}: SelectContractorsHarnessProps) {
+  const [paidDate, setPaidDate] = useState(initialDate)
+  const [selected, setSelected] = useState<string[]>([])
+  return (
+    <SelectContractors
+      contractors={initialContractors}
+      paidDate={paidDate}
+      selectedContractorIds={selected}
+      onPaidDateChange={setPaidDate}
+      onToggleContractor={id =>
+        { setSelected(prev => (prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id])); }
+      }
+      onContinue={() => { console.log('continue', { paidDate, selected }); }}
+    />
+  )
+}
+
+interface ConfigurationHarnessProps {
+  contractors: ContractorOption[]
+  initialPayments: HistoricalContractorPayment[]
+}
+
+export function ConfigurationHarness({ contractors, initialPayments }: ConfigurationHarnessProps) {
+  const [payments, setPayments] = useState(initialPayments)
+  return (
+    <HistoricalPaymentConfiguration
+      contractors={contractors}
+      payments={payments}
+      onUpdatePayment={updated =>
+        { setPayments(prev => prev.map(p => (p.contractorId === updated.contractorId ? updated : p))); }
+      }
+      onContinue={() => { console.log('continue to review'); }}
+      onBack={() => { console.log('back to select'); }}
+    />
+  )
+}

--- a/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/index.tsx
+++ b/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/index.tsx
@@ -1,0 +1,31 @@
+import { useOutletContext } from 'react-router-dom'
+import type { EntityIds } from '../../../../useEntities'
+import { ComponentStatesPage } from '../../ComponentStatesPage'
+import { CreateHistoricalPayment } from './CreateHistoricalPayment'
+import { components } from './states'
+import { Flex } from '@/components/Common'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+const BASE_PATH = '/design/create-historical-payment'
+
+export function CreateHistoricalPaymentPrototype() {
+  const { entities } = useOutletContext<{ entities: EntityIds }>()
+  const Components = useComponentContext()
+
+  if (!entities.companyId) {
+    return (
+      <Flex flexDirection="column" gap={16} alignItems="stretch">
+        <Components.Heading as="h2">Create Historical Payment</Components.Heading>
+        <Components.Alert label="Missing company ID" status="warning">
+          Set a company ID in Settings (top right) to load real data.
+        </Components.Alert>
+      </Flex>
+    )
+  }
+
+  return <CreateHistoricalPayment companyId={entities.companyId} />
+}
+
+export function CreateHistoricalPaymentStates() {
+  return <ComponentStatesPage basePath={`${BASE_PATH}/component-states`} components={components} />
+}

--- a/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/states.tsx
+++ b/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/states.tsx
@@ -1,0 +1,164 @@
+/* eslint-disable no-console */
+import type { Contractor } from '@gusto/embedded-api-v-2025-11-15/models/components/contractor'
+import { HistoricalPaymentSummary } from '../../../components/contractor/payments/HistoricalPaymentSummary/HistoricalPaymentSummary'
+import {
+  emptyPaymentFor,
+  type ContractorOption,
+  type HistoricalContractorPayment,
+} from '../../../components/contractor/payments/types'
+import type { PrototypeComponent } from '../../prototypeTypes'
+import { ConfigurationHarness, SelectContractorsHarness } from './StateHarnesses'
+
+export function toContractorOptions(contractors: Contractor[]): ContractorOption[] {
+  return contractors
+    .filter(c => c.isActive)
+    .map(c => ({
+      id: c.uuid,
+      name:
+        c.type === 'Business'
+          ? (c.businessName ?? '')
+          : `${c.firstName ?? ''} ${c.lastName ?? ''}`.trim(),
+      wageType: (c.wageType ?? 'Fixed') as ContractorOption['wageType'],
+      hourlyRate: c.hourlyRate,
+    }))
+}
+
+const mixedContractors: ContractorOption[] = [
+  { id: 'c-1', name: 'Alex Kim', wageType: 'Hourly', hourlyRate: '45' },
+  { id: 'c-2', name: 'Riley Chen', wageType: 'Fixed' },
+  { id: 'c-3', name: 'Studio Bloom LLC', wageType: 'Fixed' },
+  { id: 'c-4', name: 'Jordan Patel', wageType: 'Hourly', hourlyRate: '60' },
+]
+
+const populatedPayments: HistoricalContractorPayment[] = [
+  { contractorId: 'c-1', hours: '32', wage: '0', bonus: '100', reimbursement: '25' },
+  { contractorId: 'c-2', hours: '0', wage: '2500', bonus: '0', reimbursement: '0' },
+  { contractorId: 'c-3', hours: '0', wage: '1800', bonus: '0', reimbursement: '50' },
+]
+
+export const components: PrototypeComponent[] = [
+  {
+    slug: 'select-contractors',
+    name: 'SelectContractors',
+    description: 'Pick a paid date and which contractors are included in the payment group.',
+    configurations: [
+      {
+        slug: 'populated',
+        name: 'Mixed contractors',
+        description: 'A handful of active contractors of mixed wage types.',
+        render: () => <SelectContractorsHarness initialContractors={mixedContractors} />,
+      },
+      {
+        slug: 'with-date',
+        name: 'Date prefilled',
+        description: 'The paid date is already set; ready to pick contractors.',
+        render: () => (
+          <SelectContractorsHarness
+            initialContractors={mixedContractors}
+            initialDate="2026-05-12"
+          />
+        ),
+      },
+      {
+        slug: 'empty',
+        name: 'No active contractors',
+        description: 'Empty state when no contractors are available.',
+        render: () => <SelectContractorsHarness initialContractors={[]} />,
+      },
+    ],
+  },
+  {
+    slug: 'historical-payment-configuration',
+    name: 'HistoricalPaymentConfiguration',
+    description:
+      'Enter hours, wages, bonuses, and reimbursements per contractor. Per-row edit modal.',
+    configurations: [
+      {
+        slug: 'populated',
+        name: 'Mixed wage types, partially filled',
+        description: 'Three contractors selected with some values already entered.',
+        render: () => (
+          <ConfigurationHarness
+            contractors={mixedContractors.slice(0, 3)}
+            initialPayments={populatedPayments}
+          />
+        ),
+      },
+      {
+        slug: 'all-empty',
+        name: 'Empty rows',
+        description: 'Selected contractors but no payment values entered yet.',
+        render: () => (
+          <ConfigurationHarness
+            contractors={mixedContractors.slice(0, 3)}
+            initialPayments={mixedContractors.slice(0, 3).map(emptyPaymentFor)}
+          />
+        ),
+      },
+      {
+        slug: 'single-hourly',
+        name: 'Single hourly contractor',
+        description: 'One contractor, hourly — exercises the hours-only row layout.',
+        render: () => (
+          <ConfigurationHarness
+            contractors={[mixedContractors[0]!]}
+            initialPayments={[
+              { contractorId: 'c-1', hours: '20', wage: '0', bonus: '50', reimbursement: '0' },
+            ]}
+          />
+        ),
+      },
+    ],
+  },
+  {
+    slug: 'historical-payment-summary',
+    name: 'HistoricalPaymentSummary',
+    description: 'Review and submit screen with the per-contractor table and totals breakdown.',
+    configurations: [
+      {
+        slug: 'populated',
+        name: 'Ready to submit',
+        description: 'Three contractors with realistic amounts entered.',
+        render: () => (
+          <HistoricalPaymentSummary
+            contractors={mixedContractors.slice(0, 3)}
+            payments={populatedPayments}
+            paidDate="2026-05-12"
+            onSubmit={() => { console.log('submit historical payment'); }}
+            onBack={() => { console.log('back to configure'); }}
+          />
+        ),
+      },
+      {
+        slug: 'single-contractor',
+        name: 'Single contractor',
+        description: 'Just one row in the summary table.',
+        render: () => (
+          <HistoricalPaymentSummary
+            contractors={[mixedContractors[1]!]}
+            payments={[
+              { contractorId: 'c-2', hours: '0', wage: '3000', bonus: '0', reimbursement: '100' },
+            ]}
+            paidDate="2026-04-30"
+            onSubmit={() => { console.log('submit historical payment'); }}
+            onBack={() => { console.log('back to configure'); }}
+          />
+        ),
+      },
+      {
+        slug: 'empty',
+        name: 'Empty',
+        description: 'Nothing to submit — empty state.',
+        render: () => (
+          <HistoricalPaymentSummary
+            contractors={[]}
+            payments={[]}
+            paidDate="2026-05-12"
+            onSubmit={() => { console.log('submit'); }}
+            onBack={() => { console.log('back'); }}
+          />
+        ),
+      },
+    ],
+  },
+]

--- a/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/states.tsx
+++ b/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/states.tsx
@@ -128,9 +128,6 @@ export const components: PrototypeComponent[] = [
             onSubmit={() => {
               console.log('submit historical payment')
             }}
-            onBack={() => {
-              console.log('back to configure')
-            }}
           />
         ),
       },
@@ -148,9 +145,6 @@ export const components: PrototypeComponent[] = [
             onSubmit={() => {
               console.log('submit historical payment')
             }}
-            onBack={() => {
-              console.log('back to configure')
-            }}
           />
         ),
       },
@@ -165,9 +159,6 @@ export const components: PrototypeComponent[] = [
             paidDate="2026-05-12"
             onSubmit={() => {
               console.log('submit')
-            }}
-            onBack={() => {
-              console.log('back')
             }}
           />
         ),

--- a/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/states.tsx
+++ b/sdk-app/src/design/prototypes/contractor-payments/CreateHistoricalPayment/states.tsx
@@ -11,23 +11,24 @@ import { ConfigurationHarness, SelectContractorsHarness } from './StateHarnesses
 
 export function toContractorOptions(contractors: Contractor[]): ContractorOption[] {
   return contractors
-    .filter(c => c.isActive)
+    .filter(c => c.isActive && c.onboarded)
     .map(c => ({
       id: c.uuid,
       name:
         c.type === 'Business'
           ? (c.businessName ?? '')
           : `${c.firstName ?? ''} ${c.lastName ?? ''}`.trim(),
+      type: (c.type ?? 'Individual') as ContractorOption['type'],
       wageType: (c.wageType ?? 'Fixed') as ContractorOption['wageType'],
       hourlyRate: c.hourlyRate,
     }))
 }
 
 const mixedContractors: ContractorOption[] = [
-  { id: 'c-1', name: 'Alex Kim', wageType: 'Hourly', hourlyRate: '45' },
-  { id: 'c-2', name: 'Riley Chen', wageType: 'Fixed' },
-  { id: 'c-3', name: 'Studio Bloom LLC', wageType: 'Fixed' },
-  { id: 'c-4', name: 'Jordan Patel', wageType: 'Hourly', hourlyRate: '60' },
+  { id: 'c-1', name: 'Alex Kim', type: 'Individual', wageType: 'Hourly', hourlyRate: '45' },
+  { id: 'c-2', name: 'Riley Chen', type: 'Individual', wageType: 'Fixed' },
+  { id: 'c-3', name: 'Studio Bloom LLC', type: 'Business', wageType: 'Fixed' },
+  { id: 'c-4', name: 'Jordan Patel', type: 'Individual', wageType: 'Hourly', hourlyRate: '60' },
 ]
 
 const populatedPayments: HistoricalContractorPayment[] = [
@@ -124,8 +125,12 @@ export const components: PrototypeComponent[] = [
             contractors={mixedContractors.slice(0, 3)}
             payments={populatedPayments}
             paidDate="2026-05-12"
-            onSubmit={() => { console.log('submit historical payment'); }}
-            onBack={() => { console.log('back to configure'); }}
+            onSubmit={() => {
+              console.log('submit historical payment')
+            }}
+            onBack={() => {
+              console.log('back to configure')
+            }}
           />
         ),
       },
@@ -140,8 +145,12 @@ export const components: PrototypeComponent[] = [
               { contractorId: 'c-2', hours: '0', wage: '3000', bonus: '0', reimbursement: '100' },
             ]}
             paidDate="2026-04-30"
-            onSubmit={() => { console.log('submit historical payment'); }}
-            onBack={() => { console.log('back to configure'); }}
+            onSubmit={() => {
+              console.log('submit historical payment')
+            }}
+            onBack={() => {
+              console.log('back to configure')
+            }}
           />
         ),
       },
@@ -154,8 +163,12 @@ export const components: PrototypeComponent[] = [
             contractors={[]}
             payments={[]}
             paidDate="2026-05-12"
-            onSubmit={() => { console.log('submit'); }}
-            onBack={() => { console.log('back'); }}
+            onSubmit={() => {
+              console.log('submit')
+            }}
+            onBack={() => {
+              console.log('back')
+            }}
           />
         ),
       },

--- a/sdk-app/src/design/registry.ts
+++ b/sdk-app/src/design/registry.ts
@@ -41,6 +41,24 @@ export const categorizedRegistry: CategorizedRegistry = {
       ],
     },
     {
+      name: 'Create Historical Payment',
+      path: '/design/create-historical-payment',
+      description:
+        'Record a contractor payment that already happened outside Gusto — paid date, per-contractor amounts, no funding.',
+      children: [
+        {
+          name: 'Prototype',
+          path: '/design/create-historical-payment',
+          description: 'Live prototype against the real API.',
+        },
+        {
+          name: 'Component states',
+          path: '/design/create-historical-payment/component-states',
+          description: 'Browse form configurations with mock data.',
+        },
+      ],
+    },
+    {
       name: 'Contractor Self-Onboarding',
       path: '/design/contractor-self-onboarding',
       description: 'The contractor-facing onboarding experience after receiving an invite link.',

--- a/sdk-app/src/main.tsx
+++ b/sdk-app/src/main.tsx
@@ -32,6 +32,10 @@ import {
   RegularRateOfPayPrototype,
   RegularRateOfPayStates,
 } from './design/prototypes/regular-rate-of-pay'
+import {
+  CreateHistoricalPaymentPrototype,
+  CreateHistoricalPaymentStates,
+} from './design/prototypes/contractor-payments/CreateHistoricalPayment'
 import './app.scss'
 import '@/styles/sdk.scss'
 
@@ -115,6 +119,22 @@ const router = createBrowserRouter([
                   {
                     path: ':componentSlug/:configSlug',
                     element: <RegularRateOfPayStates />,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            path: 'create-historical-payment',
+            children: [
+              { index: true, element: <CreateHistoricalPaymentPrototype /> },
+              {
+                path: 'component-states',
+                children: [
+                  { index: true, element: <CreateHistoricalPaymentStates /> },
+                  {
+                    path: ':componentSlug/:configSlug',
+                    element: <CreateHistoricalPaymentStates />,
                   },
                 ],
               },


### PR DESCRIPTION
## Summary
Builds out the historical contractor payment prototype in sdk-app's design mode. Wires the three-step flow (select contractors → enter hours/payments → review & submit) against the live SDK API, using SDK primitives throughout.

### Highlights
- **SelectContractors** refactored to a `useDataView` multi-select with proper columns, select-all, and responsive table↔cards. Date input uses `Components.DatePicker`.
- **ContractorOption** carries the contractor `type` (Individual/Business), surfaced as supporting text under the name.
- **Submit flow** runs `contractorPaymentGroupsPreview` first and threads the server-issued `creationToken` into `contractorPaymentGroupsCreate` — required by the API.
- **Filter** contractors to `isActive && onboarded` so non-onboarded contractors don't reach the picker (matches gws-flows).
- **Back navigation** moved to a single top-of-page Back button (CaretLeftIcon, secondary) in the orchestrator. Component-level Back buttons removed.

## Test plan
- [ ] In sdk-app design mode, open the historical contractor payment prototype.
- [ ] Step 1: only onboarded + active contractors appear; date picker uses the SDK DatePicker; multi-select with select-all works.
- [ ] Step 2: top-left Back returns to step 1 with selections preserved.
- [ ] Step 3: top-left Back returns to step 2. Submit triggers preview → create and surfaces the success Alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)