### PR TITLE
feat(forms): support a value-aware function for buildFormSchema excludeFields

### DIFF
--- a/src/partner-hook-utils/form/buildFormSchema.test.ts
+++ b/src/partner-hook-utils/form/buildFormSchema.test.ts
@@ -301,6 +301,100 @@ describe('buildFormSchema', () => {
     })
   })
 
+  describe('excludeFields as a value-aware function', () => {
+    const fieldValidators = {
+      kind: z.enum(['individual', 'business']),
+      firstName: z.string(),
+      businessName: z.string(),
+    }
+
+    const requiredFieldsConfig = {
+      firstName: 'create',
+      businessName: 'create',
+    } as const
+
+    // firstName applies only to individuals; businessName only to businesses.
+    const excludeFields = (data: { kind: 'individual' | 'business' }) =>
+      data.kind === 'individual'
+        ? (['businessName'] as const).slice()
+        : (['firstName'] as const).slice()
+
+    it('skips the required check for a statically-required field the function excludes', () => {
+      const [schema] = buildFormSchema(fieldValidators, {
+        requiredFieldsConfig,
+        mode: 'create',
+        excludeFields,
+      })
+
+      const result = schema.safeParse({ kind: 'business', firstName: '', businessName: 'Acme' })
+      expect(result.success).toBe(true)
+    })
+
+    it('still flags a statically-required field the function does not exclude', () => {
+      const [schema] = buildFormSchema(fieldValidators, {
+        requiredFieldsConfig,
+        mode: 'create',
+        excludeFields,
+      })
+
+      const result = schema.safeParse({ kind: 'business', firstName: '', businessName: '' })
+      expect(result.success).toBe(false)
+      const errors = getErrorFields(result)
+      expect(errors).toContain('businessName')
+      expect(errors).not.toContain('firstName')
+    })
+
+    it('re-evaluates applicability as the discriminating value changes', () => {
+      const [schema] = buildFormSchema(fieldValidators, {
+        requiredFieldsConfig,
+        mode: 'create',
+        excludeFields,
+      })
+
+      const asIndividual = schema.safeParse({
+        kind: 'individual',
+        firstName: '',
+        businessName: '',
+      })
+      expect(getErrorFields(asIndividual)).toContain('firstName')
+      expect(getErrorFields(asIndividual)).not.toContain('businessName')
+    })
+
+    it('keeps function-excluded fields in the schema shape (validated as optional)', () => {
+      const [, { getFieldsMetadata }] = buildFormSchema(fieldValidators, {
+        requiredFieldsConfig,
+        mode: 'create',
+        excludeFields,
+      })
+      const metadata = getFieldsMetadata()
+
+      expect(metadata.firstName).toBeDefined()
+      expect(metadata.businessName).toBeDefined()
+    })
+
+    it('promotes an optional field only while the function deems it applicable', () => {
+      const optionalConfig = {
+        firstName: 'never',
+        businessName: 'never',
+      } as const
+
+      const [schema] = buildFormSchema(fieldValidators, {
+        requiredFieldsConfig: optionalConfig,
+        mode: 'create',
+        optionalFieldsToRequire: { create: ['firstName'] },
+        excludeFields,
+      })
+
+      // Applicable to individuals: promotion takes effect.
+      const asIndividual = schema.safeParse({ kind: 'individual', firstName: '', businessName: '' })
+      expect(getErrorFields(asIndividual)).toContain('firstName')
+
+      // Not applicable to businesses: promotion is suppressed by the function.
+      const asBusiness = schema.safeParse({ kind: 'business', firstName: '', businessName: '' })
+      expect(getErrorFields(asBusiness)).not.toContain('firstName')
+    })
+  })
+
   describe('function rules (predicates)', () => {
     const fieldValidators = {
       adjustForMinimumWage: z.boolean(),

--- a/src/partner-hook-utils/form/buildFormSchema.ts
+++ b/src/partner-hook-utils/form/buildFormSchema.ts
@@ -227,8 +227,9 @@ export function buildFormSchema<
   if (hasSuperRefine) {
     schema = (schema as z.ZodObject).superRefine(
       (data: Record<string, unknown>, ctx: z.RefinementCtx) => {
+        const typedData = data as FormDataFromValidators<T>
         const excludedNow = excludeFieldsFn
-          ? new Set(excludeFieldsFn(data as { [K in keyof T]: z.infer<T[K]> }, mode).map(String))
+          ? new Set(excludeFieldsFn(typedData, mode).map(String))
           : undefined
 
         for (const { name, predicate } of dynamicRequired) {
@@ -242,7 +243,7 @@ export function buildFormSchema<
           }
         }
 
-        options.superRefine?.(data as { [K in keyof T]: z.infer<T[K]> }, ctx)
+        options.superRefine?.(typedData, ctx)
       },
     )
   }

--- a/src/partner-hook-utils/form/buildFormSchema.ts
+++ b/src/partner-hook-utils/form/buildFormSchema.ts
@@ -95,7 +95,20 @@ interface BuildFormSchemaOptions<
   requiredErrorCode?: string
   mode: FormMode
   optionalFieldsToRequire?: OptionalFieldsToRequire<TConfig>
-  excludeFields?: Array<keyof T & string>
+  /**
+   * Fields that don't apply and should be dropped from required validation.
+   *
+   * An **array** removes the fields at build time — they're absent from the
+   * schema shape entirely (use when applicability is fixed by a config flag).
+   *
+   * A **function** is evaluated against the values under validation, so a field
+   * can flip in/out of applicability as other values change. The field stays in
+   * the schema (validated as optional) but its required check is skipped while
+   * the function reports it as excluded.
+   */
+  excludeFields?:
+    | Array<keyof T & string>
+    | ((data: { [K in keyof T]: z.infer<T[K]> }, mode: FormMode) => Array<keyof T & string>)
   /** Fields with existing server-side values that are redacted in the API response
    *  (e.g. SSN, EIN). These fields remain in the schema for format validation and
    *  appear in metadata (with `hasRedactedValue: true`) but are exempt from required
@@ -166,7 +179,10 @@ export function buildFormSchema<
     requiredErrorCode = 'REQUIRED',
     excludeFields = [],
   } = options
-  const excluded = new Set(excludeFields.map(String))
+  // The array form removes fields at build time; the function form is resolved
+  // per-validation in the superRefine pass below.
+  const excludeFieldsFn = typeof excludeFields === 'function' ? excludeFields : undefined
+  const staticExcluded = new Set((Array.isArray(excludeFields) ? excludeFields : []).map(String))
   const redacted = new Set((options.fieldsWithRedactedValues ?? []).map(String))
   const partnerRequired = new Set(
     resolveOptionalFieldsToRequire(options.optionalFieldsToRequire, mode),
@@ -181,7 +197,7 @@ export function buildFormSchema<
   const config = requiredFieldsConfig as Record<string, RequiredFieldRule>
 
   for (const [name, validator] of Object.entries(fieldValidators)) {
-    if (excluded.has(name)) continue
+    if (staticExcluded.has(name)) continue
     includedFieldNames.push(name)
 
     const effectiveRule = config[name] ?? 'always'
@@ -211,7 +227,12 @@ export function buildFormSchema<
   if (hasSuperRefine) {
     schema = (schema as z.ZodObject).superRefine(
       (data: Record<string, unknown>, ctx: z.RefinementCtx) => {
+        const excludedNow = excludeFieldsFn
+          ? new Set(excludeFieldsFn(data as { [K in keyof T]: z.infer<T[K]> }, mode).map(String))
+          : undefined
+
         for (const { name, predicate } of dynamicRequired) {
+          if (excludedNow?.has(name)) continue
           if (predicate(data, mode) && isEmpty(data[name])) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,


### PR DESCRIPTION
## Summary

Widens the internal `buildFormSchema` `excludeFields` option to accept **either**:

- an `Array<keyof T>` — existing behavior, removes the field from the schema at build time, **or**
- a function `(data, mode) => Array<keyof T>` — evaluated during the required-check `superRefine`, so a schema can skip requiredness checks for fields that don't currently apply (e.g. business-only fields while an individual contractor is selected).

The function form keeps fields in the schema shape (validated as optional) and keeps requiredness **static and promotable** via `optionalFieldsToRequire`. This is the foundation the upcoming `useContractorDetailsForm` hook builds on for individual/business applicability gating.

## Why

Contractor details need fields to appear/disappear based on `type`/`wageType`/self-onboarding while remaining promotable to required via the public `optionalFieldsToRequire` API. Doing this purely with functional `requiredFieldsConfig` predicates would lose promotability; a value-aware `excludeFields` keeps both.

## Test plan

- `npm run test -- --run src/partner-hook-utils/form/buildFormSchema.test.ts` (62 passing; adds a `excludeFields as a value-aware function` block)
- `npx tsc --noEmit` clean
- Array-form `excludeFields` behavior unchanged (regression covered by existing tests)

First of a 4-PR stack decomposing #2261.

Made with Cursor

Made with [Cursor](https://cursor.com)