### PR TITLE
docs(docs-site): cookie consent banner with consent-gated GA wiring

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -53,7 +53,49 @@ const config: Config = {
     locales: ['en'],
   },
 
-  plugins: [require.resolve('./plugins/global-docs-sidebar')],
+  plugins: [
+    require.resolve('./plugins/global-docs-sidebar'),
+    [
+      'docusaurus-plugin-cookie-consent',
+      {
+        title: 'Your Privacy',
+        description:
+          'Gusto uses cookies and similar technology to keep this documentation site working and, if you allow it, to measure how it is used. See our [Privacy Notice](https://gusto.com/about/privacy) for details.',
+        toastMode: true,
+        acceptAllText: 'Accept and Continue',
+        rejectOptionalText: 'Reject All',
+        showDetailsButton: false,
+        categories: {
+          analytics: {
+            label: 'Performance Cookies',
+            description:
+              'These cookies allow us to count visits and traffic sources so we can measure and improve the performance of this documentation. They help us know which pages are the most and least popular.',
+          },
+        },
+        googleConsentMode: {
+          enabled: true,
+        },
+      },
+    ],
+    // The gtag plugin MUST come after docusaurus-plugin-cookie-consent so its
+    // head-tag injection (gtag.js loader + config call) lands AFTER the
+    // consent-default script. Otherwise GA fires unrestricted and writes _ga*
+    // cookies before consent mode applies. (The classic preset also accepts a
+    // gtag option, but presets are injected before user plugins in head order,
+    // which produces the wrong sequence.) Driven by env var so the plugin is
+    // inert until GOOGLE_GTAG_ID is set in CI/build.
+    ...(process.env.GOOGLE_GTAG_ID
+      ? [
+          [
+            '@docusaurus/plugin-google-gtag',
+            {
+              trackingID: process.env.GOOGLE_GTAG_ID,
+              anonymizeIP: true,
+            },
+          ] satisfies [string, object],
+        ]
+      : []),
+  ],
 
   themes: [
     '@docusaurus/theme-mermaid',
@@ -230,6 +272,10 @@ const config: Config = {
             {
               label: 'Developer Terms of Service',
               href: 'https://gusto.com/legal/terms/developer-terms-of-service',
+            },
+            {
+              label: 'Privacy Notice',
+              href: 'https://gusto.com/about/privacy',
             },
           ],
         },

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -14,6 +14,7 @@
         "@easyops-cn/docusaurus-search-local": "^0.55.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
+        "docusaurus-plugin-cookie-consent": "^4.6.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
@@ -9805,6 +9806,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/docusaurus-plugin-cookie-consent": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-cookie-consent/-/docusaurus-plugin-cookie-consent-4.6.0.tgz",
+      "integrity": "sha512-eSFlW0PRODcLtrkkXujbkgt4dIGQWPsVyfIs3O09+Q1KzV7EyPVowec1vwROa7opJwYnON/yEf/czdP1D3XM/Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "@docusaurus/types": "^3.0.0",
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/docusaurus-plugin-typedoc": {

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -21,6 +21,7 @@
     "@easyops-cn/docusaurus-search-local": "^0.55.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
+    "docusaurus-plugin-cookie-consent": "^4.6.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -825,3 +825,219 @@ nav.theme-doc-breadcrumbs:not(:has(.breadcrumbs__item + .breadcrumbs__item)) {
   --diagram-accent-stroke: #f67660;
   --diagram-text: #f5f5f5;
 }
