### PR TITLE
fix(Badge): increase padding and use pill radius

### DIFF
--- a/src/components/Common/UI/Badge/Badge.module.scss
+++ b/src/components/Common/UI/Badge/Badge.module.scss
@@ -1,6 +1,6 @@
 .badge {
   display: inline-block;
-  padding: toRem(2) toRem(8);
+  padding: toRem(5) toRem(12);
   font-size: var(--g-fontSizeSmall);
   font-weight: var(--g-fontWeightMedium);
   text-align: center;

--- a/src/contexts/ThemeProvider/theme.ts
+++ b/src/contexts/ThemeProvider/theme.ts
@@ -96,7 +96,7 @@ export const createTheme = (colors: Partial<GustoSDKThemeColors> = {}): GustoSDK
     inputRadius: toRem(8),
     buttonRadius: toRem(8),
     cardRadius: toRem(8),
-    badgeRadius: toRem(6),
+    badgeRadius: toRem(999),
     bannerRadius: toRem(8),
     boxRadius: toRem(8),
     fontSizeRoot: getRootFontSize(),


### PR DESCRIPTION
## Summary
- Increase Badge padding from 2×8 to 5×12 for better breathing room
- Change default `badgeRadius` from 6px to 999px for a pill shape

## Test plan
- [ ] Verify Badge appearance in Storybook across variants