### PR TITLE
feat(sdk-app): inspect entity response from settings panel + Form/Request comboboxes

### DIFF
--- a/sdk-app/src/App.tsx
+++ b/sdk-app/src/App.tsx
@@ -184,6 +184,7 @@ export function App() {
           employeeId: result.entities.employeeId || '',
           contractorId: result.entities.contractorId || '',
           payrollId: result.entities.payrollId || '',
+          formId: result.entities.formId || '',
           requestId: '',
         })
         window.location.reload()

--- a/sdk-app/src/DemoSettingsPanel.module.scss
+++ b/sdk-app/src/DemoSettingsPanel.module.scss
@@ -352,3 +352,119 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.inspectBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.inspectBackdropDismiss {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.45);
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.inspectModal {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: min(45rem, 90vw);
+  max-height: 80vh;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 0.0625rem solid var(--color-border);
+  border-radius: 0.5rem;
+  box-shadow: 0 0.625rem 2rem rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+}
+
+.inspectHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.875rem 1rem;
+  border-bottom: 0.0625rem solid var(--color-border);
+}
+
+.inspectTitle {
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.inspectUrl {
+  font-size: 0.6875rem;
+  font-family: monospace;
+  color: var(--color-text-muted);
+  margin-top: 0.125rem;
+  word-break: break-all;
+}
+
+.inspectBodyMessage {
+  padding: 1.25rem 1rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+
+.inspectBody {
+  --json-key: #9333ea;
+  --json-string: #15803d;
+  --json-number: #c2410c;
+  --json-boolean: #2563eb;
+  --json-null: #6b7280;
+
+  flex: 1;
+  margin: 0;
+  padding: 0.875rem 1rem;
+  font-family: monospace;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--color-badge-bg);
+
+  :global([data-theme='dark']) & {
+    --json-key: #c084fc;
+    --json-string: #86efac;
+    --json-number: #fdba74;
+    --json-boolean: #93c5fd;
+    --json-null: #9ca3af;
+  }
+}
+
+.jsonKey {
+  color: var(--json-key);
+}
+
+.jsonString {
+  color: var(--json-string);
+}
+
+.jsonNumber {
+  color: var(--json-number);
+}
+
+.jsonBoolean {
+  color: var(--json-boolean);
+  font-weight: 600;
+}
+
+.jsonNull {
+  color: var(--json-null);
+  font-style: italic;
+}

--- a/sdk-app/src/DemoSettingsPanel.tsx
+++ b/sdk-app/src/DemoSettingsPanel.tsx
@@ -7,6 +7,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from 'react'
+import { buildEntityInspectRequest, type InspectRequest } from './entity-config'
 import type { EntityIds } from './useEntities'
 import type { TokenStatus } from './useDemoManager'
 import type { EntityCatalog } from './useEntityCatalog'
@@ -46,11 +47,6 @@ const MANUAL_FIELDS: { key: keyof ManualConfig; label: string; required?: boolea
   { key: 'payrollId', label: 'Payroll ID' },
   { key: 'formId', label: 'Form ID' },
   { key: 'requestId', label: 'Request ID' },
-]
-
-const TEXT_FIELDS: { key: keyof EntityIds; label: string }[] = [
-  { key: 'requestId', label: 'Request ID' },
-  { key: 'formId', label: 'Form ID' },
 ]
 
 interface EntityComboboxProps {
@@ -113,6 +109,90 @@ function CopyIdButton({ value, ariaLabel }: CopyIdButtonProps) {
       aria-label={ariaLabel}
     >
       {status === 'copied' ? 'Copied' : 'Copy ID'}
+    </button>
+  )
+}
+
+function highlightJsonTokens(source: string): ReactNode[] {
+  const tokenRegex =
+    /("(?:\\.|[^"\\])*")(\s*:)?|\b(true|false|null)\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g
+  const nodes: ReactNode[] = []
+  let lastIndex = 0
+  let keyCounter = 0
+  let match: RegExpExecArray | null
+  while ((match = tokenRegex.exec(source))) {
+    if (match.index > lastIndex) {
+      nodes.push(source.slice(lastIndex, match.index))
+    }
+    const [whole, str, colon, literal, num] = match
+    if (str !== undefined) {
+      const className = colon ? styles.jsonKey : styles.jsonString
+      nodes.push(
+        <span key={keyCounter++} className={className}>
+          {str}
+        </span>,
+      )
+      if (colon) nodes.push(colon)
+    } else if (literal !== undefined) {
+      nodes.push(
+        <span
+          key={keyCounter++}
+          className={literal === 'null' ? styles.jsonNull : styles.jsonBoolean}
+        >
+          {literal}
+        </span>,
+      )
+    } else if (num !== undefined) {
+      nodes.push(
+        <span key={keyCounter++} className={styles.jsonNumber}>
+          {num}
+        </span>,
+      )
+    } else {
+      nodes.push(whole)
+    }
+    lastIndex = match.index + whole.length
+  }
+  if (lastIndex < source.length) nodes.push(source.slice(lastIndex))
+  return nodes
+}
+
+type InspectFetchState =
+  | { kind: 'loading' }
+  | { kind: 'ok'; body: unknown }
+  | { kind: 'error'; status: number; body: string }
+
+interface InspectState {
+  label: string
+  url: string
+  fetch: InspectFetchState
+}
+
+interface InspectIdButtonProps {
+  label: string
+  request: InspectRequest | null
+  onInspect: (label: string, request: InspectRequest) => void
+}
+
+function InspectIdButton({ label, request, onInspect }: InspectIdButtonProps) {
+  return (
+    <button
+      type="button"
+      className={styles.btn}
+      onClick={() => {
+        if (request) onInspect(label, request)
+      }}
+      disabled={!request}
+      aria-label={`Inspect ${label.toLowerCase()} response`}
+      title={
+        request
+          ? `GET ${request.url.replace(/^\/api/, '')}${
+              request.kind === 'listFilter' ? ` (filtered for ${request.matchUuid})` : ''
+            }`
+          : 'No GET endpoint available'
+      }
+    >
+      🕵️
     </button>
   )
 }
