### PR TITLE
docs(skills): align hook skills on autogenerated docs and current conventions

### DIFF
--- a/.claude/commands/create-hook.md
+++ b/.claude/commands/create-hook.md
@@ -18,7 +18,7 @@ For the rest of this doc, `{Domain}` is the entity name (e.g. `EmployeeDetails`,
 
 Hooks live in their feature module's `shared/` directory, one directory per hook:
 
-```
+```text
 src/components/{Domain}/{Feature}/shared/use{Name}Form/
 ├── use{Name}Form.tsx        # Main hook
 ├── {camelDomain}Schema.ts   # Zod schema, error codes, form data/output types
@@ -136,7 +136,11 @@ export function create{Domain}Schema(options: {Domain}SchemaOptions = {}) {
     requiredErrorCode: {Domain}ErrorCodes.REQUIRED,
     mode,
     optionalFieldsToRequire,
-    // excludeFields: withFooField ? [] : ['foo'],
+    // excludeFields: withFooField ? [] : ['foo'],   // static, build-time field removal
+    // excludeFields: (data, mode) => (data.type === 'Business' ? ['ssn'] : ['ein']),
+    //   ^ value-aware form: applicability is decided per validation pass from the
+    //     current form values — use it for fields rendered conditionally on a
+    //     discriminator (see .claude/hooks-implementation.md → excludeFields)
     // fieldsWithRedactedValues: hasRedactedFoo ? ['foo'] : [],
     // superRefine: (data, ctx) => { /* cross-field rules */ },
   })
