### PR TITLE
fix(PaymentStatement): use supporting text variant and unwrap table cell text

### DIFF
--- a/src/components/Contractor/Payments/PaymentStatement/PaymentStatementPresentation.tsx
+++ b/src/components/Contractor/Payments/PaymentStatement/PaymentStatementPresentation.tsx
@@ -126,7 +126,7 @@ export const PaymentStatementPresentation = ({
       <Flex flexDirection="column" gap={16}>
         <Flex flexDirection="column" gap={8}>
           <Heading as="h2">{t('title', { contractorName })}</Heading>
-          <Text>{formatLongWithYear(checkDate)}</Text>
+          <Text variant="supporting">{formatLongWithYear(checkDate)}</Text>
         </Flex>
       </Flex>
 
@@ -199,11 +199,11 @@ export const PaymentStatementPresentation = ({
         columns={[
           {
             title: t('debitedColumn'),
-            render: ({ label }) => <Text>{label}</Text>,
+            render: ({ label }) => label,
           },
           {
             title: t('amountColumn'),
-            render: ({ amount }) => <Text>{amount || ''}</Text>,
+            render: ({ amount }) => amount || '',
           },
         ]}
         data={statementRows}


### PR DESCRIPTION
## Summary
- Apply the `supporting` Text variant to the check date below the statement heading.
- Remove redundant `<Text>` wrappers from the debited/amount table cells so DataView controls cell typography.

## Test plan
- [ ] Verify the contractor payment statement renders with correct typography in Storybook / sdk-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)