### PR TITLE
fix(Modal): inherit theme color and font-family inside dialog

### DIFF
--- a/src/components/Common/UI/Modal/Modal.module.scss
+++ b/src/components/Common/UI/Modal/Modal.module.scss
@@ -2,6 +2,8 @@
   border: none;
   padding: 0;
   background: transparent;
+  color: var(--g-colorBodyContent);
+  font-family: var(--g-fontFamily);
   max-width: none;
   max-height: none;
   width: 100vw;


### PR DESCRIPTION
## Summary
- Native `<dialog>` elements promoted to the top layer pick up `color: CanvasText` from the UA stylesheet, which breaks inheritance from the `.GSDK` wrapper that holds the theme.
- As a result, text descendants that rely on inheritance (e.g. `<Heading>`, `<Text>` without a color variant) didn't adapt to the active theme inside any modal.
- Re-asserts `color: var(--g-colorBodyContent)` and `font-family: var(--g-fontFamily)` on `.dialog` so every modal descendant inherits the themed values.

## Demo

**Before**
<img width="741" height="777" alt="Screenshot 2026-06-24 at 3 52 04 PM" src="https://github.com/user-attachments/assets/c4feae70-77e8-41ef-991b-8ceb738f232e" />

**After**
<img width="698" height="784" alt="Screenshot 2026-06-24 at 3 51 46 PM" src="https://github.com/user-attachments/assets/ab538517-3d7a-491a-a0f7-1919a15d30f3" />


## Test plan
- [ ] Open any modal that renders a `Heading`/`Text` (e.g. the Edit Contractor Payment modal) under a custom theme and confirm the text now reflects the themed color and font.
- [ ] Verify default-theme modals look unchanged.
- [ ] `npm run test -- --run src/components/Common/UI/Modal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)