### PR TITLE
feat(sdk-app): add Total pay column to PayrollSpreadsheet RRoP grid

### DIFF
--- a/sdk-app/src/design/components/payroll/PayrollConfigurationRrop/PayrollConfigurationRropPresentation.tsx
+++ b/sdk-app/src/design/components/payroll/PayrollConfigurationRrop/PayrollConfigurationRropPresentation.tsx
@@ -59,6 +59,7 @@ export const PayrollConfigurationRropPresentation = ({
   employeeDetails,
   fixedCompensationTypes = [],
   payPeriod,
+  paySchedule,
   onCalculatePayroll,
   onViewBlockers,
   payrollCategory = PayrollCategory.Regular,
@@ -158,6 +159,8 @@ export const PayrollConfigurationRropPresentation = ({
                 isLoading={isSpreadsheetLoading}
                 rrop={rrop}
                 payPeriod={payPeriod}
+                paySchedule={paySchedule}
+                payrollCategory={payrollCategory}
               />
             </Flex>
           </>

--- a/sdk-app/src/design/components/payroll/PayrollSpreadsheet/PayrollSpreadsheet.module.scss
+++ b/sdk-app/src/design/components/payroll/PayrollSpreadsheet/PayrollSpreadsheet.module.scss
@@ -5,7 +5,10 @@
 
 .grid {
   display: grid;
-  grid-template-columns: minmax(toRem(200), toRem(240)) repeat(11, minmax(toRem(140), 1fr));
+  grid-template-columns:
+    minmax(toRem(200), toRem(240))
+    minmax(toRem(120), toRem(140))
+    repeat(11, minmax(toRem(140), 1fr));
   min-width: max-content;
 }
 
@@ -63,7 +66,7 @@
   gap: toRem(6);
 }
 
-.cell:not(.stickyLeft):not(.cellNa) {
+.cell:not(.stickyLeft):not(.cellNa):not(.cellReadOnly) {
   cursor: text;
 }
 
@@ -74,16 +77,38 @@
 }
 
 /* The hovered or active editable cell itself stays body color (overrides row accent; bumped specificity) */
-.row .cell:not(.stickyLeft):not(.cellNa):hover,
+.row .cell:not(.stickyLeft):not(.cellNa):not(.cellReadOnly):hover,
 .row .cell:not(.stickyLeft):focus-within {
   background: var(--g-colorBody);
 }
 
-/* Hover + active outline on editable data cells (employee + N/A cells excluded) */
-.cell:not(.stickyLeft):not(.cellNa):hover,
+/* Hover + active outline on editable data cells (employee, N/A, and read-only cells excluded) */
+.cell:not(.stickyLeft):not(.cellNa):not(.cellReadOnly):hover,
 .cell:not(.stickyLeft):focus-within {
   outline: toRem(2) solid var(--g-colorBodyContent);
   outline-offset: toRem(-2);
+}
+
+.cellReadOnly {
+  cursor: not-allowed;
+  font-variant-numeric: tabular-nums;
+}
+
+.cellReadOnlyContent {
+  flex: 1;
+  min-width: 0;
+}
+
+.lockIcon {
+  flex: 0 0 auto;
+  width: toRem(14);
+  height: toRem(14);
+  color: var(--g-colorBodySubContent);
+  visibility: hidden;
+}
+
+.cellReadOnly:hover .lockIcon {
+  visibility: visible;
 }
 
 .stickyLeft {

--- a/sdk-app/src/design/components/payroll/PayrollSpreadsheet/PayrollSpreadsheet.tsx
+++ b/sdk-app/src/design/components/payroll/PayrollSpreadsheet/PayrollSpreadsheet.tsx
@@ -6,15 +6,36 @@ import type {
 } from '@gusto/embedded-api-v-2025-11-15/models/components/payroll'
 import type { PayrollFixedCompensationTypesType } from '@gusto/embedded-api-v-2025-11-15/models/components/payrollfixedcompensationtypestype'
 import type { PayrollPayPeriodType } from '@gusto/embedded-api-v-2025-11-15/models/components/payrollpayperiodtype'
+import type { PayrollEmployeeCompensationsType } from '@gusto/embedded-api-v-2025-11-15/models/components/payrollemployeecompensationstype'
+import type { PayScheduleShow as PayScheduleObject } from '@gusto/embedded-api-v-2025-11-15/models/components/payscheduleshow'
 import { Skeleton } from '../../common/Skeleton'
 import styles from './PayrollSpreadsheet.module.scss'
 import { firstLastName, formatNumberAsCurrency } from '@/helpers/formattedStrings'
-import { formatHoursDisplay } from '@/components/Payroll/helpers'
+import { calculateGrossPay, formatHoursDisplay } from '@/components/Payroll/helpers'
+import type { PayrollCategory } from '@/components/Payroll/payrollTypes'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { DataView, EmptyData, Flex, Grid, useDataView } from '@/components/Common'
 import { useDateFormatter } from '@/hooks/useDateFormatter'
 import PlusCircleIcon from '@/assets/icons/plus-circle.svg?react'
 import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
+
+function LockIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="3" y="11" width="18" height="10" rx="2" />
+      <path d="M7 11 V7 a5 5 0 0 1 10 0 V11" />
+    </svg>
+  )
+}
 
 type ColumnKind = 'hours' | 'currency' | 'reimbursements'
 
@@ -225,6 +246,10 @@ interface PayrollSpreadsheetProps {
   rrop?: boolean
   /** Used in RRoP mode to derive workweek date ranges shown in the breakdown modal. */
   payPeriod?: PayrollPayPeriodType
+  /** Required to compute Total pay for salaried employees (hours-in-pay-period derivation). */
+  paySchedule?: PayScheduleObject
+  /** Payroll category — switches PTO handling for off-cycle in the Total pay calculation. */
+  payrollCategory?: PayrollCategory
 }
 
 /** Columns that participate in the Regular Rate of Pay workweek breakdown.
@@ -369,6 +394,8 @@ export function PayrollSpreadsheet({
   isLoading = false,
   rrop = false,
   payPeriod,
+  paySchedule,
+  payrollCategory,
 }: PayrollSpreadsheetProps) {
   const Components = useComponentContext()
   const dateFormatter = useDateFormatter()
@@ -495,6 +522,45 @@ export function PayrollSpreadsheet({
       container.scrollBy({ left: -hiddenAmount, behavior: 'smooth' })
     }
   }
+
+  // Total pay derives from the live-edited compensation so the cell updates as the user types.
+  // Uses the main SDK's calculateGrossPay so the prototype matches PayrollConfiguration's column
+  // exactly (regular + overtime + fixed earnings + PTO + minimum-wage adjustment).
+  const totalPayByEmployee = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const employee of employees) {
+      const original = compensationByEmployee.get(employee.uuid)
+      if (!original) {
+        map.set(employee.uuid, 0)
+        continue
+      }
+      const updated = buildUpdatedCompensation(
+        original,
+        values,
+        reimbursementsByEmployee[employee.uuid] ?? [],
+        employee,
+      )
+      map.set(
+        employee.uuid,
+        calculateGrossPay(
+          updated as PayrollEmployeeCompensationsType,
+          employee,
+          payPeriod?.startDate,
+          paySchedule,
+          payrollCategory,
+        ),
+      )
+    }
+    return map
+  }, [
+    employees,
+    compensationByEmployee,
+    values,
+    reimbursementsByEmployee,
+    payPeriod?.startDate,
+    paySchedule,
+    payrollCategory,
+  ])
 
   const applicabilityByEmployee = useMemo(() => {
     const compByEmployee = new Map(
@@ -658,6 +724,9 @@ export function PayrollSpreadsheet({
           >
             Employee
           </div>
+          <div role="columnheader" className={styles.headerCell}>
+            Total pay
+          </div>
           {COLUMNS.map(column => (
             <div role="columnheader" key={column.id} className={styles.headerCell}>
               {column.label}
@@ -680,6 +749,19 @@ export function PayrollSpreadsheet({
                   <Skeleton width="8.75rem" height="0.875rem" />
                 ) : (
                   <span className={styles.employeeName}>{name}</span>
+                )}
+              </div>
+
+              <div role="gridcell" className={`${styles.cell} ${styles.cellReadOnly}`}>
+                {isLoading ? (
+                  <Skeleton width="4rem" height="0.875rem" />
+                ) : (
+                  <>
+                    <span className={styles.cellReadOnlyContent}>
+                      {formatNumberAsCurrency(totalPayByEmployee.get(uuid) ?? 0)}
+                    </span>
+                    <LockIcon className={styles.lockIcon} />
+                  </>
                 )}
               </div>
 


### PR DESCRIPTION
## Summary

- Adds a read-only **Total pay** column to the prototype `PayrollSpreadsheet` as the first column after Employee.
- Total is computed via the main SDK's `calculateGrossPay()` against the live-edited compensation (`buildUpdatedCompensation`), so the value matches `PayrollConfiguration`'s column exactly and updates as cells change.
- Cell uses a `not-allowed` cursor and reveals a lock icon (inline SVG, no new dependency) on hover to signal it's derived.
- Threads `paySchedule` and `payrollCategory` from `PayrollConfigurationRropPresentation` into `PayrollSpreadsheet` so `calculateGrossPay` has the inputs it needs for salaried-pay derivation.

## Test plan

- [ ] `npm run sdk-app` → open the Regular Rate of Pay prototype.
- [ ] Total pay column appears between Employee and Regular hrs; values match what `PayrollConfiguration` would show for the same prepared payroll.
- [ ] Edit Regular hrs / overtime / bonus / tips / reimbursements — total updates immediately.
- [ ] Hover the total cell — lock icon appears on the right, cursor switches to not-allowed.
- [ ] Toggle `isSpreadsheetLoading` — skeleton renders in place of the total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)