### PR TITLE
fix(docs-site): clean up breadcrumb hover state

### DIFF
--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -673,6 +673,17 @@ nav.theme-doc-breadcrumbs:not(:has(.breadcrumbs__item + .breadcrumbs__item)) {
   font-size: 0.8rem;
 }
 
+.breadcrumbs__item:not(.breadcrumbs__item--active) .breadcrumbs__link:any-link:hover {
+  background-color: transparent;
+  color: var(--ifm-color-primary-darkest);
+}
+
+[data-theme='dark']
+  .breadcrumbs__item:not(.breadcrumbs__item--active)
+  .breadcrumbs__link:any-link:hover {
+  color: var(--ifm-color-primary);
+}
+
 .breadcrumbs__item--active .breadcrumbs__link {
   background-color: transparent;
   color: var(--ifm-color-primary-darkest);


### PR DESCRIPTION
## Summary

The breadcrumb hover state was rendering as a fully-rounded gray chip — Infima's default applies `background: var(--ifm-breadcrumb-item-background-active)` paired with `border-radius: 1.5rem`, and we never overrode it. With the rest of the site moving toward minimal text-only nav treatments, the floating chip read as disconnected from the active state (which we already de-chipped).

Replace the chip with a color-only hover that previews the active treatment:
- Background dropped on hover for non-active breadcrumb items
- Color shifts to `--ifm-color-primary-darkest` (light) / `--ifm-color-primary` (dark), matching the active item's coral

Selector uses `:any-link` to match Infima's specificity — no `!important` needed.

## Test plan

- [ ] Open a docs page with multiple breadcrumb segments, hover the non-active items in light and dark mode, and confirm the gray chip is gone and the text shifts to the active coral.
- [ ] Confirm the active (last) breadcrumb item is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)