### PR TITLE
fix(AdminProfile): replace switchFieldContainer with Box component

### DIFF
--- a/src/components/Employee/Profile/onboarding/AdminProfile.module.scss
+++ b/src/components/Employee/Profile/onboarding/AdminProfile.module.scss
@@ -1,11 +1,3 @@
 .container {
   width: 100%;
 }
-
-.switchFieldContainer {
-  border: 1px solid var(--g-colorBorderSecondary);
-  border-radius: var(--g-cardRadius);
-  padding: toRem(20);
-  background-color: var(--g-colorBody);
-  box-shadow: var(--g-shadowResting);
-}

--- a/src/components/Employee/Profile/onboarding/AdminProfile.tsx
+++ b/src/components/Employee/Profile/onboarding/AdminProfile.tsx
@@ -269,13 +269,13 @@ function AdminProfileReady({
             </Flex>
 
             {isSelfOnboardingEnabled && EmployeeFields.SelfOnboarding && (
-              <div className={styles.switchFieldContainer}>
+              <Components.Box>
                 <EmployeeFields.SelfOnboarding
                   label={t('selfOnboardingLabel')}
                   description={t('selfOnboardingDescription')}
                   formHookResult={employeeDetails}
                 />
-              </div>
+              </Components.Box>
             )}
             <Grid
               gap={{ base: 20, small: 8 }}


### PR DESCRIPTION
## Summary
- Replaced the local `switchFieldContainer` div around the self-onboarding field in `AdminProfile` with the adapter-compatible `Components.Box`, so the surrounding chrome comes from the partner-injected components context instead of bespoke SDK styles.
- Removed the now-unused `.switchFieldContainer` style from `AdminProfile.module.scss`.

## Test plan
- [ ] Verify the self-onboarding switch in the employee admin profile renders inside the adapter's Box styling.
- [ ] Confirm no visual regressions for the rest of the AdminProfile form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)