### PR TITLE
docs: add Developer Terms of Service link to docs site footer

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -178,6 +178,10 @@ const config: Config = {
               label: 'GitHub',
               href: 'https://github.com/Gusto/embedded-react-sdk',
             },
+            {
+              label: 'Developer Terms of Service',
+              href: 'https://gusto.com/legal/terms/developer-terms-of-service',
+            },
           ],
         },
       ],


### PR DESCRIPTION
## Summary
- Add a **Developer Terms of Service** link to the docs site footer under the **Resources** group, pointing to https://gusto.com/legal/terms/developer-terms-of-service
- Brings the docs site footer in line with docs.gusto.com/embedded-pay/, which already exposes this link

## Test plan
- [ ] `cd docs-site && npm run start`
- [ ] Scroll to the footer; confirm **Developer Terms of Service** appears under **Resources** after **GitHub**
- [ ] Click the link; confirm it opens https://gusto.com/legal/terms/developer-terms-of-service

🤖 Generated with [Claude Code](https://claude.com/claude-code)