### PR TITLE
feat(StateTaxes): respect applicable_if for conditional field visibility

### DIFF
--- a/src/components/Company/StateTaxes/StateTaxesForm/Form.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesForm/Form.tsx
@@ -1,7 +1,9 @@
 import { useTranslation } from 'react-i18next'
 import { Fragment } from 'react/jsx-runtime'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { useStateTaxesForm } from './context'
 import { toRhfKey } from './rhfKey'
+import { isRequirementApplicable, type StateTaxesFormValues } from './applicableIf'
 import { QuestionInput } from '@/components/Common/TaxInputs/TaxInputs'
 import { useLocaleDateFormatter } from '@/contexts/LocaleProvider/useLocale'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
@@ -12,6 +14,8 @@ export function Form() {
   const dateFormatter = useLocaleDateFormatter()
   const { stateTaxRequirements } = useStateTaxesForm()
   const Components = useComponentContext()
+  const { control } = useFormContext()
+  const watchedValues = useWatch({ control }) as StateTaxesFormValues
 
   return stateTaxRequirements.requirementSets?.map(
     ({ requirements, label, effectiveFrom, key }) => (
@@ -24,8 +28,9 @@ export function Form() {
             </Components.Text>
           )}
         </div>
-        {requirements?.map(requirement => {
-          return (
+        {requirements?.flatMap(requirement => {
+          if (!key || !isRequirementApplicable(requirement, key, watchedValues)) return []
+          return [
             <QuestionInput
               requirement={{
                 ...requirement,
@@ -33,8 +38,8 @@ export function Form() {
               }}
               questionType={requirement.metadata?.type ?? 'Text'}
               key={requirement.key}
-            />
-          )
+            />,
+          ]
         })}
       </Fragment>
     ),

--- a/src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.test.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.test.tsx
@@ -72,7 +72,16 @@ describe('StateTaxesForm', () => {
       })
     })
 
-    it('renders tax rate fields', async () => {
+    it('hides applicable_if-gated rate fields until the radio is toggled', async () => {
+      const useDefaultRadioYes = await screen.findByRole('radio', { name: /^Yes$/ })
+      expect(useDefaultRadioYes).toBeChecked()
+      expect(screen.queryByLabelText(/Unemployment Insurance Rate/i)).toBeNull()
+
+      const useDefaultRadioNo = screen.getByRole('radio', {
+        name: /No, my agency gave me new rates/i,
+      })
+      await user.click(useDefaultRadioNo)
+
       await waitFor(() => {
         expect(screen.getByLabelText(/Unemployment Insurance Rate/i)).toBeInTheDocument()
       })

--- a/src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.tsx
@@ -9,7 +9,8 @@ import { Head } from './Head'
 import { StateTaxesFormProvider } from './context'
 import { Form } from './Form'
 import { Actions } from './Actions'
-import { fromRhfKey, toRhfKey } from './rhfKey'
+import { toRhfKey } from './rhfKey'
+import { isRequirementApplicable, type StateTaxesFormValues } from './applicableIf'
 import type { BaseComponentInterface, CommonComponentInterface } from '@/components/Base/Base'
 import { BaseComponent } from '@/components/Base/Base'
 import { useI18n } from '@/i18n/I18n'
@@ -163,19 +164,24 @@ function Root({ companyId, state, className, children }: StateTaxesFormProps) {
 
   const onSubmit = async (formData: InferredFormInputs) => {
     await baseSubmitHandler(formData, async payload => {
+      const formValues = payload as StateTaxesFormValues
       const requirementSets = stateTaxRequirements.requirementSets
         ?.filter(rs => rs.key && payload[rs.key])
         .map(requirementSet => {
           const requirementSetKey = requirementSet.key as string
           const payloadSet = payload[requirementSetKey] as Record<string, unknown>
 
+          const applicableRequirements = (requirementSet.requirements ?? []).filter(req =>
+            isRequirementApplicable(req, requirementSetKey, formValues),
+          )
+
           return {
             state,
             key: requirementSetKey,
             effectiveFrom: requirementSet.effectiveFrom,
-            requirements: Object.entries(payloadSet).map(([reqKey, value]) => ({
-              key: fromRhfKey(reqKey),
-              value: stringifyRequirementValue(value),
+            requirements: applicableRequirements.map(req => ({
+              key: req.key as string,
+              value: stringifyRequirementValue(payloadSet[toRhfKey(req.key as string)]),
             })),
           }
         })

--- a/src/components/Company/StateTaxes/StateTaxesForm/applicableIf.test.ts
+++ b/src/components/Company/StateTaxes/StateTaxesForm/applicableIf.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { isRequirementApplicable, type StateTaxesFormValues } from './applicableIf'
+import type { TaxRequirement } from '@gusto/embedded-api-v-2025-11-15/models/components/taxrequirement'
+
+const req = (overrides: Partial<TaxRequirement> = {}): TaxRequirement => ({
+  key: 'rate',
+  applicableIf: [],
+  ...overrides,
+})
+
+describe('isRequirementApplicable', () => {
+  it('returns true when applicableIf is missing', () => {
+    expect(isRequirementApplicable(req({ applicableIf: undefined }), 'taxrates', {})).toBe(true)
+  })
+
+  it('returns true when applicableIf is empty', () => {
+    expect(isRequirementApplicable(req({ applicableIf: [] }), 'taxrates', {})).toBe(true)
+  })
+
+  it('returns true when a single constraint matches the form value', () => {
+    const formValues: StateTaxesFormValues = {
+      taxrates: { usedefaultsuirates: false },
+    }
+    const requirement = req({
+      applicableIf: [{ key: 'usedefaultsuirates', value: false }],
+    })
+    expect(isRequirementApplicable(requirement, 'taxrates', formValues)).toBe(true)
+  })
+
+  it('returns false when a single constraint does not match', () => {
+    const formValues: StateTaxesFormValues = {
+      taxrates: { usedefaultsuirates: true },
+    }
+    const requirement = req({
+      applicableIf: [{ key: 'usedefaultsuirates', value: false }],
+    })
+    expect(isRequirementApplicable(requirement, 'taxrates', formValues)).toBe(false)
+  })
+
+  it('requires every constraint to match (AND-logic)', () => {
+    const formValues: StateTaxesFormValues = {
+      taxrates: { suireimbursable: false, usedefaultsuirates: false },
+    }
+    const requirement = req({
+      applicableIf: [
+        { key: 'suireimbursable', value: false },
+        { key: 'usedefaultsuirates', value: false },
+      ],
+    })
+    expect(isRequirementApplicable(requirement, 'taxrates', formValues)).toBe(true)
+
+    const partialMatch: StateTaxesFormValues = {
+      taxrates: { suireimbursable: false, usedefaultsuirates: true },
+    }
+    expect(isRequirementApplicable(requirement, 'taxrates', partialMatch)).toBe(false)
+  })
+
+  it('returns false when the requirement set has no form values yet', () => {
+    const requirement = req({
+      applicableIf: [{ key: 'usedefaultsuirates', value: false }],
+    })
+    expect(isRequirementApplicable(requirement, 'taxrates', {})).toBe(false)
+  })
+
+  it('round-trips constraint keys through toRhfKey', () => {
+    const formValues: StateTaxesFormValues = {
+      taxrates: { wa_wc_hourly_rate__PIPE__010103: true },
+    }
+    const requirement = req({
+      applicableIf: [{ key: 'wa_wc_hourly_rate|010103', value: true }],
+    })
+    expect(isRequirementApplicable(requirement, 'taxrates', formValues)).toBe(true)
+  })
+})

--- a/src/components/Company/StateTaxes/StateTaxesForm/applicableIf.ts
+++ b/src/components/Company/StateTaxes/StateTaxesForm/applicableIf.ts
@@ -1,0 +1,22 @@
+import type { TaxRequirement } from '@gusto/embedded-api-v-2025-11-15/models/components/taxrequirement'
+import { toRhfKey } from './rhfKey'
+
+export type StateTaxesFormValues = Record<string, Record<string, unknown> | undefined>
+
+/** @internal */
+export function isRequirementApplicable(
+  requirement: TaxRequirement,
+  setKey: string,
+  formValues: StateTaxesFormValues,
+): boolean {
+  const constraints = requirement.applicableIf
+  if (!constraints || constraints.length === 0) return true
+
+  const setValues = formValues[setKey]
+  if (!setValues) return false
+
+  return constraints.every(({ key, value }) => {
+    if (!key) return true
+    return setValues[toRhfKey(key)] === value
+  })
+}


### PR DESCRIPTION
## Summary
- Honor each `TaxRequirement.applicable_if` constraint when rendering the State Taxes form
- Add `isRequirementApplicable` helper plus unit tests
- Drop inapplicable requirements from the submit payload so stale values aren't re-asserted

## Context
The embedded API returns each `TaxRequirement` with an `applicable_if: Array<{key, value}>` field that gates visibility on the answers to other requirements in the same set. The SDK previously ignored it and rendered every requirement unconditionally — for example, Idaho's `taxrates` set returns three rate inputs that are only meant to show when the user has answered "No, my agency gave me new rates" on a parent radio, but the SDK rendered them regardless. gws-flows has honored this contract via a small JS file for years.

## Demo

<img width="801" height="715" alt="Screenshot 2026-06-23 at 5 45 32 PM" src="https://github.com/user-attachments/assets/594c07cd-c4d9-48ed-9954-07a564dcfa05" />
<img width="795" height="672" alt="Screenshot 2026-06-23 at 5 45 38 PM" src="https://github.com/user-attachments/assets/1b9516ca-bb47-4a38-be2f-1821e881735d" />


## Implementation
- New helper `src/components/Company/StateTaxes/StateTaxesForm/applicableIf.ts` evaluates `applicableIf` against the live RHF form values, prefix-aware (constraints reference the raw API key; form values are stored under `setKey.toRhfKey(reqKey)`).
- `Form.tsx` adds `useWatch({ control })` and filters each requirement before rendering.
- The submit handler in `StateTaxesForm.tsx` reuses the helper to drop inapplicable requirements from the payload.
- No Zod schema changes needed — every field was already `.optional()`.

## Test plan
- [x] Unit tests for `isRequirementApplicable` (empty / matching / non-matching / AND-logic / missing set / pipe-key round-trip)
- [x] Existing State Taxes tests pass; the WA "renders tax rate fields" test was implicitly relying on the bug and is updated to assert the corrected behavior (rate input hidden until the radio toggles to "No")
- [x] In-browser sanity check on Idaho via `npm run sdk-app` against the demo company

🤖 Generated with [Claude Code](https://claude.com/claude-code)