### PR TITLE
fix(docs-site): improve light-mode WCAG AA contrast

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -237,7 +237,37 @@ const config: Config = {
       copyright: `Copyright © ${new Date().getFullYear()} Gusto, Inc.`,
     },
     prism: {
-      theme: prismThemes.github,
+      theme: {
+        ...prismThemes.github,
+        styles: [
+          ...prismThemes.github.styles,
+          {
+            types: ['comment', 'prolog', 'doctype', 'cdata'],
+            style: { color: '#57606a', fontStyle: 'italic' },
+          },
+          { types: ['string', 'attr-value'], style: { color: '#b91c5c' } },
+          {
+            types: [
+              'entity',
+              'url',
+              'symbol',
+              'number',
+              'boolean',
+              'variable',
+              'constant',
+              'property',
+              'regex',
+              'inserted',
+            ],
+            style: { color: '#0a7b78' },
+          },
+          {
+            types: ['atrule', 'keyword', 'attr-name', 'selector'],
+            style: { color: '#0969da' },
+          },
+          { types: ['function', 'deleted', 'tag'], style: { color: '#cf222e' } },
+        ],
+      },
       darkTheme: prismThemes.nightOwl,
       additionalLanguages: ['bash', 'json', 'ruby', 'python', 'java'],
     },

--- a/docs-site/src/components/AuthFlowDiagram/styles.module.css
+++ b/docs-site/src/components/AuthFlowDiagram/styles.module.css
@@ -4,15 +4,7 @@
   align-items: stretch;
   gap: 0.5rem;
   margin: 2rem 0;