@@ -401,6 +481,82 @@ export function DemoSettingsPanel({
   const [selectedSaveName, setSelectedSaveName] = useState<string>('')
   const [saveDialogOpen, setSaveDialogOpen] = useState(false)
   const [saveDialogName, setSaveDialogName] = useState('')
+  const [inspect, setInspect] = useState<InspectState | null>(null)
+
+  const handleInspect = useCallback((label: string, request: InspectRequest) => {
+    const { url } = request
+    setInspect({ label, url, fetch: { kind: 'loading' } })
+    void (async () => {
+      try {
+        const res = await fetch(url, { signal: AbortSignal.timeout(10000) })
+        const text = await res.text()
+        if (!res.ok) {
+          setInspect(prev =>
+            prev && prev.url === url
+              ? { ...prev, fetch: { kind: 'error', status: res.status, body: text } }
+              : prev,
+          )
+          return
+        }
+        let parsed: unknown = text
+        try {
+          parsed = JSON.parse(text)
+        } catch {
+          // Non-JSON body — display as-is
+        }
+        if (request.kind === 'listFilter') {
+          const list = Array.isArray(parsed) ? (parsed as Array<Record<string, unknown>>) : []
+          const match = list.find(item => item.uuid === request.matchUuid)
+          if (!match) {
+            setInspect(prev =>
+              prev && prev.url === url
+                ? {
+                    ...prev,
+                    fetch: {
+                      kind: 'error',
+                      status: 404,
+                      body: `No item with uuid ${request.matchUuid} in list of ${list.length} from ${url.replace(/^\/api/, '')}`,
+                    },
+                  }
+                : prev,
+            )
+            return
+          }
+          setInspect(prev =>
+            prev && prev.url === url ? { ...prev, fetch: { kind: 'ok', body: match } } : prev,
+          )
+          return
+        }
+        setInspect(prev =>
+          prev && prev.url === url ? { ...prev, fetch: { kind: 'ok', body: parsed } } : prev,
+        )
+      } catch (err) {
+        setInspect(prev =>
+          prev && prev.url === url
+            ? {
+                ...prev,
+                fetch: {
+                  kind: 'error',
+                  status: 0,
+                  body: err instanceof Error ? err.message : String(err),
+                },
+              }
+            : prev,
+        )
+      }
+    })()
+  }, [])
+
+  useEffect(() => {
+    if (!inspect) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setInspect(null)
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => {
+      window.removeEventListener('keydown', handleKey)
+    }
+  }, [inspect])
 
   const saveNames = Object.keys(manualSaves).sort((a, b) => a.localeCompare(b))
 
@@ -426,7 +582,8 @@ export function DemoSettingsPanel({
     entities.employeeId !== confirmedSnapshot.current.employeeId ||
     entities.contractorId !== confirmedSnapshot.current.contractorId ||
     entities.payrollId !== confirmedSnapshot.current.payrollId ||
-    TEXT_FIELDS.some(({ key }) => entities[key] !== confirmedSnapshot.current[key])
+    entities.requestId !== confirmedSnapshot.current.requestId ||
+    entities.formId !== confirmedSnapshot.current.formId
 
   const displayEnv = env === 'localzp' ? 'local' : env
 
@@ -724,6 +881,15 @@ export function DemoSettingsPanel({
                   className={styles.readOnly}
                 />
                 <CopyIdButton value={entities.companyId} ariaLabel="Copy company ID" />
+                <InspectIdButton
+                  label="Company"
+                  request={buildEntityInspectRequest(
+                    'companyId',
+                    entities.companyId,
+                    entities.companyId,
+                  )}
+                  onInspect={handleInspect}
+                />
               </div>
             </div>
 
@@ -737,7 +903,20 @@ export function DemoSettingsPanel({
               onChange={value => {
                 onUpdateEntity('employeeId', value)
               }}
-              trailing={<CopyIdButton value={entities.employeeId} ariaLabel="Copy employee ID" />}
+              trailing={
+                <>
+                  <CopyIdButton value={entities.employeeId} ariaLabel="Copy employee ID" />
+                  <InspectIdButton
+                    label="Employee"
+                    request={buildEntityInspectRequest(
+                      'employeeId',
+                      entities.employeeId,
+                      entities.companyId,
+                    )}
+                    onInspect={handleInspect}
+                  />
+                </>
+              }
             />
 
             <EntityCombobox
@@ -751,7 +930,18 @@ export function DemoSettingsPanel({
                 onUpdateEntity('contractorId', value)
               }}
               trailing={
-                <CopyIdButton value={entities.contractorId} ariaLabel="Copy contractor ID" />
+                <>
+                  <CopyIdButton value={entities.contractorId} ariaLabel="Copy contractor ID" />
+                  <InspectIdButton
+                    label="Contractor"
+                    request={buildEntityInspectRequest(
+                      'contractorId',
+                      entities.contractorId,
+                      entities.companyId,
+                    )}
+                    onInspect={handleInspect}
+                  />
+                </>
               }
             />
 
@@ -765,29 +955,73 @@ export function DemoSettingsPanel({
               onChange={value => {
                 onUpdateEntity('payrollId', value)
               }}
-              trailing={<CopyIdButton value={entities.payrollId} ariaLabel="Copy payroll ID" />}
+              trailing={
+                <>
+                  <CopyIdButton value={entities.payrollId} ariaLabel="Copy payroll ID" />
+                  <InspectIdButton
+                    label="Payroll"
+                    request={buildEntityInspectRequest(
+                      'payrollId',
+                      entities.payrollId,
+                      entities.companyId,
+                    )}
+                    onInspect={handleInspect}
+                  />
+                </>
+              }
             />
 
-            {TEXT_FIELDS.map(({ key, label }) => {
-              const inputId = `entity-${key}-input`
-              return (
-                <div key={key} className={styles.field}>
-                  <label htmlFor={inputId}>{label}</label>
-                  <div className={styles.copyRow}>
-                    <input
-                      id={inputId}
-                      type="text"
-                      value={entities[key]}
-                      onChange={e => {
-                        onUpdateEntity(key, e.target.value)
-                      }}
-                      placeholder={`Enter ${label.toLowerCase()}...`}
-                    />
-                    <CopyIdButton value={entities[key]} ariaLabel={`Copy ${label.toLowerCase()}`} />
-                  </div>
-                </div>
-              )
-            })}
+            <EntityCombobox
+              label="Request"
+              value={entities.requestId}
+              options={entityCatalog.informationRequests}
+              isLoading={entityCatalog.isLoading}
+              placeholder="Search or paste a request id..."
+              useFallback={!isFlowTokenMode}
+              onChange={value => {
+                onUpdateEntity('requestId', value)
+              }}
+              trailing={
+                <>
+                  <CopyIdButton value={entities.requestId} ariaLabel="Copy request ID" />
+                  <InspectIdButton
+                    label="Request"
+                    request={buildEntityInspectRequest(
+                      'requestId',
+                      entities.requestId,
+                      entities.companyId,
+                    )}
+                    onInspect={handleInspect}
+                  />
+                </>
+              }
+            />
+
+            <EntityCombobox
+              label="Form"
+              value={entities.formId}
+              options={entityCatalog.forms}
+              isLoading={entityCatalog.isLoading}
+              placeholder="Search or paste a form id..."
+              useFallback={!isFlowTokenMode}
+              onChange={value => {
+                onUpdateEntity('formId', value)
+              }}
+              trailing={
+                <>
+                  <CopyIdButton value={entities.formId} ariaLabel="Copy form ID" />
+                  <InspectIdButton
+                    label="Form"
+                    request={buildEntityInspectRequest(
+                      'formId',
+                      entities.formId,
+                      entities.companyId,
+                    )}
+                    onInspect={handleInspect}
+                  />
+                </>
+              }
+            />
 
             <div className={styles.actions}>
               {hasChanges && (
@@ -847,6 +1081,55 @@ export function DemoSettingsPanel({
           </div>
         </div>
       </div>
+
+      {inspect && (
+        <div className={styles.inspectBackdrop}>
+          <button
+            type="button"
+            className={styles.inspectBackdropDismiss}
+            aria-label="Close inspect dialog"
+            onClick={() => {
+              setInspect(null)
+            }}
+          />
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={`${inspect.label} response`}
+            className={styles.inspectModal}
+          >
+            <header className={styles.inspectHeader}>
+              <div>
+                <h4 className={styles.inspectTitle}>{inspect.label} response</h4>
+                <div className={styles.inspectUrl}>GET {inspect.url.replace(/^\/api/, '')}</div>
+              </div>
+              <button
+                type="button"
+                className={styles.btn}
+                onClick={() => {
+                  setInspect(null)
+                }}
+                aria-label="Close inspect dialog"
+              >
+                Close
+              </button>
+            </header>
+            {inspect.fetch.kind === 'loading' && (
+              <div className={styles.inspectBodyMessage}>Loading…</div>
+            )}
+            {inspect.fetch.kind === 'ok' && (
+              <pre className={styles.inspectBody}>
+                {highlightJsonTokens(JSON.stringify(inspect.fetch.body, null, 2))}
+              </pre>
+            )}
+            {inspect.fetch.kind === 'error' && (
+              <pre className={styles.inspectBody}>
+                {`HTTP ${inspect.fetch.status}\n\n${inspect.fetch.body}`}
+              </pre>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/sdk-app/src/entity-config.ts
+++ b/sdk-app/src/entity-config.ts
@@ -64,6 +64,42 @@ export async function fetchEntityIds(
   )
 }
 
+export type InspectRequest =
+  | { kind: 'show'; url: string }
+  | { kind: 'listFilter'; url: string; matchUuid: string }
+
+export function buildEntityInspectRequest(
+  key: keyof EntityIds,
+  id: string,
+  companyId: string,
+): InspectRequest | null {
+  if (!id) return null
+  switch (key) {
+    case 'companyId':
+      return { kind: 'show', url: `/api/v1/companies/${id}` }
+    case 'employeeId':
+      return { kind: 'show', url: `/api/v1/employees/${id}` }
+    case 'contractorId':
+      return { kind: 'show', url: `/api/v1/contractors/${id}` }
+    case 'payrollId':
+      return companyId
+        ? { kind: 'show', url: `/api/v1/companies/${companyId}/payrolls/${id}` }
+        : null
+    case 'formId':
+      return { kind: 'show', url: `/api/v1/forms/${id}` }
+    case 'requestId':
+      return companyId
+        ? {
+            kind: 'listFilter',
+            url: `/api/v1/companies/${companyId}/information_requests`,
+            matchUuid: id,
+          }
+        : null
+    default:
+      return null
+  }
+}
+
 export async function fetchCompanyId(
   proxyBase: string,
   options: FetchEntityIdsOptions = {},

--- a/sdk-app/src/entityFormatters.ts
+++ b/sdk-app/src/entityFormatters.ts
@@ -20,6 +20,19 @@ export interface RawPayroll {
   processed?: boolean
 }
 
+export interface RawForm {
+  uuid?: string
+  name?: string | null
+  title?: string | null
+}
+
+export interface RawInformationRequest {
+  uuid?: string
+  type?: string | null
+  status?: string
+  blocking_payroll?: boolean
+}
+
 export interface EntityOption {
   value: string
   primary: string
@@ -46,4 +59,17 @@ export function formatContractor(contractor: RawContractor): string {
 export function formatEmployee(employee: RawEmployee): string {
   const name = [employee.first_name, employee.last_name].filter(Boolean).join(' ').trim()
   return name || 'Employee'
+}
+
+export function formatForm(form: RawForm): string {
+  return form.title || form.name || 'Form'
+}
+
+export function formatInformationRequestType(type: string | null | undefined): string {
+  if (!type) return 'Information request'
+  return type
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
 }

--- a/sdk-app/src/useEntityCatalog.ts
+++ b/sdk-app/src/useEntityCatalog.ts
@@ -3,9 +3,13 @@ import {
   type EntityOption,
   type RawContractor,
   type RawEmployee,
+  type RawForm,
+  type RawInformationRequest,
   type RawPayroll,
   formatContractor,
   formatEmployee,
+  formatForm,
+  formatInformationRequestType,
   formatPayPeriod,
 } from './entityFormatters'
 
@@ -13,6 +17,8 @@ export interface EntityCatalog {
   employees: EntityOption[]
   contractors: EntityOption[]
   payrolls: EntityOption[]
+  informationRequests: EntityOption[]
+  forms: EntityOption[]
   isLoading: boolean
 }
 
@@ -20,6 +26,8 @@ const EMPTY_CATALOG: EntityCatalog = {
   employees: [],
   contractors: [],
   payrolls: [],
+  informationRequests: [],
+  forms: [],
   isLoading: false,
 }
 
@@ -63,10 +71,12 @@ export function useEntityCatalog(companyId: string): EntityCatalog {
         end_date: toIso(endDate),
         per: '100',
       })
-      const [employees, contractors, payrolls] = await Promise.all([
+      const [employees, contractors, payrolls, informationRequests, forms] = await Promise.all([
         fetchList<RawEmployee>(`${base}/employees`, controller.signal),
         fetchList<RawContractor>(`${base}/contractors`, controller.signal),
         fetchList<RawPayroll>(`${base}/payrolls?${payrollsQuery.toString()}`, controller.signal),
+        fetchList<RawInformationRequest>(`${base}/information_requests`, controller.signal),
+        fetchList<RawForm>(`${base}/forms`, controller.signal),
       ])
 
       if (controller.signal.aborted) return
@@ -101,6 +111,20 @@ export function useEntityCatalog(companyId: string): EntityCatalog {
               },
             }
           }),
+        informationRequests: informationRequests
+          .filter(r => !!r.uuid)
+          .map(r => ({
+            value: r.uuid as string,
+            primary: formatInformationRequestType(r.type),
+            secondary: r.uuid as string,
+          })),
+        forms: forms
+          .filter(f => !!f.uuid)
+          .map(f => ({
+            value: f.uuid as string,
+            primary: formatForm(f),
+            secondary: f.uuid as string,
+          })),
         isLoading: false,
       })
     }


### PR DESCRIPTION
## Summary
- Adds a 🕵️ button next to each entity ID's Copy button in the demo settings panel. Clicking opens a modal with the syntax-highlighted JSON response for that entity. Disabled when the ID is empty.
- For Request ID (no GET-by-id endpoint), the inspect button fetches the company's `information_requests` list and filters client-side to the matching uuid — same payload from the user's perspective.
- Promotes Form ID and Request ID rows from plain text inputs to searchable comboboxes fed by the entity catalog (joining Employee/Contractor/Payroll). Catalog now fetches `/v1/companies/{id}/forms` and `/v1/companies/{id}/information_requests` in parallel with the others.
- Fixes Create New Demo to refresh `formId` from the new demo's entities — previously it was omitted from the entity replace, so the prior demo's stale form id survived demo swaps.

## Test plan
- [ ] Open the settings panel and click 🕵️ next to each populated entity ID. Verify the modal renders pretty-printed JSON with colored keys/strings/numbers/booleans/null tokens.
- [ ] Clear an entity ID — the 🕵️ button on that row becomes disabled.
- [ ] On the Request row, click 🕵️ and verify the modal shows a single matching record (filtered from the list endpoint).
- [ ] Set Form ID to a known-bad uuid → 🕵️ shows HTTP 404 with the error body.
- [ ] Form and Request rows now render as comboboxes — search by title/type works.
- [ ] Click "Create New Demo" → the Form ID dropdown updates to the new demo's form, not the previous demo's id.
- [ ] Modal closes via the Close button, backdrop click, and Escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)