### PR TITLE
fix(Contractor): align submit-button loading UX across onboarding

### DIFF
--- a/docs/reference/Translations/index.md
+++ b/docs/reference/Translations/index.md
@@ -1242,6 +1242,7 @@ Translation keys for the `Contractor.Address` i18n namespace.
 | <a id="property-contractoraddressstreet1"></a> `street1` | `"Street 1"` |
 | <a id="property-contractoraddressstreet2"></a> `street2` | `"Street 2"` |
 | <a id="property-contractoraddresssubmit"></a> `submit` | `"Continue"` |
+| <a id="property-contractoraddresssubmitting"></a> `submitting` | `"Saving…"` |
 | <a id="property-contractoraddressvalidations"></a> `validations` | |
 | `validations.city` | `"Please provide valid city name"` |
 | `validations.state` | `"Please select a state"` |
@@ -1392,6 +1393,7 @@ Translation keys for the `Contractor.PaymentMethod` i18n namespace.
 | <a id="property-contractorpaymentmethoddirectdepositdescription"></a> `directDepositDescription` | `"We recommend direct deposit – we’ll deposit paychecks directly into your employee’s bank account."` |
 | <a id="property-contractorpaymentmethoddirectdepositlabel"></a> `directDepositLabel` | `"Direct deposit"` |
 | <a id="property-contractorpaymentmethodpaymentfieldsetlegend"></a> `paymentFieldsetLegend` | `"Select payment method"` |
+| <a id="property-contractorpaymentmethodsubmittingcta"></a> `submittingCta` | `"Saving…"` |
 | <a id="property-contractorpaymentmethodtitle"></a> `title` | `"Contractor payment details"` |
 
 ***
@@ -1756,6 +1758,7 @@ Translation keys for the `Contractor.SignatureForm` i18n namespace.
 | Property | Default value |
 | ------ | ------ |
 | <a id="property-contractorsignatureformacknowledgecta"></a> `acknowledgeCta` | `"Acknowledge"` |
+| <a id="property-contractorsignatureformacknowledgingcta"></a> `acknowledgingCta` | `"Acknowledging…"` |
 | <a id="property-contractorsignatureformagreelabel"></a> `agreeLabel` | `"I agree to electronically sign this form."` |
 | <a id="property-contractorsignatureformbackcta"></a> `backCta` | `"Back"` |
 | <a id="property-contractorsignatureformcertificationintro"></a> `certificationIntro` | `"Under penalties of perjury, I certify that:"` |
@@ -1836,6 +1839,7 @@ Translation keys for the `Contractor.SignatureForm` i18n namespace.
 | `sections.tin` | `"Taxpayer Identification Number (TIN)"` |
 | <a id="property-contractorsignatureformsignaturerequired"></a> `signatureRequired` | `"Signature required"` |
 | <a id="property-contractorsignatureformsigncta"></a> `signCta` | `"Sign"` |
+| <a id="property-contractorsignatureformsigningcta"></a> `signingCta` | `"Signing…"` |
 | <a id="property-contractorsignatureformvalidation"></a> `validation` | |
 | `validation.agreeRequired` | `"You must agree to electronically sign this form."` |
 | `validation.invalidEin` | `"Enter a valid Employer Identification Number."` |

