### PR TITLE
fix(Employee.EmploymentEligibility): remove stray apostrophe in noncitizen description

### DIFF
--- a/src/i18n/en/Employee.EmploymentEligibility.json
+++ b/src/i18n/en/Employee.EmploymentEligibility.json
@@ -15,7 +15,7 @@
   "statusDescriptions": {
     "citizen": "A citizen is someone who was born or naturalized in the U.S. or born abroad to U.S. citizen parent(s) or who has derived citizenship through a parent's naturalization based on legal requirements.",
     "permanent_resident": "A lawful permanent resident is someone who is not a US citizen and who resides under legally recognized and lawfully recorded permanent residence as an immigrant.",
-    "noncitizen": "A noncitizen national is someone born in American Samoa, certain former citizens of the 'former Trust Territory of the Pacific Islands, and certain children of noncitizen nationals born abroad.",
+    "noncitizen": "A noncitizen national is someone born in American Samoa, certain former citizens of the former Trust Territory of the Pacific Islands, and certain children of noncitizen nationals born abroad.",
     "alien": "A noncitizen authorized to work includes anyone who is authorized to work in the United States but is not a US citizen, US national or lawful permanent resident."
   },
   "expirationDate": {


### PR DESCRIPTION
## Summary
- Removes a stray apostrophe in the `noncitizen` status description (`'former Trust Territory` → `former Trust Territory`).

## Test plan
- [ ] Verify the corrected copy renders in the EmploymentEligibility status descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)