### PR TITLE
fix(PayrollOverview): correct loading copy and gating in the run-payroll flow

### DIFF
--- a/src/components/Payroll/PayrollFlow/PayrollExecutionFlowContextual.tsx
+++ b/src/components/Payroll/PayrollFlow/PayrollExecutionFlowContextual.tsx
@@ -5,6 +5,7 @@ import { isDismissalPayroll } from '../helpers'
 import type { PayrollFlowContextInterface } from './PayrollFlowComponents'
 import { useFlow } from '@/components/Flow/useFlow'
 import { ensureRequired } from '@/helpers/ensureRequired'
+import { Loading } from '@/components/Common/Loading/Loading'
 
 /** @internal */
 export function PayrollExecutionFlowContextual() {
@@ -25,7 +26,7 @@ export function PayrollExecutionFlowContextual() {
   const resolvedPayrollId = ensureRequired(payrollUuid)
 
   return (
-    <Suspense>
+    <Suspense fallback={<Loading />}>
       <PayrollExecutionFlowWithData
         companyId={resolvedCompanyId}
         payrollId={resolvedPayrollId}

--- a/src/components/Payroll/PayrollOverview/PayrollOverview.test.tsx
+++ b/src/components/Payroll/PayrollOverview/PayrollOverview.test.tsx
@@ -196,6 +196,33 @@ describe('PayrollOverview polling', () => {
   })
 })
 
+describe('PayrollOverview submit-in-progress overlay', () => {
+  const mockOnEvent = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPayrollData = { ...basePayrollData }
+  })
+
+  it('does not show the "Submitting payroll" overlay when loading a payroll whose server-side status is already submitting', async () => {
+    mockPayrollData = {
+      ...basePayrollData,
+      processed: false,
+      processingRequest: { status: 'submitting', errors: [] },
+    }
+
+    renderWithProviders(
+      <PayrollOverview companyId="company-uuid" payrollId="payroll-uuid" onEvent={mockOnEvent} />,
+    )
+
+    expect(await screen.findByText(/Review payroll/i)).toBeInTheDocument()
+    // The "Submitting payroll" overlay is only correct when the current user
+    // just clicked Submit. A page load against an already-processing payroll
+    // must not block the review UI behind it.
+    expect(screen.queryByText(/Submitting payroll/i)).not.toBeInTheDocument()
+  })
+})
+
 describe('PayrollOverview tax totals', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/components/Payroll/PayrollOverview/PayrollOverview.test.tsx
+++ b/src/components/Payroll/PayrollOverview/PayrollOverview.test.tsx
@@ -204,7 +204,7 @@ describe('PayrollOverview submit-in-progress overlay', () => {
     mockPayrollData = { ...basePayrollData }
   })
 
-  it('does not show the "Submitting payroll" overlay when loading a payroll whose server-side status is already submitting', async () => {
+  it('renders the review UI with active Submit and Edit controls when loading a payroll whose server-side status is already submitting', async () => {
     mockPayrollData = {
       ...basePayrollData,
       processed: false,
@@ -215,11 +215,13 @@ describe('PayrollOverview submit-in-progress overlay', () => {
       <PayrollOverview companyId="company-uuid" payrollId="payroll-uuid" onEvent={mockOnEvent} />,
     )
 
-    expect(await screen.findByText(/Review payroll/i)).toBeInTheDocument()
     // The "Submitting payroll" overlay is only correct when the current user
     // just clicked Submit. A page load against an already-processing payroll
-    // must not block the review UI behind it.
-    expect(screen.queryByText(/Submitting payroll/i)).not.toBeInTheDocument()
+    // must keep the interactive review UI on screen — the Edit/Submit
+    // action buttons are the load-bearing controls that the overlay would
+    // otherwise replace.
+    expect(await screen.findByRole('button', { name: 'Submit' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeEnabled()
   })
 })
 

--- a/src/components/Payroll/PayrollOverview/PayrollOverview.tsx
+++ b/src/components/Payroll/PayrollOverview/PayrollOverview.tsx
@@ -135,6 +135,7 @@ const Root = ({
   const { baseSubmitHandler } = useBase()
   const { t } = useTranslation('Payroll.PayrollOverview')
   const [isPolling, setIsPolling] = useState(false)
+  const [hasSubmittedInSession, setHasSubmittedInSession] = useState(false)
   const [internalAlerts, setInternalAlerts] = useState(alerts || [])
   const [selectedUnblockOptions, setSelectedUnblockOptions] = useState<Record<string, string>>({})
   const [showWireDetailsConfirmation, setShowWireDetailsConfirmation] = useState(false)
@@ -250,6 +251,7 @@ const Root = ({
       ])
       setShowWireDetailsConfirmation(false)
       setIsPolling(false)
+      setHasSubmittedInSession(false)
     }
     // If we are polling and payroll is in failed state, stop polling, and emit failure event
     if (
@@ -273,6 +275,7 @@ const Root = ({
       ])
       setShowWireDetailsConfirmation(false)
       setIsPolling(false)
+      setHasSubmittedInSession(false)
     }
   }, [
     payrollData?.processingRequest?.status,
@@ -301,7 +304,7 @@ const Root = ({
   const gustoEmbedded = useGustoEmbeddedContext()
 
   if (!payrollData) {
-    return <PayrollLoading title={t('loadingTitle')} description={t('loadingDescription')} />
+    return <PayrollLoading title={t('dataLoadingTitle')} />
   }
 
   if (status === PayrollOverviewStatus.Viewing && !payrollData.calculatedAt) {
@@ -396,6 +399,7 @@ const Root = ({
       onEvent(componentEvents.RUN_PAYROLL_SUBMITTING)
       onEvent(componentEvents.RUN_PAYROLL_SUBMITTED, result)
       setIsPolling(true)
+      setHasSubmittedInSession(true)
     })
   }
 
@@ -406,7 +410,7 @@ const Root = ({
       onCancel={onCancel}
       onPayrollReceipt={onPayrollReceipt}
       onPaystubDownload={onPaystubDownload}
-      status={isPending || isPolling ? PayrollOverviewStatus.Submitting : status}
+      status={isPending || hasSubmittedInSession ? PayrollOverviewStatus.Submitting : status}
       isProcessed={
         payrollData.processed === true ||
         payrollData.processingRequest?.status === PAYROLL_PROCESSING_STATUS.submit_success

--- a/src/i18n/en/Payroll.PayrollOverview.json
+++ b/src/i18n/en/Payroll.PayrollOverview.json
@@ -19,6 +19,7 @@
   "downloadPaystubLabel": "Download paystub pdf",
   "loadingTitle": "Submitting payroll...",
   "loadingDescription": "This may take a minute or two. You can navigate away while this happens.",
+  "dataLoadingTitle": "Loading payroll...",
   "cancellingTitle": "Cancelling payroll...",
   "cancelledEmptyState": "This payroll has been cancelled.",
   "skippedBadge": "Skipped",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -3543,6 +3543,7 @@ export interface PayrollPayrollOverview{
 "downloadPaystubLabel":string;
 "loadingTitle":string;
 "loadingDescription":string;
+"dataLoadingTitle":string;
 "cancellingTitle":string;
 "cancelledEmptyState":string;
 "skippedBadge":string;


### PR DESCRIPTION
## Summary

Two related fixes to the loading states users see when entering and submitting a payroll:

- **PayrollOverview** previously surfaced "Submitting payroll..." in two wrong situations: while initially fetching any payroll (the data-fetch loader reused the submit overlay's i18n keys) and while polling an already-submitting payroll on load (the overlay was gated on \`isPolling\`, which also fires for server-side processing of an already-submitted payroll). Added a dedicated \`dataLoadingTitle\` ("Loading payroll...") for the initial fetch and gated the submit overlay on a new \`hasSubmittedInSession\` flag so it only renders for a submit the current user just initiated.
- **PayrollExecutionFlowContextual** had a Suspense boundary with no fallback, so users saw a blank screen during the upstream payroll fetch when clicking "Review and Submit". Added a basic \`<Loading />\` skeleton as the fallback. The destination component (PayrollOverview or PayrollConfiguration) still owns its own titled loading state once mounted.

## Test plan

- [ ] \`npm run test -- --run src/components/Payroll/PayrollOverview src/components/Payroll/PayrollFlow\` passes
- [ ] Storybook / sdk-app: open a calculated payroll via "Review and Submit" → expect Loading skeleton → "Loading payroll..." → content
- [ ] Click Submit → expect "Submitting payroll..." overlay during the mutation and the post-submit polling window
- [ ] Reload while a payroll is mid-processing → expect normal review UI, not the "Submitting payroll..." overlay
- [ ] Already-submitted payrolls open instantly with the right copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)