### PR TITLE
fix(SDK-137): hide bank-account list and Split button on Check toggle in onboarding

### DIFF
--- a/src/components/Employee/PaymentMethod/onboarding/ListView.test.tsx
+++ b/src/components/Employee/PaymentMethod/onboarding/ListView.test.tsx
@@ -117,6 +117,22 @@ describe('PaymentMethod onboarding ListView', () => {
     expect(screen.queryByRole('button', { name: /add.*bank account/i })).not.toBeInTheDocument()
   })
 
+  it('hides bank account list when Check is selected even if accounts exist server-side', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<PaymentMethod employeeId="employee-123" onEvent={onEvent} />)
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Chase')).toBeInTheDocument()
+      },
+      { timeout: 5000 },
+    )
+
+    await user.click(screen.getByRole('radio', { name: /check/i }))
+
+    expect(screen.queryByText('Chase')).not.toBeInTheDocument()
+  })
+
   it('navigates to BankForm when Add bank account is clicked', async () => {
     const user = userEvent.setup()
     renderWithProviders(<PaymentMethod employeeId="employee-123" onEvent={onEvent} />)
@@ -285,6 +301,23 @@ describe('PaymentMethod onboarding ListView', () => {
       )
 
       expect(screen.getByRole('button', { name: /split paycheck/i })).toBeInTheDocument()
+    })
+
+    it('hides Split paycheck button when Check is selected even with 2+ accounts', async () => {
+      const user = userEvent.setup()
+      mockTwoBankAccounts()
+      renderWithProviders(<PaymentMethod employeeId="employee-123" onEvent={onEvent} />)
+
+      await waitFor(
+        () => {
+          expect(screen.getByRole('button', { name: /split paycheck/i })).toBeInTheDocument()
+        },
+        { timeout: 5000 },
+      )
+
+      await user.click(screen.getByRole('radio', { name: /check/i }))
+
+      expect(screen.queryByRole('button', { name: /split paycheck/i })).not.toBeInTheDocument()
     })
   })
 

--- a/src/components/Employee/PaymentMethod/onboarding/ListView.tsx
+++ b/src/components/Employee/PaymentMethod/onboarding/ListView.tsx
@@ -179,11 +179,11 @@ function ListViewReady({
               }
               FieldComponent={TypeFieldComponent}
             />
-            {bankAccounts.length > 0 && (
+            {watchedType === PAYMENT_METHODS.directDeposit && bankAccounts.length > 0 && (
               <DataView label={t('bankAccountsListLabel')} {...dataViewProps} />
             )}
             <ActionsLayout>
-              {bankAccounts.length > 1 && (
+              {watchedType === PAYMENT_METHODS.directDeposit && bankAccounts.length > 1 && (
                 <Components.Button
                   variant="secondary"
                   type="button"

--- a/src/components/Employee/PaymentMethod/shared/usePaymentMethodForm/usePaymentMethodForm.test.tsx
+++ b/src/components/Employee/PaymentMethod/shared/usePaymentMethodForm/usePaymentMethodForm.test.tsx
@@ -105,6 +105,42 @@ describe('usePaymentMethodForm', () => {
     expect(submitResult).toMatchObject({ mode: 'update', data: { type: 'Check' } })
   })
 
+  it('does not call delete-bank-account when switching to Check', async () => {
+    const deleteResolver = vi.fn<HttpResponseResolver>(
+      () => new HttpResponse(null, { status: 204 }),
+    )
+
+    server.use(
+      http.put(`${API_BASE_URL}/v1/employees/:employee_id/payment_method`, () =>
+        HttpResponse.json({ version: 'next-version', type: 'Check' }),
+      ),
+      http.delete(
+        `${API_BASE_URL}/v1/employees/:employee_id/bank_accounts/:bank_account_id`,
+        deleteResolver,
+      ),
+    )
+
+    const { result } = renderHook(
+      () =>
+        usePaymentMethodForm({
+          employeeId: 'employee-123',
+          defaultValues: { type: 'Check' },
+        }),
+      { wrapper: GustoTestProvider },
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    await act(async () => {
+      assertReady(result.current)
+      await result.current.actions.onSubmit()
+    })
+
+    expect(deleteResolver).not.toHaveBeenCalled()
+  })
+
   it('preserves splits and splitBy in the PUT body when staying on Direct Deposit', async () => {
     let putBody: Record<string, unknown> | null = null
     const putResolver = vi.fn<HttpResponseResolver>(async ({ request }) => {


### PR DESCRIPTION
## Summary

- The onboarding `ListView` was gating the bank-account `DataView` and the **Split paycheck** button on `bankAccounts.length` alone. The management `PaymentMethodCard` already gates correctly on `isDirectDeposit && length`.
- The old server behavior masked this — switching from Direct Deposit to Check deleted bank accounts server-side, so the next refetch returned `[]` and the inconsistency disappeared on its own.
- [SDK-137](https://gustohq.atlassian.net/browse/SDK-137) decouples payment type from payment methods (server-side, behind a company-level FF, gradual rollout). Bank accounts now persist when switching to Check, so the missing local gate becomes user-visible: a Check-selected user keeps seeing the bank-account table and the Split button.
- Aligns the onboarding gates with the management card and adds a test that switching to Check never issues a delete-bank-account mutation.

## Files

- `src/components/Employee/PaymentMethod/onboarding/ListView.tsx` — add `watchedType === PAYMENT_METHODS.directDeposit` to the `DataView` and Split-button gates
- `src/components/Employee/PaymentMethod/onboarding/ListView.test.tsx` — two new cases: list hides on Check toggle, Split button hides on Check toggle
- `src/components/Employee/PaymentMethod/shared/usePaymentMethodForm/usePaymentMethodForm.test.tsx` — new case: switching to Check does not call `DELETE /employees/:id/bank_accounts/:id`

## Test plan

- [x] `npm run test -- --run src/components/Employee/PaymentMethod` — 91/91 pass
- [ ] Storybook smoke: open the onboarding PaymentMethod story with bank accounts present; toggle to Check; confirm the list and Split button hide. Toggle back to Direct Deposit; confirm they reappear from the same client-side data without a network round-trip.
- [ ] Manual (optional, if a flagged-on test company is available): in `sdk-app`, switch an employee DD → Check → DD; confirm bank accounts return intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-137]: https://gustohq.atlassian.net/browse/SDK-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