### PR TITLE
feat!: promotable conditional requiredness for form schemas

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -1127,7 +1127,7 @@ export interface CompensationFormFields {
 }
 
 // @public
-export type CompensationOptionalFieldsToRequire = { create?: "title"[] | undefined; update?: ("title" | "flsaStatus" | "paymentUnit" | "rate" | "effectiveDate")[] | undefined; };
+export type CompensationOptionalFieldsToRequire = { create?: ("title" | "minimumWageId")[] | undefined; update?: ("title" | "flsaStatus" | "paymentUnit" | "rate" | "effectiveDate" | "minimumWageId")[] | undefined; };
 
 // @public
 interface CompensationProps extends BaseComponentInterface<'Employee.Compensation'> {
@@ -1673,7 +1673,7 @@ export interface ContractorDetailsFormFields {
 export type ContractorDetailsNameValidation = (typeof ContractorDetailsErrorCodes)['REQUIRED' | 'INVALID_NAME'];
 
 // @public
-export type ContractorDetailsOptionalFieldsToRequire = { create?: ("ssn" | "ein" | "middleInitial")[] | undefined; update?: ("hourlyRate" | "businessName" | "ssn" | "ein" | "startDate" | "firstName" | "lastName" | "middleInitial" | "workState")[] | undefined; };
+export type ContractorDetailsOptionalFieldsToRequire = { create?: ("ssn" | "ein" | "email" | "middleInitial")[] | undefined; update?: ("hourlyRate" | "businessName" | "ssn" | "ein" | "startDate" | "email" | "firstName" | "lastName" | "middleInitial" | "workState")[] | undefined; };
 
 // @public
 export type ContractorDetailsRequiredValidation = typeof ContractorDetailsErrorCodes.REQUIRED;
@@ -2386,7 +2386,7 @@ export type EffectiveDateFieldProps = HookFieldProps<DatePickerHookFieldProps<Wo
 export type EmailFieldProps = HookFieldProps<TextInputHookFieldProps<EmailValidation>>;
 
 // @public
-export type EmailValidation = (typeof EmployeeDetailsErrorCodes)['REQUIRED' | 'INVALID_EMAIL' | 'EMAIL_REQUIRED_FOR_SELF_ONBOARDING'];
+export type EmailValidation = (typeof EmployeeDetailsErrorCodes)['REQUIRED' | 'INVALID_EMAIL'];
 
 // @public
 export type EmployeeAction = 'edit' | 'delete' | 'cancel_self_onboarding' | 'review' | 'dismiss' | 'rehire';
@@ -2400,7 +2400,6 @@ export const EmployeeDetailsErrorCodes: {
     readonly INVALID_NAME: "INVALID_NAME";
     readonly INVALID_EMAIL: "INVALID_EMAIL";
     readonly INVALID_SSN: "INVALID_SSN";
-    readonly EMAIL_REQUIRED_FOR_SELF_ONBOARDING: "EMAIL_REQUIRED_FOR_SELF_ONBOARDING";
 };
 
 // @public
@@ -3266,7 +3265,7 @@ export interface JobFormFields {
 }
 
 // @public
-export type JobOptionalFieldsToRequire = { create?: ("twoPercentShareholder" | "stateWcCovered")[] | undefined; update?: ("title" | "hireDate" | "twoPercentShareholder" | "stateWcCovered")[] | undefined; };
+export type JobOptionalFieldsToRequire = { create?: ("twoPercentShareholder" | "stateWcCovered" | "stateWcClassCode")[] | undefined; update?: ("title" | "hireDate" | "twoPercentShareholder" | "stateWcCovered" | "stateWcClassCode")[] | undefined; };
 
 // @public
 export type JobRequiredValidation = typeof JobErrorCodes.REQUIRED;
@@ -4173,7 +4172,7 @@ export interface PayScheduleFormFields {
 export type PayScheduleFrequency = "Every week" | "Every other week" | "Twice per month" | "Monthly";
 
 // @public
-export type PayScheduleOptionalFieldsToRequire = { create?: "customTwicePerMonth"[] | undefined; update?: "customTwicePerMonth"[] | undefined; };
+export type PayScheduleOptionalFieldsToRequire = { create?: ("customTwicePerMonth" | "day1" | "day2")[] | undefined; update?: ("customTwicePerMonth" | "day1" | "day2")[] | undefined; };
 
 // @public
 interface PayScheduleProps extends BaseComponentInterface<'Company.PaySchedule'> {

--- a/docs/hooks/hooks.md
+++ b/docs/hooks/hooks.md
@@ -542,7 +542,6 @@ import { EmployeeDetailsErrorCodes } from '@gusto/embedded-react-sdk'
   validationMessages={{
     REQUIRED: 'Email is required',
     INVALID_EMAIL: 'Please enter a valid email address',
-    EMAIL_REQUIRED_FOR_SELF_ONBOARDING: 'Email is required when self-onboarding is enabled',
   }}
 />
 ```

--- a/docs/hooks/useEmployeeDetailsForm.md
+++ b/docs/hooks/useEmployeeDetailsForm.md
@@ -146,7 +146,6 @@ const EmployeeDetailsErrorCodes = {
   INVALID_NAME: 'INVALID_NAME',
   INVALID_EMAIL: 'INVALID_EMAIL',
   INVALID_SSN: 'INVALID_SSN',
-  EMAIL_REQUIRED_FOR_SELF_ONBOARDING: 'EMAIL_REQUIRED_FOR_SELF_ONBOARDING',
 } as const
 ```
 
@@ -238,20 +237,19 @@ Text input for the employee's last name. Validates that the value contains only 
 
 Text input for the employee's personal email address.
 
-| Prop                 | Type                                                                                      | Required |
-| -------------------- | ----------------------------------------------------------------------------------------- | -------- |
-| `label`              | `string`                                                                                  | Yes      |
-| `description`        | `ReactNode`                                                                               | No       |
-| `validationMessages` | `{ REQUIRED: string, INVALID_EMAIL: string, EMAIL_REQUIRED_FOR_SELF_ONBOARDING: string }` | No       |
-| `FieldComponent`     | `ComponentType<TextInputProps>`                                                           | No       |
+| Prop                 | Type                                          | Required |
+| -------------------- | --------------------------------------------- | -------- |
+| `label`              | `string`                                      | Yes      |
+| `description`        | `ReactNode`                                   | No       |
+| `validationMessages` | `{ REQUIRED: string, INVALID_EMAIL: string }` | No       |
+| `FieldComponent`     | `ComponentType<TextInputProps>`               | No       |
 
 **Validation codes:**
 
-| Code                                 | When it triggers                                                 |
-| ------------------------------------ | ---------------------------------------------------------------- |
-| `REQUIRED`                           | Field is empty and marked required via `requiredFields`          |
-| `INVALID_EMAIL`                      | Non-empty value that is not a valid email format                 |
-| `EMAIL_REQUIRED_FOR_SELF_ONBOARDING` | Self-onboarding is enabled but email is empty (create mode only) |
+| Code            | When it triggers                                                                                                 |
+| --------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `REQUIRED`      | Email is empty and required — either self-onboarding is enabled or it was promoted via `optionalFieldsToRequire` |
+| `INVALID_EMAIL` | Non-empty value that is not a valid email format                                                                 |
 
 ```tsx
 <Fields.Email
@@ -260,7 +258,6 @@ Text input for the employee's personal email address.
   validationMessages={{
     REQUIRED: 'Email is required',
     INVALID_EMAIL: 'Enter a valid email address',
-    EMAIL_REQUIRED_FOR_SELF_ONBOARDING: 'Email is required when self-onboarding is enabled',
   }}
 />
 ```
@@ -466,7 +463,6 @@ function EmployeeDetailsFormReady({
           validationMessages={{
             REQUIRED: 'Email is required',
             INVALID_EMAIL: 'Enter a valid email address',
-            EMAIL_REQUIRED_FOR_SELF_ONBOARDING: 'Email is required when self-onboarding is enabled',
           }}
         />
 
@@ -570,7 +566,6 @@ function EmployeeDetailsFormReady({
         validationMessages={{
           REQUIRED: 'Email is required',
           INVALID_EMAIL: 'Enter a valid email address',
-          EMAIL_REQUIRED_FOR_SELF_ONBOARDING: 'Email is required when self-onboarding is enabled',
         }}
       />
 

--- a/docs/reference/employee/hooks/use-employee-details-form.md
+++ b/docs/reference/employee/hooks/use-employee-details-form.md
@@ -202,11 +202,7 @@ Bound to `email`. Text input.
 ```tsx
 <form.Fields.Email
   label="Email"
-  validationMessages={{
-    REQUIRED: '…',
-    INVALID_EMAIL: '…',
-    EMAIL_REQUIRED_FOR_SELF_ONBOARDING: '…',
-  }}
+  validationMessages={{ REQUIRED: '…', INVALID_EMAIL: '…' }}
 />
 ```
 
@@ -375,16 +371,16 @@ _Also accepts `description`, `formHookResult`, `placeholder`, `transform` from [
 
 ### EmailValidation
 
-> **EmailValidation** = `"REQUIRED"` \| `"INVALID_EMAIL"` \| `"EMAIL_REQUIRED_FOR_SELF_ONBOARDING"`
+> **EmailValidation** = `"REQUIRED"` \| `"INVALID_EMAIL"`
 
 Validation error codes emitted by the `email` field of [useEmployeeDetailsForm](#useemployeedetailsform).
 
 #### Remarks
 
-Use these as keys in `validationMessages` on `Fields.Email`. The
-`EMAIL_REQUIRED_FOR_SELF_ONBOARDING` code fires when self-onboarding is
-enabled but the email is empty (create mode only). See
-[EmployeeDetailsErrorCodes](#employeedetailserrorcodes).
+Use these as keys in `validationMessages` on `Fields.Email`. The `REQUIRED`
+code fires when the email is empty and required — either because
+self-onboarding is enabled or because the field was promoted via
+`optionalFieldsToRequire`. See [EmployeeDetailsErrorCodes](#employeedetailserrorcodes).
 
 ***
 
@@ -475,7 +471,7 @@ switch changes the employee's onboarding status as part of an update.
 
 ### EmployeeDetailsErrorCode
 
-> **EmployeeDetailsErrorCode** = `"REQUIRED"` \| `"INVALID_NAME"` \| `"INVALID_EMAIL"` \| `"INVALID_SSN"` \| `"EMAIL_REQUIRED_FOR_SELF_ONBOARDING"`
+> **EmployeeDetailsErrorCode** = `"REQUIRED"` \| `"INVALID_NAME"` \| `"INVALID_EMAIL"` \| `"INVALID_SSN"`
 
 Union of validation error code strings emitted by the employee details form
 schema.
@@ -496,7 +492,6 @@ hook.
 
 | Name | Type |
 | ------ | ------ |
-| `EMAIL_REQUIRED_FOR_SELF_ONBOARDING` | `"EMAIL_REQUIRED_FOR_SELF_ONBOARDING"` |
 | `INVALID_EMAIL` | `"INVALID_EMAIL"` |
 | `INVALID_NAME` | `"INVALID_NAME"` |
 | `INVALID_SSN` | `"INVALID_SSN"` |

--- a/docs/reference/employee/hooks/use-job-form.md
+++ b/docs/reference/employee/hooks/use-job-form.md
@@ -440,8 +440,8 @@ const job = useJobForm({
 
 | Property | Type | Description |
 | ------ | ------ | ------ |
-| `create?` | (`"twoPercentShareholder"` \| `"stateWcCovered"`)[] | Fields that can be required in create mode |
-| `update?` | (`"title"` \| `"hireDate"` \| `"twoPercentShareholder"` \| `"stateWcCovered"`)[] | Fields that can be required in update mode |
+| `create?` | (`"stateWcClassCode"` \| `"twoPercentShareholder"` \| `"stateWcCovered"`)[] | Fields that can be required in create mode |
+| `update?` | (`"title"` \| `"hireDate"` \| `"stateWcClassCode"` \| `"twoPercentShareholder"` \| `"stateWcCovered"`)[] | Fields that can be required in update mode |
 
 ***
 

--- a/src/components/Employee/Profile/management/ProfileEditForm.tsx
+++ b/src/components/Employee/Profile/management/ProfileEditForm.tsx
@@ -132,7 +132,6 @@ function ProfileEditFormRoot({ employeeId, className, dictionary, onEvent }: Pro
               validationMessages={{
                 REQUIRED: t('form.validations.email'),
                 INVALID_EMAIL: t('form.validations.email'),
-                EMAIL_REQUIRED_FOR_SELF_ONBOARDING: t('form.validations.email'),
               }}
             />
             <Fields.Ssn

--- a/src/components/Employee/Profile/onboarding/AdminProfile.tsx
+++ b/src/components/Employee/Profile/onboarding/AdminProfile.tsx
@@ -329,7 +329,6 @@ function AdminProfileReady({
               validationMessages={{
                 REQUIRED: t('validations.email'),
                 INVALID_EMAIL: t('validations.email'),
-                EMAIL_REQUIRED_FOR_SELF_ONBOARDING: t('validations.email'),
               }}
             />
 

--- a/src/components/Employee/Profile/shared/useEmployeeDetailsForm/employeeDetailsSchema.ts
+++ b/src/components/Employee/Profile/shared/useEmployeeDetailsForm/employeeDetailsSchema.ts
@@ -20,7 +20,6 @@ export const EmployeeDetailsErrorCodes = {
   INVALID_NAME: 'INVALID_NAME',
   INVALID_EMAIL: 'INVALID_EMAIL',
   INVALID_SSN: 'INVALID_SSN',
-  EMAIL_REQUIRED_FOR_SELF_ONBOARDING: 'EMAIL_REQUIRED_FOR_SELF_ONBOARDING',
 } as const
 
 /**
@@ -44,12 +43,7 @@ const fieldValidators = {
     .string()
     .min(1, { message: EmployeeDetailsErrorCodes.REQUIRED })
     .regex(NAME_REGEX, { message: EmployeeDetailsErrorCodes.INVALID_NAME }),
-  email: z.email({
-    error: issue =>
-      typeof issue.input === 'string' && issue.input.length === 0
-        ? EmployeeDetailsErrorCodes.REQUIRED
-        : EmployeeDetailsErrorCodes.INVALID_EMAIL,
-  }),
+  email: z.email({ error: () => EmployeeDetailsErrorCodes.INVALID_EMAIL }),
   dateOfBirth: z.iso.date({ error: () => EmployeeDetailsErrorCodes.REQUIRED }),
   ssn: z
     .string({ error: () => EmployeeDetailsErrorCodes.REQUIRED })
@@ -80,13 +74,25 @@ export type EmployeeDetailsFormOutputs = EmployeeDetailsFormData
 
 // ── Required fields config ─────────────────────────────────────────────
 
+// Requiredness mirrors the employee create/update API contract: fields the API
+// requires on create are `'create'` (optional on update), and fields the API
+// treats as optional are `'never'`.
+//
+// `email` is value-conditional: it always applies but is only required when
+// self-onboarding is on (create and update), matching the API's "if
+// self_onboarding is true, then email is required" — the employee needs an
+// email to receive the invitation. A single-operand predicate keeps
+// `buildFormSchema`'s dependency-detecting Proxy accurate, and the predicate
+// drives both validation and `fieldsMetadata.isRequired` so the rendered label
+// and validation always agree. Consumers that need email required regardless of
+// self-onboarding promote it via `optionalFieldsToRequire`.
 const requiredFieldsConfig = {
   firstName: 'create',
   lastName: 'create',
   middleInitial: 'never',
-  email: 'never',
   dateOfBirth: 'never',
   ssn: 'never',
+  email: data => data.selfOnboarding,
 } satisfies RequiredFieldConfig<typeof fieldValidators>
 
 // ── Schema factory ─────────────────────────────────────────────────────
@@ -118,17 +124,5 @@ export function createEmployeeDetailsSchema(options: EmployeeDetailsSchemaOption
     mode,
     optionalFieldsToRequire,
     fieldsWithRedactedValues: hasSsn ? ['ssn'] : [],
-    superRefine:
-      mode === 'create'
-        ? (data, ctx) => {
-            if (data.selfOnboarding && (!data.email || data.email.trim() === '')) {
-              ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['email'],
-                message: EmployeeDetailsErrorCodes.EMAIL_REQUIRED_FOR_SELF_ONBOARDING,
-              })
-            }
-          }
-        : undefined,
   })
 }

--- a/src/components/Employee/Profile/shared/useEmployeeDetailsForm/fields.tsx
+++ b/src/components/Employee/Profile/shared/useEmployeeDetailsForm/fields.tsx
@@ -38,15 +38,14 @@ export type NameValidation = (typeof EmployeeDetailsErrorCodes)['REQUIRED' | 'IN
  * Validation error codes emitted by the `email` field of {@link useEmployeeDetailsForm}.
  *
  * @remarks
- * Use these as keys in `validationMessages` on `Fields.Email`. The
- * `EMAIL_REQUIRED_FOR_SELF_ONBOARDING` code fires when self-onboarding is
- * enabled but the email is empty (create mode only). See
- * {@link EmployeeDetailsErrorCodes}.
+ * Use these as keys in `validationMessages` on `Fields.Email`. The `REQUIRED`
+ * code fires when the email is empty and required — either because
+ * self-onboarding is enabled or because the field was promoted via
+ * `optionalFieldsToRequire`. See {@link EmployeeDetailsErrorCodes}.
  *
  * @public
  */
-export type EmailValidation = (typeof EmployeeDetailsErrorCodes)[
-  'REQUIRED' | 'INVALID_EMAIL' | 'EMAIL_REQUIRED_FOR_SELF_ONBOARDING']
+export type EmailValidation = (typeof EmployeeDetailsErrorCodes)['REQUIRED' | 'INVALID_EMAIL']
 
 /**
  * The format-validation error code emitted by the `ssn` field of {@link useEmployeeDetailsForm}.

--- a/src/components/Employee/Profile/shared/useEmployeeDetailsForm/useEmployeeDetailsForm.test.tsx
+++ b/src/components/Employee/Profile/shared/useEmployeeDetailsForm/useEmployeeDetailsForm.test.tsx
@@ -355,6 +355,68 @@ describe('useEmployeeDetailsForm', () => {
       expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'lastName').isRequired).toBe(true)
       expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'email').isRequired).toBe(true)
     })
+
+    it('rejects submission when selfOnboarding is on and email is empty (baseline, not promoted)', async () => {
+      const { result } = renderHook(
+        () =>
+          useEmployeeDetailsForm({
+            companyId: 'company-1',
+            defaultValues: {
+              firstName: 'Jane',
+              lastName: 'Doe',
+              email: '',
+              selfOnboarding: true,
+            },
+          }),
+        { wrapper: GustoTestProvider },
+      )
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      const readyResult = result.current
+      assertReady(readyResult)
+
+      expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'email').isRequired).toBe(true)
+
+      await act(async () => {
+        await readyResult.actions.onSubmit()
+      })
+
+      expect(createRequestBody).toBeNull()
+    })
+
+    it('accepts submission when selfOnboarding is off and email is empty (baseline, not promoted)', async () => {
+      const { result } = renderHook(
+        () =>
+          useEmployeeDetailsForm({
+            companyId: 'company-1',
+            defaultValues: {
+              firstName: 'Jane',
+              lastName: 'Doe',
+              email: '',
+              selfOnboarding: false,
+            },
+          }),
+        { wrapper: GustoTestProvider },
+      )
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      const readyResult = result.current
+      assertReady(readyResult)
+
+      expect(fieldsMetadataEntry(readyResult.form.fieldsMetadata, 'email').isRequired).toBe(false)
+
+      await act(async () => {
+        await readyResult.actions.onSubmit()
+      })
+
+      expect(createRequestBody).not.toBeNull()
+    })
   })
 
   describe('update mode', () => {

--- a/src/partner-hook-utils/form/buildFormSchema.test.ts
+++ b/src/partner-hook-utils/form/buildFormSchema.test.ts
@@ -584,12 +584,70 @@ describe('buildFormSchema', () => {
         mode: 'create',
         optionalFieldsToRequire: {
           create: ['dependent'],
-        } as unknown as OptionalFieldsToRequire<typeof requiredFieldsConfig>,
+        },
       })
 
       const result = schema.safeParse({ toggle: false, dependent: '' })
       expect(result.success).toBe(false)
       expect(getErrorFields(result)).toContain('dependent')
+    })
+  })
+
+  describe('promotable predicate fields', () => {
+    const fieldValidators = {
+      toggle: z.boolean(),
+      dependent: z.string(),
+    }
+
+    const requiredFieldsConfig = {
+      dependent: (data: { toggle: boolean }) => data.toggle,
+    } as const
+
+    it('a predicate field is assignable to optionalFieldsToRequire without a cast', () => {
+      // Type-level proof that the framework exposes predicate ("sometimes")
+      // fields as promotable. If OptionalOnCreate/OptionalOnUpdate stopped
+      // including predicate rules, this annotation would fail to compile.
+      const optionalFieldsToRequire: OptionalFieldsToRequire<typeof requiredFieldsConfig> = {
+        create: ['dependent'],
+        update: ['dependent'],
+      }
+
+      expect(optionalFieldsToRequire.create).toContain('dependent')
+    })
+
+    it('promoting a predicate field makes it required regardless of the predicate', () => {
+      const [schema, { getFieldsMetadata }] = buildFormSchema(fieldValidators, {
+        requiredFieldsConfig,
+        mode: 'create',
+        optionalFieldsToRequire: { create: ['dependent'] },
+      })
+
+      const toggleOff = schema.safeParse({ toggle: false, dependent: '' })
+      expect(toggleOff.success).toBe(false)
+      expect(getErrorFields(toggleOff)).toContain('dependent')
+
+      const toggleOn = schema.safeParse({ toggle: true, dependent: '' })
+      expect(toggleOn.success).toBe(false)
+      expect(getErrorFields(toggleOn)).toContain('dependent')
+
+      expect(getFieldsMetadata({ toggle: false }).dependent.isRequired).toBe(true)
+    })
+
+    it('an unpromoted predicate field stays conditional', () => {
+      const [schema, { getFieldsMetadata }] = buildFormSchema(fieldValidators, {
+        requiredFieldsConfig,
+        mode: 'create',
+      })
+
+      const toggleOff = schema.safeParse({ toggle: false, dependent: '' })
+      expect(toggleOff.success).toBe(true)
+
+      const toggleOn = schema.safeParse({ toggle: true, dependent: '' })
+      expect(toggleOn.success).toBe(false)
+      expect(getErrorFields(toggleOn)).toContain('dependent')
+
+      expect(getFieldsMetadata({ toggle: false }).dependent.isRequired).toBe(false)
+      expect(getFieldsMetadata({ toggle: true }).dependent.isRequired).toBe(true)
     })
   })
 
@@ -759,7 +817,7 @@ describe('buildFormSchema', () => {
         mode: 'create',
         optionalFieldsToRequire: {
           create: ['minimumWageId'],
-        } as unknown as OptionalFieldsToRequire<typeof requiredFieldsConfig>,
+        },
       })
       const metadata = getFieldsMetadata({ adjustForMinimumWage: false })
 
@@ -867,9 +925,7 @@ describe('buildFormSchema', () => {
           mode: 'create',
           optionalFieldsToRequire: {
             create: ['dependent'],
-          } as unknown as OptionalFieldsToRequire<{
-            dependent: (data: Record<string, unknown>) => boolean
-          }>,
+          },
         },
       )
       expect(predicateDeps).toEqual([])

--- a/src/partner-hook-utils/form/buildFormSchema.ts
+++ b/src/partner-hook-utils/form/buildFormSchema.ts
@@ -36,9 +36,18 @@ export type RequiredFieldConfig<TSchema extends Record<string, z.ZodType>> = Par
 }>
 
 /**
- * Union of field names in `TConfig` whose base rule is `'update'` or `'never'`
- * — i.e. fields that are optional on create and therefore eligible to be
- * promoted to required in create mode.
+ * A predicate (value-conditional) requiredness rule. Matches any function
+ * signature so predicate rules are recognized regardless of their parameter or
+ * return types. Such fields are never statically required in a given mode, so
+ * they're eligible for promotion — see {@link OptionalOnCreate}.
+ */
+type PredicateRule = (...args: never[]) => unknown
+
+/**
+ * Union of field names in `TConfig` that are not statically required in create
+ * mode and are therefore eligible to be promoted to required in create mode:
+ * fields whose base rule is `'update'`, `'never'`, or a predicate. Promoting a
+ * predicate field upgrades it from conditionally required to always required.
  *
  * The template-literal wrapper \`\` `${...}` \`\` is intentional: wrapping a
  * conditional-mapped-type index access in a template literal forces TypeScript
@@ -49,18 +58,18 @@ export type RequiredFieldConfig<TSchema extends Record<string, z.ZodType>> = Par
  * resolved concrete union (e.g. `"stateWcCovered" | "twoPercentShareholder"`).
  */
 type OptionalOnCreate<TConfig> = `${{
-  [K in keyof TConfig & string]: TConfig[K] extends 'update' | 'never' ? K : never
+  [K in keyof TConfig & string]: TConfig[K] extends 'update' | 'never' | PredicateRule ? K : never
 }[keyof TConfig & string]}`
 
 /**
- * Union of field names in `TConfig` whose base rule is `'create'` or `'never'`
- * — i.e. fields that are optional on update and therefore eligible to be
- * promoted to required in update mode.
+ * Union of field names in `TConfig` that are not statically required in update
+ * mode and are therefore eligible to be promoted to required in update mode:
+ * fields whose base rule is `'create'`, `'never'`, or a predicate.
  *
  * See {@link OptionalOnCreate} for why the template-literal wrapper is here.
  */
 type OptionalOnUpdate<TConfig> = `${{
-  [K in keyof TConfig & string]: TConfig[K] extends 'create' | 'never' ? K : never
+  [K in keyof TConfig & string]: TConfig[K] extends 'create' | 'never' | PredicateRule ? K : never
 }[keyof TConfig & string]}`
 
 /**
@@ -68,7 +77,9 @@ type OptionalOnUpdate<TConfig> = `${{
  *
  * Only fields whose base rule allows the override appear in the `create` /
  * `update` arrays — fields that are already required in a given mode are
- * excluded from that mode's list at the type level.
+ * excluded from that mode's list at the type level. Value-conditional
+ * (predicate) fields are eligible in both modes; listing one promotes it from
+ * conditionally required to always required for that mode.
  *
  * @typeParam TConfig - The {@link RequiredFieldConfig} that constrains which fields are eligible.
  * @internal


### PR DESCRIPTION
## Summary

- Broadens `buildFormSchema`'s `optionalFieldsToRequire` to accept predicate ("sometimes") fields, letting consumers promote them from conditionally required to always required — mirroring how `'never'` fields already promote. The runtime already supported the OR semantics (`predicate: isPartnerRequired ? () => true : effectiveRule`); this unlocks it at the type level (`OptionalOnCreate` / `OptionalOnUpdate` now include a `PredicateRule`).
- Converts employee `email` to the predicate `data => data.selfOnboarding`, so its self-onboarding requirement is an API-aligned baseline that drives both validation and `fieldsMetadata.isRequired` (keeping the rendered label and validation in sync). `AdminProfile` and `ProfileEditForm` continue to promote `email` so it stays always-required in those surfaces.
- Removes the now-redundant `superRefine` block and the `EMAIL_REQUIRED_FOR_SELF_ONBOARDING` error code; regenerated derived docs/API report and updated the hand-written `docs/hooks/*.md`.

## Breaking change

`EMAIL_REQUIRED_FOR_SELF_ONBOARDING` is removed from `EmployeeDetailsErrorCodes`, and the `Fields.Email` `validationMessages` type is narrowed to `REQUIRED | INVALID_EMAIL`. An empty email while self-onboarding is enabled now emits `REQUIRED` instead of `EMAIL_REQUIRED_FOR_SELF_ONBOARDING`.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run test -- --run src/partner-hook-utils/form src/components/Employee/Profile src/components/Contractor/Profile` (258 passing)
- [x] `npm run lint:check` (0 errors)
- [x] `npm run format:check` (changed files clean)
- [x] New tests: predicate-field promotion (framework) + self-onboarding email baseline (hook), promoted vs. unpromoted
- [x] CI green

## Demo

To verify functionality, here is a version of profile with email removed from the optional fields to require. Observe that email is optional until self onboarding is toggled


https://github.com/user-attachments/assets/91c87878-c46a-48e8-b2f4-94fdce60ad88

Now restoring existing behavior promoting email to always be required

https://github.com/user-attachments/assets/16b0d950-7287-4a41-badf-870fcb43d77f

Made with [Cursor](https://cursor.com)