### PR TITLE
fix(ContractorPayments): restore hours input typing + live hint updates

### DIFF
--- a/src/components/Common/UI/NumberInput/NumberInput.tsx
+++ b/src/components/Common/UI/NumberInput/NumberInput.tsx
@@ -102,7 +102,12 @@ export function NumberInput({
         maxValue={maxValue}
         {...props}
       >
-        <Group>
+        <Group
+          onChange={(event: React.ChangeEvent<HTMLElement>) => {
+            const target = event.target as HTMLInputElement
+            onInputChange?.(target.value)
+          }}
+        >
           <Input
             adornmentStart={adornmentStart || (format === 'currency' ? currencySymbol : null)}
             adornmentEnd={adornmentEnd || (format === 'percent' ? '%' : null)}
@@ -111,9 +116,6 @@ export function NumberInput({
             placeholder={placeholder}
             aria-describedby={ariaDescribedBy}
             isDisabled={isDisabled}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              onInputChange?.(event.currentTarget.value)
-            }}
             // Select the existing value on focus so users can overwrite the
             // formatted placeholder (e.g. "0.00") by typing instead of having
             // to clear the field first.

--- a/src/components/Contractor/Payments/CreatePayment/EditContractorPaymentPresentation.tsx
+++ b/src/components/Contractor/Payments/CreatePayment/EditContractorPaymentPresentation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from 'react'
+import { useId, useState } from 'react'
 import { FormProvider, useWatch, type UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import type { EditContractorPaymentFormValues } from './EditContractorPaymentFormSchema'
@@ -42,26 +42,20 @@ export const EditContractorPaymentPresentation = ({
     control: formMethods.control,
   })
 
+  const [typedHours, setTypedHours] = useState<number>(() => formMethods.getValues('hours') ?? 0)
+
   const parseHours = (raw: string) => {
     const parsed = parseFloat(raw.replace(/[^\d.]/g, ''))
     return isNaN(parsed) ? 0 : parsed
   }
 
-  const computeHoursPayDescription = (hours: number) => {
-    if (!hourlyRate || hourlyRate <= 0) return ''
-    return t('hoursPayDescription', {
-      rate: currencyFormatter(hourlyRate),
-      total: currencyFormatter(hours * hourlyRate),
-    })
-  }
-
-  const [hoursPayDescription, setHoursPayDescription] = useState('')
-
-  useEffect(() => {
-    if (isOpen) {
-      setHoursPayDescription(computeHoursPayDescription(formMethods.getValues('hours') ?? 0))
-    }
-  }, [isOpen, hourlyRate, computeHoursPayDescription, formMethods.getValues])
+  const hoursPayDescription =
+    hourlyRate && hourlyRate > 0
+      ? t('hoursPayDescription', {
+          rate: currencyFormatter(hourlyRate),
+          total: currencyFormatter(typedHours * hourlyRate),
+        })
+      : undefined
 
   const isDirectDepositDisabled = contractorPaymentMethod === 'Check'
 
@@ -110,9 +104,12 @@ export const EditContractorPaymentPresentation = ({
                   isRequired
                   label={t('hoursLabel')}
                   adornmentEnd={t('hoursAdornment')}
-                  description={hourlyRate && hourlyRate > 0 ? hoursPayDescription : undefined}
+                  description={hoursPayDescription}
                   onInputChange={raw => {
-                    setHoursPayDescription(computeHoursPayDescription(parseHours(raw)))
+                    setTypedHours(parseHours(raw))
+                  }}
+                  onChange={value => {
+                    setTypedHours(isNaN(value) ? 0 : value)
                   }}
                 />
               )}


### PR DESCRIPTION
## Summary
- Follow-up to #2241. The hours input in the edit-contractor-payment modal was dropping typed characters and the live pay hint wasn't updating on arrow-key commits.
- Root cause: #2241 attached an `onChange` handler directly to the `<Input>` slot inside `react-aria`'s `<NumberField>`, which replaced react-aria's context-injected handler that controls the displayed text and value commits.
- Fix: move the `onChange` callback up onto `<Group>` so React's synthetic-event bubbling observes the same events without overriding react-aria's handler. Drive the hint from a `useState<number>` fed by `onInputChange` (per-keystroke) + `onChange` (arrow keys / step buttons).
- Hint stays live; the inner `<Input>` is back under react-aria's control.

## Test plan
- [ ] Open the edit-payment modal for an **hourly** contractor — typing into Hours updates the field and the hint live, character-by-character.
- [ ] Press ↑ / ↓ — Hours steps and the hint updates with each step.
- [ ] Open the modal for a **fixed-wage** contractor — no hint, no Hours field.
- [ ] Hint hides when no hourly rate is set on the contractor.
- [ ] Submit — `hours` reaches the payload unchanged.
- [ ] Regression sanity in Storybook: type into any other `NumberInput` story — no dropped characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)