### PR TITLE
feat: expand const-derived reference types; export SDKErrorCategories

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -4948,8 +4948,14 @@ export interface SDKError {
     raw?: unknown;
 }
 
-// Warning: (ae-forgotten-export) The symbol "SDKErrorCategories" needs to be exported by the entry point index.d.ts
-//
+// @public
+export const SDKErrorCategories: {
+    readonly API_ERROR: "api_error";
+    readonly VALIDATION_ERROR: "validation_error";
+    readonly NETWORK_ERROR: "network_error";
+    readonly INTERNAL_ERROR: "internal_error";
+};
+
 // @public
 export type SDKErrorCategory = (typeof SDKErrorCategories)[keyof typeof SDKErrorCategories];
 

--- a/docs-site/plugins/typedoc-custom/index.ts
+++ b/docs-site/plugins/typedoc-custom/index.ts
@@ -14,5 +14,7 @@ export function load(app: MarkdownApplication): void {
   app.converter.on(Converter.EVENT_RESOLVE_BEGIN, SDKTheme.protectPropsInterfaces, 100)
   app.converter.on(Converter.EVENT_RESOLVE_BEGIN, SDKRouter.reparentDeprecated, 50)
   app.converter.on(Converter.EVENT_RESOLVE_END, SDKRouter.stampGroupTags, 0)
+  app.converter.on(Converter.EVENT_RESOLVE_END, SDKTheme.expandConstDerivedAliases, -100)
+  app.converter.on(Converter.EVENT_RESOLVE_END, SDKTheme.dropRedundantConstDefaults, -100)
   app.converter.on(Converter.EVENT_RESOLVE_END, SDKTheme.removePropsFromGroups, -200)
 }

--- a/docs-site/plugins/typedoc-custom/sdk-router.test.ts
+++ b/docs-site/plugins/typedoc-custom/sdk-router.test.ts
@@ -4,18 +4,29 @@ import {
   Comment,
   CommentTag,
   DeclarationReflection,
+  IndexedAccessType,
+  IntrinsicType,
+  LiteralType,
   ParameterReflection,
   ProjectReflection,
+  QueryType,
   ReferenceReflection,
   ReferenceType,
   ReflectionGroup,
   ReflectionKind,
   SignatureReflection,
   SourceReference,
+  TypeOperatorType,
+  UnionType,
   FileRegistry,
 } from 'typedoc'
 import { MarkdownPageEvent } from 'typedoc-plugin-markdown'
 import { SDKRouter } from './router'