+
+/* ── Cookie consent banner ──
+   The plugin renders a 500px bottom-left toast card. We override it to a full-
+   width hairline rail anchored to the bottom, with the inner content centered
+   on the same 1400px column as the navbar/footer and styled with the docs
+   site's existing pill-button + body-text language. */
+
+.cookie-consent-toast.cookie-consent-modal {
+  position: fixed;
+  inset: auto 0 0 0;
+  width: 100%;
+  max-width: none;
+  max-height: none;
+  border: none;
+  border-top: 1px solid rgba(27, 27, 29, 0.08);
+  border-radius: 0;
+  /* Translucent surface + blurred backdrop so content behind shows through
+     subtly — banner reads as a layer floating above the page. */
+  background-color: rgba(255, 255, 255, 0.82);
+  -webkit-backdrop-filter: saturate(180%) blur(18px);
+  backdrop-filter: saturate(180%) blur(18px);
+  box-shadow:
+    0 -1px 0 rgba(255, 255, 255, 0.6) inset,
+    0 -12px 32px -8px rgba(15, 15, 15, 0.12),
+    0 -2px 8px -2px rgba(15, 15, 15, 0.06);
+  color: var(--gusto-body-text-color);
+  z-index: 200;
+
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.9rem max(1.5rem, calc((100vw - 1400px) / 2));
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .cookie-consent-toast.cookie-consent-modal {
+    background-color: #ffffff;
+  }
+}
+
+[data-theme='dark'] .cookie-consent-toast.cookie-consent-modal {
+  background-color: rgba(10, 10, 10, 0.78);
+  border-top-color: rgba(255, 255, 255, 0.14);
+  box-shadow:
+    0 -1px 0 rgba(255, 255, 255, 0.06) inset,
+    0 -12px 36px -8px rgba(0, 0, 0, 0.55),
+    0 -2px 10px -2px rgba(0, 0, 0, 0.4);
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  [data-theme='dark'] .cookie-consent-toast.cookie-consent-modal {
+    background-color: #050505;
+  }
+}
+
+/* Push page content above the rail so the bottom of the page isn't covered. */
+body:has(.cookie-consent-toast.cookie-consent-modal) {
+  padding-bottom: 88px;
+}
+
+/* Title is the dialog's accessible name (aria-labelledby) — hide visually. */
+.cookie-consent-toast .cookie-consent-title {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.cookie-consent-toast .cookie-consent-description {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  max-width: 64ch;
+  color: var(--gusto-body-text-color);
+}
+
+.cookie-consent-toast .cookie-consent-description a {
+  color: var(--ifm-link-color);
+  text-decoration: underline;
+}
+
+.cookie-consent-toast .cookie-consent-description a:hover {
+  color: var(--ifm-link-hover-color);
+}
+
+.cookie-consent-toast .cookie-consent-buttons {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  flex-wrap: nowrap;
+}
+
+/* With only one optional category exposed, "Reject optional" and "Reject all"
+   do the same thing — hide the third sibling (Reject all) to keep the rail tidy. */
+.cookie-consent-toast .cookie-consent-buttons > button:nth-of-type(3) {
+  display: none;
+}
+
+.cookie-consent-toast .cookie-consent-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.25rem;
+  padding: 0 1.1rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  flex: 0 0 auto;
+  min-width: 0;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    transform 0.12s ease,
+    box-shadow 0.12s ease;
+}
+
+.cookie-consent-toast .cookie-consent-button-primary {
+  background-color: var(--ifm-color-primary);
+  color: #ffffff;
+  border: 1px solid transparent;
+}
+
+.cookie-consent-toast .cookie-consent-button-primary:hover:not(:disabled) {
+  background-color: var(--ifm-color-primary-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(241, 94, 73, 0.25);
+}
+
+.cookie-consent-toast .cookie-consent-button-secondary {
+  background-color: transparent;
+  color: var(--ifm-navbar-link-color);
+  border: 1px solid rgba(27, 27, 29, 0.16);
+}
+
+.cookie-consent-toast .cookie-consent-button-secondary:hover:not(:disabled) {
+  background-color: rgba(27, 27, 29, 0.05);
+  border-color: rgba(27, 27, 29, 0.24);
+  transform: translateY(-1px);
+}
+
+[data-theme='dark'] .cookie-consent-toast .cookie-consent-button-secondary {
+  color: var(--ifm-navbar-link-color);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+[data-theme='dark'] .cookie-consent-toast .cookie-consent-button-secondary:hover:not(:disabled) {
+  background-color: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.cookie-consent-toast .cookie-consent-button-text {
+  background: transparent;
+  border: none;
+  height: auto;
+  padding: 0 0.4rem;
+  color: var(--ifm-link-color);
+  text-decoration: underline;
+  font-weight: 400;
+}
+
+.cookie-consent-toast .cookie-consent-button-text:hover:not(:disabled) {
+  color: var(--ifm-link-hover-color);
+  opacity: 1;
+}
+
+/* Expanded details panel — when "Show details" is open, the categories section
+   stacks below the description. Tame the spacing so it fits the rail. */
+.cookie-consent-toast .cookie-consent-details {
+  grid-column: 1 / -1;
+  margin: 0.5rem 0 0 0;
+  padding: 0.75rem 1rem;
+  background-color: rgba(27, 27, 29, 0.03);
+  border: 1px solid rgba(27, 27, 29, 0.08);
+  border-radius: 8px;
+}
+
+[data-theme='dark'] .cookie-consent-toast .cookie-consent-details {
+  background-color: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+@media (max-width: 768px) {
+  .cookie-consent-toast.cookie-consent-modal {
+    grid-template-columns: 1fr;
+    gap: 0.85rem;
+    padding: 1rem 1.25rem;
+  }
+
+  .cookie-consent-toast .cookie-consent-buttons {
+    flex-wrap: wrap;
+  }
+
+  .cookie-consent-toast .cookie-consent-button-primary,
+  .cookie-consent-toast .cookie-consent-button-secondary {
+    flex: 1 1 calc(50% - 0.25rem);
+  }
+
+  .cookie-consent-toast .cookie-consent-button-text {
+    flex: 1 1 100%;
+  }
+
+  body:has(.cookie-consent-toast.cookie-consent-modal) {
+    padding-bottom: 200px;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a full-width bottom cookie consent banner to **sdk.gusto.com** via [`docusaurus-plugin-cookie-consent`](https://github.com/mcclowes/docusaurus-plugin-cookie-consent) v4.6.0, configured with **Google Consent Mode v2**. Analytics cookies cannot write until the user accepts.
- Copy + category labels mirror gusto.com's OneTrust language ("Accept and Continue", "Reject All", "Performance Cookies", "Privacy Notice"). gusto.com itself does not show a bottom banner (`NoBanner: true` in its OneTrust config) — this is a more conservative posture our privacy team specifically asked for.
- Adds a **Privacy Notice** link to the docs-site footer (alongside the existing Developer Terms of Service link added in #2226).
- **GA is wired but not enabled.** The `@docusaurus/plugin-google-gtag` plugin is gated on `process.env.GOOGLE_GTAG_ID`. With no env var, no `gtag.js`, no measurement ID hardcoded — just the consent banner and the consent-default script. Turning GA on later = set the env var in build; no code change.

## The non-obvious fix

Don't add `gtag: { trackingID }` to the `classic` preset (the "obvious" path). Docusaurus injects preset head tags **before** user-plugin head tags, so `gtag('config', 'G-…')` runs and writes `_ga` cookies before `gtag('consent', 'default', 'denied')` arrives.

This PR registers `@docusaurus/plugin-google-gtag` directly in `plugins[]` **after** the cookie-consent plugin, which flips the head-tag order:

1. `consent default = denied` (cookie-consent plugin)
2. `gtag.js` loader (gtag plugin)
3. `gtag('config', 'G-…')` (gtag plugin) — sees consent already denied, behaves accordingly

There's a comment in `docusaurus.config.ts` explaining why so this doesn't regress.

## Local verification (results)

Tested with a temporary `GOOGLE_GTAG_ID=G-TEST0000ZZ`:

| Scenario | `_ga` / `_ga_*` cookies |
|---|---|
| Page load, banner showing, no choice made | ✅ none |
| After clicking **Reject All** | ✅ none |
| After clicking **Accept and Continue** | ✅ `_ga` and `_ga_TEST0000ZZ` appear |

`window.dataLayer` order on fresh load: `consent default (denied)` → `gtag js` → `gtag config G-…` → ... → `consent update (granted/denied)` on the user's choice.

## Test plan

GA isn't shipping in this PR. To test the gating behavior locally, set a fake measurement ID before building:

```bash
cd docs-site
npm install
GOOGLE_GTAG_ID=G-TEST0000ZZ npm run build
GOOGLE_GTAG_ID=G-TEST0000ZZ npm run serve
# open http://localhost:3000/
```

(Any `G-XXXXXXXXXX`-shaped string works — `gtag.js` doesn't validate the ID against Google's servers for the purpose of cookie behavior.)

In the browser, with DevTools open to **Application → Storage**:

- [ ] **Fresh load (no choice yet)**: Banner appears at the bottom of the page. **No `_ga*` cookies** under `localhost`. `window.dataLayer` (Console) contains `['consent','default',{ analytics_storage: 'denied', … }]` *before* `['config','G-TEST0000ZZ',…]`.
- [ ] **Click "Reject All"**: Banner dismisses. `localStorage['cookie-consent-preferences']` shows `analytics: false`. Still **no `_ga*` cookies**.
- [ ] **Clear `localStorage` + cookies, reload, click "Accept and Continue"**: Banner dismisses. `_ga` and `_ga_TEST0000ZZ` cookies appear. `localStorage['cookie-consent-preferences']` shows `analytics: true`. `dataLayer` contains a `['consent','update',{ analytics_storage: 'granted', … }]` entry.
- [ ] **Reload after accepting**: Banner does NOT reappear (preference persists). GA cookies still present.
- [ ] **Without setting `GOOGLE_GTAG_ID`** (`npm run start` or `npm run build && npm run serve`): Banner still shows. No `gtag.js` loads. No GA cookies in any state. (This is what we're actually shipping.)
- [ ] Visual: banner is full-width at the bottom, light hairline border on top, layered shadow, matches the docs site's pill-button language (coral primary, neutral-border secondary). Light + dark mode both look right. Mobile (≤768px) collapses to a single column.
- [ ] Footer Resources column now has a **Privacy Notice** link → `https://gusto.com/about/privacy`.

After local testing, unset the env var:
```bash
unset GOOGLE_GTAG_ID
```

## Out of scope

- Actually enabling GA. Privacy approval first, then set `GOOGLE_GTAG_ID` in the build (presumably the docs publish workflow).
- Migrating to OneTrust to match gusto.com 1:1. Would give us identical brand/banner/preferences but is a much bigger lift and pulls a third-party SDK into the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)