### PR TITLE
fix(ContractorPayments): use SDK DatePicker for payment date input

### DIFF
--- a/e2e/tests/contractor/05-payment-validation-failure.spec.ts
+++ b/e2e/tests/contractor/05-payment-validation-failure.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../utils/localTestFixture'
-import { waitForLoadingComplete } from '../../utils/helpers'
+import { fillDate, waitForLoadingComplete } from '../../utils/helpers'
 
 test.describe('ContractorPaymentFlow - submit payment lifecycle', () => {
   test.beforeEach(({}, testInfo) => {
@@ -34,11 +34,15 @@ test.describe('ContractorPaymentFlow - submit payment lifecycle', () => {
       return
     }
 
-    const dateInput = page.getByLabel(/payment date/i)
-    await expect(dateInput).toBeVisible()
+    const dateGroup = page.getByRole('group', { name: /payment date/i })
+    await expect(dateGroup).toBeVisible()
     const futureDate = new Date()
     futureDate.setDate(futureDate.getDate() + 7)
-    await dateInput.fill(futureDate.toISOString().slice(0, 10))
+    await fillDate(page, 'Payment date', {
+      month: futureDate.getMonth() + 1,
+      day: futureDate.getDate(),
+      year: futureDate.getFullYear(),
+    })
 
     await page.getByRole('button', { name: /^continue$/i }).click()
     await waitForLoadingComplete(page, 30000)

--- a/e2e/utils/contractorFlowDrivers.ts
+++ b/e2e/utils/contractorFlowDrivers.ts
@@ -244,30 +244,48 @@ async function startNewPayment(page: Page): Promise<void> {
 }
 
 async function setPaymentDate(page: Page): Promise<void> {
-  const dateInput = page.getByLabel(/^payment date$/i)
-  await expect(dateInput).toBeVisible({ timeout: LONG_WAIT })
+  const dateGroup = page.getByRole('group', { name: /^payment date$/i })
+  await expect(dateGroup).toBeVisible({ timeout: LONG_WAIT })
 
   // Direct deposit needs a payment date several business days out. Pick the
   // next business day at least 21d ahead — generous so we clear cutoff,
   // weekends, ALL US federal holidays in the next 3 weeks, AND the demo
   // backend's own "next valid date" calculation which sometimes disagrees
   // with ours.
-  const targetIso = nextBusinessDay(new Date(), 21).toISOString().slice(0, 10)
+  const targetDate = nextBusinessDay(new Date(), 21)
 
   // The SDK's CreatePayment component has a useEffect that recomputes the
   // initial payment date once `paymentSpeed` resolves from the API and
   // overwrites whatever the user typed before that effect fired. Setting
   // the date once, then waiting on the read-back, lets us catch the
-  // overwrite case and re-fill: poll the input value until it matches our
-  // target, retrying the fill if the SDK has overwritten it.
+  // overwrite case and re-fill: poll the spinbutton values until they match
+  // our target, retrying the fill if the SDK has overwritten it.
+  const targetMonth = targetDate.getUTCMonth() + 1
+  const targetDay = targetDate.getUTCDate()
+  const targetYear = targetDate.getUTCFullYear()
+
   for (let attempt = 0; attempt < 5; attempt++) {
-    await dateInput.fill(targetIso)
+    await fillDate(page, 'Payment date', {
+      month: targetMonth,
+      day: targetDay,
+      year: targetYear,
+    })
     await page.waitForTimeout(500)
-    const currentValue = await dateInput.inputValue()
-    if (currentValue === targetIso) return
+
+    const monthValue = await dateGroup.getByRole('spinbutton', { name: /^month/i }).inputValue()
+    const dayValue = await dateGroup.getByRole('spinbutton', { name: /^day/i }).inputValue()
+    const yearValue = await dateGroup.getByRole('spinbutton', { name: /^year/i }).inputValue()
+
+    if (
+      monthValue === String(targetMonth) &&
+      dayValue === String(targetDay) &&
+      yearValue === String(targetYear)
+    ) {
+      return
+    }
   }
   throw new Error(
-    `Payment date input did not stick at ${targetIso} after 5 fill attempts; SDK is overwriting via useEffect race`,
+    `Payment date input did not stick at ${targetYear}-${targetMonth}-${targetDay} after 5 fill attempts; SDK is overwriting via useEffect race`,
   )
 }
 

--- a/e2e/utils/contractorFlowDrivers.ts
+++ b/e2e/utils/contractorFlowDrivers.ts
@@ -272,9 +272,9 @@ async function setPaymentDate(page: Page): Promise<void> {
     })
     await page.waitForTimeout(500)
 
-    const monthValue = await dateGroup.getByRole('spinbutton', { name: /^month/i }).inputValue()
-    const dayValue = await dateGroup.getByRole('spinbutton', { name: /^day/i }).inputValue()
-    const yearValue = await dateGroup.getByRole('spinbutton', { name: /^year/i }).inputValue()
+    const monthValue = await dateGroup.getByRole('spinbutton', { name: /^month/i }).textContent()
+    const dayValue = await dateGroup.getByRole('spinbutton', { name: /^day/i }).textContent()
+    const yearValue = await dateGroup.getByRole('spinbutton', { name: /^year/i }).textContent()
 
     if (
       monthValue === String(targetMonth) &&

--- a/src/components/Contractor/Payments/CreatePayment/CreatePaymentPresentation.tsx
+++ b/src/components/Contractor/Payments/CreatePayment/CreatePaymentPresentation.tsx
@@ -12,6 +12,11 @@ import { HamburgerMenu } from '@/components/Common/HamburgerMenu'
 import { useI18n } from '@/i18n'
 import { formatHoursDisplay } from '@/components/Payroll/helpers'
 import useNumberFormatter from '@/hooks/useNumberFormatter'
+import {
+  formatDateToStringDate,
+  normalizeDateToLocal,
+  normalizeToDate,
+} from '@/helpers/dateFormatting'
 
 const ZERO_HOURS_DISPLAY = '0.000'
 
@@ -50,7 +55,7 @@ export const CreatePaymentPresentation = ({
   isLoading,
   paymentSpeedDays,
 }: ContractorPaymentCreatePaymentPresentationProps) => {
-  const { Button, Text, Heading, TextInput, Alert } = useComponentContext()
+  const { Button, Text, Heading, DatePicker, Alert } = useComponentContext()
   useI18n('Contractor.Payments.CreatePayment')
   const { t } = useTranslation('Contractor.Payments.CreatePayment')
   const currencyFormatter = useNumberFormatter('currency')
@@ -110,10 +115,12 @@ export const CreatePaymentPresentation = ({
       ))}
 
       <Flex flexDirection="column" gap={8}>
-        <TextInput
-          type="date"
-          value={paymentDate}
-          onChange={onPaymentDateChange}
+        <DatePicker
+          value={paymentDate ? normalizeToDate(paymentDate) : null}
+          onChange={date => {
+            const normalized = normalizeDateToLocal(date)
+            onPaymentDateChange(normalized ? (formatDateToStringDate(normalized) ?? '') : '')
+          }}
           label={t('dateLabel')}
           isRequired
         />


### PR DESCRIPTION
## Summary
- Swap the raw `TextInput type="date"` in `CreatePaymentPresentation` for the adapter's `DatePicker` so the payment date field renders the SDK's date input + calendar picker.
- Convert at the presentation boundary between the parent's `YYYY-MM-DD` string state and `Date | null` using the existing `normalizeToDate` / `normalizeDateToLocal` / `formatDateToStringDate` helpers — same pattern `DatePickerField` uses internally. Parent state and the `RFCDate(paymentDate)` API contract are unchanged.

## Test plan
- [ ] Verify the payment date field renders the SDK calendar picker in Storybook / sdk-app
- [ ] Pick a date and confirm `checkDate` in the preview/create request matches the selection
- [ ] Confirm the initial value (today + payment speed business days) still populates correctly