+import {
+  defaultValueRestatesLiteralType,
+  documentedUnderlyingConst,
+  isOpaqueConstDerivedType,
+} from './theme'
 import {
   componentPropsInterfaces,
   domainFromSources,
@@ -1486,5 +1497,122 @@ describe('serializeFrontmatter', () => {
   it('serializes custom_edit_url: null as null', () => {
     const result = serializeFrontmatter(sample)
     expect(result).toContain('custom_edit_url: null')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isOpaqueConstDerivedType (gate for expandConstDerivedAliases)
+// ---------------------------------------------------------------------------
+
+describe('isOpaqueConstDerivedType', () => {
+  const project = makeProject()
+  const constRef = ReferenceType.createResolvedReference(
+    'fieldValidators',
+    makeChild(project, 'fieldValidators', ReflectionKind.Variable),
+    project,
+  )
+
+  it('matches `keyof typeof <const>`', () => {
+    expect(isOpaqueConstDerivedType(new TypeOperatorType(new QueryType(constRef), 'keyof'))).toBe(
+      true,
+    )
+  })
+
+  it('matches indexed access (`typeof <const>[…]`)', () => {
+    const indexed = new IndexedAccessType(
+      new QueryType(constRef),
+      new TypeOperatorType(new QueryType(constRef), 'keyof'),
+    )
+    expect(isOpaqueConstDerivedType(indexed)).toBe(true)
+  })
+
+  it('matches a bare `typeof <const>` query', () => {
+    expect(isOpaqueConstDerivedType(new QueryType(constRef))).toBe(true)
+  })
+
+  it('leaves non-keyof type operators (e.g. `readonly`) untouched', () => {
+    expect(
+      isOpaqueConstDerivedType(new TypeOperatorType(new IntrinsicType('string'), 'readonly')),
+    ).toBe(false)
+  })
+
+  it('leaves already-resolved unions and literals untouched', () => {
+    expect(
+      isOpaqueConstDerivedType(new UnionType([new LiteralType('a'), new LiteralType('b')])),
+    ).toBe(false)
+    expect(isOpaqueConstDerivedType(new LiteralType('a'))).toBe(false)
+    expect(isOpaqueConstDerivedType(new IntrinsicType('string'))).toBe(false)
+    expect(isOpaqueConstDerivedType(undefined)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// documentedUnderlyingConst (keeps large documented-const unions as links)
+// ---------------------------------------------------------------------------
+
+describe('documentedUnderlyingConst', () => {
+  const project = makeProject()
+  const constReflection = makeChild(project, 'componentEvents', ReflectionKind.Variable)
+  const resolved = new QueryType(
+    ReferenceType.createResolvedReference('componentEvents', constReflection, project),
+  )
+  const broken = new QueryType(
+    ReferenceType.createBrokenReference('fieldValidators', project, undefined),
+  )
+
+  it('resolves the const behind `keyof typeof <documented const>`', () => {
+    expect(documentedUnderlyingConst(new TypeOperatorType(resolved, 'keyof'))).toBe(constReflection)
+  })
+
+  it('resolves the const behind an indexed access', () => {
+    const indexed = new IndexedAccessType(resolved, new TypeOperatorType(resolved, 'keyof'))
+    expect(documentedUnderlyingConst(indexed)).toBe(constReflection)
+  })
+
+  it('returns null when the underlying const has no reflection (unexported)', () => {
+    expect(documentedUnderlyingConst(new TypeOperatorType(broken, 'keyof'))).toBeNull()
+    expect(documentedUnderlyingConst(broken)).toBeNull()
+  })
+
+  it('returns null for non-const-derived types', () => {
+    expect(documentedUnderlyingConst(new LiteralType('a'))).toBeNull()
+    expect(documentedUnderlyingConst(undefined)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// defaultValueRestatesLiteralType (drops redundant `as const` default column)
+// ---------------------------------------------------------------------------
+
+describe('defaultValueRestatesLiteralType', () => {
+  function member(type: LiteralType | undefined, defaultValue: string | undefined) {
+    const r = new DeclarationReflection('API_ERROR', ReflectionKind.Property)
+    if (type) r.type = type
+    r.defaultValue = defaultValue
+    return r
+  }
+
+  it('is true when a string default restates its literal type', () => {
+    expect(
+      defaultValueRestatesLiteralType(member(new LiteralType('api_error'), "'api_error'")),
+    ).toBe(true)
+  })
+
+  it('is true for numeric and boolean literal restatements', () => {
+    expect(defaultValueRestatesLiteralType(member(new LiteralType(42), '42'))).toBe(true)
+    expect(defaultValueRestatesLiteralType(member(new LiteralType(true), 'true'))).toBe(true)
+  })
+
+  it('is false when the default differs from the literal type', () => {
+    expect(defaultValueRestatesLiteralType(member(new LiteralType('api_error'), "'other'"))).toBe(
+      false,
+    )
+  })
+
+  it('is false when there is no default or the type is not a literal', () => {
+    expect(defaultValueRestatesLiteralType(member(new LiteralType('api_error'), undefined))).toBe(
+      false,
+    )
+    expect(defaultValueRestatesLiteralType(member(undefined, "'api_error'"))).toBe(false)
   })
 })

--- a/docs-site/plugins/typedoc-custom/theme.ts
+++ b/docs-site/plugins/typedoc-custom/theme.ts
@@ -20,6 +20,7 @@ import {
   TypeOperatorType,
   UnionType,
 } from 'typedoc'
+import type * as ts from 'typescript'
 import { MarkdownPageEvent, MarkdownTheme, MarkdownThemeContext } from 'typedoc-plugin-markdown'
 import {
   componentPropsInterfaces,
@@ -1109,6 +1110,69 @@ function fieldPropsReflection(type: SomeType | undefined): DeclarationReflection
 }
 
 /**
+ * Whether an alias's type is an opaque const-derived expression — `keyof typeof
+ * <const>`, an indexed access (`typeof <const>[…]`, `(typeof <const>)[number]`),
+ * or a bare `typeof <const>` query. These render as an unresolvable reference to
+ * a (usually module-internal, unexported) const rather than useful text, and are
+ * the only aliases {@link SDKTheme.expandConstDerivedAliases} rewrites.
+ */
+export function isOpaqueConstDerivedType(type: SomeType | undefined): boolean {
+  return (
+    (type instanceof TypeOperatorType && type.operator === 'keyof') ||
+    type instanceof IndexedAccessType ||
+    type instanceof QueryType
+  )
+}
+
+/**
+ * The const a `keyof typeof <const>` / `typeof <const>[…]` / `typeof <const>`
+ * alias reads from, but only when that const is itself a documented reflection —
+ * in which case the opaque form already renders as a useful link and a large
+ * expansion would just be a wall of literals. Returns `null` when the const is
+ * unexported/undocumented (a dead reference worth expanding regardless of size).
+ */
+export function documentedUnderlyingConst(
+  type: SomeType | undefined,
+): DeclarationReflection | null {
+  let query: SomeType | undefined
+  if (type instanceof TypeOperatorType && type.operator === 'keyof') query = type.target
+  else if (type instanceof IndexedAccessType) query = type.objectType
+  else if (type instanceof QueryType) query = type
+  if (!(query instanceof QueryType)) return null
+  const reflection = query.queryType.reflection
+  return reflection instanceof DeclarationReflection ? reflection : null
+}
+
+/** Above this member count, a documented-const union stays a link, not a wall of literals. */
+const MAX_INLINE_LITERALS = 12
+
+/**
+ * The string-literal members of a resolved TS type, or `null` if the type is not
+ * a union (or single) of string literals — in which case the alias is left as-is
+ * rather than rewritten to something lossy.
+ */
+function stringLiteralMembers(type: ts.Type): string[] | null {
+  const parts = type.isUnion() ? type.types : [type]
+  const values: string[] = []
+  for (const part of parts) {
+    if (!part.isStringLiteral()) return null
+    values.push(part.value)
+  }
+  return values.length > 0 ? values : null
+}
+
+/**
+ * Whether a member's rendered `defaultValue` merely restates its literal `type`
+ * — true for every member of an `as const` object (`API_ERROR: 'api_error'`
+ * typed as `"api_error"`), where the "Default value" table column is pure noise.
+ */
+export function defaultValueRestatesLiteralType(reflection: DeclarationReflection): boolean {
+  if (reflection.defaultValue === undefined) return false
+  if (!(reflection.type instanceof LiteralType)) return false
+  return reflection.defaultValue.replace(/^['"]|['"]$/g, '') === String(reflection.type.value)
+}
+
+/**
  * Collect the string-literal validation codes a type resolves to — walking
  * unions, type-alias references, and `typeof XxxErrorCodes.CODE` queries (whose
  * queried property's literal value, or failing that its name, is the code).
@@ -2109,6 +2173,58 @@ export class SDKTheme extends MarkdownTheme {
   static serializeFrontmatter(page: MarkdownPageEvent): void {
     if (!page.frontmatter) return
     page.contents = `${buildFrontmatterYaml(page.frontmatter)}\n\n${page.contents}`
+  }
+
+  // Expand opaque const-derived string-union aliases in place so they render as
+  // `"a" | "b" | "c"` instead of an unresolvable `keyof typeof <internalConst>`
+  // / `typeof <const>[…]` expression. Covers field-name unions (`keyof typeof
+  // fieldValidators`), the error-category union (`typeof SDKErrorCategories[keyof
+  // typeof SDKErrorCategories]`), and `as const` value unions (`(typeof FOO)
+  // [number]`). The referenced const is often module-internal with no reflection,
+  // so resolution goes through the TS type checker — it sees the fully-resolved
+  // literal union regardless. Only aliases whose resolved type is entirely string
+  // literals are rewritten; anything else is left untouched. A large union backed
+  // by a *documented* const (e.g. `EventType` over the exported `componentEvents`)
+  // is left as-is — its opaque form already links to that const, which beats
+  // inlining hundreds of literals.
+  static expandConstDerivedAliases(context: Context): void {
+    // `context.program` throws outside file conversion; at RESOLVE_END read the
+    // (single, entry-point) program directly for a checker that resolves aliases.
+    const checker = context.programs[0]?.getTypeChecker()
+    if (!checker) return
+    for (const reflection of Object.values(context.project.reflections)) {
+      if (!(reflection instanceof DeclarationReflection)) continue
+      if (reflection.kind !== ReflectionKind.TypeAlias) continue
+      if (!isOpaqueConstDerivedType(reflection.type)) continue
+
+      const symbol = context.getSymbolFromReflection(reflection)
+      if (!symbol) continue
+      const literals = stringLiteralMembers(checker.getDeclaredTypeOfSymbol(symbol))
+      if (!literals) continue
+      if (literals.length > MAX_INLINE_LITERALS && documentedUnderlyingConst(reflection.type)) {
+        continue
+      }
+
+      reflection.type =
+        literals.length === 1
+          ? new LiteralType(literals[0]!)
+          : new UnionType(literals.map(value => new LiteralType(value)))
+    }
+  }
+
+  // Drop the redundant "Default value" table column from `as const` object
+  // constants (e.g. `SDKErrorCategories`, the `XxxErrorCodes` maps), where each
+  // member's default merely restates its literal type. The column is genuinely
+  // useful elsewhere (real defaults on params/props), so this only clears the
+  // duplicate values — typeDeclarationTable then omits the column once no member
+  // carries a defaultValue.
+  static dropRedundantConstDefaults(context: Context): void {
+    for (const reflection of Object.values(context.project.reflections)) {
+      if (!(reflection instanceof DeclarationReflection)) continue
+      if (defaultValueRestatesLiteralType(reflection)) {
+        reflection.defaultValue = undefined
+      }
+    }
   }
 
   // Must run before CommentPlugin's RESOLVE_BEGIN handler (priority 0) so that

--- a/docs/reference/company/hooks/use-pay-schedule-form.md
+++ b/docs/reference/company/hooks/use-pay-schedule-form.md
@@ -369,42 +369,11 @@ _Also accepts `description`, `formHookResult`, `portalContainer` from [SelectHoo
 
 ## Validations
 
-<a id="payscheduleerrorcodes"></a>
-
-### PayScheduleErrorCodes
-
-> `const` **PayScheduleErrorCodes**: `object`
-
-Validation error codes emitted by [usePayScheduleForm](#usepayscheduleform) fields.
-
-#### Type Declaration
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `DAY_RANGE` | `"DAY_RANGE"` | `'DAY_RANGE'` |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-#### Remarks
-
-Use these as `validationMessages` keys on the corresponding `Fields.*` components.
-
-***
-
-<a id="payscheduleerrorcode"></a>
-
-### PayScheduleErrorCode
-
-> **PayScheduleErrorCode** = *typeof* [`PayScheduleErrorCodes`](#payscheduleerrorcodes)\[keyof *typeof* [`PayScheduleErrorCodes`](#payscheduleerrorcodes)\]
-
-Union of validation error code strings emitted by the pay schedule form.
-
-***
-
 <a id="dayvalidation"></a>
 
 ### DayValidation
 
-> **DayValidation** = *typeof* [`PayScheduleErrorCodes`](#payscheduleerrorcodes)\[`"REQUIRED"` \| `"DAY_RANGE"`\]
+> **DayValidation** = `"REQUIRED"` \| `"DAY_RANGE"`
 
 Validation error codes emitted by the `day1` and `day2` fields of [usePayScheduleForm](#usepayscheduleform).
 
@@ -419,7 +388,7 @@ See [PayScheduleErrorCodes](#payscheduleerrorcodes).
 
 ### PayScheduleRequiredValidation
 
-> **PayScheduleRequiredValidation** = *typeof* `PayScheduleErrorCodes.REQUIRED`
+> **PayScheduleRequiredValidation** = `"REQUIRED"`
 
 The required-field error code produced by [usePayScheduleForm](#usepayscheduleform) fields that only emit `REQUIRED`.
 
@@ -429,11 +398,42 @@ Used as the `validationMessages` key for the custom name, frequency, anchor
 pay date, and anchor end-of-pay-period fields. See [PayScheduleErrorCodes](#payscheduleerrorcodes).
 
 ## Utility Types
+<a id="payscheduleerrorcode"></a>
+
+### PayScheduleErrorCode
+
+> **PayScheduleErrorCode** = `"REQUIRED"` \| `"DAY_RANGE"`
+
+Union of validation error code strings emitted by the pay schedule form.
+
+***
+
+<a id="payscheduleerrorcodes"></a>
+
+### PayScheduleErrorCodes
+
+> `const` **PayScheduleErrorCodes**: `object`
+
+Validation error codes emitted by [usePayScheduleForm](#usepayscheduleform) fields.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| `DAY_RANGE` | `"DAY_RANGE"` |
+| `REQUIRED` | `"REQUIRED"` |
+
+#### Remarks
+
+Use these as `validationMessages` keys on the corresponding `Fields.*` components.
+
+***
+
 <a id="payschedulefield"></a>
 
 ### PayScheduleField
 
-> **PayScheduleField** = keyof *typeof* `fieldValidators`
+> **PayScheduleField** = `"frequency"` \| `"anchorPayDate"` \| `"anchorEndOfPayPeriod"` \| `"day1"` \| `"day2"` \| `"customName"` \| `"customTwicePerMonth"`
 
 Union of field names managed by the pay schedule form.
 
@@ -493,7 +493,7 @@ Shape of the validated values produced by the pay schedule form on submit.
 
 ### PayScheduleFrequency
 
-> **PayScheduleFrequency** = *typeof* `FREQUENCY_VALUES`\[`number`\]
+> **PayScheduleFrequency** = `"Every week"` \| `"Every other week"` \| `"Twice per month"` \| `"Monthly"`
 
 Pay schedule frequency values accepted by [usePayScheduleForm](#usepayscheduleform).
 

--- a/docs/reference/company/hooks/use-sign-company-form.md
+++ b/docs/reference/company/hooks/use-sign-company-form.md
@@ -212,39 +212,11 @@ _Also accepts `description`, `formHookResult`, `placeholder`, `transform` from [
 
 ## Validations
 
-<a id="signcompanyformerrorcodes"></a>
-
-### SignCompanyFormErrorCodes
-
-> `const` **SignCompanyFormErrorCodes**: `object`
-
-Validation error codes emitted by the sign-company-form schema. Map these
-codes to localized copy in `validationMessages` when composing the hook.
-
-#### Type Declaration
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-***
-
-<a id="signcompanyformerrorcode"></a>
-
-### SignCompanyFormErrorCode
-
-> **SignCompanyFormErrorCode** = *typeof* [`SignCompanyFormErrorCodes`](#signcompanyformerrorcodes)\[keyof *typeof* [`SignCompanyFormErrorCodes`](#signcompanyformerrorcodes)\]
-
-Union of validation error code strings emitted by the sign-company-form
-schema.
-
-***
-
 <a id="signcompanyformrequiredvalidation"></a>
 
 ### SignCompanyFormRequiredValidation
 
-> **SignCompanyFormRequiredValidation** = *typeof* `SignCompanyFormErrorCodes.REQUIRED`
+> **SignCompanyFormRequiredValidation** = `"REQUIRED"`
 
 The required-field error code emitted by every field of [useSignCompanyForm](#usesigncompanyform).
 
@@ -269,11 +241,39 @@ Shape of the values managed by the sign-company form.
 
 ***
 
+<a id="signcompanyformerrorcode"></a>
+
+### SignCompanyFormErrorCode
+
+> **SignCompanyFormErrorCode** = `"REQUIRED"`
+
+Union of validation error code strings emitted by the sign-company-form
+schema.
+
+***
+
+<a id="signcompanyformerrorcodes"></a>
+
+### SignCompanyFormErrorCodes
+
+> `const` **SignCompanyFormErrorCodes**: `object`
+
+Validation error codes emitted by the sign-company-form schema. Map these
+codes to localized copy in `validationMessages` when composing the hook.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| `REQUIRED` | `"REQUIRED"` |
+
+***
+
 <a id="signcompanyformfield"></a>
 
 ### SignCompanyFormField
 
-> **SignCompanyFormField** = keyof *typeof* `fieldValidators`
+> **SignCompanyFormField** = `"signature"` \| `"confirmSignature"`
 
 Field names accepted by the sign-company form.
 

--- a/docs/reference/contractor/hooks/use-contractor-address-form.md
+++ b/docs/reference/contractor/hooks/use-contractor-address-form.md
@@ -286,41 +286,11 @@ _Also accepts `description`, `formHookResult`, `placeholder`, `transform` from [
 
 ## Validations
 
-<a id="contractoraddresserrorcodes"></a>
-
-### ContractorAddressErrorCodes
-
-> `const` **ContractorAddressErrorCodes**: `object`
-
-Validation error codes emitted by the contractor address form schema. Map
-these codes to localized copy in `validationMessages` when composing the
-hook.
-
-#### Type Declaration
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `INVALID_ZIP` | `"INVALID_ZIP"` | `'INVALID_ZIP'` |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-***
-
-<a id="contractoraddresserrorcode"></a>
-
-### ContractorAddressErrorCode
-
-> **ContractorAddressErrorCode** = *typeof* [`ContractorAddressErrorCodes`](#contractoraddresserrorcodes)\[keyof *typeof* [`ContractorAddressErrorCodes`](#contractoraddresserrorcodes)\]
-
-Union of validation error code strings emitted by the contractor address
-form schema.
-
-***
-
 <a id="contractoraddressrequiredvalidation"></a>
 
 ### ContractorAddressRequiredValidation
 
-> **ContractorAddressRequiredValidation** = *typeof* `ContractorAddressErrorCodes.REQUIRED`
+> **ContractorAddressRequiredValidation** = `"REQUIRED"`
 
 The required-field error code produced by [useContractorAddressForm](#usecontractoraddressform) fields that only emit `REQUIRED`.
 
@@ -335,7 +305,7 @@ See [ContractorAddressErrorCodes](#contractoraddresserrorcodes).
 
 ### ContractorAddressZipValidation
 
-> **ContractorAddressZipValidation** = *typeof* [`ContractorAddressErrorCodes`](#contractoraddresserrorcodes)\[`"REQUIRED"` \| `"INVALID_ZIP"`\]
+> **ContractorAddressZipValidation** = `"REQUIRED"` \| `"INVALID_ZIP"`
 
 Validation error codes emitted by the `zip` field of [useContractorAddressForm](#usecontractoraddressform).
 
@@ -345,11 +315,41 @@ Use these as keys in `validationMessages` on `Fields.Zip`. See
 [ContractorAddressErrorCodes](#contractoraddresserrorcodes).
 
 ## Utility Types
+<a id="contractoraddresserrorcode"></a>
+
+### ContractorAddressErrorCode
+
+> **ContractorAddressErrorCode** = `"REQUIRED"` \| `"INVALID_ZIP"`
+
+Union of validation error code strings emitted by the contractor address
+form schema.
+
+***
+
+<a id="contractoraddresserrorcodes"></a>
+
+### ContractorAddressErrorCodes
+
+> `const` **ContractorAddressErrorCodes**: `object`
+
+Validation error codes emitted by the contractor address form schema. Map
+these codes to localized copy in `validationMessages` when composing the
+hook.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| `INVALID_ZIP` | `"INVALID_ZIP"` |
+| `REQUIRED` | `"REQUIRED"` |
+
+***
+
 <a id="contractoraddressfield"></a>
 
 ### ContractorAddressField
 
-> **ContractorAddressField** = keyof *typeof* `fieldValidators`
+> **ContractorAddressField** = `"street1"` \| `"city"` \| `"state"` \| `"zip"` \| `"street2"`
 
 Field names accepted by the contractor address form.
 

--- a/docs/reference/contractor/hooks/use-contractor-bank-account-form.md
+++ b/docs/reference/contractor/hooks/use-contractor-bank-account-form.md
@@ -253,6 +253,59 @@ _Also accepts `description`, `formHookResult`, `placeholder`, `transform` from [
 
 ## Validations
 
+<a id="contractorbankaccountaccountnumbervalidation"></a>
+
+### ContractorBankAccountAccountNumberValidation
+
+> **ContractorBankAccountAccountNumberValidation** = `"REQUIRED"` \| `"INVALID_ACCOUNT_NUMBER"`
+
+Validation error codes emitted by the `accountNumber` field of
+[useContractorBankAccountForm](#usecontractorbankaccountform).
+
+***
+
+<a id="contractorbankaccountrequiredvalidation"></a>
+
+### ContractorBankAccountRequiredValidation
+
+> **ContractorBankAccountRequiredValidation** = `"REQUIRED"`
+
+Validation error code emitted by [useContractorBankAccountForm](#usecontractorbankaccountform) fields
+that only emit `REQUIRED`.
+
+***
+
+<a id="contractorbankaccountroutingnumbervalidation"></a>
+
+### ContractorBankAccountRoutingNumberValidation
+
+> **ContractorBankAccountRoutingNumberValidation** = `"REQUIRED"` \| `"INVALID_ROUTING_NUMBER"`
+
+Validation error codes emitted by the `routingNumber` field of
+[useContractorBankAccountForm](#usecontractorbankaccountform).
+
+## Utility Types
+<a id="contractoraccounttype"></a>
+
+### ContractorAccountType
+
+> **ContractorAccountType** = `"Checking"` \| `"Savings"`
+
+Union of bank account type values that the form accepts.
+
+***
+
+<a id="contractorbankaccounterrorcode"></a>
+
+### ContractorBankAccountErrorCode
+
+> **ContractorBankAccountErrorCode** = `"REQUIRED"` \| `"INVALID_ROUTING_NUMBER"` \| `"INVALID_ACCOUNT_NUMBER"`
+
+Union of validation error code strings emitted by the contractor bank account
+form schema.
+
+***
+
 <a id="contractorbankaccounterrorcodes"></a>
 
 ### ContractorBankAccountErrorCodes
@@ -265,64 +318,11 @@ hook.
 
 #### Type Declaration
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `INVALID_ACCOUNT_NUMBER` | `"INVALID_ACCOUNT_NUMBER"` | `'INVALID_ACCOUNT_NUMBER'` |
-| `INVALID_ROUTING_NUMBER` | `"INVALID_ROUTING_NUMBER"` | `'INVALID_ROUTING_NUMBER'` |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-***
-
-<a id="contractorbankaccounterrorcode"></a>
-
-### ContractorBankAccountErrorCode
-
-> **ContractorBankAccountErrorCode** = *typeof* [`ContractorBankAccountErrorCodes`](#contractorbankaccounterrorcodes)\[keyof *typeof* [`ContractorBankAccountErrorCodes`](#contractorbankaccounterrorcodes)\]
-
-Union of validation error code strings emitted by the contractor bank account
-form schema.
-
-***
-
-<a id="contractorbankaccountaccountnumbervalidation"></a>
-
-### ContractorBankAccountAccountNumberValidation
-
-> **ContractorBankAccountAccountNumberValidation** = *typeof* [`ContractorBankAccountErrorCodes`](#contractorbankaccounterrorcodes)\[keyof `Pick`\<*typeof* [`ContractorBankAccountErrorCodes`](#contractorbankaccounterrorcodes), `"REQUIRED"` \| `"INVALID_ACCOUNT_NUMBER"`\>\]
-
-Validation error codes emitted by the `accountNumber` field of
-[useContractorBankAccountForm](#usecontractorbankaccountform).
-
-***
-
-<a id="contractorbankaccountrequiredvalidation"></a>
-
-### ContractorBankAccountRequiredValidation
-
-> **ContractorBankAccountRequiredValidation** = *typeof* `ContractorBankAccountErrorCodes.REQUIRED`
-
-Validation error code emitted by [useContractorBankAccountForm](#usecontractorbankaccountform) fields
-that only emit `REQUIRED`.
-
-***
-
-<a id="contractorbankaccountroutingnumbervalidation"></a>
-
-### ContractorBankAccountRoutingNumberValidation
-
-> **ContractorBankAccountRoutingNumberValidation** = *typeof* [`ContractorBankAccountErrorCodes`](#contractorbankaccounterrorcodes)\[keyof `Pick`\<*typeof* [`ContractorBankAccountErrorCodes`](#contractorbankaccounterrorcodes), `"REQUIRED"` \| `"INVALID_ROUTING_NUMBER"`\>\]
-
-Validation error codes emitted by the `routingNumber` field of
-[useContractorBankAccountForm](#usecontractorbankaccountform).
-
-## Utility Types
-<a id="contractoraccounttype"></a>
-
-### ContractorAccountType
-
-> **ContractorAccountType** = *typeof* [`ContractorBankAccountTypes`](#contractorbankaccounttypes)\[`number`\]
-
-Union of bank account type values that the form accepts.
+| Name | Type |
+| ------ | ------ |
+| `INVALID_ACCOUNT_NUMBER` | `"INVALID_ACCOUNT_NUMBER"` |
+| `INVALID_ROUTING_NUMBER` | `"INVALID_ROUTING_NUMBER"` |
+| `REQUIRED` | `"REQUIRED"` |
 
 ***
 
@@ -357,7 +357,7 @@ Shape of the values managed by the contractor bank account form.
 
 ### ContractorBankAccountFormField
 
-> **ContractorBankAccountFormField** = keyof *typeof* `fieldValidators`
+> **ContractorBankAccountFormField** = `"routingNumber"` \| `"accountNumber"` \| `"name"` \| `"accountType"`
 
 Field names accepted by the contractor bank account form.
 

--- a/docs/reference/contractor/hooks/use-contractor-details-form.md
+++ b/docs/reference/contractor/hooks/use-contractor-details-form.md
@@ -598,6 +598,87 @@ _Also accepts `description`, `formHookResult`, `portalContainer` from [SelectHoo
 
 ## Validations
 
+<a id="contractordetailseinrequiredvalidation"></a>
+
+### ContractorDetailsEinRequiredValidation
+
+> **ContractorDetailsEinRequiredValidation** = `"REQUIRED"`
+
+Required-field error code emitted by the `ein` field of [useContractorDetailsForm](#usecontractordetailsform).
+
+***
+
+<a id="contractordetailseinvalidation"></a>
+
+### ContractorDetailsEinValidation
+
+> **ContractorDetailsEinValidation** = `"INVALID_EIN"`
+
+Format-validation error code emitted by the `ein` field of [useContractorDetailsForm](#usecontractordetailsform).
+
+***
+
+<a id="contractordetailsemailvalidation"></a>
+
+### ContractorDetailsEmailValidation
+
+> **ContractorDetailsEmailValidation** = `"REQUIRED"` \| `"INVALID_EMAIL"`
+
+Validation error codes emitted by the `email` field of [useContractorDetailsForm](#usecontractordetailsform).
+
+***
+
+<a id="contractordetailsnamevalidation"></a>
+
+### ContractorDetailsNameValidation
+
+> **ContractorDetailsNameValidation** = `"REQUIRED"` \| `"INVALID_NAME"`
+
+Validation error codes emitted by the name fields of [useContractorDetailsForm](#usecontractordetailsform).
+
+***
+
+<a id="contractordetailsrequiredvalidation"></a>
+
+### ContractorDetailsRequiredValidation
+
+> **ContractorDetailsRequiredValidation** = `"REQUIRED"`
+
+Error code emitted by fields of [useContractorDetailsForm](#usecontractordetailsform) that only
+produce `REQUIRED`.
+
+***
+
+<a id="contractordetailsssnrequiredvalidation"></a>
+
+### ContractorDetailsSsnRequiredValidation
+
+> **ContractorDetailsSsnRequiredValidation** = `"REQUIRED"`
+
+Required-field error code emitted by the `ssn` field of [useContractorDetailsForm](#usecontractordetailsform).
+
+***
+
+<a id="contractordetailsssnvalidation"></a>
+
+### ContractorDetailsSsnValidation
+
+> **ContractorDetailsSsnValidation** = `"INVALID_SSN"`
+
+Format-validation error code emitted by the `ssn` field of [useContractorDetailsForm](#usecontractordetailsform).
+
+## Utility Types
+<a id="contractordetailserrorcode"></a>
+
+### ContractorDetailsErrorCode
+
+> **ContractorDetailsErrorCode** = `"REQUIRED"` \| `"INVALID_NAME"` \| `"INVALID_EMAIL"` \| `"INVALID_SSN"` \| `"INVALID_EIN"`
+
+Union of validation error code strings emitted by the contractor details
+form schema.
+
+***
+
 <a id="contractordetailserrorcodes"></a>
 
 ### ContractorDetailsErrorCodes
@@ -610,97 +691,16 @@ hook.
 
 #### Type Declaration
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `INVALID_EIN` | `"INVALID_EIN"` | `'INVALID_EIN'` |
-| `INVALID_EMAIL` | `"INVALID_EMAIL"` | `'INVALID_EMAIL'` |
-| `INVALID_NAME` | `"INVALID_NAME"` | `'INVALID_NAME'` |
-| `INVALID_SSN` | `"INVALID_SSN"` | `'INVALID_SSN'` |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
+| Name | Type |
+| ------ | ------ |
+| `INVALID_EIN` | `"INVALID_EIN"` |
+| `INVALID_EMAIL` | `"INVALID_EMAIL"` |
+| `INVALID_NAME` | `"INVALID_NAME"` |
+| `INVALID_SSN` | `"INVALID_SSN"` |
+| `REQUIRED` | `"REQUIRED"` |
 
 ***
 
-<a id="contractordetailserrorcode"></a>
-
-### ContractorDetailsErrorCode
-
-> **ContractorDetailsErrorCode** = *typeof* [`ContractorDetailsErrorCodes`](#contractordetailserrorcodes)\[keyof *typeof* [`ContractorDetailsErrorCodes`](#contractordetailserrorcodes)\]
-
-Union of validation error code strings emitted by the contractor details
-form schema.
-
-***
-
-<a id="contractordetailseinrequiredvalidation"></a>
-
-### ContractorDetailsEinRequiredValidation
-
-> **ContractorDetailsEinRequiredValidation** = *typeof* `ContractorDetailsErrorCodes.REQUIRED`
-
-Required-field error code emitted by the `ein` field of [useContractorDetailsForm](#usecontractordetailsform).
-
-***
-
-<a id="contractordetailseinvalidation"></a>
-
-### ContractorDetailsEinValidation
-
-> **ContractorDetailsEinValidation** = *typeof* `ContractorDetailsErrorCodes.INVALID_EIN`
-
-Format-validation error code emitted by the `ein` field of [useContractorDetailsForm](#usecontractordetailsform).
-
-***
-
-<a id="contractordetailsemailvalidation"></a>
-
-### ContractorDetailsEmailValidation
-
-> **ContractorDetailsEmailValidation** = *typeof* [`ContractorDetailsErrorCodes`](#contractordetailserrorcodes)\[`"REQUIRED"` \| `"INVALID_EMAIL"`\]
-
-Validation error codes emitted by the `email` field of [useContractorDetailsForm](#usecontractordetailsform).
-
-***
-
-<a id="contractordetailsnamevalidation"></a>
-
-### ContractorDetailsNameValidation
-
-> **ContractorDetailsNameValidation** = *typeof* [`ContractorDetailsErrorCodes`](#contractordetailserrorcodes)\[`"REQUIRED"` \| `"INVALID_NAME"`\]
-
-Validation error codes emitted by the name fields of [useContractorDetailsForm](#usecontractordetailsform).
-
-***
-
-<a id="contractordetailsrequiredvalidation"></a>
-
-### ContractorDetailsRequiredValidation
-
-> **ContractorDetailsRequiredValidation** = *typeof* `ContractorDetailsErrorCodes.REQUIRED`
-
-Error code emitted by fields of [useContractorDetailsForm](#usecontractordetailsform) that only
-produce `REQUIRED`.
-
-***
-
-<a id="contractordetailsssnrequiredvalidation"></a>
-
-### ContractorDetailsSsnRequiredValidation
-
-> **ContractorDetailsSsnRequiredValidation** = *typeof* `ContractorDetailsErrorCodes.REQUIRED`
-
-Required-field error code emitted by the `ssn` field of [useContractorDetailsForm](#usecontractordetailsform).
-
-***
-
-<a id="contractordetailsssnvalidation"></a>
-
-### ContractorDetailsSsnValidation
-
-> **ContractorDetailsSsnValidation** = *typeof* `ContractorDetailsErrorCodes.INVALID_SSN`
-
-Format-validation error code emitted by the `ssn` field of [useContractorDetailsForm](#usecontractordetailsform).
-
-## Utility Types
 <a id="contractordetailsfieldsmetadata"></a>
 
 ### ContractorDetailsFieldsMetadata

--- a/docs/reference/contractor/hooks/use-contractor-payment-method-form.md
+++ b/docs/reference/contractor/hooks/use-contractor-payment-method-form.md
@@ -156,7 +156,7 @@ _Also accepts `description`, `formHookResult` from [RadioGroupHookFieldProps](..
 
 ### ContractorPaymentMethodErrorCode
 
-> **ContractorPaymentMethodErrorCode** = *typeof* [`ContractorPaymentMethodErrorCodes`](#contractorpaymentmethoderrorcodes)\[keyof *typeof* [`ContractorPaymentMethodErrorCodes`](#contractorpaymentmethoderrorcodes)\]
+> **ContractorPaymentMethodErrorCode** = `"REQUIRED"`
 
 Union of validation error code strings emitted by the contractor payment
 method form schema.
@@ -175,9 +175,9 @@ hook.
 
 #### Type Declaration
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
+| Name | Type |
+| ------ | ------ |
+| `REQUIRED` | `"REQUIRED"` |
 
 ***
 
@@ -209,7 +209,7 @@ Shape of the values managed by the contractor payment method form.
 
 ### ContractorPaymentMethodFormField
 
-> **ContractorPaymentMethodFormField** = keyof *typeof* `fieldValidators`
+> **ContractorPaymentMethodFormField** = `"type"`
 
 Field names accepted by the contractor payment method form.
 
@@ -230,7 +230,7 @@ on submit.
 
 ### ContractorPaymentMethodFormType
 
-> **ContractorPaymentMethodFormType** = *typeof* `PAYMENT_METHOD_TYPES`\[`number`\]
+> **ContractorPaymentMethodFormType** = `"Check"` \| `"Direct Deposit"`
 
 Union of payment method type values that the form accepts.
 

--- a/docs/reference/employee/hooks/use-bank-form.md
+++ b/docs/reference/employee/hooks/use-bank-form.md
@@ -243,41 +243,11 @@ _Also accepts `description`, `formHookResult`, `placeholder`, `transform` from [
 
 ## Validations
 
-<a id="bankformerrorcodes"></a>
-
-### BankFormErrorCodes
-
-> `const` **BankFormErrorCodes**: `object`
-
-Validation error codes emitted by the bank account form schema. Map these
-codes to localized copy in `validationMessages` when composing the hook.
-
-#### Type Declaration
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `INVALID_ACCOUNT_NUMBER` | `"INVALID_ACCOUNT_NUMBER"` | `'INVALID_ACCOUNT_NUMBER'` |
-| `INVALID_ROUTING_NUMBER` | `"INVALID_ROUTING_NUMBER"` | `'INVALID_ROUTING_NUMBER'` |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-***
-
-<a id="bankformerrorcode"></a>
-
-### BankFormErrorCode
-
-> **BankFormErrorCode** = *typeof* [`BankFormErrorCodes`](#bankformerrorcodes)\[keyof *typeof* [`BankFormErrorCodes`](#bankformerrorcodes)\]
-
-Union of validation error code strings emitted by the bank account form
-schema.
-
-***
-
 <a id="accountnumbervalidation"></a>
 
 ### AccountNumberValidation
 
-> **AccountNumberValidation** = *typeof* [`BankFormErrorCodes`](#bankformerrorcodes)\[keyof `Pick`\<*typeof* [`BankFormErrorCodes`](#bankformerrorcodes), `"REQUIRED"` \| `"INVALID_ACCOUNT_NUMBER"`\>\]
+> **AccountNumberValidation** = `"REQUIRED"` \| `"INVALID_ACCOUNT_NUMBER"`
 
 Validation error codes emitted by the `accountNumber` field of [useBankForm](#usebankform).
 
@@ -287,7 +257,7 @@ Validation error codes emitted by the `accountNumber` field of [useBankForm](#us
 
 ### BankFormRequiredValidation
 
-> **BankFormRequiredValidation** = *typeof* `BankFormErrorCodes.REQUIRED`
+> **BankFormRequiredValidation** = `"REQUIRED"`
 
 Validation error codes emitted by [useBankForm](#usebankform) fields that only emit `REQUIRED`.
 
@@ -297,7 +267,7 @@ Validation error codes emitted by [useBankForm](#usebankform) fields that only e
 
 ### RoutingNumberValidation
 
-> **RoutingNumberValidation** = *typeof* [`BankFormErrorCodes`](#bankformerrorcodes)\[keyof `Pick`\<*typeof* [`BankFormErrorCodes`](#bankformerrorcodes), `"REQUIRED"` \| `"INVALID_ROUTING_NUMBER"`\>\]
+> **RoutingNumberValidation** = `"REQUIRED"` \| `"INVALID_ROUTING_NUMBER"`
 
 Validation error codes emitted by the `routingNumber` field of [useBankForm](#usebankform).
 
@@ -316,7 +286,7 @@ Supported bank account type values: checking and savings.
 
 ### AccountType
 
-> **AccountType** = *typeof* [`ACCOUNT_TYPES`](#account_types)\[`number`\]
+> **AccountType** = `"Checking"` \| `"Savings"`
 
 Union of bank account type values that the form accepts.
 
@@ -339,11 +309,41 @@ Shape of the values managed by the bank account form.
 
 ***
 
+<a id="bankformerrorcode"></a>
+
+### BankFormErrorCode
+
+> **BankFormErrorCode** = `"REQUIRED"` \| `"INVALID_ROUTING_NUMBER"` \| `"INVALID_ACCOUNT_NUMBER"`
+
+Union of validation error code strings emitted by the bank account form
+schema.
+
+***
+
+<a id="bankformerrorcodes"></a>
+
+### BankFormErrorCodes
+
+> `const` **BankFormErrorCodes**: `object`
+
+Validation error codes emitted by the bank account form schema. Map these
+codes to localized copy in `validationMessages` when composing the hook.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| `INVALID_ACCOUNT_NUMBER` | `"INVALID_ACCOUNT_NUMBER"` |
+| `INVALID_ROUTING_NUMBER` | `"INVALID_ROUTING_NUMBER"` |
+| `REQUIRED` | `"REQUIRED"` |
+
+***
+
 <a id="bankformfield"></a>
 
 ### BankFormField
 
-> **BankFormField** = keyof *typeof* `fieldValidators`
+> **BankFormField** = `"routingNumber"` \| `"accountNumber"` \| `"name"` \| `"accountType"`
 
 Field names accepted by the bank account form.
 

--- a/docs/reference/employee/hooks/use-child-support-garnishment-form.md
+++ b/docs/reference/employee/hooks/use-child-support-garnishment-form.md
@@ -412,37 +412,6 @@ _Also accepts `description`, `formHookResult`, `portalContainer` from [SelectHoo
 
 ## Validations
 
-<a id="childsupportgarnishmentformerrorcodes"></a>
-
-### ChildSupportGarnishmentFormErrorCodes
-
-> `const` **ChildSupportGarnishmentFormErrorCodes**: `object`
-
-Validation error codes emitted by the child support garnishment form schema.
-Map these codes to localized copy in `validationMessages` when composing the
-hook.
-
-#### Type Declaration
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `NEGATIVE_AMOUNT` | `"NEGATIVE_AMOUNT"` | `'NEGATIVE_AMOUNT'` |
-| `PERCENT_OUT_OF_RANGE` | `"PERCENT_OUT_OF_RANGE"` | `'PERCENT_OUT_OF_RANGE'` |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-***
-
-<a id="childsupportgarnishmentformerrorcode"></a>
-
-### ChildSupportGarnishmentFormErrorCode
-
-> **ChildSupportGarnishmentFormErrorCode** = *typeof* [`ChildSupportGarnishmentFormErrorCodes`](#childsupportgarnishmentformerrorcodes)\[keyof *typeof* [`ChildSupportGarnishmentFormErrorCodes`](#childsupportgarnishmentformerrorcodes)\]
-
-Union of validation error code strings emitted by the child support
-garnishment form schema.
-
-***
-
 <a id="childsupportgarnishmentamountvalidation"></a>
 
 ### ChildSupportGarnishmentAmountValidation
@@ -463,7 +432,7 @@ accepts a percentage of paycheck (0–100). See
 
 ### ChildSupportGarnishmentNegativeAmountValidation
 
-> **ChildSupportGarnishmentNegativeAmountValidation** = *typeof* `ChildSupportGarnishmentFormErrorCodes.NEGATIVE_AMOUNT`
+> **ChildSupportGarnishmentNegativeAmountValidation** = `"NEGATIVE_AMOUNT"`
 
 The negative-amount error code produced by [useChildSupportGarnishmentForm](#usechildsupportgarnishmentform)'s currency fields.
 
@@ -478,7 +447,7 @@ Used as a `validationMessages` key on `Fields.PayPeriodMaximum`. See
 
 ### ChildSupportGarnishmentPercentValidation
 
-> **ChildSupportGarnishmentPercentValidation** = *typeof* `ChildSupportGarnishmentFormErrorCodes.PERCENT_OUT_OF_RANGE`
+> **ChildSupportGarnishmentPercentValidation** = `"PERCENT_OUT_OF_RANGE"`
 
 The percent-out-of-range error code produced by [useChildSupportGarnishmentForm](#usechildsupportgarnishmentform)'s percentage field.
 
@@ -493,7 +462,7 @@ See [ChildSupportGarnishmentFormErrorCodes](#childsupportgarnishmentformerrorcod
 
 ### ChildSupportGarnishmentRequiredValidation
 
-> **ChildSupportGarnishmentRequiredValidation** = *typeof* `ChildSupportGarnishmentFormErrorCodes.REQUIRED`
+> **ChildSupportGarnishmentRequiredValidation** = `"REQUIRED"`
 
 The required-field error code produced by [useChildSupportGarnishmentForm](#usechildsupportgarnishmentform) fields that only emit `REQUIRED`.
 
@@ -537,6 +506,37 @@ Shape of the values managed by the child support garnishment form.
 | `payPeriodMaximum` | `number` |
 | `remittanceNumber` | `string` |
 | `state` | `string` |
+
+***
+
+<a id="childsupportgarnishmentformerrorcode"></a>
+
+### ChildSupportGarnishmentFormErrorCode
+
+> **ChildSupportGarnishmentFormErrorCode** = `"REQUIRED"` \| `"NEGATIVE_AMOUNT"` \| `"PERCENT_OUT_OF_RANGE"`
+
+Union of validation error code strings emitted by the child support
+garnishment form schema.
+
+***
+
+<a id="childsupportgarnishmentformerrorcodes"></a>
+
+### ChildSupportGarnishmentFormErrorCodes
+
+> `const` **ChildSupportGarnishmentFormErrorCodes**: `object`
+
+Validation error codes emitted by the child support garnishment form schema.
+Map these codes to localized copy in `validationMessages` when composing the
+hook.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| `NEGATIVE_AMOUNT` | `"NEGATIVE_AMOUNT"` |
+| `PERCENT_OUT_OF_RANGE` | `"PERCENT_OUT_OF_RANGE"` |
+| `REQUIRED` | `"REQUIRED"` |
 
 ***
 
@@ -631,6 +631,6 @@ subset via `requiredAttrKeys` so callers can drive their own UI on which
 
 ### SupportedRequiredAttrKey
 
-> **SupportedRequiredAttrKey** = *typeof* [`SUPPORTED_REQUIRED_ATTR_KEYS`](#supported_required_attr_keys)\[`number`\]
+> **SupportedRequiredAttrKey** = `"case_number"` \| `"order_number"` \| `"remittance_number"`
 
 Union of child support attribute key strings recognized by the form.

--- a/docs/reference/employee/hooks/use-compensation-form.md
+++ b/docs/reference/employee/hooks/use-compensation-form.md
@@ -400,6 +400,60 @@ _Also accepts `description`, `formHookResult`, `placeholder`, `transform` from [
 
 ## Validations
 
+<a id="compensationeffectivedatevalidation"></a>
+
+### CompensationEffectiveDateValidation
+
+> **CompensationEffectiveDateValidation** = `"REQUIRED"` \| `"EFFECTIVE_DATE_BEFORE_HIRE"` \| `"EFFECTIVE_DATE_BEFORE_MIN"`
+
+Validation error codes emitted by the `effectiveDate` field of [useCompensationForm](#usecompensationform).
+
+#### Remarks
+
+Use these as keys in `validationMessages` on `Fields.EffectiveDate`. See
+[CompensationErrorCodes](#compensationerrorcodes) for the full description of each code.
+
+***
+
+<a id="compensationrequiredvalidation"></a>
+
+### CompensationRequiredValidation
+
+> **CompensationRequiredValidation** = `"REQUIRED"`
+
+The required-field error code produced by [useCompensationForm](#usecompensationform) fields that only emit `REQUIRED`.
+
+#### Remarks
+
+Used as the `validationMessages` key for the title, FLSA status, payment
+unit, and minimum-wage selection fields. See [CompensationErrorCodes](#compensationerrorcodes).
+
+***
+
+<a id="ratevalidation"></a>
+
+### RateValidation
+
+> **RateValidation** = `"REQUIRED"` \| `"RATE_MINIMUM"` \| `"RATE_EXEMPT_THRESHOLD"`
+
+Validation error codes emitted by the `rate` field of [useCompensationForm](#usecompensationform).
+
+#### Remarks
+
+Use these as keys in `validationMessages` on `Fields.Rate`. See
+[CompensationErrorCodes](#compensationerrorcodes) for the full description of each code.
+
+## Utility Types
+<a id="compensationerrorcode"></a>
+
+### CompensationErrorCode
+
+> **CompensationErrorCode** = `"REQUIRED"` \| `"RATE_MINIMUM"` \| `"RATE_EXEMPT_THRESHOLD"` \| `"PAYMENT_UNIT_OWNER"` \| `"PAYMENT_UNIT_COMMISSION"` \| `"RATE_COMMISSION_ZERO"` \| `"EFFECTIVE_DATE_BEFORE_HIRE"` \| `"EFFECTIVE_DATE_BEFORE_MIN"`
+
+Union of every error code produced by the [useCompensationForm](#usecompensationform) schema.
+
+***
+
 <a id="compensationerrorcodes"></a>
 
 ### CompensationErrorCodes
@@ -410,16 +464,16 @@ Validation error codes produced by the [useCompensationForm](#usecompensationfor
 
 #### Type Declaration
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `EFFECTIVE_DATE_BEFORE_HIRE` | `"EFFECTIVE_DATE_BEFORE_HIRE"` | `'EFFECTIVE_DATE_BEFORE_HIRE'` |
-| `EFFECTIVE_DATE_BEFORE_MIN` | `"EFFECTIVE_DATE_BEFORE_MIN"` | `'EFFECTIVE_DATE_BEFORE_MIN'` |
-| `PAYMENT_UNIT_COMMISSION` | `"PAYMENT_UNIT_COMMISSION"` | `'PAYMENT_UNIT_COMMISSION'` |
-| `PAYMENT_UNIT_OWNER` | `"PAYMENT_UNIT_OWNER"` | `'PAYMENT_UNIT_OWNER'` |
-| `RATE_COMMISSION_ZERO` | `"RATE_COMMISSION_ZERO"` | `'RATE_COMMISSION_ZERO'` |
-| `RATE_EXEMPT_THRESHOLD` | `"RATE_EXEMPT_THRESHOLD"` | `'RATE_EXEMPT_THRESHOLD'` |
-| `RATE_MINIMUM` | `"RATE_MINIMUM"` | `'RATE_MINIMUM'` |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
+| Name | Type |
+| ------ | ------ |
+| `EFFECTIVE_DATE_BEFORE_HIRE` | `"EFFECTIVE_DATE_BEFORE_HIRE"` |
+| `EFFECTIVE_DATE_BEFORE_MIN` | `"EFFECTIVE_DATE_BEFORE_MIN"` |
+| `PAYMENT_UNIT_COMMISSION` | `"PAYMENT_UNIT_COMMISSION"` |
+| `PAYMENT_UNIT_OWNER` | `"PAYMENT_UNIT_OWNER"` |
+| `RATE_COMMISSION_ZERO` | `"RATE_COMMISSION_ZERO"` |
+| `RATE_EXEMPT_THRESHOLD` | `"RATE_EXEMPT_THRESHOLD"` |
+| `RATE_MINIMUM` | `"RATE_MINIMUM"` |
+| `REQUIRED` | `"REQUIRED"` |
 
 #### Remarks
 
@@ -454,60 +508,6 @@ import { CompensationErrorCodes } from '@gusto/embedded-react-sdk'
 
 ***
 
-<a id="compensationerrorcode"></a>
-
-### CompensationErrorCode
-
-> **CompensationErrorCode** = *typeof* [`CompensationErrorCodes`](#compensationerrorcodes)\[keyof *typeof* [`CompensationErrorCodes`](#compensationerrorcodes)\]
-
-Union of every error code produced by the [useCompensationForm](#usecompensationform) schema.
-
-***
-
-<a id="compensationeffectivedatevalidation"></a>
-
-### CompensationEffectiveDateValidation
-
-> **CompensationEffectiveDateValidation** = *typeof* [`CompensationErrorCodes`](#compensationerrorcodes)\[`"REQUIRED"` \| `"EFFECTIVE_DATE_BEFORE_HIRE"` \| `"EFFECTIVE_DATE_BEFORE_MIN"`\]
-
-Validation error codes emitted by the `effectiveDate` field of [useCompensationForm](#usecompensationform).
-
-#### Remarks
-
-Use these as keys in `validationMessages` on `Fields.EffectiveDate`. See
-[CompensationErrorCodes](#compensationerrorcodes) for the full description of each code.
-
-***
-
-<a id="compensationrequiredvalidation"></a>
-
-### CompensationRequiredValidation
-
-> **CompensationRequiredValidation** = *typeof* `CompensationErrorCodes.REQUIRED`
-
-The required-field error code produced by [useCompensationForm](#usecompensationform) fields that only emit `REQUIRED`.
-
-#### Remarks
-
-Used as the `validationMessages` key for the title, FLSA status, payment
-unit, and minimum-wage selection fields. See [CompensationErrorCodes](#compensationerrorcodes).
-
-***
-
-<a id="ratevalidation"></a>
-
-### RateValidation
-
-> **RateValidation** = *typeof* [`CompensationErrorCodes`](#compensationerrorcodes)\[`"REQUIRED"` \| `"RATE_MINIMUM"` \| `"RATE_EXEMPT_THRESHOLD"`\]
-
-Validation error codes emitted by the `rate` field of [useCompensationForm](#usecompensationform).
-
-#### Remarks
-
-Use these as keys in `validationMessages` on `Fields.Rate`. See
-[CompensationErrorCodes](#compensationerrorcodes) for the full description of each code.
-
-## Utility Types
 <a id="compensationfieldsmetadata"></a>
 
 ### CompensationFieldsMetadata

--- a/docs/reference/employee/hooks/use-deduction-form.md
+++ b/docs/reference/employee/hooks/use-deduction-form.md
@@ -375,34 +375,6 @@ _Also accepts `description`, `format`, `formHookResult`, `max`, `min`, `placehol
 
 ## Validations
 
-<a id="deductionformerrorcodes"></a>
-
-### DeductionFormErrorCodes
-
-> `const` **DeductionFormErrorCodes**: `object`
-
-Validation error codes emitted by the deduction form schema. Map these
-codes to localized copy in `validationMessages` when composing the hook.
-
-#### Type Declaration
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `NEGATIVE_AMOUNT` | `"NEGATIVE_AMOUNT"` | `'NEGATIVE_AMOUNT'` |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-***
-
-<a id="deductionformerrorcode"></a>
-
-### DeductionFormErrorCode
-
-> **DeductionFormErrorCode** = *typeof* [`DeductionFormErrorCodes`](#deductionformerrorcodes)\[keyof *typeof* [`DeductionFormErrorCodes`](#deductionformerrorcodes)\]
-
-Union of validation error code strings emitted by the deduction form schema.
-
-***
-
 <a id="deductionformamountvalidation"></a>
 
 ### DeductionFormAmountValidation
@@ -438,7 +410,7 @@ description of each code.
 
 ### DeductionFormNegativeAmountValidation
 
-> **DeductionFormNegativeAmountValidation** = *typeof* `DeductionFormErrorCodes.NEGATIVE_AMOUNT`
+> **DeductionFormNegativeAmountValidation** = `"NEGATIVE_AMOUNT"`
 
 The negative-amount error code produced by [useDeductionForm](#usedeductionform)'s currency fields.
 
@@ -453,7 +425,7 @@ and `Fields.AnnualMaximum`. See [DeductionFormErrorCodes](#deductionformerrorcod
 
 ### DeductionFormRequiredValidation
 
-> **DeductionFormRequiredValidation** = *typeof* `DeductionFormErrorCodes.REQUIRED`
+> **DeductionFormRequiredValidation** = `"REQUIRED"`
 
 The required-field error code produced by [useDeductionForm](#usedeductionform) fields that only emit `REQUIRED`.
 
@@ -481,6 +453,34 @@ Shape of the values managed by the deduction form.
 | `garnishmentType` | `"child_support"` \| `"federal_tax_lien"` \| `"state_tax_lien"` \| `"student_loan"` \| `"creditor_garnishment"` \| `"federal_loan"` \| `"other_garnishment"` |
 | `recurring` | `boolean` |
 | `totalAmount` | `number` |
+
+***
+
+<a id="deductionformerrorcode"></a>
+
+### DeductionFormErrorCode
+
+> **DeductionFormErrorCode** = `"REQUIRED"` \| `"NEGATIVE_AMOUNT"`
+
+Union of validation error code strings emitted by the deduction form schema.
+
+***
+
+<a id="deductionformerrorcodes"></a>
+
+### DeductionFormErrorCodes
+
+> `const` **DeductionFormErrorCodes**: `object`
+
+Validation error codes emitted by the deduction form schema. Map these
+codes to localized copy in `validationMessages` when composing the hook.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| `NEGATIVE_AMOUNT` | `"NEGATIVE_AMOUNT"` |
+| `REQUIRED` | `"REQUIRED"` |
 
 ***
 

--- a/docs/reference/employee/hooks/use-employee-details-form.md
+++ b/docs/reference/employee/hooks/use-employee-details-form.md
@@ -371,44 +371,11 @@ _Also accepts `description`, `formHookResult`, `placeholder`, `transform` from [
 
 ## Validations
 
-<a id="employeedetailserrorcodes"></a>
-
-### EmployeeDetailsErrorCodes
-
-> `const` **EmployeeDetailsErrorCodes**: `object`
-
-Validation error codes emitted by the employee details form schema. Map
-these codes to localized copy in `validationMessages` when composing the
-hook.
-
-#### Type Declaration
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `EMAIL_REQUIRED_FOR_SELF_ONBOARDING` | `"EMAIL_REQUIRED_FOR_SELF_ONBOARDING"` | `'EMAIL_REQUIRED_FOR_SELF_ONBOARDING'` |
-| `INVALID_EMAIL` | `"INVALID_EMAIL"` | `'INVALID_EMAIL'` |
-| `INVALID_NAME` | `"INVALID_NAME"` | `'INVALID_NAME'` |
-| `INVALID_SSN` | `"INVALID_SSN"` | `'INVALID_SSN'` |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-***
-
-<a id="employeedetailserrorcode"></a>
-
-### EmployeeDetailsErrorCode
-
-> **EmployeeDetailsErrorCode** = *typeof* [`EmployeeDetailsErrorCodes`](#employeedetailserrorcodes)\[keyof *typeof* [`EmployeeDetailsErrorCodes`](#employeedetailserrorcodes)\]
-
-Union of validation error code strings emitted by the employee details form
-schema.
-
-***
-
 <a id="emailvalidation"></a>
 
 ### EmailValidation
 
-> **EmailValidation** = *typeof* [`EmployeeDetailsErrorCodes`](#employeedetailserrorcodes)\[`"REQUIRED"` \| `"INVALID_EMAIL"` \| `"EMAIL_REQUIRED_FOR_SELF_ONBOARDING"`\]
+> **EmailValidation** = `"REQUIRED"` \| `"INVALID_EMAIL"` \| `"EMAIL_REQUIRED_FOR_SELF_ONBOARDING"`
 
 Validation error codes emitted by the `email` field of [useEmployeeDetailsForm](#useemployeedetailsform).
 
@@ -425,7 +392,7 @@ enabled but the email is empty (create mode only). See
 
 ### EmployeeDetailsRequiredValidation
 
-> **EmployeeDetailsRequiredValidation** = *typeof* `EmployeeDetailsErrorCodes.REQUIRED`
+> **EmployeeDetailsRequiredValidation** = `"REQUIRED"`
 
 The required-field error code produced by [useEmployeeDetailsForm](#useemployeedetailsform) fields that only emit `REQUIRED`.
 
@@ -440,7 +407,7 @@ birth fields. See [EmployeeDetailsErrorCodes](#employeedetailserrorcodes).
 
 ### NameValidation
 
-> **NameValidation** = *typeof* [`EmployeeDetailsErrorCodes`](#employeedetailserrorcodes)\[`"REQUIRED"` \| `"INVALID_NAME"`\]
+> **NameValidation** = `"REQUIRED"` \| `"INVALID_NAME"`
 
 Validation error codes emitted by the name fields of [useEmployeeDetailsForm](#useemployeedetailsform).
 
@@ -456,7 +423,7 @@ description of each code.
 
 ### SsnRequiredValidation
 
-> **SsnRequiredValidation** = *typeof* `EmployeeDetailsErrorCodes.REQUIRED`
+> **SsnRequiredValidation** = `"REQUIRED"`
 
 The required-field error code for the `ssn` field of [useEmployeeDetailsForm](#useemployeedetailsform).
 
@@ -471,7 +438,7 @@ an SSN on file, even if `ssn` is included in `optionalFieldsToRequire`.
 
 ### SsnValidation
 
-> **SsnValidation** = *typeof* `EmployeeDetailsErrorCodes.INVALID_SSN`
+> **SsnValidation** = `"INVALID_SSN"`
 
 The format-validation error code emitted by the `ssn` field of [useEmployeeDetailsForm](#useemployeedetailsform).
 
@@ -501,6 +468,39 @@ switch changes the employee's onboarding status as part of an update.
 | `onEmployeeCreated?` | (`employee`: [`Employee`](../../APIModels/index.md#employee)) => `void` | Fired after a new employee is successfully created. |
 | `onEmployeeUpdated?` | (`employee`: [`Employee`](../../APIModels/index.md#employee)) => `void` | Fired after an existing employee is successfully updated. |
 | `onOnboardingStatusUpdated?` | (`status`: `unknown`) => `void` | Fired when an update toggles self-onboarding and the employee's onboarding status changes. |
+
+***
+
+<a id="employeedetailserrorcode"></a>
+
+### EmployeeDetailsErrorCode
+
+> **EmployeeDetailsErrorCode** = `"REQUIRED"` \| `"INVALID_NAME"` \| `"INVALID_EMAIL"` \| `"INVALID_SSN"` \| `"EMAIL_REQUIRED_FOR_SELF_ONBOARDING"`
+
+Union of validation error code strings emitted by the employee details form
+schema.
+
+***
+
+<a id="employeedetailserrorcodes"></a>
+
+### EmployeeDetailsErrorCodes
+
+> `const` **EmployeeDetailsErrorCodes**: `object`
+
+Validation error codes emitted by the employee details form schema. Map
+these codes to localized copy in `validationMessages` when composing the
+hook.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| `EMAIL_REQUIRED_FOR_SELF_ONBOARDING` | `"EMAIL_REQUIRED_FOR_SELF_ONBOARDING"` |
+| `INVALID_EMAIL` | `"INVALID_EMAIL"` |
+| `INVALID_NAME` | `"INVALID_NAME"` |
+| `INVALID_SSN` | `"INVALID_SSN"` |
+| `REQUIRED` | `"REQUIRED"` |
 
 ***
 

--- a/docs/reference/employee/hooks/use-employee-state-taxes-form.md
+++ b/docs/reference/employee/hooks/use-employee-state-taxes-form.md
@@ -416,7 +416,7 @@ validation messages.
 
 ### EmployeeStateTaxesErrorCode
 
-> **EmployeeStateTaxesErrorCode** = *typeof* [`EmployeeStateTaxesErrorCodes`](#employeestatetaxeserrorcodes)\[keyof *typeof* [`EmployeeStateTaxesErrorCodes`](#employeestatetaxeserrorcodes)\]
+> **EmployeeStateTaxesErrorCode** = `"REQUIRED"`
 
 Union of validation error code strings emitted by the employee state taxes
 form schema.
@@ -433,9 +433,9 @@ Validation error codes produced by the [useEmployeeStateTaxesForm](#useemployees
 
 #### Type Declaration
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
+| Name | Type |
+| ------ | ------ |
+| `REQUIRED` | `"REQUIRED"` |
 
 #### Remarks
 

--- a/docs/reference/employee/hooks/use-federal-taxes-form.md
+++ b/docs/reference/employee/hooks/use-federal-taxes-form.md
@@ -316,6 +316,31 @@ _Also accepts `description`, `formHookResult` from [RadioGroupHookFieldProps](..
 
 ## Validations
 
+<a id="federaltaxesrequiredvalidation"></a>
+
+### FederalTaxesRequiredValidation
+
+> **FederalTaxesRequiredValidation** = `"REQUIRED"`
+
+The required-field error code produced by [useFederalTaxesForm](#usefederaltaxesform) fields.
+
+#### Remarks
+
+Used as the `validationMessages` key for every federal taxes field. See
+[FederalTaxesErrorCodes](#federaltaxeserrorcodes).
+
+## Utility Types
+<a id="federaltaxeserrorcode"></a>
+
+### FederalTaxesErrorCode
+
+> **FederalTaxesErrorCode** = `"REQUIRED"`
+
+Union of validation error code strings emitted by the federal taxes form
+schema.
+
+***
+
 <a id="federaltaxeserrorcodes"></a>
 
 ### FederalTaxesErrorCodes
@@ -327,42 +352,17 @@ codes to localized copy in `validationMessages` when composing the hook.
 
 #### Type Declaration
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
+| Name | Type |
+| ------ | ------ |
+| `REQUIRED` | `"REQUIRED"` |
 
 ***
 
-<a id="federaltaxeserrorcode"></a>
-
-### FederalTaxesErrorCode
-
-> **FederalTaxesErrorCode** = *typeof* [`FederalTaxesErrorCodes`](#federaltaxeserrorcodes)\[keyof *typeof* [`FederalTaxesErrorCodes`](#federaltaxeserrorcodes)\]
-
-Union of validation error code strings emitted by the federal taxes form
-schema.
-
-***
-
-<a id="federaltaxesrequiredvalidation"></a>
-
-### FederalTaxesRequiredValidation
-
-> **FederalTaxesRequiredValidation** = *typeof* `FederalTaxesErrorCodes.REQUIRED`
-
-The required-field error code produced by [useFederalTaxesForm](#usefederaltaxesform) fields.
-
-#### Remarks
-
-Used as the `validationMessages` key for every federal taxes field. See
-[FederalTaxesErrorCodes](#federaltaxeserrorcodes).
-
-## Utility Types
 <a id="federaltaxesfield"></a>
 
 ### FederalTaxesField
 
-> **FederalTaxesField** = keyof *typeof* `fieldValidators`
+> **FederalTaxesField** = `"deductions"` \| `"extraWithholding"` \| `"filingStatus"` \| `"otherIncome"` \| `"twoJobs"` \| `"dependentsAmount"`
 
 Field names accepted by the federal taxes form.
 
@@ -454,7 +454,7 @@ household, and exempt from withholding.
 
 ### FilingStatusValue
 
-> **FilingStatusValue** = *typeof* [`FILING_STATUS_VALUES`](#filing_status_values)\[`number`\]
+> **FilingStatusValue** = `"Single"` \| `"Married"` \| `"Head of Household"` \| `"Exempt from withholding"`
 
 Union of filing status values that the form accepts.
 

--- a/docs/reference/employee/hooks/use-home-address-form.md
+++ b/docs/reference/employee/hooks/use-home-address-form.md
@@ -403,40 +403,11 @@ _Also accepts `description`, `formHookResult`, `placeholder`, `transform` from [
 
 ## Validations
 
-<a id="homeaddresserrorcodes"></a>
-
-### HomeAddressErrorCodes
-
-> `const` **HomeAddressErrorCodes**: `object`
-
-Validation error codes emitted by the home address form schema. Map these
-codes to localized copy in `validationMessages` when composing the hook.
-
-#### Type Declaration
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `INVALID_ZIP` | `"INVALID_ZIP"` | `'INVALID_ZIP'` |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-***
-
-<a id="homeaddresserrorcode"></a>
-
-### HomeAddressErrorCode
-
-> **HomeAddressErrorCode** = *typeof* [`HomeAddressErrorCodes`](#homeaddresserrorcodes)\[keyof *typeof* [`HomeAddressErrorCodes`](#homeaddresserrorcodes)\]
-
-Union of validation error code strings emitted by the home address form
-schema.
-
-***
-
 <a id="homeaddressrequiredvalidation"></a>
 
 ### HomeAddressRequiredValidation
 
-> **HomeAddressRequiredValidation** = *typeof* `HomeAddressErrorCodes.REQUIRED`
+> **HomeAddressRequiredValidation** = `"REQUIRED"`
 
 The required-field error code produced by [useHomeAddressForm](#usehomeaddressform) fields that only emit `REQUIRED`.
 
@@ -451,7 +422,7 @@ withholding, and effective date fields. See [HomeAddressErrorCodes](#homeaddress
 
 ### ZipValidation
 
-> **ZipValidation** = *typeof* [`HomeAddressErrorCodes`](#homeaddresserrorcodes)\[`"REQUIRED"` \| `"INVALID_ZIP"`\]
+> **ZipValidation** = `"REQUIRED"` \| `"INVALID_ZIP"`
 
 Validation error codes emitted by the `zip` field of [useHomeAddressForm](#usehomeaddressform).
 
@@ -461,11 +432,40 @@ Use these as keys in `validationMessages` on `Fields.Zip`. See
 [HomeAddressErrorCodes](#homeaddresserrorcodes).
 
 ## Utility Types
+<a id="homeaddresserrorcode"></a>
+
+### HomeAddressErrorCode
+
+> **HomeAddressErrorCode** = `"REQUIRED"` \| `"INVALID_ZIP"`
+
+Union of validation error code strings emitted by the home address form
+schema.
+
+***
+
+<a id="homeaddresserrorcodes"></a>
+
+### HomeAddressErrorCodes
+
+> `const` **HomeAddressErrorCodes**: `object`
+
+Validation error codes emitted by the home address form schema. Map these
+codes to localized copy in `validationMessages` when composing the hook.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| `INVALID_ZIP` | `"INVALID_ZIP"` |
+| `REQUIRED` | `"REQUIRED"` |
+
+***
+
 <a id="homeaddressfield"></a>
 
 ### HomeAddressField
 
-> **HomeAddressField** = keyof *typeof* `fieldValidators`
+> **HomeAddressField** = `"street1"` \| `"city"` \| `"state"` \| `"zip"` \| `"street2"` \| `"effectiveDate"` \| `"courtesyWithholding"`
 
 Field names accepted by the home address form.
 

--- a/docs/reference/employee/hooks/use-job-form.md
+++ b/docs/reference/employee/hooks/use-job-form.md
@@ -305,6 +305,31 @@ _Also accepts `description`, `formHookResult` from [CheckboxHookFieldProps](../.
 
 ## Validations
 
+<a id="jobrequiredvalidation"></a>
+
+### JobRequiredValidation
+
+> **JobRequiredValidation** = `"REQUIRED"`
+
+The validation error code a [useJobForm](#usejobform) field can produce.
+
+#### Remarks
+
+Currently a single literal — `'REQUIRED'` — surfaced as the key in
+`validationMessages` on each `Fields.*` component. Future schema additions
+may extend the union.
+
+## Utility Types
+<a id="joberrorcode"></a>
+
+### JobErrorCode
+
+> **JobErrorCode** = `"REQUIRED"`
+
+Union of every error code produced by the [useJobForm](#usejobform) schema.
+
+***
+
 <a id="joberrorcodes"></a>
 
 ### JobErrorCodes
@@ -315,9 +340,9 @@ Validation error codes produced by the [useJobForm](#usejobform) schema.
 
 #### Type Declaration
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
+| Name | Type |
+| ------ | ------ |
+| `REQUIRED` | `"REQUIRED"` |
 
 #### Remarks
 
@@ -337,31 +362,6 @@ import { JobErrorCodes } from '@gusto/embedded-react-sdk'
 
 ***
 
-<a id="joberrorcode"></a>
-
-### JobErrorCode
-
-> **JobErrorCode** = *typeof* [`JobErrorCodes`](#joberrorcodes)\[keyof *typeof* [`JobErrorCodes`](#joberrorcodes)\]
-
-Union of every error code produced by the [useJobForm](#usejobform) schema.
-
-***
-
-<a id="jobrequiredvalidation"></a>
-
-### JobRequiredValidation
-
-> **JobRequiredValidation** = *typeof* `JobErrorCodes.REQUIRED`
-
-The validation error code a [useJobForm](#usejobform) field can produce.
-
-#### Remarks
-
-Currently a single literal — `'REQUIRED'` — surfaced as the key in
-`validationMessages` on each `Fields.*` component. Future schema additions
-may extend the union.
-
-## Utility Types
 <a id="jobfieldsmetadata"></a>
 
 ### JobFieldsMetadata

--- a/docs/reference/employee/hooks/use-payment-method-form.md
+++ b/docs/reference/employee/hooks/use-payment-method-form.md
@@ -161,39 +161,11 @@ _Also accepts `description`, `formHookResult` from [RadioGroupHookFieldProps](..
 
 ## Validations
 
-<a id="paymentmethodformerrorcodes"></a>
-
-### PaymentMethodFormErrorCodes
-
-> `const` **PaymentMethodFormErrorCodes**: `object`
-
-Validation error codes emitted by the payment method form schema. Map these
-codes to localized copy in `validationMessages` when composing the hook.
-
-#### Type Declaration
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-***
-
-<a id="paymentmethodformerrorcode"></a>
-
-### PaymentMethodFormErrorCode
-
-> **PaymentMethodFormErrorCode** = *typeof* [`PaymentMethodFormErrorCodes`](#paymentmethodformerrorcodes)\[keyof *typeof* [`PaymentMethodFormErrorCodes`](#paymentmethodformerrorcodes)\]
-
-Union of validation error code strings emitted by the payment method form
-schema.
-
-***
-
 <a id="paymentmethodformrequiredvalidation"></a>
 
 ### PaymentMethodFormRequiredValidation
 
-> **PaymentMethodFormRequiredValidation** = *typeof* `PaymentMethodFormErrorCodes.REQUIRED`
+> **PaymentMethodFormRequiredValidation** = `"REQUIRED"`
 
 Validation error codes emitted by [usePaymentMethodForm](#usepaymentmethodform) fields that only emit `REQUIRED`.
 
@@ -222,11 +194,39 @@ Shape of the values managed by the payment method form.
 
 ***
 
+<a id="paymentmethodformerrorcode"></a>
+
+### PaymentMethodFormErrorCode
+
+> **PaymentMethodFormErrorCode** = `"REQUIRED"`
+
+Union of validation error code strings emitted by the payment method form
+schema.
+
+***
+
+<a id="paymentmethodformerrorcodes"></a>
+
+### PaymentMethodFormErrorCodes
+
+> `const` **PaymentMethodFormErrorCodes**: `object`
+
+Validation error codes emitted by the payment method form schema. Map these
+codes to localized copy in `validationMessages` when composing the hook.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| `REQUIRED` | `"REQUIRED"` |
+
+***
+
 <a id="paymentmethodformfield"></a>
 
 ### PaymentMethodFormField
 
-> **PaymentMethodFormField** = keyof *typeof* `fieldValidators`
+> **PaymentMethodFormField** = `"type"`
 
 Field names accepted by the payment method form.
 
@@ -267,7 +267,7 @@ Shape of the validated values produced by the payment method form on submit.
 
 ### PaymentMethodType
 
-> **PaymentMethodType** = *typeof* [`PAYMENT_METHOD_TYPES`](#payment_method_types)\[`number`\]
+> **PaymentMethodType** = `"Check"` \| `"Direct Deposit"`
 
 Union of payment method type values that the form accepts.
 

--- a/docs/reference/employee/hooks/use-sign-employee-form.md
+++ b/docs/reference/employee/hooks/use-sign-employee-form.md
@@ -402,40 +402,11 @@ _Also accepts `description`, `formHookResult`, `portalContainer` from [SelectHoo
 
 ## Validations
 
-<a id="signemployeeformerrorcodes"></a>
-
-### SignEmployeeFormErrorCodes
-
-> `const` **SignEmployeeFormErrorCodes**: `object`
-
-Validation error codes emitted by the I-9 sign-employee form schema. Map
-these codes to localized copy in `validationMessages` when composing the
-hook.
-
-#### Type Declaration
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-***
-
-<a id="signemployeeformerrorcode"></a>
-
-### SignEmployeeFormErrorCode
-
-> **SignEmployeeFormErrorCode** = *typeof* [`SignEmployeeFormErrorCodes`](#signemployeeformerrorcodes)\[keyof *typeof* [`SignEmployeeFormErrorCodes`](#signemployeeformerrorcodes)\]
-
-Union of validation error code strings emitted by the I-9 sign-employee
-form schema.
-
-***
-
 <a id="signemployeeformrequiredvalidation"></a>
 
 ### SignEmployeeFormRequiredValidation
 
-> **SignEmployeeFormRequiredValidation** = *typeof* `SignEmployeeFormErrorCodes.REQUIRED`
+> **SignEmployeeFormRequiredValidation** = `"REQUIRED"`
 
 The required-field error code emitted by every field of [useSignEmployeeForm](#usesignemployeeform).
 
@@ -449,7 +420,7 @@ See [SignEmployeeFormErrorCodes](#signemployeeformerrorcodes).
 
 ### MAX\_PREPARERS
 
-> `const` **MAX\_PREPARERS**: `4` = `4`
+> `const` **MAX\_PREPARERS**: `4`
 
 Maximum number of I-9 preparers and translators the form supports.
 
@@ -539,11 +510,40 @@ Shape of the values managed by the I-9 sign-employee form.
 
 ***
 
+<a id="signemployeeformerrorcode"></a>
+
+### SignEmployeeFormErrorCode
+
+> **SignEmployeeFormErrorCode** = `"REQUIRED"`
+
+Union of validation error code strings emitted by the I-9 sign-employee
+form schema.
+
+***
+
+<a id="signemployeeformerrorcodes"></a>
+
+### SignEmployeeFormErrorCodes
+
+> `const` **SignEmployeeFormErrorCodes**: `object`
+
+Validation error codes emitted by the I-9 sign-employee form schema. Map
+these codes to localized copy in `validationMessages` when composing the
+hook.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| `REQUIRED` | `"REQUIRED"` |
+
+***
+
 <a id="signemployeeformfield"></a>
 
 ### SignEmployeeFormField
 
-> **SignEmployeeFormField** = keyof *typeof* `fieldValidators`
+> **SignEmployeeFormField** = `"signature"` \| `"preparerFirstName"` \| `"preparerLastName"` \| `"preparerStreet1"` \| `"preparerStreet2"` \| `"preparerCity"` \| `"preparerState"` \| `"preparerZip"` \| `"preparerSignature"` \| `"preparerAgree"` \| `"preparer2FirstName"` \| `"preparer2LastName"` \| `"preparer2Street1"` \| `"preparer2Street2"` \| `"preparer2City"` \| `"preparer2State"` \| `"preparer2Zip"` \| `"preparer2Signature"` \| `"preparer2Agree"` \| `"preparer3FirstName"` \| `"preparer3LastName"` \| `"preparer3Street1"` \| `"preparer3Street2"` \| `"preparer3City"` \| `"preparer3State"` \| `"preparer3Zip"` \| `"preparer3Signature"` \| `"preparer3Agree"` \| `"preparer4FirstName"` \| `"preparer4LastName"` \| `"preparer4Street1"` \| `"preparer4Street2"` \| `"preparer4City"` \| `"preparer4State"` \| `"preparer4Zip"` \| `"preparer4Signature"` \| `"preparer4Agree"` \| `"confirmSignature"` \| `"usedPreparer"`
 
 Field names accepted by the I-9 sign-employee form.
 

--- a/docs/reference/employee/hooks/use-split-payments-form.md
+++ b/docs/reference/employee/hooks/use-split-payments-form.md
@@ -238,57 +238,11 @@ required by the hook; the rest are required.
 
 ## Validations
 
-<a id="splitpaymentsformerrorcodes"></a>
-
-### SplitPaymentsFormErrorCodes
-
-> `const` **SplitPaymentsFormErrorCodes**: `object`
-
-Validation error codes emitted by the split payments form schema. Map these
-codes to localized copy in `validationMessages` when composing the hook.
-
-#### Type Declaration
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `DUPLICATE_PRIORITIES` | `"DUPLICATE_PRIORITIES"` | `'DUPLICATE_PRIORITIES'` |
-| `INVALID_AMOUNT` | `"INVALID_AMOUNT"` | `'INVALID_AMOUNT'` |
-| `INVALID_PERCENTAGE` | `"INVALID_PERCENTAGE"` | `'INVALID_PERCENTAGE'` |
-| `PERCENTAGE_TOTAL_MISMATCH` | `"PERCENTAGE_TOTAL_MISMATCH"` | `'PERCENTAGE_TOTAL_MISMATCH'` |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-***
-
-<a id="splitfieldvalidation"></a>
-
-### SplitFieldValidation
-
-> **SplitFieldValidation** = *typeof* `SplitPaymentsFormErrorCodes.REQUIRED` \| *typeof* `SplitPaymentsFormErrorCodes.INVALID_AMOUNT` \| *typeof* `SplitPaymentsFormErrorCodes.INVALID_PERCENTAGE`
-
-Validation codes a bound split-amount Field can emit at submit time:
-`REQUIRED` (every non-remainder split must have a value), `INVALID_AMOUNT`
-(Amount mode, `value < 0`), `INVALID_PERCENTAGE` (Percentage mode, non-integer
-or out of `0..100`). Supply translations for all three via `validationMessages`.
-The sum-to-100 invariant is surfaced separately via `status.hasPercentageImbalance`.
-
-***
-
-<a id="splitpaymentsformerrorcode"></a>
-
-### SplitPaymentsFormErrorCode
-
-> **SplitPaymentsFormErrorCode** = *typeof* [`SplitPaymentsFormErrorCodes`](#splitpaymentsformerrorcodes)\[keyof *typeof* [`SplitPaymentsFormErrorCodes`](#splitpaymentsformerrorcodes)\]
-
-Union of validation error code strings emitted by the split payments form
-schema.
-
-***
-
 <a id="splitpaymentsformrequiredvalidation"></a>
 
 ### SplitPaymentsFormRequiredValidation
 
-> **SplitPaymentsFormRequiredValidation** = *typeof* `SplitPaymentsFormErrorCodes.REQUIRED`
+> **SplitPaymentsFormRequiredValidation** = `"REQUIRED"`
 
 Validation error codes emitted by [useSplitPaymentsForm](#usesplitpaymentsform) fields that only emit `REQUIRED`.
 
@@ -308,9 +262,23 @@ amount per account.
 
 ### SplitByValue
 
-> **SplitByValue** = *typeof* [`SPLIT_BY_VALUES`](#split_by_values)\[`number`\]
+> **SplitByValue** = `"Percentage"` \| `"Amount"`
 
 Union of split-by mode values that the form accepts.
+
+***
+
+<a id="splitfieldvalidation"></a>
+
+### SplitFieldValidation
+
+> **SplitFieldValidation** = *typeof* `SplitPaymentsFormErrorCodes.REQUIRED` \| *typeof* `SplitPaymentsFormErrorCodes.INVALID_AMOUNT` \| *typeof* `SplitPaymentsFormErrorCodes.INVALID_PERCENTAGE`
+
+Validation codes a bound split-amount Field can emit at submit time:
+`REQUIRED` (every non-remainder split must have a value), `INVALID_AMOUNT`
+(Amount mode, `value < 0`), `INVALID_PERCENTAGE` (Percentage mode, non-integer
+or out of `0..100`). Supply translations for all three via `validationMessages`.
+The sum-to-100 invariant is surfaced separately via `status.hasPercentageImbalance`.
 
 ***
 
@@ -333,11 +301,43 @@ Shape of the values managed by the split payments form. `splitAmount` and
 
 ***
 
+<a id="splitpaymentsformerrorcode"></a>
+
+### SplitPaymentsFormErrorCode
+
+> **SplitPaymentsFormErrorCode** = `"REQUIRED"` \| `"INVALID_PERCENTAGE"` \| `"INVALID_AMOUNT"` \| `"DUPLICATE_PRIORITIES"` \| `"PERCENTAGE_TOTAL_MISMATCH"`
+
+Union of validation error code strings emitted by the split payments form
+schema.
+
+***
+
+<a id="splitpaymentsformerrorcodes"></a>
+
+### SplitPaymentsFormErrorCodes
+
+> `const` **SplitPaymentsFormErrorCodes**: `object`
+
+Validation error codes emitted by the split payments form schema. Map these
+codes to localized copy in `validationMessages` when composing the hook.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| `DUPLICATE_PRIORITIES` | `"DUPLICATE_PRIORITIES"` |
+| `INVALID_AMOUNT` | `"INVALID_AMOUNT"` |
+| `INVALID_PERCENTAGE` | `"INVALID_PERCENTAGE"` |
+| `PERCENTAGE_TOTAL_MISMATCH` | `"PERCENTAGE_TOTAL_MISMATCH"` |
+| `REQUIRED` | `"REQUIRED"` |
+
+***
+
 <a id="splitpaymentsformfield"></a>
 
 ### SplitPaymentsFormField
 
-> **SplitPaymentsFormField** = keyof *typeof* `fieldValidators`
+> **SplitPaymentsFormField** = `"priority"` \| `"splitBy"` \| `"splitAmount"`
 
 Field names accepted by the split payments form.
 

--- a/docs/reference/employee/hooks/use-work-address-form.md
+++ b/docs/reference/employee/hooks/use-work-address-form.md
@@ -248,39 +248,11 @@ _Also accepts `description`, `formHookResult`, `portalContainer` from [SelectHoo
 
 ## Validations
 
-<a id="workaddresserrorcodes"></a>
-
-### WorkAddressErrorCodes
-
-> `const` **WorkAddressErrorCodes**: `object`
-
-Validation error codes emitted by the work address form schema. Map these
-codes to localized copy in `validationMessages` when composing the hook.
-
-#### Type Declaration
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `REQUIRED` | `"REQUIRED"` | `'REQUIRED'` |
-
-***
-
-<a id="workaddresserrorcode"></a>
-
-### WorkAddressErrorCode
-
-> **WorkAddressErrorCode** = *typeof* [`WorkAddressErrorCodes`](#workaddresserrorcodes)\[keyof *typeof* [`WorkAddressErrorCodes`](#workaddresserrorcodes)\]
-
-Union of validation error code strings emitted by the work address form
-schema.
-
-***
-
 <a id="workaddressrequiredvalidation"></a>
 
 ### WorkAddressRequiredValidation
 
-> **WorkAddressRequiredValidation** = *typeof* `WorkAddressErrorCodes.REQUIRED`
+> **WorkAddressRequiredValidation** = `"REQUIRED"`
 
 The required-field error code produced by [useWorkAddressForm](#useworkaddressform) fields that only emit `REQUIRED`.
 
@@ -305,11 +277,39 @@ the hook resolves the current work address itself.
 
 ***
 
+<a id="workaddresserrorcode"></a>
+
+### WorkAddressErrorCode
+
+> **WorkAddressErrorCode** = `"REQUIRED"`
+
+Union of validation error code strings emitted by the work address form
+schema.
+
+***
+
+<a id="workaddresserrorcodes"></a>
+
+### WorkAddressErrorCodes
+
+> `const` **WorkAddressErrorCodes**: `object`
+
+Validation error codes emitted by the work address form schema. Map these
+codes to localized copy in `validationMessages` when composing the hook.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| `REQUIRED` | `"REQUIRED"` |
+
+***
+
 <a id="workaddressfield"></a>
 
 ### WorkAddressField
 
-> **WorkAddressField** = keyof *typeof* `fieldValidators`
+> **WorkAddressField** = `"effectiveDate"` \| `"locationUuid"`
 
 Field names accepted by the work address form.
 

--- a/docs/reference/employee/onboarding/blocks.md
+++ b/docs/reference/employee/onboarding/blocks.md
@@ -659,7 +659,7 @@ the API, the corresponding values are overwritten.
 
 ### OnboardingExecutionInitialState
 
-> **OnboardingExecutionInitialState** = keyof *typeof* `INITIAL_COMPONENT_MAP`
+> **OnboardingExecutionInitialState** = `"employeeProfile"`
 
 The set of steps [OnboardingExecutionFlow](onboarding-execution-flow.md) can be started on.
 

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -24,288 +24,288 @@ Catalog of every event key that an SDK component can emit through `onEvent`.
 
 #### Type Declaration
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `BREADCRUMB_NAVIGATE` | `"breadcrumb/navigate"` | `'breadcrumb/navigate'` |
-| `CANCEL` | `"CANCEL"` | `'CANCEL'` |
-| `COMPANY_ASSIGN_SIGNATORY_DONE` | `"company/signatory/assignSignatory/done"` | `'company/signatory/assignSignatory/done'` |
-| `COMPANY_ASSIGN_SIGNATORY_MODE_UPDATED` | `"company/signatory/assignSignatory/modeUpdated"` | `'company/signatory/assignSignatory/modeUpdated'` |
-| `COMPANY_BANK_ACCOUNT_CANCEL` | `"company/bankAccount/cancel"` | `'company/bankAccount/cancel'` |
-| `COMPANY_BANK_ACCOUNT_CHANGE` | `"company/bankAccount/change"` | `'company/bankAccount/change'` |
-| `COMPANY_BANK_ACCOUNT_CREATED` | `"company/bankAccount/created"` | `'company/bankAccount/created'` |
-| `COMPANY_BANK_ACCOUNT_DONE` | `"company/bankAccount/done"` | `'company/bankAccount/done'` |
-| `COMPANY_BANK_ACCOUNT_VERIFIED` | `"company/bankAccount/verified"` | `'company/bankAccount/verified'` |
-| `COMPANY_BANK_ACCOUNT_VERIFY` | `"company/bankAccount/verify"` | `'company/bankAccount/verify'` |
-| `COMPANY_CREATE_SIGNATORY_DONE` | `"company/signatory/createSignatory/done"` | `'company/signatory/createSignatory/done'` |
-| `COMPANY_FEDERAL_TAXES_DONE` | `"company/federalTaxes/done"` | `'company/federalTaxes/done'` |
-| `COMPANY_FEDERAL_TAXES_UPDATED` | `"company/federalTaxes/updated"` | `'company/federalTaxes/updated'` |
-| `COMPANY_FORM_EDIT_SIGNATORY` | `"company/forms/editSignatory"` | `'company/forms/editSignatory'` |
-| `COMPANY_FORMS_DONE` | `"company/forms/done"` | `'company/forms/done'` |
-| `COMPANY_INDUSTRY` | `"company/industry"` | `'company/industry'` |
-| `COMPANY_INDUSTRY_SELECTED` | `"company/industry/selected"` | `'company/industry/selected'` |
-| `COMPANY_INVITE_SIGNATORY_DONE` | `"company/signatory/inviteSignatory/done"` | `'company/signatory/inviteSignatory/done'` |
-| `COMPANY_LOCATION_CREATE` | `"company/location/add"` | `'company/location/add'` |
-| `COMPANY_LOCATION_CREATED` | `"company/location/add/done"` | `'company/location/add/done'` |
-| `COMPANY_LOCATION_DONE` | `"company/location/done"` | `'company/location/done'` |
-| `COMPANY_LOCATION_EDIT` | `"company/location/edit"` | `'company/location/edit'` |
-| `COMPANY_LOCATION_UPDATED` | `"company/location/edit/done"` | `'company/location/edit/done'` |
-| `COMPANY_OVERVIEW_CONTINUE` | `"company/overview/continue"` | `'company/overview/continue'` |
-| `COMPANY_OVERVIEW_DONE` | `"company/overview/done"` | `'company/overview/done'` |
-| `COMPANY_SIGN_FORM` | `"company/forms/sign/signForm"` | `'company/forms/sign/signForm'` |
-| `COMPANY_SIGN_FORM_BACK` | `"company/forms/sign/back"` | `'company/forms/sign/back'` |
-| `COMPANY_SIGN_FORM_DONE` | `"company/forms/sign/done"` | `'company/forms/sign/done'` |
-| `COMPANY_SIGNATORY_CREATED` | `"company/signatory/created"` | `'company/signatory/created'` |
-| `COMPANY_SIGNATORY_INVITED` | `"company/signatory/invited"` | `'company/signatory/invited'` |
-| `COMPANY_SIGNATORY_UPDATED` | `"company/signatory/updated"` | `'company/signatory/updated'` |
-| `COMPANY_STATE_TAX_DONE` | `"company/stateTaxes/done"` | `'company/stateTaxes/done'` |
-| `COMPANY_STATE_TAX_EDIT` | `"company/stateTaxes/edit"` | `'company/stateTaxes/edit'` |
-| `COMPANY_STATE_TAX_UPDATED` | `"company/stateTaxes/updated"` | `'company/stateTaxes/updated'` |
-| `COMPANY_VIEW_FORM_TO_SIGN` | `"company/forms/view"` | `'company/forms/view'` |
-| `CONTRACTOR_ADDRESS_DONE` | `"contractor/address/done"` | `'contractor/address/done'` |
-| `CONTRACTOR_ADDRESS_UPDATED` | `"contractor/address/updated"` | `'contractor/address/updated'` |
-| `CONTRACTOR_BANK_ACCOUNT_CREATED` | `"contractor/bankAccount/created"` | `'contractor/bankAccount/created'` |
-| `CONTRACTOR_CREATE` | `"contractor/create"` | `'contractor/create'` |
-| `CONTRACTOR_CREATED` | `"contractor/created"` | `'contractor/created'` |
-| `CONTRACTOR_DELETED` | `"contractor/deleted"` | `'contractor/deleted'` |
-| `CONTRACTOR_DOCUMENTS_DONE` | `"contractor/documents/done"` | `'contractor/documents/done'` |
-| `CONTRACTOR_INVITE_CONTRACTOR` | `"contractor/invite/selfOnboarding"` | `'contractor/invite/selfOnboarding'` |
-| `CONTRACTOR_NEW_HIRE_REPORT_DONE` | `"contractor/newHireReport/done"` | `'contractor/newHireReport/done'` |
-| `CONTRACTOR_NEW_HIRE_REPORT_UPDATED` | `"contractor/newHireReport/updated"` | `'contractor/newHireReport/updated'` |
-| `CONTRACTOR_ONBOARDING_CONTINUE` | `"contractor/onboarding/continue"` | `'contractor/onboarding/continue'` |
-| `CONTRACTOR_ONBOARDING_STATUS_UPDATED` | `"contractor/onboardingStatus/updated"` | `'contractor/onboardingStatus/updated'` |
-| `CONTRACTOR_PAYMENT_BACK_TO_EDIT` | `"contractor/payments/backToEdit"` | `'contractor/payments/backToEdit'` |
-| `CONTRACTOR_PAYMENT_CANCEL` | `"contractor/payments/cancel"` | `'contractor/payments/cancel'` |
-| `CONTRACTOR_PAYMENT_CREATE` | `"contractor/payments/create"` | `'contractor/payments/create'` |
-| `CONTRACTOR_PAYMENT_CREATED` | `"contractor/payments/created"` | `'contractor/payments/created'` |
-| `CONTRACTOR_PAYMENT_EDIT` | `"contractor/payments/edit"` | `'contractor/payments/edit'` |
-| `CONTRACTOR_PAYMENT_EXIT` | `"contractor/payments/exit"` | `'contractor/payments/exit'` |
-| `CONTRACTOR_PAYMENT_METHOD_DONE` | `"contractor/paymentMethod/done"` | `'contractor/paymentMethod/done'` |
-| `CONTRACTOR_PAYMENT_METHOD_UPDATED` | `"contractor/paymentMethod/updated"` | `'contractor/paymentMethod/updated'` |
-| `CONTRACTOR_PAYMENT_PREVIEW` | `"contractor/payments/preview"` | `'contractor/payments/preview'` |
-| `CONTRACTOR_PAYMENT_RFI_RESPOND` | `"contractor/payments/rfi/respond"` | `'contractor/payments/rfi/respond'` |
-| `CONTRACTOR_PAYMENT_SUBMIT` | `"contractor/payments/submit"` | `'contractor/payments/submit'` |
-| `CONTRACTOR_PAYMENT_UPDATE` | `"contractor/payments/update"` | `'contractor/payments/update'` |
-| `CONTRACTOR_PAYMENT_VIEW` | `"contractor/payments/view"` | `'contractor/payments/view'` |
-| `CONTRACTOR_PAYMENT_VIEW_DETAILS` | `"contractor/payments/view/details"` | `'contractor/payments/view/details'` |
-| `CONTRACTOR_PROFILE_DONE` | `"contractor/profile/done"` | `'contractor/profile/done'` |
-| `CONTRACTOR_SELF_ONBOARDING_DONE` | `"contractor/selfOnboarding/done"` | `'contractor/selfOnboarding/done'` |
-| `CONTRACTOR_SELF_ONBOARDING_START` | `"contractor/selfOnboarding/start"` | `'contractor/selfOnboarding/start'` |
-| `CONTRACTOR_SUBMIT_DONE` | `"contractor/submit/done"` | `'contractor/submit/done'` |
-| `CONTRACTOR_UPDATE` | `"contractor/update"` | `'contractor/update'` |
-| `CONTRACTOR_UPDATED` | `"contractor/updated"` | `'contractor/updated'` |
-| `CONTRACTOR_VIEW_DOCUMENT_TO_SIGN` | `"contractor/documents/view"` | `'contractor/documents/view'` |
-| `DISMISSAL_PAY_PERIOD_SELECTED` | `"dismissal/payPeriod/selected"` | `'dismissal/payPeriod/selected'` |
-| `EMPLOYEE_BANK_ACCOUNT_CREATE` | `"employee/bankAccount/create"` | `'employee/bankAccount/create'` |
-| `EMPLOYEE_BANK_ACCOUNT_CREATED` | `"employee/bankAccount/created"` | `'employee/bankAccount/created'` |
-| `EMPLOYEE_BANK_ACCOUNT_DELETED` | `"employee/bankAccount/deleted"` | `'employee/bankAccount/deleted'` |
-| `EMPLOYEE_CHANGE_ELIGIBILITY_STATUS` | `"employee/employmentEligibility/change"` | `'employee/employmentEligibility/change'` |
-| `EMPLOYEE_COMPENSATION_CANCEL` | `"employee/compensations/cancel"` | `'employee/compensations/cancel'` |
-| `EMPLOYEE_COMPENSATION_CHANGE_CANCELLED` | `"employee/compensations/changeCancelled"` | `'employee/compensations/changeCancelled'` |
-| `EMPLOYEE_COMPENSATION_CREATE` | `"employee/compensations/create"` | `'employee/compensations/create'` |
-| `EMPLOYEE_COMPENSATION_CREATED` | `"employee/compensations/created"` | `'employee/compensations/created'` |
-| `EMPLOYEE_COMPENSATION_DONE` | `"employee/compensations/done"` | `'employee/compensations/done'` |
-| `EMPLOYEE_COMPENSATION_RETURN_TO_LIST` | `"employee/compensations/returnToList"` | `'employee/compensations/returnToList'` |
-| `EMPLOYEE_COMPENSATION_UPDATED` | `"employee/compensations/updated"` | `'employee/compensations/updated'` |
-| `EMPLOYEE_CREATE` | `"employee/create"` | `'employee/create'` |
-| `EMPLOYEE_CREATED` | `"employee/created"` | `'employee/created'` |
-| `EMPLOYEE_DASHBOARD_TAB_CHANGE` | `"employee/dashboard/tabChange"` | `'employee/dashboard/tabChange'` |
-| `EMPLOYEE_DEDUCTION_ADD` | `"employee/deductions/add"` | `'employee/deductions/add'` |
-| `EMPLOYEE_DEDUCTION_CANCEL` | `"employee/deductions/cancel"` | `'employee/deductions/cancel'` |
-| `EMPLOYEE_DEDUCTION_CANCEL_EMPTY` | `"employee/deductions/cancelEmpty"` | `'employee/deductions/cancelEmpty'` |
-| `EMPLOYEE_DEDUCTION_CREATED` | `"employee/deductions/created"` | `'employee/deductions/created'` |
-| `EMPLOYEE_DEDUCTION_DELETED` | `"employee/deductions/deleted"` | `'employee/deductions/deleted'` |
-| `EMPLOYEE_DEDUCTION_DELETED_EMPTY` | `"employee/deductions/deletedEmpty"` | `'employee/deductions/deletedEmpty'` |
-| `EMPLOYEE_DEDUCTION_DONE` | `"employee/deductions/done"` | `'employee/deductions/done'` |
-| `EMPLOYEE_DEDUCTION_EDIT` | `"employee/deductions/edit"` | `'employee/deductions/edit'` |
-| `EMPLOYEE_DEDUCTION_UPDATED` | `"employee/deductions/updated"` | `'employee/deductions/updated'` |
-| `EMPLOYEE_DELETED` | `"employee/deleted"` | `'employee/deleted'` |
-| `EMPLOYEE_DISMISS` | `"employee/dismiss"` | `'employee/dismiss'` |
-| `EMPLOYEE_DOCUMENTS_DONE` | `"employee/documents/done"` | `'employee/documents/done'` |
-| `EMPLOYEE_EMPLOYMENT_ELIGIBILITY_DONE` | `"employee/employmentEligibility/done"` | `'employee/employmentEligibility/done'` |
-| `EMPLOYEE_FEDERAL_TAXES_DONE` | `"employee/federalTaxes/done"` | `'employee/federalTaxes/done'` |
-| `EMPLOYEE_FEDERAL_TAXES_EDIT` | `"employee/federalTaxes/edit"` | `'employee/federalTaxes/edit'` |
-| `EMPLOYEE_FEDERAL_TAXES_UPDATED` | `"employee/federalTaxes/updated"` | `'employee/federalTaxes/updated'` |
-| `EMPLOYEE_FORMS_DONE` | `"employee/forms/done"` | `'employee/forms/done'` |
-| `EMPLOYEE_HOME_ADDRESS_CREATED` | `"employee/addresses/home/created"` | `'employee/addresses/home/created'` |
-| `EMPLOYEE_HOME_ADDRESS_UPDATED` | `"employee/addresses/home/updated"` | `'employee/addresses/home/updated'` |
-| `EMPLOYEE_JOB_ADD` | `"employee/job/add"` | `'employee/job/add'` |
-| `EMPLOYEE_JOB_ADD_ANOTHER` | `"employee/job/addAnother"` | `'employee/job/addAnother'` |
-| `EMPLOYEE_JOB_CREATED` | `"employee/job/created"` | `'employee/job/created'` |
-| `EMPLOYEE_JOB_DELETED` | `"employee/job/deleted"` | `'employee/job/deleted'` |
-| `EMPLOYEE_JOB_EDIT` | `"employee/job/edit"` | `'employee/job/edit'` |
-| `EMPLOYEE_JOB_UPDATED` | `"employee/job/updated"` | `'employee/job/updated'` |
-| `EMPLOYEE_MANAGEMENT_COMPENSATION_ADD_ANOTHER_JOB_FORM_CANCELLED` | `"employee/management/compensation/addAnotherJobForm/cancelled"` | `'employee/management/compensation/addAnotherJobForm/cancelled'` |
-| `EMPLOYEE_MANAGEMENT_COMPENSATION_ADD_ANOTHER_JOB_FORM_SUBMITTED` | `"employee/management/compensation/addAnotherJobForm/submitted"` | `'employee/management/compensation/addAnotherJobForm/submitted'` |
-| `EMPLOYEE_MANAGEMENT_COMPENSATION_ADD_JOB_FORM_CANCELLED` | `"employee/management/compensation/addJobForm/cancelled"` | `'employee/management/compensation/addJobForm/cancelled'` |
-| `EMPLOYEE_MANAGEMENT_COMPENSATION_ADD_JOB_FORM_SUBMITTED` | `"employee/management/compensation/addJobForm/submitted"` | `'employee/management/compensation/addJobForm/submitted'` |
-| `EMPLOYEE_MANAGEMENT_COMPENSATION_ALERT_DISMISSED` | `"employee/management/compensation/alertDismissed"` | `'employee/management/compensation/alertDismissed'` |
-| `EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_ADD_ANOTHER_REQUESTED` | `"employee/management/compensation/card/addAnotherRequested"` | `'employee/management/compensation/card/addAnotherRequested'` |
-| `EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_ADD_REQUESTED` | `"employee/management/compensation/card/addRequested"` | `'employee/management/compensation/card/addRequested'` |
-| `EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_CHANGE_CANCELLED` | `"employee/management/compensation/card/changeCancelled"` | `'employee/management/compensation/card/changeCancelled'` |
-| `EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_EDIT_REQUESTED` | `"employee/management/compensation/card/editRequested"` | `'employee/management/compensation/card/editRequested'` |
-| `EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_JOB_DELETED` | `"employee/management/compensation/card/jobDeleted"` | `'employee/management/compensation/card/jobDeleted'` |
-| `EMPLOYEE_MANAGEMENT_COMPENSATION_EDIT_FORM_CANCELLED` | `"employee/management/compensation/editForm/cancelled"` | `'employee/management/compensation/editForm/cancelled'` |
-| `EMPLOYEE_MANAGEMENT_COMPENSATION_EDIT_FORM_SUBMITTED` | `"employee/management/compensation/editForm/submitted"` | `'employee/management/compensation/editForm/submitted'` |
-| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_ALERT_DISMISSED` | `"employee/management/deductions/alertDismissed"` | `'employee/management/deductions/alertDismissed'` |
-| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_CARD_ADD_REQUESTED` | `"employee/management/deductions/card/addRequested"` | `'employee/management/deductions/card/addRequested'` |
-| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_CARD_DELETED` | `"employee/management/deductions/card/deleted"` | `'employee/management/deductions/card/deleted'` |
-| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_CARD_EDIT_REQUESTED` | `"employee/management/deductions/card/editRequested"` | `'employee/management/deductions/card/editRequested'` |
-| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_EDIT_FORM_CANCELLED` | `"employee/management/deductions/editForm/cancelled"` | `'employee/management/deductions/editForm/cancelled'` |
-| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_EDIT_FORM_CREATED` | `"employee/management/deductions/editForm/created"` | `'employee/management/deductions/editForm/created'` |
-| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_EDIT_FORM_UPDATED` | `"employee/management/deductions/editForm/updated"` | `'employee/management/deductions/editForm/updated'` |
-| `EMPLOYEE_MANAGEMENT_DOCUMENTS_CARD_VIEW_REQUESTED` | `"employee/management/documents/card/viewRequested"` | `'employee/management/documents/card/viewRequested'` |
-| `EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_ALERT_DISMISSED` | `"employee/management/federalTaxes/alertDismissed"` | `'employee/management/federalTaxes/alertDismissed'` |
-| `EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_CARD_EDIT_REQUESTED` | `"employee/management/federalTaxes/card/editRequested"` | `'employee/management/federalTaxes/card/editRequested'` |
-| `EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_EDIT_FORM_CANCELLED` | `"employee/management/federalTaxes/editForm/cancelled"` | `'employee/management/federalTaxes/editForm/cancelled'` |
-| `EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_EDIT_FORM_SUBMITTED` | `"employee/management/federalTaxes/editForm/submitted"` | `'employee/management/federalTaxes/editForm/submitted'` |
-| `EMPLOYEE_MANAGEMENT_HOME_ADDRESS_CREATED` | `"employee/management/homeAddress/created"` | `'employee/management/homeAddress/created'` |
-| `EMPLOYEE_MANAGEMENT_HOME_ADDRESS_DELETED` | `"employee/management/homeAddress/deleted"` | `'employee/management/homeAddress/deleted'` |
-| `EMPLOYEE_MANAGEMENT_HOME_ADDRESS_EDIT_CANCELLED` | `"employee/management/homeAddress/editCancelled"` | `'employee/management/homeAddress/editCancelled'` |
-| `EMPLOYEE_MANAGEMENT_HOME_ADDRESS_EDIT_REQUESTED` | `"employee/management/homeAddress/editRequested"` | `'employee/management/homeAddress/editRequested'` |
-| `EMPLOYEE_MANAGEMENT_HOME_ADDRESS_UPDATED` | `"employee/management/homeAddress/updated"` | `'employee/management/homeAddress/updated'` |
-| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_ALERT_DISMISSED` | `"employee/management/paymentMethod/alertDismissed"` | `'employee/management/paymentMethod/alertDismissed'` |
-| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_BANK_FORM_CANCELLED` | `"employee/management/paymentMethod/bankForm/cancelled"` | `'employee/management/paymentMethod/bankForm/cancelled'` |
-| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_BANK_FORM_SUBMITTED` | `"employee/management/paymentMethod/bankForm/submitted"` | `'employee/management/paymentMethod/bankForm/submitted'` |
-| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_CARD_ADD_REQUESTED` | `"employee/management/paymentMethod/card/addRequested"` | `'employee/management/paymentMethod/card/addRequested'` |
-| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_CARD_BANK_ACCOUNT_DELETED` | `"employee/management/paymentMethod/card/bankAccountDeleted"` | `'employee/management/paymentMethod/card/bankAccountDeleted'` |
-| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_CARD_SPLIT_REQUESTED` | `"employee/management/paymentMethod/card/splitRequested"` | `'employee/management/paymentMethod/card/splitRequested'` |
-| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_SPLIT_FORM_CANCELLED` | `"employee/management/paymentMethod/splitForm/cancelled"` | `'employee/management/paymentMethod/splitForm/cancelled'` |
-| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_SPLIT_FORM_SUBMITTED` | `"employee/management/paymentMethod/splitForm/submitted"` | `'employee/management/paymentMethod/splitForm/submitted'` |
-| `EMPLOYEE_MANAGEMENT_PAYSTUBS_CARD_DOWNLOAD_REQUESTED` | `"employee/management/paystubs/card/downloadRequested"` | `'employee/management/paystubs/card/downloadRequested'` |
-| `EMPLOYEE_MANAGEMENT_PAYSTUBS_CARD_DOWNLOADED` | `"employee/management/paystubs/card/downloaded"` | `'employee/management/paystubs/card/downloaded'` |
-| `EMPLOYEE_MANAGEMENT_PROFILE_ALERT_DISMISSED` | `"employee/management/profile/alertDismissed"` | `'employee/management/profile/alertDismissed'` |
-| `EMPLOYEE_MANAGEMENT_PROFILE_EDIT_CANCELLED` | `"employee/management/profile/editCancelled"` | `'employee/management/profile/editCancelled'` |
-| `EMPLOYEE_MANAGEMENT_PROFILE_EDIT_REQUESTED` | `"employee/management/profile/editRequested"` | `'employee/management/profile/editRequested'` |
-| `EMPLOYEE_MANAGEMENT_PROFILE_UPDATED` | `"employee/management/profile/updated"` | `'employee/management/profile/updated'` |
-| `EMPLOYEE_MANAGEMENT_STATE_TAXES_ALERT_DISMISSED` | `"employee/management/stateTaxes/alertDismissed"` | `'employee/management/stateTaxes/alertDismissed'` |
-| `EMPLOYEE_MANAGEMENT_STATE_TAXES_EDIT_CANCELLED` | `"employee/management/stateTaxes/editCancelled"` | `'employee/management/stateTaxes/editCancelled'` |
-| `EMPLOYEE_MANAGEMENT_STATE_TAXES_EDIT_REQUESTED` | `"employee/management/stateTaxes/editRequested"` | `'employee/management/stateTaxes/editRequested'` |
-| `EMPLOYEE_MANAGEMENT_STATE_TAXES_UPDATED` | `"employee/management/stateTaxes/updated"` | `'employee/management/stateTaxes/updated'` |
-| `EMPLOYEE_MANAGEMENT_WORK_ADDRESS_CREATED` | `"employee/management/workAddress/created"` | `'employee/management/workAddress/created'` |
-| `EMPLOYEE_MANAGEMENT_WORK_ADDRESS_DELETED` | `"employee/management/workAddress/deleted"` | `'employee/management/workAddress/deleted'` |
-| `EMPLOYEE_MANAGEMENT_WORK_ADDRESS_EDIT_CANCELLED` | `"employee/management/workAddress/editCancelled"` | `'employee/management/workAddress/editCancelled'` |
-| `EMPLOYEE_MANAGEMENT_WORK_ADDRESS_EDIT_REQUESTED` | `"employee/management/workAddress/editRequested"` | `'employee/management/workAddress/editRequested'` |
-| `EMPLOYEE_MANAGEMENT_WORK_ADDRESS_UPDATED` | `"employee/management/workAddress/updated"` | `'employee/management/workAddress/updated'` |
-| `EMPLOYEE_ONBOARDING_DOCUMENTS_CONFIG_UPDATED` | `"employee/onboardingDocumentsConfig/updated"` | `'employee/onboardingDocumentsConfig/updated'` |
-| `EMPLOYEE_ONBOARDING_DONE` | `"employee/onboarding/done"` | `'employee/onboarding/done'` |
-| `EMPLOYEE_ONBOARDING_STATUS_UPDATED` | `"employee/onboardingStatus/updated"` | `'employee/onboardingStatus/updated'` |
-| `EMPLOYEE_PAYMENT_METHOD_DONE` | `"employee/paymentMethod/done"` | `'employee/paymentMethod/done'` |
-| `EMPLOYEE_PAYMENT_METHOD_RESET` | `"employee/paymentMethod/reset"` | `'employee/paymentMethod/reset'` |
-| `EMPLOYEE_PAYMENT_METHOD_UPDATED` | `"employee/paymentMethod/updated"` | `'employee/paymentMethod/updated'` |
-| `EMPLOYEE_PROFILE_DONE` | `"employee/profile/done"` | `'employee/profile/done'` |
-| `EMPLOYEE_REHIRE` | `"employee/rehire"` | `'employee/rehire'` |
-| `EMPLOYEE_RETURN_TO_LIST` | `"employee/returnToList"` | `'employee/returnToList'` |
-| `EMPLOYEE_SELF_ONBOARDING_START` | `"employee/selfOnboarding/start"` | `'employee/selfOnboarding/start'` |
-| `EMPLOYEE_SIGN_FORM` | `"employee/forms/sign"` | `'employee/forms/sign'` |
-| `EMPLOYEE_SPLIT_PAYCHECK` | `"employee/bankAccount/split"` | `'employee/bankAccount/split'` |
-| `EMPLOYEE_SPLIT_PAYMENT` | `"employee/paymentMethod/split"` | `'employee/paymentMethod/split'` |
-| `EMPLOYEE_STATE_TAXES_DONE` | `"employee/stateTaxes/done"` | `'employee/stateTaxes/done'` |
-| `EMPLOYEE_STATE_TAXES_UPDATED` | `"employee/stateTaxes/updated"` | `'employee/stateTaxes/updated'` |
-| `EMPLOYEE_SUMMARY_VIEW` | `"employee/summary"` | `'employee/summary'` |
-| `EMPLOYEE_TERMINATION_CANCELLED` | `"employee/termination/cancelled"` | `'employee/termination/cancelled'` |
-| `EMPLOYEE_TERMINATION_CREATED` | `"employee/termination/created"` | `'employee/termination/created'` |
-| `EMPLOYEE_TERMINATION_DONE` | `"employee/termination/done"` | `'employee/termination/done'` |
-| `EMPLOYEE_TERMINATION_EDIT` | `"employee/termination/edit"` | `'employee/termination/edit'` |
-| `EMPLOYEE_TERMINATION_PAYROLL_CREATED` | `"employee/termination/payroll/created"` | `'employee/termination/payroll/created'` |
-| `EMPLOYEE_TERMINATION_PAYROLL_FAILED` | `"employee/termination/payroll/failed"` | `'employee/termination/payroll/failed'` |
-| `EMPLOYEE_TERMINATION_RUN_OFF_CYCLE_PAYROLL` | `"employee/termination/runOffCyclePayroll"` | `'employee/termination/runOffCyclePayroll'` |
-| `EMPLOYEE_TERMINATION_RUN_PAYROLL` | `"employee/termination/runPayroll"` | `'employee/termination/runPayroll'` |
-| `EMPLOYEE_TERMINATION_UPDATED` | `"employee/termination/updated"` | `'employee/termination/updated'` |
-| `EMPLOYEE_TERMINATION_VIEW_SUMMARY` | `"employee/termination/viewSummary"` | `'employee/termination/viewSummary'` |
-| `EMPLOYEE_UPDATE` | `"employee/update"` | `'employee/update'` |
-| `EMPLOYEE_UPDATED` | `"employee/updated"` | `'employee/updated'` |
-| `EMPLOYEE_VIEW_FORM_TO_SIGN` | `"employee/forms/view"` | `'employee/forms/view'` |
-| `EMPLOYEE_WORK_ADDRESS` | `"employee/addresses/work"` | `'employee/addresses/work'` |
-| `EMPLOYEE_WORK_ADDRESS_CREATED` | `"employee/addresses/work/created"` | `'employee/addresses/work/created'` |
-| `EMPLOYEE_WORK_ADDRESS_DELETED` | `"employee/addresses/work/deleted"` | `'employee/addresses/work/deleted'` |
-| `EMPLOYEE_WORK_ADDRESS_UPDATE` | `"employee/addresses/work/update"` | `'employee/addresses/work/update'` |
-| `EMPLOYEE_WORK_ADDRESS_UPDATED` | `"employee/addresses/work/updated"` | `'employee/addresses/work/updated'` |
-| `EMPLOYEES_LIST` | `"company/employees"` | `'company/employees'` |
-| `ERROR` | `"ERROR"` | `'ERROR'` |
-| `INFORMATION_REQUEST_FORM_CANCEL` | `"informationRequest/form/cancel"` | `'informationRequest/form/cancel'` |
-| `INFORMATION_REQUEST_FORM_DONE` | `"informationRequest/form/done"` | `'informationRequest/form/done'` |
-| `INFORMATION_REQUEST_FORM_SUBMIT` | `"informationRequest/form/submit"` | `'informationRequest/form/submit'` |
-| `INFORMATION_REQUEST_RESPOND` | `"informationRequest/respond"` | `'informationRequest/respond'` |
-| `OFF_CYCLE_CREATED` | `"offCycle/created"` | `'offCycle/created'` |
-| `OFF_CYCLE_DEDUCTIONS_CHANGE` | `"offCycle/deductionsChange"` | `'offCycle/deductionsChange'` |
-| `OFF_CYCLE_SELECT_REASON` | `"offCycle/selectReason"` | `'offCycle/selectReason'` |
-| `PAY_SCHEDULE_CREATE` | `"paySchedule/create"` | `'paySchedule/create'` |
-| `PAY_SCHEDULE_CREATED` | `"paySchedule/created"` | `'paySchedule/created'` |
-| `PAY_SCHEDULE_DELETE` | `"paySchedule/delete"` | `'paySchedule/delete'` |
-| `PAY_SCHEDULE_DELETED` | `"paySchedule/deleted"` | `'paySchedule/deleted'` |
-| `PAY_SCHEDULE_DONE` | `"paySchedule/done"` | `'paySchedule/done'` |
-| `PAY_SCHEDULE_UPDATE` | `"paySchedule/update"` | `'paySchedule/update'` |
-| `PAY_SCHEDULE_UPDATED` | `"paySchedule/updated"` | `'paySchedule/updated'` |
-| `PAYROLL_DELETED` | `"payroll/deleted"` | `'payroll/deleted'` |
-| `PAYROLL_EXIT_FLOW` | `"payroll/saveAndExit"` | `'payroll/saveAndExit'` |
-| `PAYROLL_SKIPPED` | `"payroll/skipped"` | `'payroll/skipped'` |
-| `PAYROLL_WIRE_FORM_CANCEL` | `"payroll/wire/form/cancel"` | `'payroll/wire/form/cancel'` |
-| `PAYROLL_WIRE_FORM_DONE` | `"payroll/wire/form/done"` | `'payroll/wire/form/done'` |
-| `PAYROLL_WIRE_INSTRUCTIONS_CANCEL` | `"payroll/wire/instructions/cancel"` | `'payroll/wire/instructions/cancel'` |
-| `PAYROLL_WIRE_INSTRUCTIONS_DONE` | `"payroll/wire/instructions/done"` | `'payroll/wire/instructions/done'` |
-| `PAYROLL_WIRE_INSTRUCTIONS_SELECT` | `"payroll/wire/instructions/select"` | `'payroll/wire/instructions/select'` |
-| `PAYROLL_WIRE_START_TRANSFER` | `"payroll/wire/startTransfer"` | `'payroll/wire/startTransfer'` |
-| `RECOVERY_CASE_RESOLVE` | `"recoveryCase/resolve"` | `'recoveryCase/resolve'` |
-| `RECOVERY_CASE_RESUBMIT` | `"recoveryCase/resubmit"` | `'recoveryCase/resubmit'` |
-| `RECOVERY_CASE_RESUBMIT_CANCEL` | `"recoveryCase/resubmit/cancel"` | `'recoveryCase/resubmit/cancel'` |
-| `RECOVERY_CASE_RESUBMIT_DONE` | `"recoveryCase/resubmit/done"` | `'recoveryCase/resubmit/done'` |
-| `REVIEW_PAYROLL` | `"payroll/review"` | `'payroll/review'` |
-| `ROBOT_MACHINE_DONE` | `"done"` | `'done'` |
-| `RUN_OFF_CYCLE_PAYROLL` | `"runPayroll/offCycle/start"` | `'runPayroll/offCycle/start'` |
-| `RUN_PAYROLL_BACK` | `"runPayroll/back"` | `'runPayroll/back'` |
-| `RUN_PAYROLL_BLOCKER_RESOLUTION_ATTEMPTED` | `"runPayroll/blocker/resolutionAttempted"` | `'runPayroll/blocker/resolutionAttempted'` |
-| `RUN_PAYROLL_BLOCKERS_DETECTED` | `"runPayroll/blockers/detected"` | `'runPayroll/blockers/detected'` |
-| `RUN_PAYROLL_BLOCKERS_VIEW_ALL` | `"runPayroll/blockers/viewAll"` | `'runPayroll/blockers/viewAll'` |
-| `RUN_PAYROLL_CALCULATED` | `"runPayroll/calculated"` | `'runPayroll/calculated'` |
-| `RUN_PAYROLL_CANCELLED` | `"runPayroll/cancelled"` | `'runPayroll/cancelled'` |
-| `RUN_PAYROLL_CANCELLED_ALERT_DISMISSED` | `"runPayroll/cancelled/alertDismissed"` | `'runPayroll/cancelled/alertDismissed'` |
-| `RUN_PAYROLL_DATES_CONFIGURED` | `"runPayroll/dates/configured"` | `'runPayroll/dates/configured'` |
-| `RUN_PAYROLL_EDIT` | `"runPayroll/edit"` | `'runPayroll/edit'` |
-| `RUN_PAYROLL_EMPLOYEE_CANCELLED` | `"runPayroll/employee/cancelled"` | `'runPayroll/employee/cancelled'` |
-| `RUN_PAYROLL_EMPLOYEE_EDIT` | `"runPayroll/employee/edit"` | `'runPayroll/employee/edit'` |
-| `RUN_PAYROLL_EMPLOYEE_SAVED` | `"runPayroll/employee/saved"` | `'runPayroll/employee/saved'` |
-| `RUN_PAYROLL_EMPLOYEE_SKIP` | `"runPayroll/employee/skip"` | `'runPayroll/employee/skip'` |
-| `RUN_PAYROLL_GROSS_UP_CALCULATED` | `"runPayroll/grossUp/calculated"` | `'runPayroll/grossUp/calculated'` |
-| `RUN_PAYROLL_GROSS_UP_SELECTED` | `"runPayroll/grossUp/selected"` | `'runPayroll/grossUp/selected'` |
-| `RUN_PAYROLL_PDF_PAYSTUB_VIEWED` | `"runPayroll/pdfPaystub/viewed"` | `'runPayroll/pdfPaystub/viewed'` |
-| `RUN_PAYROLL_PROCESSED` | `"runPayroll/processed"` | `'runPayroll/processed'` |
-| `RUN_PAYROLL_PROCESSING_FAILED` | `"runPayroll/processingFailed"` | `'runPayroll/processingFailed'` |
-| `RUN_PAYROLL_RECEIPT_GET` | `"runPayroll/receipt/get"` | `'runPayroll/receipt/get'` |
-| `RUN_PAYROLL_RECEIPT_VIEWED` | `"runPayroll/receipt/viewed"` | `'runPayroll/receipt/viewed'` |
-| `RUN_PAYROLL_SELECTED` | `"runPayroll/selected"` | `'runPayroll/selected'` |
-| `RUN_PAYROLL_SUBMITTED` | `"runPayroll/submitted"` | `'runPayroll/submitted'` |
-| `RUN_PAYROLL_SUBMITTING` | `"runPayroll/submitting"` | `'runPayroll/submitting'` |
-| `RUN_PAYROLL_SUMMARY_VIEWED` | `"runPayroll/summary/viewed"` | `'runPayroll/summary/viewed'` |
-| `RUN_TRANSITION_PAYROLL` | `"transition/runPayroll"` | `'transition/runPayroll'` |
-| `TIME_OFF_ADD_EMPLOYEES_BACK` | `"timeOff/addEmployees/back"` | `'timeOff/addEmployees/back'` |
-| `TIME_OFF_ADD_EMPLOYEES_DONE` | `"timeOff/addEmployees/done"` | `'timeOff/addEmployees/done'` |
-| `TIME_OFF_ADD_EMPLOYEES_ERROR` | `"timeOff/addEmployees/error"` | `'timeOff/addEmployees/error'` |
-| `TIME_OFF_ADD_EMPLOYEES_TO_POLICY` | `"timeOff/addEmployeesToPolicy"` | `'timeOff/addEmployeesToPolicy'` |
-| `TIME_OFF_BACK_TO_LIST` | `"timeOff/backToList"` | `'timeOff/backToList'` |
-| `TIME_OFF_CHANGE_SETTINGS` | `"timeOff/changeSettings"` | `'timeOff/changeSettings'` |
-| `TIME_OFF_CREATE_POLICY` | `"timeOff/createPolicy"` | `'timeOff/createPolicy'` |
-| `TIME_OFF_DELETE_POLICY_DONE` | `"timeOff/deletePolicy/done"` | `'timeOff/deletePolicy/done'` |
-| `TIME_OFF_EDIT_HOLIDAY_POLICY` | `"timeOff/editHolidayPolicy"` | `'timeOff/editHolidayPolicy'` |
-| `TIME_OFF_EDIT_POLICY` | `"timeOff/editPolicy"` | `'timeOff/editPolicy'` |
-| `TIME_OFF_HOLIDAY_ADD_EMPLOYEES` | `"timeOff/holidayAddEmployees"` | `'timeOff/holidayAddEmployees'` |
-| `TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE` | `"timeOff/holidayAddEmployees/done"` | `'timeOff/holidayAddEmployees/done'` |
-| `TIME_OFF_HOLIDAY_ADD_EMPLOYEES_ERROR` | `"timeOff/holidayAddEmployees/error"` | `'timeOff/holidayAddEmployees/error'` |
-| `TIME_OFF_HOLIDAY_CREATE_ERROR` | `"timeOff/holidayCreate/error"` | `'timeOff/holidayCreate/error'` |
-| `TIME_OFF_HOLIDAY_SELECTION_DONE` | `"timeOff/holidaySelection/done"` | `'timeOff/holidaySelection/done'` |
-| `TIME_OFF_HOLIDAY_SELECTION_EDIT_DONE` | `"timeOff/holidaySelection/editDone"` | `'timeOff/holidaySelection/editDone'` |
-| `TIME_OFF_POLICY_CREATE_ERROR` | `"timeOff/policyCreate/error"` | `'timeOff/policyCreate/error'` |
-| `TIME_OFF_POLICY_DETAILS_DONE` | `"timeOff/policyDetails/done"` | `'timeOff/policyDetails/done'` |
-| `TIME_OFF_POLICY_SETTINGS_BACK` | `"timeOff/policySettings/back"` | `'timeOff/policySettings/back'` |
-| `TIME_OFF_POLICY_SETTINGS_DONE` | `"timeOff/policySettings/done"` | `'timeOff/policySettings/done'` |
-| `TIME_OFF_POLICY_SETTINGS_ERROR` | `"timeOff/policySettings/error"` | `'timeOff/policySettings/error'` |
-| `TIME_OFF_POLICY_TYPE_SELECTED` | `"timeOff/policyTypeSelected"` | `'timeOff/policyTypeSelected'` |
-| `TIME_OFF_VIEW_HOLIDAY_EMPLOYEES` | `"timeOff/viewHolidayEmployees"` | `'timeOff/viewHolidayEmployees'` |
-| `TIME_OFF_VIEW_HOLIDAY_SCHEDULE` | `"timeOff/viewHolidaySchedule"` | `'timeOff/viewHolidaySchedule'` |
-| `TIME_OFF_VIEW_POLICY` | `"timeOff/viewPolicy"` | `'timeOff/viewPolicy'` |
-| `TIME_OFF_VIEW_POLICY_DETAILS` | `"timeOff/viewPolicyDetails"` | `'timeOff/viewPolicyDetails'` |
-| `TIME_OFF_VIEW_POLICY_EMPLOYEES` | `"timeOff/viewPolicyEmployees"` | `'timeOff/viewPolicyEmployees'` |
-| `TRANSITION_CREATED` | `"transition/created"` | `'transition/created'` |
-| `TRANSITION_PAYROLL_SKIPPED` | `"transition/payrollSkipped"` | `'transition/payrollSkipped'` |
+| Name | Type |
+| ------ | ------ |
+| `BREADCRUMB_NAVIGATE` | `"breadcrumb/navigate"` |
+| `CANCEL` | `"CANCEL"` |
+| `COMPANY_ASSIGN_SIGNATORY_DONE` | `"company/signatory/assignSignatory/done"` |
+| `COMPANY_ASSIGN_SIGNATORY_MODE_UPDATED` | `"company/signatory/assignSignatory/modeUpdated"` |
+| `COMPANY_BANK_ACCOUNT_CANCEL` | `"company/bankAccount/cancel"` |
+| `COMPANY_BANK_ACCOUNT_CHANGE` | `"company/bankAccount/change"` |
+| `COMPANY_BANK_ACCOUNT_CREATED` | `"company/bankAccount/created"` |
+| `COMPANY_BANK_ACCOUNT_DONE` | `"company/bankAccount/done"` |
+| `COMPANY_BANK_ACCOUNT_VERIFIED` | `"company/bankAccount/verified"` |
+| `COMPANY_BANK_ACCOUNT_VERIFY` | `"company/bankAccount/verify"` |
+| `COMPANY_CREATE_SIGNATORY_DONE` | `"company/signatory/createSignatory/done"` |
+| `COMPANY_FEDERAL_TAXES_DONE` | `"company/federalTaxes/done"` |
+| `COMPANY_FEDERAL_TAXES_UPDATED` | `"company/federalTaxes/updated"` |
+| `COMPANY_FORM_EDIT_SIGNATORY` | `"company/forms/editSignatory"` |
+| `COMPANY_FORMS_DONE` | `"company/forms/done"` |
+| `COMPANY_INDUSTRY` | `"company/industry"` |
+| `COMPANY_INDUSTRY_SELECTED` | `"company/industry/selected"` |
+| `COMPANY_INVITE_SIGNATORY_DONE` | `"company/signatory/inviteSignatory/done"` |
+| `COMPANY_LOCATION_CREATE` | `"company/location/add"` |
+| `COMPANY_LOCATION_CREATED` | `"company/location/add/done"` |
+| `COMPANY_LOCATION_DONE` | `"company/location/done"` |
+| `COMPANY_LOCATION_EDIT` | `"company/location/edit"` |
+| `COMPANY_LOCATION_UPDATED` | `"company/location/edit/done"` |
+| `COMPANY_OVERVIEW_CONTINUE` | `"company/overview/continue"` |
+| `COMPANY_OVERVIEW_DONE` | `"company/overview/done"` |
+| `COMPANY_SIGN_FORM` | `"company/forms/sign/signForm"` |
+| `COMPANY_SIGN_FORM_BACK` | `"company/forms/sign/back"` |
+| `COMPANY_SIGN_FORM_DONE` | `"company/forms/sign/done"` |
+| `COMPANY_SIGNATORY_CREATED` | `"company/signatory/created"` |
+| `COMPANY_SIGNATORY_INVITED` | `"company/signatory/invited"` |
+| `COMPANY_SIGNATORY_UPDATED` | `"company/signatory/updated"` |
+| `COMPANY_STATE_TAX_DONE` | `"company/stateTaxes/done"` |
+| `COMPANY_STATE_TAX_EDIT` | `"company/stateTaxes/edit"` |
+| `COMPANY_STATE_TAX_UPDATED` | `"company/stateTaxes/updated"` |
+| `COMPANY_VIEW_FORM_TO_SIGN` | `"company/forms/view"` |
+| `CONTRACTOR_ADDRESS_DONE` | `"contractor/address/done"` |
+| `CONTRACTOR_ADDRESS_UPDATED` | `"contractor/address/updated"` |
+| `CONTRACTOR_BANK_ACCOUNT_CREATED` | `"contractor/bankAccount/created"` |
+| `CONTRACTOR_CREATE` | `"contractor/create"` |
+| `CONTRACTOR_CREATED` | `"contractor/created"` |
+| `CONTRACTOR_DELETED` | `"contractor/deleted"` |
+| `CONTRACTOR_DOCUMENTS_DONE` | `"contractor/documents/done"` |
+| `CONTRACTOR_INVITE_CONTRACTOR` | `"contractor/invite/selfOnboarding"` |
+| `CONTRACTOR_NEW_HIRE_REPORT_DONE` | `"contractor/newHireReport/done"` |
+| `CONTRACTOR_NEW_HIRE_REPORT_UPDATED` | `"contractor/newHireReport/updated"` |
+| `CONTRACTOR_ONBOARDING_CONTINUE` | `"contractor/onboarding/continue"` |
+| `CONTRACTOR_ONBOARDING_STATUS_UPDATED` | `"contractor/onboardingStatus/updated"` |
+| `CONTRACTOR_PAYMENT_BACK_TO_EDIT` | `"contractor/payments/backToEdit"` |
+| `CONTRACTOR_PAYMENT_CANCEL` | `"contractor/payments/cancel"` |
+| `CONTRACTOR_PAYMENT_CREATE` | `"contractor/payments/create"` |
+| `CONTRACTOR_PAYMENT_CREATED` | `"contractor/payments/created"` |
+| `CONTRACTOR_PAYMENT_EDIT` | `"contractor/payments/edit"` |
+| `CONTRACTOR_PAYMENT_EXIT` | `"contractor/payments/exit"` |
+| `CONTRACTOR_PAYMENT_METHOD_DONE` | `"contractor/paymentMethod/done"` |
+| `CONTRACTOR_PAYMENT_METHOD_UPDATED` | `"contractor/paymentMethod/updated"` |
+| `CONTRACTOR_PAYMENT_PREVIEW` | `"contractor/payments/preview"` |
+| `CONTRACTOR_PAYMENT_RFI_RESPOND` | `"contractor/payments/rfi/respond"` |
+| `CONTRACTOR_PAYMENT_SUBMIT` | `"contractor/payments/submit"` |
+| `CONTRACTOR_PAYMENT_UPDATE` | `"contractor/payments/update"` |
+| `CONTRACTOR_PAYMENT_VIEW` | `"contractor/payments/view"` |
+| `CONTRACTOR_PAYMENT_VIEW_DETAILS` | `"contractor/payments/view/details"` |
+| `CONTRACTOR_PROFILE_DONE` | `"contractor/profile/done"` |
+| `CONTRACTOR_SELF_ONBOARDING_DONE` | `"contractor/selfOnboarding/done"` |
+| `CONTRACTOR_SELF_ONBOARDING_START` | `"contractor/selfOnboarding/start"` |
+| `CONTRACTOR_SUBMIT_DONE` | `"contractor/submit/done"` |
+| `CONTRACTOR_UPDATE` | `"contractor/update"` |
+| `CONTRACTOR_UPDATED` | `"contractor/updated"` |
+| `CONTRACTOR_VIEW_DOCUMENT_TO_SIGN` | `"contractor/documents/view"` |
+| `DISMISSAL_PAY_PERIOD_SELECTED` | `"dismissal/payPeriod/selected"` |
+| `EMPLOYEE_BANK_ACCOUNT_CREATE` | `"employee/bankAccount/create"` |
+| `EMPLOYEE_BANK_ACCOUNT_CREATED` | `"employee/bankAccount/created"` |
+| `EMPLOYEE_BANK_ACCOUNT_DELETED` | `"employee/bankAccount/deleted"` |
+| `EMPLOYEE_CHANGE_ELIGIBILITY_STATUS` | `"employee/employmentEligibility/change"` |
+| `EMPLOYEE_COMPENSATION_CANCEL` | `"employee/compensations/cancel"` |
+| `EMPLOYEE_COMPENSATION_CHANGE_CANCELLED` | `"employee/compensations/changeCancelled"` |
+| `EMPLOYEE_COMPENSATION_CREATE` | `"employee/compensations/create"` |
+| `EMPLOYEE_COMPENSATION_CREATED` | `"employee/compensations/created"` |
+| `EMPLOYEE_COMPENSATION_DONE` | `"employee/compensations/done"` |
+| `EMPLOYEE_COMPENSATION_RETURN_TO_LIST` | `"employee/compensations/returnToList"` |
+| `EMPLOYEE_COMPENSATION_UPDATED` | `"employee/compensations/updated"` |
+| `EMPLOYEE_CREATE` | `"employee/create"` |
+| `EMPLOYEE_CREATED` | `"employee/created"` |
+| `EMPLOYEE_DASHBOARD_TAB_CHANGE` | `"employee/dashboard/tabChange"` |
+| `EMPLOYEE_DEDUCTION_ADD` | `"employee/deductions/add"` |
+| `EMPLOYEE_DEDUCTION_CANCEL` | `"employee/deductions/cancel"` |
+| `EMPLOYEE_DEDUCTION_CANCEL_EMPTY` | `"employee/deductions/cancelEmpty"` |
+| `EMPLOYEE_DEDUCTION_CREATED` | `"employee/deductions/created"` |
+| `EMPLOYEE_DEDUCTION_DELETED` | `"employee/deductions/deleted"` |
+| `EMPLOYEE_DEDUCTION_DELETED_EMPTY` | `"employee/deductions/deletedEmpty"` |
+| `EMPLOYEE_DEDUCTION_DONE` | `"employee/deductions/done"` |
+| `EMPLOYEE_DEDUCTION_EDIT` | `"employee/deductions/edit"` |
+| `EMPLOYEE_DEDUCTION_UPDATED` | `"employee/deductions/updated"` |
+| `EMPLOYEE_DELETED` | `"employee/deleted"` |
+| `EMPLOYEE_DISMISS` | `"employee/dismiss"` |
+| `EMPLOYEE_DOCUMENTS_DONE` | `"employee/documents/done"` |
+| `EMPLOYEE_EMPLOYMENT_ELIGIBILITY_DONE` | `"employee/employmentEligibility/done"` |
+| `EMPLOYEE_FEDERAL_TAXES_DONE` | `"employee/federalTaxes/done"` |
+| `EMPLOYEE_FEDERAL_TAXES_EDIT` | `"employee/federalTaxes/edit"` |
+| `EMPLOYEE_FEDERAL_TAXES_UPDATED` | `"employee/federalTaxes/updated"` |
+| `EMPLOYEE_FORMS_DONE` | `"employee/forms/done"` |
+| `EMPLOYEE_HOME_ADDRESS_CREATED` | `"employee/addresses/home/created"` |
+| `EMPLOYEE_HOME_ADDRESS_UPDATED` | `"employee/addresses/home/updated"` |
+| `EMPLOYEE_JOB_ADD` | `"employee/job/add"` |
+| `EMPLOYEE_JOB_ADD_ANOTHER` | `"employee/job/addAnother"` |
+| `EMPLOYEE_JOB_CREATED` | `"employee/job/created"` |
+| `EMPLOYEE_JOB_DELETED` | `"employee/job/deleted"` |
+| `EMPLOYEE_JOB_EDIT` | `"employee/job/edit"` |
+| `EMPLOYEE_JOB_UPDATED` | `"employee/job/updated"` |
+| `EMPLOYEE_MANAGEMENT_COMPENSATION_ADD_ANOTHER_JOB_FORM_CANCELLED` | `"employee/management/compensation/addAnotherJobForm/cancelled"` |
+| `EMPLOYEE_MANAGEMENT_COMPENSATION_ADD_ANOTHER_JOB_FORM_SUBMITTED` | `"employee/management/compensation/addAnotherJobForm/submitted"` |
+| `EMPLOYEE_MANAGEMENT_COMPENSATION_ADD_JOB_FORM_CANCELLED` | `"employee/management/compensation/addJobForm/cancelled"` |
+| `EMPLOYEE_MANAGEMENT_COMPENSATION_ADD_JOB_FORM_SUBMITTED` | `"employee/management/compensation/addJobForm/submitted"` |
+| `EMPLOYEE_MANAGEMENT_COMPENSATION_ALERT_DISMISSED` | `"employee/management/compensation/alertDismissed"` |
+| `EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_ADD_ANOTHER_REQUESTED` | `"employee/management/compensation/card/addAnotherRequested"` |
+| `EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_ADD_REQUESTED` | `"employee/management/compensation/card/addRequested"` |
+| `EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_CHANGE_CANCELLED` | `"employee/management/compensation/card/changeCancelled"` |
+| `EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_EDIT_REQUESTED` | `"employee/management/compensation/card/editRequested"` |
+| `EMPLOYEE_MANAGEMENT_COMPENSATION_CARD_JOB_DELETED` | `"employee/management/compensation/card/jobDeleted"` |
+| `EMPLOYEE_MANAGEMENT_COMPENSATION_EDIT_FORM_CANCELLED` | `"employee/management/compensation/editForm/cancelled"` |
+| `EMPLOYEE_MANAGEMENT_COMPENSATION_EDIT_FORM_SUBMITTED` | `"employee/management/compensation/editForm/submitted"` |
+| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_ALERT_DISMISSED` | `"employee/management/deductions/alertDismissed"` |
+| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_CARD_ADD_REQUESTED` | `"employee/management/deductions/card/addRequested"` |
+| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_CARD_DELETED` | `"employee/management/deductions/card/deleted"` |
+| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_CARD_EDIT_REQUESTED` | `"employee/management/deductions/card/editRequested"` |
+| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_EDIT_FORM_CANCELLED` | `"employee/management/deductions/editForm/cancelled"` |
+| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_EDIT_FORM_CREATED` | `"employee/management/deductions/editForm/created"` |
+| `EMPLOYEE_MANAGEMENT_DEDUCTIONS_EDIT_FORM_UPDATED` | `"employee/management/deductions/editForm/updated"` |
+| `EMPLOYEE_MANAGEMENT_DOCUMENTS_CARD_VIEW_REQUESTED` | `"employee/management/documents/card/viewRequested"` |
+| `EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_ALERT_DISMISSED` | `"employee/management/federalTaxes/alertDismissed"` |
+| `EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_CARD_EDIT_REQUESTED` | `"employee/management/federalTaxes/card/editRequested"` |
+| `EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_EDIT_FORM_CANCELLED` | `"employee/management/federalTaxes/editForm/cancelled"` |
+| `EMPLOYEE_MANAGEMENT_FEDERAL_TAXES_EDIT_FORM_SUBMITTED` | `"employee/management/federalTaxes/editForm/submitted"` |
+| `EMPLOYEE_MANAGEMENT_HOME_ADDRESS_CREATED` | `"employee/management/homeAddress/created"` |
+| `EMPLOYEE_MANAGEMENT_HOME_ADDRESS_DELETED` | `"employee/management/homeAddress/deleted"` |
+| `EMPLOYEE_MANAGEMENT_HOME_ADDRESS_EDIT_CANCELLED` | `"employee/management/homeAddress/editCancelled"` |
+| `EMPLOYEE_MANAGEMENT_HOME_ADDRESS_EDIT_REQUESTED` | `"employee/management/homeAddress/editRequested"` |
+| `EMPLOYEE_MANAGEMENT_HOME_ADDRESS_UPDATED` | `"employee/management/homeAddress/updated"` |
+| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_ALERT_DISMISSED` | `"employee/management/paymentMethod/alertDismissed"` |
+| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_BANK_FORM_CANCELLED` | `"employee/management/paymentMethod/bankForm/cancelled"` |
+| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_BANK_FORM_SUBMITTED` | `"employee/management/paymentMethod/bankForm/submitted"` |
+| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_CARD_ADD_REQUESTED` | `"employee/management/paymentMethod/card/addRequested"` |
+| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_CARD_BANK_ACCOUNT_DELETED` | `"employee/management/paymentMethod/card/bankAccountDeleted"` |
+| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_CARD_SPLIT_REQUESTED` | `"employee/management/paymentMethod/card/splitRequested"` |
+| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_SPLIT_FORM_CANCELLED` | `"employee/management/paymentMethod/splitForm/cancelled"` |
+| `EMPLOYEE_MANAGEMENT_PAYMENT_METHOD_SPLIT_FORM_SUBMITTED` | `"employee/management/paymentMethod/splitForm/submitted"` |
+| `EMPLOYEE_MANAGEMENT_PAYSTUBS_CARD_DOWNLOAD_REQUESTED` | `"employee/management/paystubs/card/downloadRequested"` |
+| `EMPLOYEE_MANAGEMENT_PAYSTUBS_CARD_DOWNLOADED` | `"employee/management/paystubs/card/downloaded"` |
+| `EMPLOYEE_MANAGEMENT_PROFILE_ALERT_DISMISSED` | `"employee/management/profile/alertDismissed"` |
+| `EMPLOYEE_MANAGEMENT_PROFILE_EDIT_CANCELLED` | `"employee/management/profile/editCancelled"` |
+| `EMPLOYEE_MANAGEMENT_PROFILE_EDIT_REQUESTED` | `"employee/management/profile/editRequested"` |
+| `EMPLOYEE_MANAGEMENT_PROFILE_UPDATED` | `"employee/management/profile/updated"` |
+| `EMPLOYEE_MANAGEMENT_STATE_TAXES_ALERT_DISMISSED` | `"employee/management/stateTaxes/alertDismissed"` |
+| `EMPLOYEE_MANAGEMENT_STATE_TAXES_EDIT_CANCELLED` | `"employee/management/stateTaxes/editCancelled"` |
+| `EMPLOYEE_MANAGEMENT_STATE_TAXES_EDIT_REQUESTED` | `"employee/management/stateTaxes/editRequested"` |
+| `EMPLOYEE_MANAGEMENT_STATE_TAXES_UPDATED` | `"employee/management/stateTaxes/updated"` |
+| `EMPLOYEE_MANAGEMENT_WORK_ADDRESS_CREATED` | `"employee/management/workAddress/created"` |
+| `EMPLOYEE_MANAGEMENT_WORK_ADDRESS_DELETED` | `"employee/management/workAddress/deleted"` |
+| `EMPLOYEE_MANAGEMENT_WORK_ADDRESS_EDIT_CANCELLED` | `"employee/management/workAddress/editCancelled"` |
+| `EMPLOYEE_MANAGEMENT_WORK_ADDRESS_EDIT_REQUESTED` | `"employee/management/workAddress/editRequested"` |
+| `EMPLOYEE_MANAGEMENT_WORK_ADDRESS_UPDATED` | `"employee/management/workAddress/updated"` |
+| `EMPLOYEE_ONBOARDING_DOCUMENTS_CONFIG_UPDATED` | `"employee/onboardingDocumentsConfig/updated"` |
+| `EMPLOYEE_ONBOARDING_DONE` | `"employee/onboarding/done"` |
+| `EMPLOYEE_ONBOARDING_STATUS_UPDATED` | `"employee/onboardingStatus/updated"` |
+| `EMPLOYEE_PAYMENT_METHOD_DONE` | `"employee/paymentMethod/done"` |
+| `EMPLOYEE_PAYMENT_METHOD_RESET` | `"employee/paymentMethod/reset"` |
+| `EMPLOYEE_PAYMENT_METHOD_UPDATED` | `"employee/paymentMethod/updated"` |
+| `EMPLOYEE_PROFILE_DONE` | `"employee/profile/done"` |
+| `EMPLOYEE_REHIRE` | `"employee/rehire"` |
+| `EMPLOYEE_RETURN_TO_LIST` | `"employee/returnToList"` |
+| `EMPLOYEE_SELF_ONBOARDING_START` | `"employee/selfOnboarding/start"` |
+| `EMPLOYEE_SIGN_FORM` | `"employee/forms/sign"` |
+| `EMPLOYEE_SPLIT_PAYCHECK` | `"employee/bankAccount/split"` |
+| `EMPLOYEE_SPLIT_PAYMENT` | `"employee/paymentMethod/split"` |
+| `EMPLOYEE_STATE_TAXES_DONE` | `"employee/stateTaxes/done"` |
+| `EMPLOYEE_STATE_TAXES_UPDATED` | `"employee/stateTaxes/updated"` |
+| `EMPLOYEE_SUMMARY_VIEW` | `"employee/summary"` |
+| `EMPLOYEE_TERMINATION_CANCELLED` | `"employee/termination/cancelled"` |
+| `EMPLOYEE_TERMINATION_CREATED` | `"employee/termination/created"` |
+| `EMPLOYEE_TERMINATION_DONE` | `"employee/termination/done"` |
+| `EMPLOYEE_TERMINATION_EDIT` | `"employee/termination/edit"` |
+| `EMPLOYEE_TERMINATION_PAYROLL_CREATED` | `"employee/termination/payroll/created"` |
+| `EMPLOYEE_TERMINATION_PAYROLL_FAILED` | `"employee/termination/payroll/failed"` |
+| `EMPLOYEE_TERMINATION_RUN_OFF_CYCLE_PAYROLL` | `"employee/termination/runOffCyclePayroll"` |
+| `EMPLOYEE_TERMINATION_RUN_PAYROLL` | `"employee/termination/runPayroll"` |
+| `EMPLOYEE_TERMINATION_UPDATED` | `"employee/termination/updated"` |
+| `EMPLOYEE_TERMINATION_VIEW_SUMMARY` | `"employee/termination/viewSummary"` |
+| `EMPLOYEE_UPDATE` | `"employee/update"` |
+| `EMPLOYEE_UPDATED` | `"employee/updated"` |
+| `EMPLOYEE_VIEW_FORM_TO_SIGN` | `"employee/forms/view"` |
+| `EMPLOYEE_WORK_ADDRESS` | `"employee/addresses/work"` |
+| `EMPLOYEE_WORK_ADDRESS_CREATED` | `"employee/addresses/work/created"` |
+| `EMPLOYEE_WORK_ADDRESS_DELETED` | `"employee/addresses/work/deleted"` |
+| `EMPLOYEE_WORK_ADDRESS_UPDATE` | `"employee/addresses/work/update"` |
+| `EMPLOYEE_WORK_ADDRESS_UPDATED` | `"employee/addresses/work/updated"` |
+| `EMPLOYEES_LIST` | `"company/employees"` |
+| `ERROR` | `"ERROR"` |
+| `INFORMATION_REQUEST_FORM_CANCEL` | `"informationRequest/form/cancel"` |
+| `INFORMATION_REQUEST_FORM_DONE` | `"informationRequest/form/done"` |
+| `INFORMATION_REQUEST_FORM_SUBMIT` | `"informationRequest/form/submit"` |
+| `INFORMATION_REQUEST_RESPOND` | `"informationRequest/respond"` |
+| `OFF_CYCLE_CREATED` | `"offCycle/created"` |
+| `OFF_CYCLE_DEDUCTIONS_CHANGE` | `"offCycle/deductionsChange"` |
+| `OFF_CYCLE_SELECT_REASON` | `"offCycle/selectReason"` |
+| `PAY_SCHEDULE_CREATE` | `"paySchedule/create"` |
+| `PAY_SCHEDULE_CREATED` | `"paySchedule/created"` |
+| `PAY_SCHEDULE_DELETE` | `"paySchedule/delete"` |
+| `PAY_SCHEDULE_DELETED` | `"paySchedule/deleted"` |
+| `PAY_SCHEDULE_DONE` | `"paySchedule/done"` |
+| `PAY_SCHEDULE_UPDATE` | `"paySchedule/update"` |
+| `PAY_SCHEDULE_UPDATED` | `"paySchedule/updated"` |
+| `PAYROLL_DELETED` | `"payroll/deleted"` |
+| `PAYROLL_EXIT_FLOW` | `"payroll/saveAndExit"` |
+| `PAYROLL_SKIPPED` | `"payroll/skipped"` |
+| `PAYROLL_WIRE_FORM_CANCEL` | `"payroll/wire/form/cancel"` |
+| `PAYROLL_WIRE_FORM_DONE` | `"payroll/wire/form/done"` |
+| `PAYROLL_WIRE_INSTRUCTIONS_CANCEL` | `"payroll/wire/instructions/cancel"` |
+| `PAYROLL_WIRE_INSTRUCTIONS_DONE` | `"payroll/wire/instructions/done"` |
+| `PAYROLL_WIRE_INSTRUCTIONS_SELECT` | `"payroll/wire/instructions/select"` |
+| `PAYROLL_WIRE_START_TRANSFER` | `"payroll/wire/startTransfer"` |
+| `RECOVERY_CASE_RESOLVE` | `"recoveryCase/resolve"` |
+| `RECOVERY_CASE_RESUBMIT` | `"recoveryCase/resubmit"` |
+| `RECOVERY_CASE_RESUBMIT_CANCEL` | `"recoveryCase/resubmit/cancel"` |
+| `RECOVERY_CASE_RESUBMIT_DONE` | `"recoveryCase/resubmit/done"` |
+| `REVIEW_PAYROLL` | `"payroll/review"` |
+| `ROBOT_MACHINE_DONE` | `"done"` |
+| `RUN_OFF_CYCLE_PAYROLL` | `"runPayroll/offCycle/start"` |
+| `RUN_PAYROLL_BACK` | `"runPayroll/back"` |
+| `RUN_PAYROLL_BLOCKER_RESOLUTION_ATTEMPTED` | `"runPayroll/blocker/resolutionAttempted"` |
+| `RUN_PAYROLL_BLOCKERS_DETECTED` | `"runPayroll/blockers/detected"` |
+| `RUN_PAYROLL_BLOCKERS_VIEW_ALL` | `"runPayroll/blockers/viewAll"` |
+| `RUN_PAYROLL_CALCULATED` | `"runPayroll/calculated"` |
+| `RUN_PAYROLL_CANCELLED` | `"runPayroll/cancelled"` |
+| `RUN_PAYROLL_CANCELLED_ALERT_DISMISSED` | `"runPayroll/cancelled/alertDismissed"` |
+| `RUN_PAYROLL_DATES_CONFIGURED` | `"runPayroll/dates/configured"` |
+| `RUN_PAYROLL_EDIT` | `"runPayroll/edit"` |
+| `RUN_PAYROLL_EMPLOYEE_CANCELLED` | `"runPayroll/employee/cancelled"` |
+| `RUN_PAYROLL_EMPLOYEE_EDIT` | `"runPayroll/employee/edit"` |
+| `RUN_PAYROLL_EMPLOYEE_SAVED` | `"runPayroll/employee/saved"` |
+| `RUN_PAYROLL_EMPLOYEE_SKIP` | `"runPayroll/employee/skip"` |
+| `RUN_PAYROLL_GROSS_UP_CALCULATED` | `"runPayroll/grossUp/calculated"` |
+| `RUN_PAYROLL_GROSS_UP_SELECTED` | `"runPayroll/grossUp/selected"` |
+| `RUN_PAYROLL_PDF_PAYSTUB_VIEWED` | `"runPayroll/pdfPaystub/viewed"` |
+| `RUN_PAYROLL_PROCESSED` | `"runPayroll/processed"` |
+| `RUN_PAYROLL_PROCESSING_FAILED` | `"runPayroll/processingFailed"` |
+| `RUN_PAYROLL_RECEIPT_GET` | `"runPayroll/receipt/get"` |
+| `RUN_PAYROLL_RECEIPT_VIEWED` | `"runPayroll/receipt/viewed"` |
+| `RUN_PAYROLL_SELECTED` | `"runPayroll/selected"` |
+| `RUN_PAYROLL_SUBMITTED` | `"runPayroll/submitted"` |
+| `RUN_PAYROLL_SUBMITTING` | `"runPayroll/submitting"` |
+| `RUN_PAYROLL_SUMMARY_VIEWED` | `"runPayroll/summary/viewed"` |
+| `RUN_TRANSITION_PAYROLL` | `"transition/runPayroll"` |
+| `TIME_OFF_ADD_EMPLOYEES_BACK` | `"timeOff/addEmployees/back"` |
+| `TIME_OFF_ADD_EMPLOYEES_DONE` | `"timeOff/addEmployees/done"` |
+| `TIME_OFF_ADD_EMPLOYEES_ERROR` | `"timeOff/addEmployees/error"` |
+| `TIME_OFF_ADD_EMPLOYEES_TO_POLICY` | `"timeOff/addEmployeesToPolicy"` |
+| `TIME_OFF_BACK_TO_LIST` | `"timeOff/backToList"` |
+| `TIME_OFF_CHANGE_SETTINGS` | `"timeOff/changeSettings"` |
+| `TIME_OFF_CREATE_POLICY` | `"timeOff/createPolicy"` |
+| `TIME_OFF_DELETE_POLICY_DONE` | `"timeOff/deletePolicy/done"` |
+| `TIME_OFF_EDIT_HOLIDAY_POLICY` | `"timeOff/editHolidayPolicy"` |
+| `TIME_OFF_EDIT_POLICY` | `"timeOff/editPolicy"` |
+| `TIME_OFF_HOLIDAY_ADD_EMPLOYEES` | `"timeOff/holidayAddEmployees"` |
+| `TIME_OFF_HOLIDAY_ADD_EMPLOYEES_DONE` | `"timeOff/holidayAddEmployees/done"` |
+| `TIME_OFF_HOLIDAY_ADD_EMPLOYEES_ERROR` | `"timeOff/holidayAddEmployees/error"` |
+| `TIME_OFF_HOLIDAY_CREATE_ERROR` | `"timeOff/holidayCreate/error"` |
+| `TIME_OFF_HOLIDAY_SELECTION_DONE` | `"timeOff/holidaySelection/done"` |
+| `TIME_OFF_HOLIDAY_SELECTION_EDIT_DONE` | `"timeOff/holidaySelection/editDone"` |
+| `TIME_OFF_POLICY_CREATE_ERROR` | `"timeOff/policyCreate/error"` |
+| `TIME_OFF_POLICY_DETAILS_DONE` | `"timeOff/policyDetails/done"` |
+| `TIME_OFF_POLICY_SETTINGS_BACK` | `"timeOff/policySettings/back"` |
+| `TIME_OFF_POLICY_SETTINGS_DONE` | `"timeOff/policySettings/done"` |
+| `TIME_OFF_POLICY_SETTINGS_ERROR` | `"timeOff/policySettings/error"` |
+| `TIME_OFF_POLICY_TYPE_SELECTED` | `"timeOff/policyTypeSelected"` |
+| `TIME_OFF_VIEW_HOLIDAY_EMPLOYEES` | `"timeOff/viewHolidayEmployees"` |
+| `TIME_OFF_VIEW_HOLIDAY_SCHEDULE` | `"timeOff/viewHolidaySchedule"` |
+| `TIME_OFF_VIEW_POLICY` | `"timeOff/viewPolicy"` |
+| `TIME_OFF_VIEW_POLICY_DETAILS` | `"timeOff/viewPolicyDetails"` |
+| `TIME_OFF_VIEW_POLICY_EMPLOYEES` | `"timeOff/viewPolicyEmployees"` |
+| `TRANSITION_CREATED` | `"transition/created"` |
+| `TRANSITION_PAYROLL_SKIPPED` | `"transition/payrollSkipped"` |
 
 #### Remarks
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -210,7 +210,7 @@ The configured provider tree wrapping `children`.
 
 ### I9\_FORM\_NAME
 
-> `const` **I9\_FORM\_NAME**: `"US_I-9"` = `'US_I-9'`
+> `const` **I9\_FORM\_NAME**: `"US_I-9"`
 
 The form `name` identifying the federal I-9 (Employment Eligibility Verification) document.
 
@@ -232,13 +232,44 @@ Pay period unit values for the `paymentUnit` field on a compensation, describing
 
 #### Type Declaration
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| <a id="property-pay_periodshour"></a> `HOUR` | `"Hour"` | `'Hour'` |
-| <a id="property-pay_periodsmonth"></a> `MONTH` | `"Month"` | `'Month'` |
-| <a id="property-pay_periodspaycheck"></a> `PAYCHECK` | `"Paycheck"` | `'Paycheck'` |
-| <a id="property-pay_periodsweek"></a> `WEEK` | `"Week"` | `'Week'` |
-| <a id="property-pay_periodsyear"></a> `YEAR` | `"Year"` | `'Year'` |
+| Name | Type |
+| ------ | ------ |
+| <a id="property-pay_periodshour"></a> `HOUR` | `"Hour"` |
+| <a id="property-pay_periodsmonth"></a> `MONTH` | `"Month"` |
+| <a id="property-pay_periodspaycheck"></a> `PAYCHECK` | `"Paycheck"` |
+| <a id="property-pay_periodsweek"></a> `WEEK` | `"Week"` |
+| <a id="property-pay_periodsyear"></a> `YEAR` | `"Year"` |
+
+***
+
+<a id="sdkerrorcategories"></a>
+
+### SDKErrorCategories
+
+> `const` **SDKErrorCategories**: `object`
+
+Constant map of [SDKErrorCategory](#sdkerrorcategory) string values keyed by uppercase name.
+
+#### Type Declaration
+
+| Name | Type |
+| ------ | ------ |
+| <a id="property-sdkerrorcategoriesapi_error"></a> `API_ERROR` | `"api_error"` |
+| <a id="property-sdkerrorcategoriesinternal_error"></a> `INTERNAL_ERROR` | `"internal_error"` |
+| <a id="property-sdkerrorcategoriesnetwork_error"></a> `NETWORK_ERROR` | `"network_error"` |
+| <a id="property-sdkerrorcategoriesvalidation_error"></a> `VALIDATION_ERROR` | `"validation_error"` |
+
+#### Remarks
+
+Use this when you need to reference a category value by name (e.g.
+`SDKErrorCategories.API_ERROR`). Each entry corresponds to one classification:
+
+| Value | When it applies |
+| ----- | --------------- |
+| `api_error` | HTTP error response from the Gusto API (422, 404, 409, 500, etc.) |
+| `validation_error` | Client-side Zod schema validation before the request was sent |
+| `network_error` | Network connectivity failure (connection refused, timeout, abort) |
+| `internal_error` | Unexpected runtime error (unhandled exception, initialization failure) |
 
 ## Interfaces
 
@@ -948,7 +979,7 @@ Each key names a component's resource namespace.
 
 ### SDKErrorCategory
 
-> **SDKErrorCategory** = *typeof* `SDKErrorCategories`\[keyof *typeof* `SDKErrorCategories`\]
+> **SDKErrorCategory** = `"api_error"` \| `"validation_error"` \| `"network_error"` \| `"internal_error"`
 
 High-level classification of where an [SDKError](#sdkerror) originated.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export type {
   SDKHooks,
 } from '@/types/hooks'
 export type { SDKError, SDKErrorCategory, SDKFieldError } from '@/types/sdkError'
-export { normalizeToSDKError, SDKInternalError } from '@/types/sdkError'
+export { SDKErrorCategories, normalizeToSDKError, SDKInternalError } from '@/types/sdkError'
 export type {
   ObservabilityHook,
   ObservabilityError,


### PR DESCRIPTION
## Summary

Opaque re-exports and `as const`-derived aliases rendered as bare, unresolvable expressions in the generated reference (`keyof typeof <internalConst>`, `typeof <const>[…]`). This wires the reference to expand them into real documented text, straight from the type graph — no hand-maintenance.

Implements [SDK-1073](https://gustohq.atlassian.net/browse/SDK-1073). The ticket offered an *expand-or-suppress* fork for convenience string-union aliases; we evaluated suppress and **chose expand** (the field-name unions are useful and internally referenced, so removing them would be a breaking loss). Net result: **no breaking change**.

## What changed

**Two TypeDoc resolve-handlers** (`docs-site/plugins/typedoc-custom/theme.ts`):

- **`expandConstDerivedAliases`** — rewrites `keyof typeof <const>`, `typeof <const>[…]`, and `(typeof <const>)[number]` aliases to their literal string union, resolved via the TS checker (works even when the underlying const is unexported — the reason they rendered bare). A large union backed by a *documented* const (e.g. `EventType` over the exported `componentEvents`) stays a link rather than a wall of literals.
- **`dropRedundantConstDefaults`** — drops the redundant "Default value" column from `as const` maps (`SDKErrorCategories`, the `XxxErrorCodes`) where each member's default merely restates its literal type. Genuinely informative defaults (e.g. `EmployeeOnboardingStatus → OnboardingStatus.*`) keep the column.

**Source:** exports the `SDKErrorCategories` const so its when-each-applies table renders in the reference.

## Results

| Type | Before | After |
|---|---|---|
| `SDKErrorCategory` | `typeof SDKErrorCategories[keyof …]` | `"api_error" \| "validation_error" \| "network_error" \| "internal_error"` + the const's table |
| `WorkAddressField` &c. | `keyof typeof fieldValidators` | `"effectiveDate" \| "locationUuid"` … |
| value/validation unions (`AccountType`, `RateValidation`, …) | opaque | expanded literals |
| `EventType` (280 members, documented const) | link | link (unchanged — no wall) |
| `onSaved`/`Form` payload | — | already cross-links to `APIModels.Form` |

## Tests

`docs-site/plugins/typedoc-custom/sdk-router.test.ts` — +13 unit tests covering the shape gate, the documented-const size guard, and the redundant-default detection (127 pass). End-to-end coverage is the regenerated `docs/reference/**` + API report (via `npm run derive`, 0 errors).

## Follow-up

The i18n `Resources` / `dictionary` surface (the giant provider `dictionary?` cell + a per-namespace overridable-keys reference) is a separate, larger effort — tracked as a follow-up, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-1073]: https://gustohq.atlassian.net/browse/SDK-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