### PR TITLE
fix(ContractorPayments): align numeric columns and table footer

### DIFF
--- a/src/components/Common/DataView/DataTable/DataTable.test.tsx
+++ b/src/components/Common/DataView/DataTable/DataTable.test.tsx
@@ -205,6 +205,19 @@ describe('DataTable Component', () => {
       expect(screen.getByText('Name').closest('div')?.className).toMatch(/cellEnd/)
       expect(screen.getByText('Alice').closest('div')?.className).toMatch(/cellEnd/)
     })
+
+    test('applies column justify to footer cells', () => {
+      renderTable({
+        columns: [
+          { key: 'name', title: 'Name', render: item => item.name },
+          { key: 'age', title: 'Age', justify: 'end', render: item => item.age.toString() },
+        ],
+        footer: () => ({ name: 'Total', age: '55' }),
+      })
+
+      expect(screen.getByText('Total').closest('div')?.className).not.toMatch(/cellEnd/)
+      expect(screen.getByText('55').closest('div')?.className).toMatch(/cellEnd/)
+    })
   })
 
   describe('accessibility', () => {

--- a/src/components/Common/DataView/DataTable/DataTable.tsx
+++ b/src/components/Common/DataView/DataTable/DataTable.tsx
@@ -204,7 +204,7 @@ export const DataTable = <T,>({
       const columnKey = typeof column.key === 'string' ? column.key : `column-${index}`
       footerCells.push({
         key: `footer-${columnKey}`,
-        content: footerContent[columnKey] || '',
+        content: withJustify(footerContent[columnKey] || '', column.justify),
       })
     })
 

--- a/src/components/Contractor/Payments/CreatePayment/CreatePaymentPresentation.tsx
+++ b/src/components/Contractor/Payments/CreatePayment/CreatePaymentPresentation.tsx
@@ -137,6 +137,7 @@ export const CreatePaymentPresentation = ({
             },
             {
               title: t('contractorTableHeaders.hours'),
+              justify: 'end',
               render: paymentData => {
                 const hours = Number(paymentData.hours || '0')
                 return paymentData.contractorDetails?.wageType === 'Hourly' && hours
@@ -146,6 +147,7 @@ export const CreatePaymentPresentation = ({
             },
             {
               title: t('contractorTableHeaders.wage'),
+              justify: 'end',
               render: paymentData => {
                 const amount =
                   paymentData.contractorDetails?.wageType === 'Fixed' && paymentData.wage
@@ -156,14 +158,17 @@ export const CreatePaymentPresentation = ({
             },
             {
               title: t('contractorTableHeaders.bonus'),
+              justify: 'end',
               render: paymentData => currencyFormatter(Number(paymentData.bonus || '0')),
             },
             {
               title: t('contractorTableHeaders.reimbursement'),
+              justify: 'end',
               render: paymentData => currencyFormatter(Number(paymentData.reimbursement || '0')),
             },
             {
               title: t('contractorTableHeaders.total'),
+              justify: 'end',
               render: ({ bonus, reimbursement, wage, hours, contractorDetails }) => {
                 const totalAmount =
                   Number(bonus || '0') +

--- a/src/components/Contractor/Payments/CreatePayment/PreviewPresentation.tsx
+++ b/src/components/Contractor/Payments/CreatePayment/PreviewPresentation.tsx
@@ -192,6 +192,7 @@ export const PreviewPresentation = ({
           },
           {
             title: t('contractorTableHeaders.hours'),
+            justify: 'end',
             render: contractorPayment => {
               const hours = Number(contractorPayment.hours || '0')
               return contractorPayment.wageType === 'Hourly' && hours
@@ -201,6 +202,7 @@ export const PreviewPresentation = ({
           },
           {
             title: t('contractorTableHeaders.wage'),
+            justify: 'end',
             render: contractorPayment =>
               contractorPayment.wageType === 'Fixed' && contractorPayment.wage
                 ? currencyFormatter(Number(contractorPayment.wage || '0'))
@@ -208,15 +210,18 @@ export const PreviewPresentation = ({
           },
           {
             title: t('contractorTableHeaders.bonus'),
+            justify: 'end',
             render: contractorPayment => currencyFormatter(Number(contractorPayment.bonus || '0')),
           },
           {
             title: t('contractorTableHeaders.reimbursement'),
+            justify: 'end',
             render: contractorPayment =>
               currencyFormatter(Number(contractorPayment.reimbursement || '0')),
           },
           {
             title: t('contractorTableHeaders.total'),
+            justify: 'end',
             render: contractorPayment =>
               currencyFormatter(Number(contractorPayment.wageTotal || '0')),
           },

--- a/src/components/Contractor/Payments/PaymentHistory/PaymentHistoryPresentation.tsx
+++ b/src/components/Contractor/Payments/PaymentHistory/PaymentHistoryPresentation.tsx
@@ -71,45 +71,40 @@ export const PaymentHistoryPresentation = ({
                 },
                 {
                   title: t('tableHeaders.wageType'),
-                  render: ({ wageType }) => <Text>{wageType}</Text>,
+                  render: ({ wageType }) => wageType,
                 },
                 {
                   title: t('tableHeaders.paymentMethod'),
-                  render: ({ paymentMethod }) => <Text>{paymentMethod}</Text>,
+                  render: ({ paymentMethod }) => paymentMethod,
                 },
                 {
                   title: t('tableHeaders.hours'),
-                  render: ({ hours }) => (
-                    <Text>{hours ? formatHoursDisplay(Number(hours)) : '–'}</Text>
-                  ),
+                  justify: 'end',
+                  render: ({ hours }) => (hours ? formatHoursDisplay(Number(hours)) : '–'),
                 },
                 {
                   title: t('tableHeaders.wage'),
-                  render: ({ wage }) => <Text>{wage ? currencyFormatter(Number(wage)) : '–'}</Text>,
+                  justify: 'end',
+                  render: ({ wage }) => (wage ? currencyFormatter(Number(wage)) : '–'),
                 },
                 {
                   title: t('tableHeaders.bonus'),
-                  render: ({ bonus }) => (
-                    <Text>{bonus ? currencyFormatter(Number(bonus)) : '–'}</Text>
-                  ),
+                  justify: 'end',
+                  render: ({ bonus }) => (bonus ? currencyFormatter(Number(bonus)) : '–'),
                 },
                 {
                   title: t('tableHeaders.reimbursements'),
-                  render: ({ reimbursement }) => (
-                    <Text>{reimbursement ? currencyFormatter(Number(reimbursement)) : '–'}</Text>
-                  ),
+                  justify: 'end',
+                  render: ({ reimbursement }) =>
+                    reimbursement ? currencyFormatter(Number(reimbursement)) : '–',
                 },
                 {
                   title: t('tableHeaders.total'),
-                  render: ({ wageTotal, reimbursement, bonus }) => (
-                    <Text>
-                      {wageTotal
-                        ? currencyFormatter(
-                            Number(wageTotal) + Number(reimbursement) + Number(bonus),
-                          )
-                        : '–'}
-                    </Text>
-                  ),
+                  justify: 'end',
+                  render: ({ wageTotal, reimbursement, bonus }) =>
+                    wageTotal
+                      ? currencyFormatter(Number(wageTotal) + Number(reimbursement) + Number(bonus))
+                      : '–',
                 },
               ]}
               itemMenu={({ contractorUuid, mayCancel, uuid }) => {

--- a/src/components/Contractor/Payments/PaymentSummary/PaymentSummaryPresentation.tsx
+++ b/src/components/Contractor/Payments/PaymentSummary/PaymentSummaryPresentation.tsx
@@ -69,7 +69,7 @@ export const PaymentSummaryPresentation = ({
   }, [contractorPayments])
 
   return (
-    <Flex flexDirection="column" gap={16}>
+    <Flex flexDirection="column" gap={24}>
       {alerts.length > 0 && (
         <Flex flexDirection="column" gap={16}>
           {alerts.map((alert, index) => (
@@ -112,98 +112,106 @@ export const PaymentSummaryPresentation = ({
       </Flex>
 
       {/* Payment Summary Table */}
-      <DataView
-        columns={[
-          {
-            title: t('totalAmount'),
-            render: () => currencyFormatter(Number(contractorPaymentGroup.totals?.amount || '0')),
-          },
-          {
-            title: t('debitAmount'),
-            render: () =>
-              currencyFormatter(Number(contractorPaymentGroup.totals?.debitAmount || '0')),
-          },
-          {
-            title: t('debitAccount'),
-            render: () => bankAccount?.hiddenAccountNumber ?? t('notAvailable'),
-          },
-          {
-            title: t('debitDate'),
-            render: () => contractorPaymentGroup.debitDate || t('notAvailable'),
-          },
-          {
-            title: t('contractorPayDate'),
-            render: () => contractorPaymentGroup.checkDate || t('notAvailable'),
-          },
-        ]}
-        data={[contractorPaymentGroup]}
-        label={t('paymentSummaryTitle')}
-      />
-
-      {/* Contractor Payments Table */}
-      {contractorPayments.length > 0 && (
+      <Flex flexDirection="column" gap={32}>
         <DataView
           columns={[
             {
-              title: t('contractor'),
-              render: contractorPayment =>
-                getContractorDisplayName(
-                  contractors.find(
-                    contractor => contractor.uuid === contractorPayment.contractorUuid,
-                  ),
-                ),
+              title: t('totalAmount'),
+              render: () => currencyFormatter(Number(contractorPaymentGroup.totals?.amount || '0')),
             },
             {
-              title: t('wageType'),
-              render: contractorPayment => formatWageType(contractorPayment),
+              title: t('debitAmount'),
+              render: () =>
+                currencyFormatter(Number(contractorPaymentGroup.totals?.debitAmount || '0')),
             },
             {
-              title: t('paymentMethod'),
-              render: contractorPayment =>
-                contractorPayment.paymentMethod === 'Direct Deposit'
-                  ? t('paymentMethods.directDeposit')
-                  : contractorPayment.paymentMethod === 'Check'
-                    ? t('paymentMethods.check')
-                    : contractorPayment.paymentMethod || t('notAvailable'),
+              title: t('debitAccount'),
+              render: () => bankAccount?.hiddenAccountNumber ?? t('notAvailable'),
             },
             {
-              title: t('hours'),
-              render: contractorPayment =>
-                contractorPayment.wageType === 'Hourly' && contractorPayment.hours
-                  ? formatHoursDisplay(parseFloat(contractorPayment.hours))
-                  : ZERO_HOURS_DISPLAY,
+              title: t('debitDate'),
+              render: () => contractorPaymentGroup.debitDate || t('notAvailable'),
             },
             {
-              title: t('wage'),
-              render: contractorPayment => currencyFormatter(Number(contractorPayment.wage || '0')),
-            },
-            {
-              title: t('bonus'),
-              render: contractorPayment =>
-                currencyFormatter(Number(contractorPayment.bonus || '0')),
-            },
-            {
-              title: t('reimbursement'),
-              render: contractorPayment =>
-                currencyFormatter(Number(contractorPayment.reimbursement || '0')),
-            },
-            {
-              title: t('total'),
-              render: contractorPayment =>
-                currencyFormatter(Number(contractorPayment.wageTotal || '0')),
+              title: t('contractorPayDate'),
+              render: () => contractorPaymentGroup.checkDate || t('notAvailable'),
             },
           ]}
-          data={contractorPayments}
-          footer={() => ({
-            'column-0': t('totalsLabel'),
-            'column-4': currencyFormatter(totals.wageAmount || 0),
-            'column-5': currencyFormatter(totals.bonusAmount || 0),
-            'column-6': currencyFormatter(totals.reimbursementAmount || 0),
-            'column-7': currencyFormatter(totals.totalAmount || 0),
-          })}
-          label={t('contractorPaymentsTitle')}
+          data={[contractorPaymentGroup]}
+          label={t('paymentSummaryTitle')}
         />
-      )}
+
+        {/* Contractor Payments Table */}
+        {contractorPayments.length > 0 && (
+          <DataView
+            columns={[
+              {
+                title: t('contractor'),
+                render: contractorPayment =>
+                  getContractorDisplayName(
+                    contractors.find(
+                      contractor => contractor.uuid === contractorPayment.contractorUuid,
+                    ),
+                  ),
+              },
+              {
+                title: t('wageType'),
+                render: contractorPayment => formatWageType(contractorPayment),
+              },
+              {
+                title: t('paymentMethod'),
+                render: contractorPayment =>
+                  contractorPayment.paymentMethod === 'Direct Deposit'
+                    ? t('paymentMethods.directDeposit')
+                    : contractorPayment.paymentMethod === 'Check'
+                      ? t('paymentMethods.check')
+                      : contractorPayment.paymentMethod || t('notAvailable'),
+              },
+              {
+                title: t('hours'),
+                justify: 'end',
+                render: contractorPayment =>
+                  contractorPayment.wageType === 'Hourly' && contractorPayment.hours
+                    ? formatHoursDisplay(parseFloat(contractorPayment.hours))
+                    : ZERO_HOURS_DISPLAY,
+              },
+              {
+                title: t('wage'),
+                justify: 'end',
+                render: contractorPayment =>
+                  currencyFormatter(Number(contractorPayment.wage || '0')),
+              },
+              {
+                title: t('bonus'),
+                justify: 'end',
+                render: contractorPayment =>
+                  currencyFormatter(Number(contractorPayment.bonus || '0')),
+              },
+              {
+                title: t('reimbursement'),
+                justify: 'end',
+                render: contractorPayment =>
+                  currencyFormatter(Number(contractorPayment.reimbursement || '0')),
+              },
+              {
+                title: t('total'),
+                justify: 'end',
+                render: contractorPayment =>
+                  currencyFormatter(Number(contractorPayment.wageTotal || '0')),
+              },
+            ]}
+            data={contractorPayments}
+            footer={() => ({
+              'column-0': t('totalsLabel'),
+              'column-4': currencyFormatter(totals.wageAmount || 0),
+              'column-5': currencyFormatter(totals.bonusAmount || 0),
+              'column-6': currencyFormatter(totals.reimbursementAmount || 0),
+              'column-7': currencyFormatter(totals.totalAmount || 0),
+            })}
+            label={t('contractorPaymentsTitle')}
+          />
+        )}
+      </Flex>
     </Flex>
   )
 }

--- a/src/components/Contractor/Payments/PaymentsList/PaymentsListPresentation.tsx
+++ b/src/components/Contractor/Payments/PaymentsList/PaymentsListPresentation.tsx
@@ -58,10 +58,12 @@ export const PaymentsListPresentation = ({
       },
       {
         title: t('wageTotalColumnLabel'),
+        justify: 'end',
         render: ({ totals }) => currencyFormatter(Number(totals?.wageAmount || 0)),
       },
       {
         title: t('reimbursementTotalColumnLabel'),
+        justify: 'end',
         render: ({ totals }) => currencyFormatter(Number(totals?.reimbursementAmount) || 0),
       },
     ],


### PR DESCRIPTION
## Summary
- Right-align numeric columns (hours, wage, bonus, reimbursement, total) across contractor payment tables (CreatePayment, Preview, PaymentsList, PaymentHistory, PaymentSummary)
- Fix `DataTable` footer cells to honor each column's `justify` setting so totals line up under their column values
- Update DataTable tests to cover footer justify behavior

## Test plan
- [ ] `npm run test -- --run src/components/Common/DataView/DataTable/DataTable.test.tsx`
- [ ] Verify each contractor payments table in Storybook / sdk-app: numeric columns and footer totals are right-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)