### PR TITLE
refactor(StateTaxes): flatten form into a single evenly-spaced stack

### DIFF
--- a/src/components/Company/StateTaxes/StateTaxesForm/Form.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesForm/Form.tsx
@@ -1,42 +1,26 @@
-import { useTranslation } from 'react-i18next'
-import { Fragment } from 'react/jsx-runtime'
 import { useStateTaxesForm } from './context'
 import { toRhfKey } from './rhfKey'
 import { QuestionInput } from '@/components/Common/TaxInputs/TaxInputs'
-import { useLocaleDateFormatter } from '@/contexts/LocaleProvider/useLocale'
-import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { Flex } from '@/components/Common/Flex/Flex'
 
 /** @internal */
 export function Form() {
-  const { t } = useTranslation('Company.StateTaxes', { keyPrefix: 'form' })
-  const dateFormatter = useLocaleDateFormatter()
   const { stateTaxRequirements } = useStateTaxesForm()
-  const Components = useComponentContext()
 
-  return stateTaxRequirements.requirementSets?.map(
-    ({ requirements, label, effectiveFrom, key }) => (
-      <Fragment key={key}>
-        <div>
-          <Components.Heading as="h3">{label}</Components.Heading>
-          {effectiveFrom && (
-            <Components.Text size="sm">
-              {t('effectiveFromLabel', { date: dateFormatter.format(new Date(effectiveFrom)) })}
-            </Components.Text>
-          )}
-        </div>
-        {requirements?.map(requirement => {
-          return (
-            <QuestionInput
-              requirement={{
-                ...requirement,
-                key: `${key}.${toRhfKey(requirement.key as string)}`,
-              }}
-              questionType={requirement.metadata?.type ?? 'Text'}
-              key={requirement.key}
-            />
-          )
-        })}
-      </Fragment>
-    ),
+  return (
+    <Flex flexDirection="column" gap={20}>
+      {stateTaxRequirements.requirementSets?.flatMap(({ requirements, key }) =>
+        requirements?.map(requirement => (
+          <QuestionInput
+            key={`${key}.${requirement.key}`}
+            requirement={{
+              ...requirement,
+              key: `${key}.${toRhfKey(requirement.key as string)}`,
+            }}
+            questionType={requirement.metadata?.type ?? 'Text'}
+          />
+        )),
+      )}
+    </Flex>
   )
 }


### PR DESCRIPTION
## Summary
- Drop per-requirement-set heading and effective-date subtext from the form
- Render every input as a sibling of one outer `Flex` with `gap={20}` so spacing is uniform across the form
- Use `flatMap` to concatenate requirements across sets while preserving the set-prefixed RHF field key

## Test plan
- [ ] Open a state taxes form for a state with a single requirement set; verify inputs are stacked with even 20px gaps
- [ ] Open a state taxes form for a state with multiple requirement sets; verify inputs from different sets sit as siblings with the same spacing
- [ ] Submit the form; confirm the request body still groups requirements by set key

🤖 Generated with [Claude Code](https://claude.com/claude-code)