### PR TITLE
chore: release 0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,26 +4,15 @@
 
 ### ⚠ Breaking Changes
 
-- **The standalone field exports `NameField`, `RoutingNumberField`, `AccountNumberField`, `AccountTypeField`, and `ContractorPaymentMethodTypeField` have been removed** ([#2303](https://github.com/Gusto/embedded-react-sdk/issues/2303)). Access these field components from the relevant hook's `form.Fields` instead.
+- **The field exports `NameField`, `RoutingNumberField`, `AccountNumberField`, `AccountTypeField`, and `ContractorPaymentMethodTypeField` have been removed** ([#2303](https://github.com/Gusto/embedded-react-sdk/issues/2303)). These fields depend on their form's context and were never functional when imported and rendered on their own, so this only affects direct imports of the symbols. Access them from the relevant hook's `form.Fields`, which wires up the required context:
 
   ```tsx
-  // Before
-  import {
-    NameField,
-    RoutingNumberField,
-    AccountNumberField,
-    AccountTypeField,
-  } from '@gusto/embedded-react-sdk'
-  // ...render <NameField />, <RoutingNumberField />, etc. directly
-
-  // After
   const { form } = useContractorBankAccountForm({ contractorId })
   const { Name, RoutingNumber, AccountNumber, AccountType } = form.Fields
   // ...render <Name />, <RoutingNumber />, etc.
 
-  // ContractorPaymentMethodTypeField is now form.Fields.Type on useContractorPaymentMethodForm
   const paymentMethodForm = useContractorPaymentMethodForm({ contractorId })
-  const { Type } = paymentMethodForm.form.Fields
+  const { Type } = paymentMethodForm.form.Fields // was ContractorPaymentMethodTypeField
   ```
 
 ### Features & Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [0.50.0](https://github.com/Gusto/embedded-react-sdk/compare/v0.49.0...v0.50.0) (2026-07-01)
+
+### ⚠ Breaking Changes
+
+- **The standalone field exports `NameField`, `RoutingNumberField`, `AccountNumberField`, `AccountTypeField`, and `ContractorPaymentMethodTypeField` have been removed** ([#2303](https://github.com/Gusto/embedded-react-sdk/issues/2303)). Access these field components from the relevant hook's `form.Fields` instead.
+
+  ```tsx
+  // Before
+  import {
+    NameField,
+    RoutingNumberField,
+    AccountNumberField,
+    AccountTypeField,
+  } from '@gusto/embedded-react-sdk'
+  // ...render <NameField />, <RoutingNumberField />, etc. directly
+
+  // After
+  const { form } = useContractorBankAccountForm({ contractorId })
+  const { Name, RoutingNumber, AccountNumber, AccountType } = form.Fields
+  // ...render <Name />, <RoutingNumber />, etc.
+
+  // ContractorPaymentMethodTypeField is now form.Fields.Type on useContractorPaymentMethodForm
+  const paymentMethodForm = useContractorPaymentMethodForm({ contractorId })
+  const { Type } = paymentMethodForm.form.Fields
+  ```
+
+### Features & Enhancements
+
+- Add `useContractorBankAccountForm` and `useContractorPaymentMethodForm` hooks for building contractor payment-method and bank-account forms, each exposing its field components on `form.Fields` ([#2301](https://github.com/Gusto/embedded-react-sdk/issues/2301), [#2302](https://github.com/Gusto/embedded-react-sdk/issues/2302))
+- `Contractor.PaymentMethod` now composes the new payment-method and bank-account hooks ([#2303](https://github.com/Gusto/embedded-react-sdk/issues/2303))
+- Expand const-derived reference types and export `SDKErrorCategories` ([#2320](https://github.com/Gusto/embedded-react-sdk/issues/2320))
+
+### Chores & Maintenance
+
+- Bump dev dependencies (`@commitlint/cli`, `@commitlint/config-conventional`, `typescript-eslint`)
+
 ## [0.49.0](https://github.com/Gusto/embedded-react-sdk/compare/v0.48.3...v0.49.0) (2026-06-30)
 
 ### ⚠ Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Chores & Maintenance
 
+- Bump `i18next` from 26.3.3 to 26.3.4 ([#2324](https://github.com/Gusto/embedded-react-sdk/issues/2324))
 - Bump dev dependencies (`@commitlint/cli`, `@commitlint/config-conventional`, `typescript-eslint`)
 
 ## [0.49.0](https://github.com/Gusto/embedded-react-sdk/compare/v0.48.3...v0.49.0) (2026-06-30)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-react-sdk",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "MIT",
       "dependencies": {
         "@gusto/embedded-api-v-2025-11-15": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "homepage": "https://github.com/Gusto/embedded-react-sdk",
   "bugs": {
     "url": "https://github.com/Gusto/embedded-react-sdk/issues"


### PR DESCRIPTION
Release 0.50.0. See `CHANGELOG.md` for the curated notes.

## Highlights

### ⚠ Breaking Changes

- Removed the standalone field exports `NameField`, `RoutingNumberField`, `AccountNumberField`, `AccountTypeField`, and `ContractorPaymentMethodTypeField`. Access them from the relevant hook's `form.Fields` instead (see CHANGELOG for the migration example).

### Features & Enhancements

- Add `useContractorBankAccountForm` and `useContractorPaymentMethodForm` hooks.
- `Contractor.PaymentMethod` composes the new hooks.
- Expand const-derived reference types and export `SDKErrorCategories`.

Merging this triggers the Publish to NPM and Sync Docs Source workflows automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)