-  padding: 1.5rem;
-  background-color: var(--ifm-background-surface-color, #ffffff);
-  border: 1px solid var(--ifm-toc-border-color);
-  border-radius: 12px;
-}
-
-[data-theme='dark'] .diagram {
-  background-color: rgba(255, 255, 255, 0.02);
-  border-color: rgba(255, 255, 255, 0.08);
+  padding: 1.5rem 0;
 }
 
 .node {
@@ -47,7 +39,7 @@
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: rgba(27, 27, 29, 0.55);
+  color: rgba(27, 27, 29, 0.72);
 }
 
 [data-theme='dark'] .label {
@@ -86,7 +78,7 @@
 .connectorCaption {
   font-size: 0.7rem;
   font-weight: 500;
-  color: rgba(27, 27, 29, 0.55);
+  color: rgba(27, 27, 29, 0.72);
   white-space: nowrap;
 }
 

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -26,14 +26,14 @@ html {
   --ifm-navbar-height: 3.75rem;
   --ifm-navbar-search-input-background-color: rgba(27, 27, 29, 0.04);
   --ifm-navbar-search-input-color: #1b1b1d;
-  --ifm-navbar-search-input-placeholder-color: rgba(82, 88, 96, 0.7);
+  --ifm-navbar-search-input-placeholder-color: rgba(27, 27, 29, 0.72);
   --ifm-navbar-search-input-icon: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%23525860" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>');
 
   --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%23525860" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m6 15 6-6 6 6"/></svg>');
   --ifm-menu-link-sublist-icon-filter: none;
 
-  --ifm-link-color: #f15e49;
-  --ifm-link-hover-color: #d91f0c;
+  --ifm-link-color: #d91f0c;
+  --ifm-link-hover-color: #b71b0a;
   --ifm-breadcrumb-color-active: #f15e49;
 
   --ifm-toc-border-color: #ebedf0;
@@ -307,8 +307,12 @@ aside.theme-doc-sidebar-container {
 
 .menu__link--active:not(.menu__link--sublist) {
   background-color: transparent;
-  color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-darkest);
   font-weight: 500;
+}
+
+[data-theme='dark'] .menu__link--active:not(.menu__link--sublist) {
+  color: var(--ifm-color-primary);
 }
 
 .menu__list .menu__list .menu__link--active:not(.menu__link--sublist) {
@@ -395,12 +399,20 @@ aside.theme-doc-sidebar-container {
 }
 
 .menu__list-item-collapsible--active > .menu__link {
+  color: var(--ifm-color-primary-darkest);
+}
+
+[data-theme='dark'] .menu__list-item-collapsible--active > .menu__link {
   color: var(--ifm-color-primary);
 }
 
 .menu__list-item-collapsible > .menu__link--sublist.menu__link--active {
-  color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-darkest);
   font-weight: 500;
+}
+
+[data-theme='dark'] .menu__list-item-collapsible > .menu__link--sublist.menu__link--active {
+  color: var(--ifm-color-primary);
 }
 
 .menu__list .menu__list {
@@ -517,7 +529,7 @@ h2.theme-doc-card-heading {
   text-align: left;
   padding: 10px 32px 10px 0;
   border: none;
-  color: rgba(27, 27, 29, 0.6);
+  color: rgba(27, 27, 29, 0.75);
 }
 
 [data-theme='dark'] .markdown table th {
@@ -618,11 +630,19 @@ pre code,
 }
 
 .table-of-contents__link--active {
-  color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-darkest);
   font-weight: 500;
 }
 
+[data-theme='dark'] .table-of-contents__link--active {
+  color: var(--ifm-color-primary);
+}
+
 .table-of-contents__link:hover {
+  color: var(--ifm-color-primary-darkest);
+}
+
+[data-theme='dark'] .table-of-contents__link:hover {
   color: var(--ifm-color-primary);
 }
 
@@ -655,8 +675,12 @@ nav.theme-doc-breadcrumbs:not(:has(.breadcrumbs__item + .breadcrumbs__item)) {
 
 .breadcrumbs__item--active .breadcrumbs__link {
   background-color: transparent;
-  color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-darkest);
   font-weight: 600;
+}
+
+[data-theme='dark'] .breadcrumbs__item--active .breadcrumbs__link {
+  color: var(--ifm-color-primary);
 }
 
 [data-theme='dark'] .breadcrumbs__item--active .breadcrumbs__link {
@@ -712,7 +736,7 @@ nav.theme-doc-breadcrumbs:not(:has(.breadcrumbs__item + .breadcrumbs__item)) {
 
 .footer__copyright {
   font-size: 0.85rem;
-  color: rgba(27, 27, 29, 0.55);
+  color: rgba(27, 27, 29, 0.72);
 }
 
 [data-theme='dark'] .footer__copyright {

--- a/docs-site/src/pages/index.module.css
+++ b/docs-site/src/pages/index.module.css
@@ -429,7 +429,7 @@
   display: inline-flex;
   align-items: center;
   padding: 0.75rem 2rem;
-  background-color: #f15e49;
+  background-color: var(--ifm-color-primary-darkest);
   color: #ffffff;
   border-radius: 8px;
   font-weight: 600;
@@ -441,7 +441,7 @@
 }
 
 .heroPrimary:hover {
-  background-color: #f67660;
+  background-color: #b71b0a;
   color: #ffffff;
   text-decoration: none;
 }

--- a/docs-site/src/pages/index.module.css
+++ b/docs-site/src/pages/index.module.css
@@ -309,7 +309,7 @@
 .previewContinue {
   padding: 0.5rem 1.25rem;
   background: linear-gradient(135deg, #ff8266, #e15a43);
-  color: #ffffff;
+  color: #1b1b1d;
   border-radius: 6px;
   font-size: 0.85rem;
   font-weight: 600;
@@ -429,8 +429,8 @@
   display: inline-flex;
   align-items: center;
   padding: 0.75rem 2rem;
-  background-color: var(--ifm-color-primary-darkest);
-  color: #ffffff;
+  background-color: var(--ifm-color-primary);
+  color: #1b1b1d;
   border-radius: 8px;
   font-weight: 600;
   font-size: 1rem;
@@ -441,8 +441,8 @@
 }
 
 .heroPrimary:hover {
-  background-color: #b71b0a;
-  color: #ffffff;
+  background-color: #f67660;
+  color: #1b1b1d;
   text-decoration: none;
 }
 

--- a/docs-site/src/theme/MDXComponents/index.tsx
+++ b/docs-site/src/theme/MDXComponents/index.tsx
@@ -3,7 +3,7 @@ import MDXComponents from '@theme-original/MDXComponents'
 import DocCardList from '@theme/DocCardList'
 
 const Table = (props: ComponentProps<'table'>) => (
-  <div className="markdownTableWrapper">
+  <div className="markdownTableWrapper" tabIndex={0}>
     <table {...props} />
   </div>
 )


### PR DESCRIPTION
## Summary

Round of axe-reported WCAG 2 AA contrast fixes scoped to the docs site in **light mode**. Dark mode is left intact (most of these tokens are mode-correct on dark backgrounds already; where a dark fallback was needed, e.g. sidebar/TOC active states, an explicit `[data-theme='dark']` override keeps the brand coral).

### Contrast fixes

- **Navbar search trigger** — `--ifm-navbar-search-input-placeholder-color` darkened to `rgba(27, 27, 29, 0.72)` (~6.4:1 on the input bg).
- **Footer copyright** — alpha `0.55 → 0.72`, aligned with `.footer__link-item`.
- **Body prose links** — light-mode `--ifm-link-color`: `#f15e49 → #d91f0c` (~5.0:1 on white); hover token bumped to match.
- **TOC, sidebar, and breadcrumb active states** — swapped `var(--ifm-color-primary)` → `var(--ifm-color-primary-darkest)`, with `[data-theme='dark']` overrides reverting to brand coral on dark backgrounds.
- **Markdown table headers** — alpha `0.6 → 0.75` so plain `<th>` and `<th><code>` both clear AA.
- **Prism syntax tokens** (light theme) — appended override entries to `prismThemes.github` so the failing colors pick up:
  - `comment` `#999988 → #57606a`
  - `string` `#e3116c → #b91c5c`
  - `function/deleted/tag` `#d73a49 → #cf222e`
  - `atrule/keyword/attr-name/selector` `#00a4db → #0969da`
  - `property/number/symbol/...` `#36acaa → #0a7b78`
- **AuthFlowDiagram label / connector caption** — alpha `0.55 → 0.72`.

### Other docs-site adjustments

- `markdownTableWrapper` is now `tabIndex={0}` so Safari users can keyboard-scroll wide tables.
- AuthFlowDiagram chrome simplified: dropped the surrounding panel border, background, and border-radius; kept vertical padding only.

## Test plan

- [ ] Run the dev server (`docs-site`) and confirm light-mode visuals on the homepage, a docs page (sidebar/TOC/breadcrumb active states), a docs page with markdown tables, and a page that embeds `<AuthFlowDiagram />`.
- [ ] Re-run the axe / WAVE check on the pages above in light mode — the issues listed should clear.
- [ ] Toggle to dark mode and confirm: nav/TOC/breadcrumb active states render with the brand coral, code blocks still use nightOwl, AuthFlowDiagram chrome reads as expected without the prior border/background.
- [ ] Keyboard-tab through a markdown table on Safari and verify the wrapper accepts focus and arrow-key scrolling.