### PR TITLE
feat(sdk-app): turn RRoP workweek-split modal into a spreadsheet

### DIFF
--- a/sdk-app/src/design/components/payroll/PayrollSpreadsheet/BreakdownModal.tsx
+++ b/sdk-app/src/design/components/payroll/PayrollSpreadsheet/BreakdownModal.tsx
@@ -1,0 +1,222 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+import type { PayrollPayPeriodType } from '@gusto/embedded-api-v-2025-11-15/models/components/payrollpayperiodtype'
+import styles from './PayrollSpreadsheet.module.scss'
+import { type ColumnDef, type Workweek, formatCellValue, sumBreakdown } from './shared'
+import { Flex } from '@/components/Common'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { useDateFormatter } from '@/hooks/useDateFormatter'
+
+interface BreakdownModalProps {
+  employeeName: string
+  payPeriod?: PayrollPayPeriodType
+  workweeks: Workweek[]
+  columns: ColumnDef[]
+  focusColumnId?: string
+  initialBreakdowns: Record<string, string[]>
+  onClose: () => void
+  onSave: (breakdowns: Record<string, string[]>) => void
+}
+
+export function BreakdownModal({
+  employeeName,
+  payPeriod,
+  workweeks,
+  columns,
+  focusColumnId,
+  initialBreakdowns,
+  onClose,
+  onSave,
+}: BreakdownModalProps) {
+  const Components = useComponentContext()
+  const dateFormatter = useDateFormatter()
+  const [draftBreakdowns, setDraftBreakdowns] = useState(initialBreakdowns)
+  const backdropRef = useRef<HTMLDivElement>(null)
+  // Keyed by `${columnId}|${weekIdx}` so the open effect can focus the cell the user clicked
+  // without re-firing focus on every keystroke (which would yank focus back to the seeded cell).
+  const inputRefs = useRef<Map<string, HTMLInputElement>>(new Map())
+
+  useLayoutEffect(() => {
+    const backdrop = backdropRef.current
+    if (!backdrop) return
+    // The Modal primitive caps inner .modal at 544rem; widen it so the workweek×column grid
+    // (up to 6 columns + Type + Total) doesn't horizontally overflow.
+    const modalEl = backdrop.querySelector<HTMLElement>(':scope > div')
+    if (modalEl) modalEl.style.maxWidth = 'min(960px, 95vw)'
+    if (focusColumnId) {
+      const target = inputRefs.current.get(`${focusColumnId}|0`)
+      target?.focus()
+      target?.select()
+    }
+  }, [focusColumnId])
+
+  const focusedColumn = focusColumnId ? columns.find(c => c.id === focusColumnId) : undefined
+  const otherColumns = focusedColumn ? columns.filter(c => c.id !== focusedColumn.id) : columns
+  const primaryColumns = focusedColumn ? [focusedColumn] : []
+
+  const renderRow = (column: ColumnDef) => {
+    const sum = sumBreakdown(draftBreakdowns[column.id] ?? [])
+    const totalDisplay = formatCellValue(String(sum), column.kind)
+    const totalHasValue = totalDisplay !== ''
+    const totalCellClassName = [
+      styles.breakdownCell,
+      styles.breakdownTotalCell,
+      column.kind === 'currency' && totalHasValue ? styles.currencyHasValue : '',
+    ]
+      .filter(Boolean)
+      .join(' ')
+    return (
+      <div role="row" key={column.id} className={styles.breakdownRow}>
+        <div role="rowheader" className={`${styles.breakdownCell} ${styles.breakdownTypeCell}`}>
+          {column.label}
+        </div>
+        <div role="gridcell" className={totalCellClassName}>
+          <span className={styles.breakdownTotalValue}>
+            {totalHasValue
+              ? column.kind === 'currency'
+                ? `$${totalDisplay}`
+                : `${totalDisplay} ${column.kind === 'hours' ? 'hrs' : ''}`.trim()
+              : ''}
+          </span>
+        </div>
+        {workweeks.map((week, weekIdx) => {
+          const raw = draftBreakdowns[column.id]?.[weekIdx] ?? ''
+          const hasValue = raw !== '' && raw !== '0' && raw !== '0.0' && raw !== '0.00'
+          const cellClassName = [
+            styles.breakdownCell,
+            column.kind === 'currency' && hasValue ? styles.currencyHasValue : '',
+          ]
+            .filter(Boolean)
+            .join(' ')
+          const refKey = `${column.id}|${weekIdx}`
+          return (
+            <div
+              role="gridcell"
+              key={`${week.startDate}-${week.endDate}`}
+              className={cellClassName}
+            >
+              <label
+                className={styles.cellLabel}
+                aria-label={`${column.label} — Week ${weekIdx + 1}`}
+              >
+                {column.kind === 'currency' && <span className={styles.affix}>$</span>}
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  className={styles.cellInput}
+                  value={raw}
+                  ref={node => {
+                    if (node) inputRefs.current.set(refKey, node)
+                    else inputRefs.current.delete(refKey)
+                  }}
+                  onChange={e => {
+                    const next = e.target.value
+                    setDraftBreakdowns(prev => {
+                      const arr = prev[column.id] ?? []
+                      const updated = [...arr]
+                      updated[weekIdx] = next
+                      return { ...prev, [column.id]: updated }
+                    })
+                  }}
+                  onBlur={e => {
+                    const normalized = formatCellValue(e.target.value, column.kind)
+                    setDraftBreakdowns(prev => {
+                      const arr = prev[column.id] ?? []
+                      if ((arr[weekIdx] ?? '') === normalized) return prev
+                      const updated = [...arr]
+                      updated[weekIdx] = normalized
+                      return { ...prev, [column.id]: updated }
+                    })
+                  }}
+                  min={0}
+                  step={0.01}
+                />
+                {column.kind === 'hours' && <span className={styles.affix}>hrs</span>}
+              </label>
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+
+  const renderGrid = (cols: ColumnDef[]) => (
+    <div
+      role="grid"
+      className={styles.breakdownGrid}
+      style={{
+        gridTemplateColumns: `minmax(8rem, 12rem) minmax(6rem, 8rem) repeat(${workweeks.length}, minmax(9rem, 1fr))`,
+      }}
+    >
+      <div role="row" className={styles.breakdownHeaderRow}>
+        <div role="columnheader" className={styles.breakdownHeaderCell}>
+          Type
+        </div>
+        <div role="columnheader" className={styles.breakdownHeaderCell}>
+          Total
+        </div>
+        {workweeks.map((week, weekIdx) => {
+          const { startDate, endDate } = dateFormatter.formatPayPeriod(week.startDate, week.endDate)
+          return (
+            <div
+              role="columnheader"
+              key={`${week.startDate}-${week.endDate}`}
+              className={styles.breakdownHeaderCell}
+            >
+              Week {weekIdx + 1}: {startDate} – {endDate}
+            </div>
+          )
+        })}
+      </div>
+      {cols.map(renderRow)}
+    </div>
+  )
+
+  return (
+    <Components.Modal
+      isOpen
+      onClose={onClose}
+      shouldCloseOnBackdropClick
+      containerRef={backdropRef}
+      footer={
+        <Flex justifyContent="flex-end" gap={8}>
+          <Components.Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Components.Button>
+          <Components.Button
+            onClick={() => {
+              onSave(draftBreakdowns)
+            }}
+          >
+            Save
+          </Components.Button>
+        </Flex>
+      }
+    >
+      <Flex flexDirection="column" gap={24}>
+        <Flex flexDirection="column" gap={4}>
+          <Components.Heading as="h3" styledAs="h4">
+            Workweek breakdown for {employeeName}
+          </Components.Heading>
+          {payPeriod?.startDate && payPeriod.endDate && (
+            <Components.Text variant="supporting">
+              {(() => {
+                const { startDate, endDate } = dateFormatter.formatPayPeriod(
+                  payPeriod.startDate,
+                  payPeriod.endDate,
+                )
+                return `${startDate} – ${endDate}`
+              })()}
+            </Components.Text>
+          )}
+        </Flex>
+        {primaryColumns.length > 0 && renderGrid(primaryColumns)}
+        {otherColumns.length > 0 && (
+          <Components.Heading as="h4" styledAs="h5">
+            More hours and earnings
+          </Components.Heading>
+        )}
+        {otherColumns.length > 0 && renderGrid(otherColumns)}
+      </Flex>
+    </Components.Modal>
+  )
+}

--- a/sdk-app/src/design/components/payroll/PayrollSpreadsheet/PayrollSpreadsheet.module.scss
+++ b/sdk-app/src/design/components/payroll/PayrollSpreadsheet/PayrollSpreadsheet.module.scss
@@ -66,8 +66,12 @@
   gap: toRem(6);
 }
 
-.cell:not(.stickyLeft):not(.cellNa):not(.cellReadOnly) {
+.cell:not(.stickyLeft):not(.cellNa):not(.cellReadOnly):not(:has(.cellTrigger)) {
   cursor: text;
+}
+
+.cell:not(.stickyLeft):not(.cellNa):not(.cellReadOnly):has(.cellTrigger) {
+  cursor: pointer;
 }
 
 /* Row hover OR row has an active (focused) cell → all cells get accent background */
@@ -172,7 +176,9 @@
 }
 
 .cell:focus-within .affix,
-.cell.currencyHasValue .affix {
+.cell.currencyHasValue .affix,
+.breakdownCell:focus-within .affix,
+.breakdownCell.currencyHasValue .affix {
   visibility: visible;
 }
 
@@ -183,6 +189,7 @@
   outline: none;
   display: flex;
   align-items: center;
+  align-self: stretch;
   gap: toRem(6);
   flex: 1;
   margin: toRem(-8) toRem(-12);
@@ -195,6 +202,88 @@
 }
 
 .cellTriggerValue {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Workweek-breakdown spreadsheet, rendered inside the RRoP modal. Mirrors the main
+ * .grid aesthetic (cell borders, hover/focus outline, affix visibility) so the modal
+ * reads as a continuation of the parent spreadsheet. */
+.breakdownGrid {
+  display: grid;
+  width: 100%;
+  border: toRem(1) solid var(--g-colorBorderSecondary);
+  border-radius: toRem(6);
+  overflow: hidden;
+  font-variant-numeric: tabular-nums;
+}
+
+.breakdownHeaderRow,
+.breakdownRow {
+  display: contents;
+}
+
+.breakdownHeaderCell,
+.breakdownCell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: toRem(6);
+  padding: toRem(8) toRem(12);
+  border-bottom: toRem(1) solid var(--g-colorBorderSecondary);
+  border-right: toRem(1) solid var(--g-colorBorderSecondary);
+  min-height: toRem(44);
+  color: var(--g-colorBodyContent);
+  font-size: var(--g-fontSizeSmall);
+  background: var(--g-colorBody);
+}
+
+.breakdownHeaderCell {
+  font-weight: 600;
+  background: var(--g-colorBodyAccent);
+}
+
+.breakdownGrid > [role='row']:last-child > .breakdownCell,
+.breakdownGrid > [role='row']:last-child > .breakdownHeaderCell {
+  border-bottom: none;
+}
+
+.breakdownGrid [role='row'] > :last-child {
+  border-right: none;
+}
+
+.breakdownCell:not(.breakdownTypeCell):not(.breakdownTotalCell) {
+  cursor: text;
+}
+
+.breakdownRow:hover .breakdownCell,
+.breakdownRow:has(.breakdownCell:focus-within) .breakdownCell {
+  background: var(--g-colorBodyAccent);
+}
+
+.breakdownRow .breakdownCell:not(.breakdownTypeCell):not(.breakdownTotalCell):hover,
+.breakdownRow .breakdownCell:focus-within {
+  background: var(--g-colorBody);
+}
+
+.breakdownCell:not(.breakdownTypeCell):not(.breakdownTotalCell):hover,
+.breakdownCell:focus-within {
+  outline: toRem(2) solid var(--g-colorBodyContent);
+  outline-offset: toRem(-2);
+}
+
+.breakdownTypeCell {
+  font-weight: 600;
+  background: var(--g-colorBodyAccent);
+}
+
+.breakdownTotalCell {
+  cursor: default;
+  background: var(--g-colorBodyAccent);
+  font-variant-numeric: tabular-nums;
+}
+
+.breakdownTotalValue {
   flex: 1;
   min-width: 0;
 }

--- a/sdk-app/src/design/components/payroll/PayrollSpreadsheet/PayrollSpreadsheet.tsx
+++ b/sdk-app/src/design/components/payroll/PayrollSpreadsheet/PayrollSpreadsheet.tsx
@@ -9,13 +9,20 @@ import type { PayrollPayPeriodType } from '@gusto/embedded-api-v-2025-11-15/mode
 import type { PayrollEmployeeCompensationsType } from '@gusto/embedded-api-v-2025-11-15/models/components/payrollemployeecompensationstype'
 import type { PayScheduleShow as PayScheduleObject } from '@gusto/embedded-api-v-2025-11-15/models/components/payscheduleshow'
 import { Skeleton } from '../../common/Skeleton'
+import { BreakdownModal } from './BreakdownModal'
 import styles from './PayrollSpreadsheet.module.scss'
+import {
+  type ColumnDef,
+  type ColumnKind,
+  type Workweek,
+  formatCellValue,
+  sumBreakdown,
+} from './shared'
 import { firstLastName, formatNumberAsCurrency } from '@/helpers/formattedStrings'
-import { calculateGrossPay, formatHoursDisplay } from '@/components/Payroll/helpers'
+import { calculateGrossPay } from '@/components/Payroll/helpers'
 import type { PayrollCategory } from '@/components/Payroll/payrollTypes'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { DataView, EmptyData, Flex, Grid, useDataView } from '@/components/Common'
-import { useDateFormatter } from '@/hooks/useDateFormatter'
 import PlusCircleIcon from '@/assets/icons/plus-circle.svg?react'
 import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
 
@@ -35,14 +42,6 @@ function LockIcon({ className }: { className?: string }) {
       <path d="M7 11 V7 a5 5 0 0 1 10 0 V11" />
     </svg>
   )
-}
-
-type ColumnKind = 'hours' | 'currency' | 'reimbursements'
-
-interface ColumnDef {
-  id: string
-  label: string
-  kind: ColumnKind
 }
 
 const COLUMNS: ColumnDef[] = [
@@ -77,17 +76,6 @@ type CellKey = `${string}|${string}`
 
 function cellKey(employeeUuid: string, columnId: string): CellKey {
   return `${employeeUuid}|${columnId}`
-}
-
-/** Formats a stored cell value for the given column kind. Two decimals max, empty if zero/blank.
- *  Mirrors `formatHoursDisplay` (hours: integer → `40.0`, decimal → `40.25`) and
- *  `toFixed(2)` for currency (matches PayrollEditEmployee's amount submission). */
-function formatCellValue(raw: string, kind: ColumnKind): string {
-  if (raw === '') return ''
-  const num = Number(raw)
-  if (!Number.isFinite(num) || num === 0) return ''
-  if (kind === 'hours') return formatHoursDisplay(num)
-  return num.toFixed(2)
 }
 
 function getPrimaryJobFlsa(employee: Employee): string | undefined {
@@ -270,11 +258,6 @@ const RROP_BREAKDOWN_COLUMNS = new Set<string>([
  *  that employee. */
 const RROP_TRIGGER_COLUMNS = new Set<string>(['overtime', 'doubleOvertime'])
 
-interface Workweek {
-  startDate: string
-  endDate: string
-}
-
 /** Splits the pay period into consecutive 7-day workweeks anchored at startDate.
  *  Last week clamps to endDate. Returns [] if the pay period is missing or invalid. */
 function deriveWorkweeks(payPeriod: PayrollPayPeriodType | undefined): Workweek[] {
@@ -299,13 +282,6 @@ function toIsoDate(d: Date): string {
   const mm = String(d.getMonth() + 1).padStart(2, '0')
   const dd = String(d.getDate()).padStart(2, '0')
   return `${yyyy}-${mm}-${dd}`
-}
-
-function sumBreakdown(breakdown: string[]): number {
-  return breakdown.reduce((acc, v) => {
-    const n = Number(v)
-    return acc + (Number.isFinite(n) ? n : 0)
-  }, 0)
 }
 
 const SAVE_DEBOUNCE_MS = 600
@@ -398,7 +374,6 @@ export function PayrollSpreadsheet({
   payrollCategory,
 }: PayrollSpreadsheetProps) {
   const Components = useComponentContext()
-  const dateFormatter = useDateFormatter()
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const stickyHeaderRef = useRef<HTMLDivElement>(null)
   const [isHorizontallyScrolled, setIsHorizontallyScrolled] = useState(false)
@@ -418,11 +393,10 @@ export function PayrollSpreadsheet({
 
   const [openModal, setOpenModal] = useState<{
     employeeUuid: string
-    columnId: string
-    kind: ColumnKind
-    columnLabel: string
+    focusColumnId?: string
+    columns: ColumnDef[]
+    initialBreakdowns: Record<string, string[]>
   } | null>(null)
-  const [draftBreakdown, setDraftBreakdown] = useState<string[]>([])
 
   const [openReimbursementsModal, setOpenReimbursementsModal] = useState<{
     employeeUuid: string
@@ -593,40 +567,60 @@ export function PayrollSpreadsheet({
     flushSave(employeeUuid)
   }
 
-  const openBreakdownModal = (employeeUuid: string, column: ColumnDef) => {
+  // RRoP-included columns that apply to a given employee, in COLUMNS order.
+  const getModalColumns = (employeeUuid: string): ColumnDef[] => {
+    const applicability = applicabilityByEmployee.get(employeeUuid) ?? {}
+    return COLUMNS.filter(c => RROP_BREAKDOWN_COLUMNS.has(c.id) && applicability[c.id])
+  }
+
+  const seedDraftForColumn = (employeeUuid: string, column: ColumnDef): string[] => {
     const key = cellKey(employeeUuid, column.id)
     const existing = breakdowns[key]
-    const zero = column.kind === 'hours' ? '0.0' : '0.00'
     if (existing && existing.length === workweeks.length) {
-      setDraftBreakdown(existing)
-    } else {
-      // First open: seed Week 1 with the current total so the existing value isn't lost,
-      // and zero out the rest. Real API will eventually supply the per-workweek split.
-      const total = values[key] ?? ''
-      const seed = workweeks.map((_, idx) => (idx === 0 ? total || zero : zero))
-      setDraftBreakdown(seed)
+      // Existing entries may have been normalized to '0' on save; blank those so the
+      // modal matches the parent grid's "empty when zero" rule.
+      return existing.map(v => formatCellValue(v, column.kind))
+    }
+    // First open: seed Week 1 with the current total so the existing value isn't lost.
+    // Remaining weeks stay blank. Real API will eventually supply the per-workweek split.
+    const total = values[key] ?? ''
+    return workweeks.map((_, idx) => (idx === 0 ? total : ''))
+  }
+
+  const openBreakdownModal = (employeeUuid: string, focusColumn?: ColumnDef) => {
+    const modalColumns = getModalColumns(employeeUuid)
+    const initialBreakdowns: Record<string, string[]> = {}
+    for (const column of modalColumns) {
+      initialBreakdowns[column.id] = seedDraftForColumn(employeeUuid, column)
     }
     setOpenModal({
       employeeUuid,
-      columnId: column.id,
-      kind: column.kind,
-      columnLabel: column.label,
+      focusColumnId: focusColumn?.id,
+      columns: modalColumns,
+      initialBreakdowns,
     })
   }
 
   const closeBreakdownModal = () => {
     setOpenModal(null)
-    setDraftBreakdown([])
   }
 
-  const saveBreakdownModal = () => {
-    if (!openModal) return
-    const { employeeUuid, columnId, kind } = openModal
-    const key = cellKey(employeeUuid, columnId)
-    const normalized = draftBreakdown.map(v => (v === '' ? '0' : v))
-    const total = sumBreakdown(normalized)
-    setBreakdowns(prev => ({ ...prev, [key]: normalized }))
-    setValues(prev => ({ ...prev, [key]: formatCellValue(String(total), kind) }))
+  const commitBreakdowns = (
+    employeeUuid: string,
+    modalColumns: ColumnDef[],
+    drafts: Record<string, string[]>,
+  ) => {
+    const nextBreakdowns: Record<CellKey, string[]> = {}
+    const nextValues: Record<CellKey, string> = {}
+    for (const column of modalColumns) {
+      const draft = drafts[column.id] ?? []
+      const normalized = draft.map(v => (v === '' ? '0' : v))
+      const key = cellKey(employeeUuid, column.id)
+      nextBreakdowns[key] = normalized
+      nextValues[key] = formatCellValue(String(sumBreakdown(normalized)), column.kind)
+    }
+    setBreakdowns(prev => ({ ...prev, ...nextBreakdowns }))
+    setValues(prev => ({ ...prev, ...nextValues }))
     closeBreakdownModal()
     flushSave(employeeUuid)
   }
@@ -691,7 +685,6 @@ export function PayrollSpreadsheet({
           : ''
       })()
     : ''
-  const modalColumnLabel = openModal?.columnLabel ?? ''
 
   // Per-employee: does this row have a non-empty Overtime or Double overtime value?
   // When true, the other RRoP-included columns (regular hours, bonus, commission,
@@ -878,66 +871,18 @@ export function PayrollSpreadsheet({
       </div>
 
       {openModal && (
-        <Components.Modal
-          isOpen
+        <BreakdownModal
+          employeeName={modalEmployeeName}
+          payPeriod={payPeriod}
+          workweeks={workweeks}
+          columns={openModal.columns}
+          focusColumnId={openModal.focusColumnId}
+          initialBreakdowns={openModal.initialBreakdowns}
           onClose={closeBreakdownModal}
-          shouldCloseOnBackdropClick
-          footer={
-            <Flex justifyContent="flex-end" gap={8}>
-              <Components.Button variant="secondary" onClick={closeBreakdownModal}>
-                Cancel
-              </Components.Button>
-              <Components.Button onClick={saveBreakdownModal}>Save</Components.Button>
-            </Flex>
-          }
-        >
-          <Flex flexDirection="column" gap={24}>
-            <Flex flexDirection="column" gap={4}>
-              <Components.Heading as="h3" styledAs="h4">
-                {modalColumnLabel} breakdown for {modalEmployeeName}
-              </Components.Heading>
-              {payPeriod?.startDate && payPeriod.endDate && (
-                <Components.Text variant="supporting">
-                  Pay period:{' '}
-                  {(() => {
-                    const { startDate, endDate } = dateFormatter.formatPayPeriod(
-                      payPeriod.startDate,
-                      payPeriod.endDate,
-                    )
-                    return `${startDate} – ${endDate}`
-                  })()}
-                </Components.Text>
-              )}
-            </Flex>
-            <Flex flexDirection="column" gap={16}>
-              {workweeks.map((week, idx) => {
-                const { startDate, endDate } = dateFormatter.formatPayPeriod(
-                  week.startDate,
-                  week.endDate,
-                )
-                const isHours = openModal.kind === 'hours'
-                return (
-                  <Components.NumberInput
-                    key={`${week.startDate}-${week.endDate}`}
-                    label={`Week ${idx + 1}: ${startDate} – ${endDate}`}
-                    format={isHours ? 'decimal' : 'currency'}
-                    min={0}
-                    isRequired
-                    value={Number(draftBreakdown[idx] ?? '0') || 0}
-                    onChange={value => {
-                      setDraftBreakdown(prev => {
-                        const next = [...prev]
-                        next[idx] = Number.isFinite(value) ? String(value) : '0'
-                        return next
-                      })
-                    }}
-                    adornmentEnd={isHours ? <span>hrs</span> : undefined}
-                  />
-                )
-              })}
-            </Flex>
-          </Flex>
-        </Components.Modal>
+          onSave={drafts => {
+            commitBreakdowns(openModal.employeeUuid, openModal.columns, drafts)
+          }}
+        />
       )}
 
       {openReimbursementsModal && (

--- a/sdk-app/src/design/components/payroll/PayrollSpreadsheet/shared.ts
+++ b/sdk-app/src/design/components/payroll/PayrollSpreadsheet/shared.ts
@@ -1,0 +1,32 @@
+import { formatHoursDisplay } from '@/components/Payroll/helpers'
+
+export type ColumnKind = 'hours' | 'currency' | 'reimbursements'
+
+export interface ColumnDef {
+  id: string
+  label: string
+  kind: ColumnKind
+}
+
+export interface Workweek {
+  startDate: string
+  endDate: string
+}
+
+/** Formats a stored cell value for the given column kind. Two decimals max, empty if zero/blank.
+ *  Mirrors `formatHoursDisplay` (hours: integer → `40.0`, decimal → `40.25`) and
+ *  `toFixed(2)` for currency (matches PayrollEditEmployee's amount submission). */
+export function formatCellValue(raw: string, kind: ColumnKind): string {
+  if (raw === '') return ''
+  const num = Number(raw)
+  if (!Number.isFinite(num) || num === 0) return ''
+  if (kind === 'hours') return formatHoursDisplay(num)
+  return num.toFixed(2)
+}
+
+export function sumBreakdown(breakdown: string[]): number {
+  return breakdown.reduce((acc, v) => {
+    const n = Number(v)
+    return acc + (Number.isFinite(n) ? n : 0)
+  }, 0)
+}


### PR DESCRIPTION
## Summary

- Replaces the single-column, stacked-NumberInput workweek-split modal in PayrollSpreadsheet (RRoP mode) with a per-employee spreadsheet: Type | Total | Week N, with the clicked column on top and remaining applicable RRoP earnings under a *More hours and earnings* heading.
- Cells reuse the parent grid's aesthetic (affix visibility, focus outline, "empty when zero" rule); Total column auto-sums as you type.
- Modal lifted into its own `BreakdownModal` component; shared types/helpers (`ColumnDef`, `Workweek`, `formatCellValue`, `sumBreakdown`) extracted to `shared.ts`.
- Parent grid: clicks and the pointer cursor now reach edge-to-edge on RRoP-trigger and reimbursements cells (was previously only the inner button area).

## Test plan

- [ ] `npm run sdk-app` on :5200, open the PayrollSpreadsheet design prototype with `rrop=true` and a multi-week pay period
- [ ] Click an Overtime cell → modal opens with OT on top, focus on Week 1 / OT
- [ ] Enter values across both weeks; verify Total column updates live and `$` / `hrs` affixes only appear on focus or when a cell has a value
- [ ] Save → main grid cell shows the column sum; reopen the modal, splits are preserved
- [ ] With OT > 0, click any RRoP-included cell (regular hrs, bonus, …) → modal reopens showing that column on top and the rest under *More hours and earnings*
- [ ] Salaried employee with no hourly comps: only currency RRoP columns appear (regular hrs/OT/2×OT filtered out by applicability)
- [ ] Click anywhere within an RRoP-trigger cell (including the padding/edges) → modal opens; pointer cursor visible across the whole cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)