### PR TITLE
docs: allow search engine indexing

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -140,6 +140,16 @@ const config: Config = {
           }),
         },
         blog: false,
+        sitemap: {
+          // robots.txt blocks crawlers from fetching older-minor snapshots; keep
+          // them out of the sitemap too, so it advertises only the canonical,
+          // unprefixed /docs/<page> (the latest minor, driven by lastVersion).
+          // versions[0] is that latest minor served unprefixed, so slice(1) drops
+          // just the /docs/<X.Y>/ snapshots — no maintenance as new minors land.
+          ignorePatterns: hasVersions ? versions.slice(1).map(v => `/docs/${v}/**`) : [],
+          changefreq: 'weekly',
+          priority: 0.5,
+        },
         theme: {
           customCss: ['./src/css/custom.css'],
         },

--- a/docs-site/static/robots.txt
+++ b/docs-site/static/robots.txt
@@ -4,9 +4,6 @@ Allow: /
 # Only the unprefixed canonical /docs/<page> route (the latest released
 # minor) should be indexed.
 #
-# In-development docs that track main in Gusto/embedded-react-sdk.
-Disallow: /docs/next/
-#
 # Snapshots of older minors live at /docs/<X.Y>/<page>. Block by prefix.
 # Extend this list when we ship a new major (e.g. Disallow: /docs/1.).
 Disallow: /docs/0.

--- a/docs-site/static/robots.txt
+++ b/docs-site/static/robots.txt
@@ -1,0 +1,14 @@
+User-agent: *
+Allow: /
+
+# Only the unprefixed canonical /docs/<page> route (the latest released
+# minor) should be indexed.
+#
+# In-development docs that track main in Gusto/embedded-react-sdk.
+Disallow: /docs/next/
+#
+# Snapshots of older minors live at /docs/<X.Y>/<page>. Block by prefix.
+# Extend this list when we ship a new major (e.g. Disallow: /docs/1.).
+Disallow: /docs/0.
+
+Sitemap: https://sdk.gusto.com/sitemap.xml


### PR DESCRIPTION
## Summary

Switches `docs-site/static/robots.txt` from `Disallow: /` to an allow policy that exposes only the canonical latest-version URLs to search engines, and configures `@docusaurus/plugin-sitemap` to keep the sitemap consistent with it.

The published site serves two flavors of every doc:

| URL | Indexable? |
|---|---|
| `/docs/<page>` — latest released minor (canonical) | yes |
| `/docs/<X.Y>/<page>` — snapshot of an older minor | no |

There is **no `/docs/next/` route** — `docs` is configured with `includeCurrentVersion: false`, so the in-development docs that track `main` are never published. Earlier drafts blocked `/docs/next/`; those directives were inert and have been removed from both robots.txt and the sitemap config.

## robots.txt directives

- `Disallow: /docs/0.` — prefix match that covers every `0.x` minor snapshot (`/docs/0.47/`, `/docs/0.48/`, …). The unprefixed canonical `/docs/<page>` (the latest minor, driven by Docusaurus's `lastVersion`) is unaffected and stays indexable. When we ship `1.0`, add `Disallow: /docs/1.` as a one-line edit.

## Sitemap config

`robots.txt` tells crawlers what NOT to fetch, but the auto-generated sitemap would still advertise every version path. `docs-site/docusaurus.config.ts` now configures `@docusaurus/plugin-sitemap` (via the `classic` preset) to exclude the same paths:

\`\`\`ts
sitemap: {
  ignorePatterns: hasVersions ? versions.slice(1).map(v => \`/docs/\${v}/**\`) : [],
  changefreq: 'weekly',
  priority: 0.5,
},
\`\`\`

`versions[0]` is the latest minor, served unprefixed at `/docs/`, so `slice(1)` excludes only the older `/docs/<X.Y>/` snapshots — dynamic, no maintenance as new minors land.

On `changefreq` and `priority`: Google largely ignores them as ranking signals (its own crawl scheduler wins), but `weekly` matches the release cadence and is a reasonable hint. The main lever is what's *in* the sitemap vs not, which `ignorePatterns` handles.

## Test plan

- [ ] After this PR merges, hit `https://sdk.gusto.com/robots.txt` and confirm the new contents.
- [ ] Once versioning is live, fetch `https://sdk.gusto.com/sitemap.xml` and confirm only canonical `/docs/<page>` URLs appear.
- [ ] Submit the site / sitemap in Google Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)