### PR TITLE
fix(storybook): target es2022 for Vite build and esbuild deps

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -27,6 +27,14 @@ const config: StorybookConfig = {
       css: {
         preprocessorOptions: scssPreprocessorOptions,
       },
+      build: {
+        target: 'es2022',
+      },
+      optimizeDeps: {
+        esbuildOptions: {
+          target: 'es2022',
+        },
+      },
     })
   },
 }


### PR DESCRIPTION
## Summary
- Add `build.target: 'es2022'` and `optimizeDeps.esbuildOptions.target: 'es2022'` to the Storybook Vite config so modern syntax (top-level await, class fields, etc.) compiles cleanly under Storybook.

## Test plan
- [ ] `npm run storybook` starts without target-related errors.
- [ ] Stories that rely on modern syntax (top-level await in setup, class fields) render without runtime errors.