### PR TITLE
fix(ContractorPayments): fix hours input not updating correctly

### DIFF
--- a/src/components/Contractor/Payments/CreatePayment/EditContractorPaymentPresentation.test.tsx
+++ b/src/components/Contractor/Payments/CreatePayment/EditContractorPaymentPresentation.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
+import { EditContractorPaymentPresentation } from './EditContractorPaymentPresentation'
+import type { EditContractorPaymentFormValues } from './EditContractorPaymentFormSchema'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+
+const renderPresentation = (defaultValues: Partial<EditContractorPaymentFormValues>) => {
+  const Harness = () => {
+    const formMethods = useForm<EditContractorPaymentFormValues>({
+      defaultValues: {
+        wageType: 'Hourly',
+        paymentMethod: 'Check',
+        contractorUuid: 'contractor-1',
+        ...defaultValues,
+      },
+    })
+
+    return (
+      <EditContractorPaymentPresentation
+        isOpen
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        formMethods={formMethods}
+      />
+    )
+  }
+
+  return renderWithProviders(<Harness />)
+}
+
+describe('EditContractorPaymentPresentation hours pay hint initialization', () => {
+  it('seeds the hint from an existing hours value on first render', async () => {
+    renderPresentation({ hourlyRate: 25, hours: 10 })
+
+    await waitFor(() => {
+      expect(screen.getByText(content => content.includes('$250.00'))).toBeInTheDocument()
+    })
+  })
+
+  it('defaults to zero hours when the initial value is undefined', async () => {
+    renderPresentation({ hourlyRate: 25, hours: undefined })
+
+    await waitFor(() => {
+      expect(screen.getByText(content => content.includes('$0.00'))).toBeInTheDocument()
+    })
+    expect(screen.queryByText(content => content.includes('NaN'))).toBeNull()
+  })
+
+  it('defaults to zero hours when the initial value is NaN', async () => {
+    renderPresentation({ hourlyRate: 25, hours: Number.NaN })
+
+    await waitFor(() => {
+      expect(screen.getByText(content => content.includes('$0.00'))).toBeInTheDocument()
+    })
+    expect(screen.queryByText(content => content.includes('NaN'))).toBeNull()
+  })
+
+  it('recomputes the hint as hours are typed into the input', async () => {
+    const user = userEvent.setup()
+    renderPresentation({ hourlyRate: 25, hours: undefined })
+
+    await waitFor(() => {
+      expect(screen.getByText(content => content.includes('$0.00'))).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByLabelText('Hours'), '20')
+
+    await waitFor(() => {
+      expect(screen.getByText(content => content.includes('$500.00'))).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/Contractor/Payments/CreatePayment/EditContractorPaymentPresentation.tsx
+++ b/src/components/Contractor/Payments/CreatePayment/EditContractorPaymentPresentation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from 'react'
+import { useId, useState } from 'react'
 import { FormProvider, useWatch, type UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import type { EditContractorPaymentFormValues } from './EditContractorPaymentFormSchema'
@@ -55,13 +55,12 @@ export const EditContractorPaymentPresentation = ({
     })
   }
 
-  const [hoursPayDescription, setHoursPayDescription] = useState('')
-
-  useEffect(() => {
-    if (isOpen) {
-      setHoursPayDescription(computeHoursPayDescription(formMethods.getValues('hours') ?? 0))
-    }
-  }, [isOpen, hourlyRate, computeHoursPayDescription, formMethods.getValues])
+  const initialHours = formMethods.getValues('hours')
+  const [hoursPayDescription, setHoursPayDescription] = useState(
+    computeHoursPayDescription(
+      typeof initialHours === 'undefined' || Number.isNaN(initialHours) ? 0 : initialHours,
+    ),
+  )
 
   const isDirectDepositDisabled = contractorPaymentMethod === 'Check'
 


### PR DESCRIPTION
## Summary
- Initialize the hourly pay hint (`hoursPayDescription`) synchronously from the current form value instead of via an effect (effect was clearing the value)
- Default to `0` when the raw `hours` value is `undefined` or `NaN`, preventing a malformed pay hint on first render.
- Removed the now-unused `useEffect` import.

## Test plan
- [x] Open the Edit Contractor Payment modal with no/empty hours → pay hint shows the rate with a $0.00 total (no NaN).
- [x] Open with existing hours → pay hint reflects hours × rate.
- [x] Editing hours continues to update the hint via `onInputChange`.

Made with [Cursor](https://cursor.com)