### PR TITLE
test: remove brittle footer cell justify className assertion

### DIFF
--- a/src/components/Common/DataView/DataTable/DataTable.test.tsx
+++ b/src/components/Common/DataView/DataTable/DataTable.test.tsx
@@ -205,19 +205,6 @@ describe('DataTable Component', () => {
       expect(screen.getByText('Name').closest('div')?.className).toMatch(/cellEnd/)
       expect(screen.getByText('Alice').closest('div')?.className).toMatch(/cellEnd/)
     })
-
-    test('applies column justify to footer cells', () => {
-      renderTable({
-        columns: [
-          { key: 'name', title: 'Name', render: item => item.name },
-          { key: 'age', title: 'Age', justify: 'end', render: item => item.age.toString() },
-        ],
-        footer: () => ({ name: 'Total', age: '55' }),
-      })
-
-      expect(screen.getByText('Total').closest('div')?.className).not.toMatch(/cellEnd/)
-      expect(screen.getByText('55').closest('div')?.className).toMatch(/cellEnd/)
-    })
   })
 
   describe('accessibility', () => {


### PR DESCRIPTION
## Summary
- Removes the `applies column justify to footer cells` test in `DataTable.test.tsx` per reviewer feedback on #2225 — asserting on CSS module classnames couples the test to layout implementation details.

## Test plan
- [x] `npm run test -- --run src/components/Common/DataView/DataTable/DataTable.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)