--- a/src/components/Contractor/Address/Address.tsx
+++ b/src/components/Contractor/Address/Address.tsx
@@ -156,8 +156,8 @@ function AddressRoot({
               </Grid>
 
               <ActionsLayout>
-                <Components.Button type="submit" isLoading={contractorAddress.status.isPending}>
-                  {t('submit')}
+                <Components.Button type="submit" isDisabled={contractorAddress.status.isPending}>
+                  {contractorAddress.status.isPending ? t('submitting') : t('submit')}
                 </Components.Button>
               </ActionsLayout>
             </Flex>

--- a/src/components/Contractor/Documents/SignatureForm/SignatureForm.tsx
+++ b/src/components/Contractor/Documents/SignatureForm/SignatureForm.tsx
@@ -130,8 +130,14 @@ function Root({ documentUuid, dictionary }: SignatureFormProps) {
               <Components.Button variant="secondary" type="button" onClick={handleBack}>
                 {t('backCta')}
               </Components.Button>
-              <Components.Button type="submit" isLoading={isPending}>
-                {hasFields ? t('signCta') : t('acknowledgeCta')}
+              <Components.Button type="submit" isDisabled={isPending}>
+                {hasFields
+                  ? isPending
+                    ? t('signingCta')
+                    : t('signCta')
+                  : isPending
+                    ? t('acknowledgingCta')
+                    : t('acknowledgeCta')}
               </Components.Button>
             </ActionsLayout>
           </Flex>

--- a/src/components/Contractor/PaymentMethod/PaymentMethod.tsx
+++ b/src/components/Contractor/PaymentMethod/PaymentMethod.tsx
@@ -178,7 +178,7 @@ function Root({ contractorId, className, onEvent }: Omit<PaymentMethodProps, 'di
             )}
             <ActionsLayout>
               <Components.Button type="submit" variant="primary" isDisabled={isPending}>
-                {t('continueCta')}
+                {isPending ? t('submittingCta') : t('continueCta')}
               </Components.Button>
             </ActionsLayout>
           </Flex>

--- a/src/i18n/en/Contractor.Address.json
+++ b/src/i18n/en/Contractor.Address.json
@@ -10,6 +10,7 @@
   "statePlaceholder": "Select state...",
   "zip": "Zip",
   "submit": "Continue",
+  "submitting": "Saving…",
   "validations": {
     "street1": "Street address is required",
     "city": "Please provide valid city name",

--- a/src/i18n/en/Contractor.PaymentMethod.json
+++ b/src/i18n/en/Contractor.PaymentMethod.json
@@ -6,6 +6,7 @@
   "checkLabel": "Check",
   "checkDescription": "If you select check as the payment method, you’ll need to write a physical check to this employee each payday.",
   "continueCta": "Continue",
+  "submittingCta": "Saving…",
   "bankAccountForm": {
     "nameLabel": "Account nickname",
     "routingNumberLabel": "Routing number",

--- a/src/i18n/en/Contractor.SignatureForm.json
+++ b/src/i18n/en/Contractor.SignatureForm.json
@@ -110,5 +110,7 @@
   },
   "backCta": "Back",
   "signCta": "Sign",
-  "acknowledgeCta": "Acknowledge"
+  "signingCta": "Signing…",
+  "acknowledgeCta": "Acknowledge",
+  "acknowledgingCta": "Acknowledging…"
 }

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -1724,6 +1724,8 @@ export namespace Translations {
     zip: string
     /** @defaultValue `"Continue"` */
     submit: string
+    /** @defaultValue `"Saving…"` */
+    submitting: string
     validations: {
       /** @defaultValue `"Street address is required"` */
       street1: string
@@ -1862,6 +1864,8 @@ export namespace Translations {
     checkDescription: string
     /** @defaultValue `"Continue"` */
     continueCta: string
+    /** @defaultValue `"Saving…"` */
+    submittingCta: string
     bankAccountForm: {
       /** @defaultValue `"Account nickname"` */
       nameLabel: string
@@ -2619,8 +2623,12 @@ export namespace Translations {
     backCta: string
     /** @defaultValue `"Sign"` */
     signCta: string
+    /** @defaultValue `"Signing…"` */
+    signingCta: string
     /** @defaultValue `"Acknowledge"` */
     acknowledgeCta: string
+    /** @defaultValue `"Acknowledging…"` */
+    acknowledgingCta: string
   }
   /** Translation keys for the `Contractor.Submit` i18n namespace. */
   export interface ContractorSubmit {


### PR DESCRIPTION
## Summary
- Contractor `Address`, `PaymentMethod`, and `SignatureForm` submit buttons previously used the `Button` spinner (`isLoading`) while the rest of the contractor self-onboarding flow (e.g. `ContractorProfile`) uses the `isDisabled` + label-swap pattern. Aligned all three to the label-swap pattern.
- Added new i18n strings: `Contractor.Address.submitting` ("Saving…"), `Contractor.PaymentMethod.submittingCta` ("Saving…"), and `Contractor.SignatureForm.signingCta` / `acknowledgingCta` ("Signing…" / "Acknowledging…").
- Regenerated `src/i18n/types.d.ts`.

## Test plan
- [ ] `npm run test -- --run src/components/Contractor/Address/Address.test.tsx` (14 passing)
- [ ] `npm run test -- --run src/components/Contractor/PaymentMethod/PaymentMethod.test.tsx` (10 passing)
- [ ] `npm run test -- --run src/components/Contractor/Documents/SignatureForm/SignatureForm.test.tsx` (15 passing)
- [ ] Manual: submit each form and confirm the button label swaps to the pending state and back