### PR TITLE
feat: handle migration_blocker / migration_warning categories (v2026-02-01)

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -818,7 +818,18 @@ export const PAYROLL_PROCESSING_STATUS = {
   processing_failed: 'processing_failed',
 } as const
 
-/** @internal */
+/**
+ * Blocker types the SDK knows how to surface a resolution UI for. Anything not
+ * in this list falls through to <GenericBlocker> at the render sites
+ * (PayrollOverviewPresentation, contractor PreviewPresentation).
+ *
+ * SDK-1000: v2026-02-01 introduces `migration_blocker` and `migration_warning`
+ * categories. They are intentionally NOT added here — they are informational
+ * (not partner-resolvable) so the GenericBlocker fallback is the correct
+ * rendering. Revisit if SDK-999 testing surfaces a resolvable migration sub-type.
+ *
+ * @internal
+ */
 export const PAYROLL_RESOLVABLE_SUBMISSION_BLOCKER_TYPES: string[] = [
   'fast_ach_threshold_exceeded',
   'needs_earned_access_for_fast_ach',


### PR DESCRIPTION
## Summary

🔴 Sub-PR off #2233 (the v2026-02-01 base bump).

v2026-02-01 introduces `migration_blocker` and `migration_warning` blocker categories. This PR captures the **decision** to NOT extend the resolvable-blocker whitelist for these — the existing `<GenericBlocker>` fallback at both render sites handles unknown types gracefully and disables submit, which is the correct behavior for informational (non-partner-resolvable) blockers.

## Changes

- **`src/shared/constants.ts`**: documents the decision inline on `PAYROLL_RESOLVABLE_SUBMISSION_BLOCKER_TYPES`. No runtime change.
- **`e2e/tests/payroll/06-migration-blocker-rendering.spec.ts`** (new): scaffolds an E2E assertion that GenericBlocker renders + submit is disabled for unknown blocker types. Currently `test.skip` — needs a Demo company provisioned in a mid-migration state to actually exercise. Tracked alongside SDK-999.

## Revisit triggers

Open the whitelist back up if SDK-999 testing reveals:
- A migration sub-type is partner-resolvable (e.g. has a "click to acknowledge" affordance)
- Generic copy is confusing in real UX testing — would warrant a dedicated `MigrationBlockerBanner` component

## References

- Notion deep-dive: https://app.notion.com/p/387ad673c6c2811cb9f1c4a9aac7be46
- Render sites: `PayrollOverviewPresentation.tsx:668`, `PreviewPresentation.tsx:140`
- Jira: SDK-1000

## Test plan

- [ ] Confirm GenericBlocker fallback path triggers when blockerType is unknown
- [ ] Wire up a Demo migration scenario and un-skip `06-migration-blocker-rendering.spec.ts`
- [ ] Sanity-check that submit is disabled when migration_blocker is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)