@@ -361,7 +365,7 @@ export type {Domain}FieldsMetadata = Use{Domain}FormReady['form']['fieldsMetadat
 
 #### `index.ts`
 
-Re-export the hook, the schema factory + error codes, and every field-prop type. Rename `RequiredValidation` to `{Domain}RequiredValidation` so it doesn't collide when partners import multiple hooks.
+Re-export the hook, error codes, and every field-prop type. The schema factory (`create{Domain}Schema`) is `@internal`; the inner barrel may carry it for SDK use, but it must **not** be promoted to `src/index.ts` (see Step 4). Rename `RequiredValidation` to `{Domain}RequiredValidation` so it doesn't collide when partners import multiple hooks.
 
 ```typescript
 export { use{Domain}Form } from './use{Domain}Form'
@@ -376,7 +380,7 @@ export type {
   {Domain}FormFields,
 } from './use{Domain}Form'
 export {
-  create{Domain}Schema,
+  create{Domain}Schema, // @internal — for SDK use only; do NOT re-export from src/index.ts
   {Domain}ErrorCodes,
   type {Domain}ErrorCode,
   type {Domain}FormData,
@@ -406,7 +410,6 @@ Add the new hook to barrels in this order:
    export {
      use{Domain}Form,
      {Domain}ErrorCodes,
-     create{Domain}Schema,
    } from '@/components/{Domain}/{Feature}/shared/use{Name}Form'
    export type {
      {Domain}SubmitOptions,
@@ -421,7 +424,7 @@ Add the new hook to barrels in this order:
    } from '@/components/{Domain}/{Feature}/shared/use{Name}Form'
    ```
 
-   Public surface checklist: hook function, error-codes constant, schema factory, ready/result/fields-metadata types, optional-fields-to-require type, every per-field props type, validation-type aliases, and submit-options/callbacks types if defined. Keep `buildFormSchema`, `useDeriveFieldsMetadata`, `withOptions`, `composeErrorHandler`, and other SDK-internal utilities **off** the public barrel — see `.claude/hooks-implementation.md → Exports Checklist`.
+   Public surface checklist: hook function, error-codes constant, ready/result/fields-metadata types, optional-fields-to-require type, every per-field props type, validation-type aliases, and submit-options/callbacks types if defined. Do **not** export the schema factory: `create{Domain}Schema` and `{Domain}SchemaOptions` are `@internal` — exporting them from `src/index.ts` makes api-extractor emit an `ae-internal-missing-underscore` warning, and partners build forms through the hook, not the raw factory. Keep them, along with `buildFormSchema`, `useDeriveFieldsMetadata`, `withOptions`, `composeErrorHandler`, and other SDK-internal utilities, **off** the public barrel — see `.claude/hooks-implementation.md → Exports Checklist`.
 
 ### Step 5: Verify
 
@@ -438,9 +441,8 @@ Hooks must not own translations: do **not** call `useTranslation` or `t()` insid
 
 ### Step 6: Document the hook
 
-Two doc updates are required for every public partner hook (skip when the hook is intentionally internal-only):
+Document the public surface with **inline TSDoc** and let the reference docs autogenerate. Do **not** hand-write a `docs/hooks/use{Name}Form.md` page or hand-maintain a `docs/hooks/hooks.md` row — the partner-facing reference is generated from the TSDoc, so the inline comments are the single source of truth.
 
-1. Add a row to the inventory table in `docs/hooks/hooks.md`.
-2. Create `docs/hooks/use{Name}Form.md` following the structure of `docs/hooks/useEmployeeDetailsForm.md` and `docs/hooks/useCompensationForm.md` — frontmatter, props table, return type blocks, fields reference, and both `SDKFormProvider` and `formHookResult`-prop usage examples.
+Run `/tsdoc` once the hook compiles and tests pass. It loads `.claude/tsdoc-guides/hooks.md` and writes TSDoc directly onto the exported symbols: `use{Name}Form`, `Use{Domain}FormProps`, the ready/result/outputs types, the `{Domain}ErrorCodes` constant, every per-field component, and every field-prop type. Keep `create{Domain}Schema`, `{Domain}SchemaOptions`, and other factory/internal symbols `@internal` (see Step 4) so the generator leaves them out of the reference.
 
-See `.claude/skills/migrate-sdk-component-to-hooks/SKILL.md → 11. Documentation` for the required sections and styling conventions.
+See `.claude/skills/migrate-sdk-component-to-hooks/SKILL.md → 11. Documentation`.

--- a/.claude/hooks-implementation.md
+++ b/.claude/hooks-implementation.md
@@ -9,7 +9,7 @@ Reference implementations:
 
 Each hook lives in its own folder following the feature module pattern: `src/components/{Domain}/{Feature}/shared/use{Name}Form/`
 
-```
+```text
 src/components/{Domain}/{Feature}/shared/use{Name}Form/
 ├── use{Name}Form.tsx        # Main hook: data fetching, form setup, return shape
 ├── {domain}Schema.ts        # Zod schema, error codes, form data/output types
@@ -146,14 +146,24 @@ useCompensationForm({
 
 ### When to Use `superRefine` vs. `requiredFieldsConfig` vs. `optionalFieldsToRequire`
 
-| Technique                           | When to use                                                           | Example                             | Metadata-aware?                                    |
-| ----------------------------------- | --------------------------------------------------------------------- | ----------------------------------- | -------------------------------------------------- |
-| `requiredFieldsConfig` rule         | Declarative field-level requiredness                                  | `jobTitle: 'create'`                | Yes                                                |
-| `optionalFieldsToRequire` (partner) | Partner promotes optional field to required                           | `{ create: ['jobTitle'] }`          | Yes                                                |
-| `excludeFields`                     | Field conditionally absent from schema                                | `excludeFields: ['startDate']`      | Yes (field absent)                                 |
-| `fieldsWithRedactedValues`          | Field has a stored server-side value redacted in the API response     | `fieldsWithRedactedValues: ['ssn']` | Yes (`hasRedactedValue: true`, keeps `isRequired`) |
-| Predicate rule                      | Requiredness depends on runtime form values                           | `data => data.adjustForMinimumWage` | Yes (via Proxy auto-detection)                     |
-| `superRefine`                       | Cross-field validation logic (rate thresholds, cascading constraints) | FLSA + rate + paymentUnit rules     | No — validation only                               |
+| Technique                           | When to use                                                           | Example                                                                         | Metadata-aware?                                    |
+| ----------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `requiredFieldsConfig` rule         | Declarative field-level requiredness                                  | `jobTitle: 'create'`                                                            | Yes                                                |
+| `optionalFieldsToRequire` (partner) | Partner promotes optional field to required                           | `{ create: ['jobTitle'] }`                                                      | Yes                                                |
+| `excludeFields` (array)             | Field statically absent from schema for a hook configuration          | `excludeFields: ['startDate']`                                                  | Yes (field absent)                                 |
+| `excludeFields` (function)          | Field applicability depends on runtime form values (conditional UI)   | `excludeFields: (data, mode) => (data.type === 'Business' ? ['ssn'] : ['ein'])` | Yes (skipped while excluded)                       |
+| `fieldsWithRedactedValues`          | Field has a stored server-side value redacted in the API response     | `fieldsWithRedactedValues: ['ssn']`                                             | Yes (`hasRedactedValue: true`, keeps `isRequired`) |
+| Predicate rule                      | Requiredness depends on runtime form values                           | `data => data.adjustForMinimumWage`                                             | Yes (via Proxy auto-detection)                     |
+| `superRefine`                       | Cross-field validation logic (rate thresholds, cascading constraints) | FLSA + rate + paymentUnit rules                                                 | No — validation only                               |
+
+### Value-aware `excludeFields`
+
+`excludeFields` accepts either form:
+
+- **Array** — `excludeFields: ['startDate']` removes the field from the schema shape at build time. Use it when a field is statically absent for a given hook configuration (e.g. a `withStartDateField` flag).
+- **Function** — `excludeFields: (data, mode) => string[]` is evaluated during the required-check pass with the current form values. The named fields stay in the schema shape, but their requiredness checks are skipped whenever the function excludes them. Use it for fields rendered conditionally on a discriminator (individual vs. business contractor, hourly vs. fixed wage, a self-onboarding toggle) so a hidden field never raises a phantom "required" error.
+
+The function form keeps requiredness **static and promotable**: `requiredFieldsConfig` and the partner's `optionalFieldsToRequire` still decide whether an _applicable_ field is required, while `excludeFields` only gates _applicability_. Build the schema once (no need to rebuild it per keystroke), and drive the component's render-gating from the same discriminators the function reads — the hook watches them with `useWatch` — so the UI and validation always agree on which fields are live. See `createContractorDetailsSchema` / `useContractorDetailsForm` for the canonical example.
 
 ### `z.preprocess` and Type Inference
 
@@ -407,6 +417,8 @@ Reference `gws-flows/app/frontend/react_sdk/CustomCompensationForm.tsx` as the r
 
 Infrastructure utilities like `buildFormSchema`, `useDeriveFieldsMetadata`, `deriveFieldsMetadata`, `withOptions`, `FormFieldsMetadataProvider`, `composeErrorHandler`, `collectErrors`, generic `*HookField` components, and base types like `HookFormInternals`, `BaseFormHookReady` are used by the SDK to build hooks — not by partners. Only promote to the public barrel if a partner use case demands it.
 
+The schema factory `create{Domain}Schema` and its `{Domain}SchemaOptions` are also `@internal`. The inner hook barrel may re-export them for SDK use, but **do not** add them to `src/index.ts`: they are tagged `@internal`, so api-extractor emits an `ae-internal-missing-underscore` warning when they appear on the public entry point. Partners build forms through the hook, not the raw factory — `{Domain}FormData` / `{Domain}FormOutputs` cover the types they actually need.
+
 Do NOT re-export `@gusto/embedded-api` entity types directly — partners derive them from field prop generics (e.g. `NonNullable<FlsaStatusFieldProps['getOptionLabel']>` infers the entity type).
 
 ## 7. Validation Parity with Stable Components
@@ -454,6 +466,7 @@ The `gws-flows` repo has side-by-side comparison pages that render the stable co
 Use Playwright's `page.route()` to intercept and capture PUT/POST request bodies from each form column, then diff them:
 
 1. Install route interception via `browser_run_code`:
+
    ```javascript
    page.__capturedBodies = []
    await page.route('**/fe_sdk/**', async route => {
@@ -468,6 +481,7 @@ Use Playwright's `page.route()` to intercept and capture PUT/POST request bodies
      await route.continue()
    })
    ```
+
 2. Submit each form column, reading captured bodies between submissions
 3. Compare request URLs, methods, and JSON bodies across columns
 

--- a/.claude/skills/migrate-sdk-component-to-hooks/SKILL.md
+++ b/.claude/skills/migrate-sdk-component-to-hooks/SKILL.md
@@ -79,6 +79,34 @@ function MyComponentRoot({ onEvent, ...hookProps }: MyComponentProps) {
 }
 ```
 
+#### Props: extend `BaseComponentInterface`, never intersect with `&`
+
+A public component's props **interface** carries the base surface by extending `BaseComponentInterface<'Domain.MyComponent'>` (which itself extends `CommonComponentInterface`, providing `onEvent`, `children`, `className`, `dictionary`, `FallbackComponent`, and `LoaderComponent`). The exported function is typed with that single interface:
+
+```tsx
+export interface MyComponentProps extends BaseComponentInterface<'Domain.MyComponent'> {
+  employeeId?: string
+  // ...other inputs this component accepts
+}
+
+export function MyComponent(props: MyComponentProps) {
+  /* ... */
+}
+```
+
+Do **not** intersect the base into the function signature:
+
+```tsx
+// ❌ flagged in PR #2276 — breaks the generated docs
+export function MyComponent(props: MyComponentProps & BaseComponentInterface) {
+  /* ... */
+}
+```
+
+`&` at the signature makes the docs generator inline the entire `BaseComponentInterface<…full resource-key union…>` into the `props` row, blowing up the generated reference table. `extends` instead renders the base props as the clean _"Inherits … from BaseComponentInterface"_ line.
+
+If an internal/presentational child needs the props **without** the base-only fields, derive them with `Omit<MyComponentProps, BaseComponentKeys>` — don't strip the base off the public interface to build the child's type. (When the entry-point example above extends `UseMyFormProps`, extend `BaseComponentInterface<'Domain.MyComponent'>` alongside it to pick up `onEvent` and friends, rather than re-declaring them by hand.)
+
 `BaseBoundaries` provides:
 
 - `QueryErrorResetBoundary` — resets React Query errors on retry
@@ -386,6 +414,8 @@ const HomeAddressFields = homeAddress.form.Fields
 ```
 
 If you find yourself manually gating visibility based on another field's value, that logic almost certainly belongs inside the hook's schema or `Fields` selection. Move it there instead of reproducing it per-component.
+
+For fields whose applicability depends on another field's value (individual vs. business contractor, hourly vs. fixed wage, a self-onboarding toggle), the hook's schema gates them with a **value-aware `excludeFields` function** — `excludeFields: (data, mode) => string[]` — so requiredness checks are skipped while a field is inapplicable, and the hook returns that field as `undefined` on `form.Fields`. The component just renders whatever `Fields` exposes; it never re-derives the condition. See `.claude/hooks-implementation.md → Value-aware excludeFields` and `useContractorDetailsForm` for the canonical example.
 
 ### Validation Messages
 


### PR DESCRIPTION
## Summary

Follow-up to the `useContractorDetailsForm` stack (#2275 / #2276). Updates the Claude hook skills so they teach the conventions we actually landed on, instead of the now-stale guidance that produced friction during that migration.

Touches three internal docs:
- `.claude/commands/create-hook.md`
- `.claude/hooks-implementation.md`
- `.claude/skills/migrate-sdk-component-to-hooks/SKILL.md`

## Changes

- **Docs are autogenerated, not hand-written.** `create-hook.md` Step 6 no longer tells you to hand-write `docs/hooks/use{Name}Form.md` (or hand-maintain the `hooks.md` row). It now points at `/tsdoc` for inline TSDoc — the single source of truth for the autogenerated partner reference — matching the migrate skill's §11.
- **Schema factory stays `@internal`.** Dropped `create{Domain}Schema` / `{Domain}SchemaOptions` from the public `src/index.ts` export recommendation and checklist. They're tagged `@internal`, so promoting them makes api-extractor emit `ae-internal-missing-underscore`. The inner barrel may carry the factory for SDK use, annotated to keep it off the public entry point.
- **Component props: `extends`, not `&`.** Added a rec to the migrate skill: a public component's props interface should `extends BaseComponentInterface<'Domain.Component'>` and the function should be typed `(props: XxxProps)`. Intersecting `& BaseComponentInterface` at the signature inlines the entire resource-key union into the generated docs table (flagged on #2276). Internal children that need props without the base fields use `Omit<XxxProps, BaseComponentKeys>`.
- **Value-aware `excludeFields`.** Documented (in `hooks-implementation.md` + migrate skill, with a pointer from `create-hook.md`) that `buildFormSchema`'s `excludeFields` accepts a `(data, mode) => fields` function for fields whose applicability depends on runtime form values — keeping requiredness static and promotable via `optionalFieldsToRequire`.
- Fixed a few pre-existing markdownlint errors in the touched files (`.claude/*.md` is only linted when staged).

## Note on "generate docs"

The merged `useContractorDetailsForm` hook already carries complete, lint-clean inline TSDoc (verified: `eslint` reports zero TSDoc-coverage violations across the hook directory), so there was no doc-generation diff to ship — only these forward-looking skill corrections.

## Test plan

- [x] `markdownlint-cli2` clean on the three files
- [x] pre-commit hooks (markdownlint + cspell + commitlint) pass
- [ ] Skim the rendered diffs for tone/accuracy

Made with [Cursor](https://cursor.com)