### PR TITLE
fix(Company): prevent Enter key from cancelling State Taxes and Location edit forms

### DIFF
--- a/src/components/Company/Locations/LocationForm/Actions.tsx
+++ b/src/components/Company/Locations/LocationForm/Actions.tsx
@@ -11,7 +11,7 @@ export const Actions = () => {
 
   return (
     <ActionsLayout>
-      <Components.Button variant="secondary" onClick={handleCancel}>
+      <Components.Button type="button" variant="secondary" onClick={handleCancel}>
         {t('cancelCta')}
       </Components.Button>
       <Components.Button type="submit" isLoading={isPending} data-testid="location-submit">

--- a/src/components/Company/Locations/LocationForm/LocationForm.test.tsx
+++ b/src/components/Company/Locations/LocationForm/LocationForm.test.tsx
@@ -5,12 +5,15 @@ import userEvent from '@testing-library/user-event'
 import { QueryClient } from '@tanstack/react-query'
 import { LocationForm } from './LocationForm'
 import { setupApiTestMocks } from '@/test/mocks/apiServer'
-import { companyEvents } from '@/shared/constants'
+import { companyEvents, componentEvents } from '@/shared/constants'
 import { basicLocation, getCompanyLocation, getLocation } from '@/test/mocks/apis/company_locations'
 import { server } from '@/test/mocks/server'
 import { API_BASE_URL } from '@/test/constants'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
 import { GustoTestProvider } from '@/test/GustoTestApiProvider'
+import { GustoProvider } from '@/contexts'
+import { createSdkQueryClient } from '@/contexts/ApiProvider/createSdkQueryClient'
+import type { ButtonProps } from '@/components/Common/UI/Button/ButtonTypes'
 
 describe('LocationForm', () => {
   const onEvent = vi.fn()
@@ -112,6 +115,58 @@ describe('LocationForm (edit mode)', () => {
     expect(capturedRequestBody).toBeDefined()
     expect(capturedRequestBody).not.toHaveProperty('mailing_address')
     expect(capturedRequestBody).toHaveProperty('filing_address', false)
+  })
+})
+
+// Regression: pressing Enter in a field must submit the form, not cancel it.
+// The bug only surfaces when the partner supplies a Button that renders a
+// native <button> (whose default type is "submit"): with the Cancel button
+// rendered first and missing type="button", the browser's implicit form
+// submission activates Cancel instead of submitting. This override reproduces
+// that partner setup; the SDK's built-in react-aria Button already forces
+// type="button" and would mask the regression.
+describe('LocationForm (Enter key submits with a native-button component override)', () => {
+  const onEvent = vi.fn()
+  const user = userEvent.setup()
+
+  const NativeButton = ({ children, onClick, type, isDisabled }: ButtonProps) => (
+    <button type={type} onClick={onClick} disabled={isDisabled}>
+      {children}
+    </button>
+  )
+
+  beforeEach(() => {
+    onEvent.mockReset()
+    setupApiTestMocks()
+    server.use(getLocation)
+    server.use(
+      http.put(`${API_BASE_URL}/v1/locations/:location_id`, () =>
+        HttpResponse.json({ ...basicLocation, version: '2.0' }),
+      ),
+    )
+    render(
+      <GustoProvider
+        config={{ baseUrl: API_BASE_URL }}
+        queryClient={createSdkQueryClient()}
+        components={{ Button: NativeButton }}
+      >
+        <LocationForm companyId="company-123" locationId={basicLocation.uuid} onEvent={onEvent} />
+      </GustoProvider>,
+    )
+  })
+
+  it('submits the form when Enter is pressed in a field instead of cancelling', async () => {
+    const streetField = await screen.findByLabelText('Street 1')
+    await user.click(streetField)
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(onEvent).toHaveBeenCalledWith(
+        companyEvents.COMPANY_LOCATION_UPDATED,
+        expect.anything(),
+      )
+    })
+    expect(onEvent).not.toHaveBeenCalledWith(componentEvents.CANCEL)
   })
 })
 

--- a/src/components/Company/StateTaxes/StateTaxesForm/Actions.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesForm/Actions.tsx
@@ -11,7 +11,7 @@ export function Actions() {
 
   return (
     <ActionsLayout>
-      <Components.Button variant="secondary" onClick={handleCancel}>
+      <Components.Button type="button" variant="secondary" onClick={handleCancel}>
         {t('cancelCta')}
       </Components.Button>
       <Components.Button variant="primary" type="submit" isDisabled={isPending}>

--- a/src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.test.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.test.tsx
@@ -8,6 +8,9 @@ import { componentEvents } from '@/shared/constants'
 import { GustoTestProvider } from '@/test/GustoTestApiProvider'
 import { server } from '@/test/mocks/server'
 import { API_BASE_URL } from '@/test/constants'
+import { GustoProvider } from '@/contexts'
+import { createSdkQueryClient } from '@/contexts/ApiProvider/createSdkQueryClient'
+import type { ButtonProps } from '@/components/Common/UI/Button/ButtonTypes'
 
 describe('StateTaxesForm', () => {
   const onEvent = vi.fn()
@@ -52,6 +55,49 @@ describe('StateTaxesForm', () => {
       await user.click(cancelButton)
 
       expect(onEvent).toHaveBeenCalledWith(componentEvents.CANCEL)
+    })
+  })
+
+  // Regression: pressing Enter in a field must submit the form, not cancel it.
+  // The bug only surfaces when the partner supplies a Button that renders a
+  // native <button> (whose default type is "submit"): with the Cancel button
+  // rendered first and missing type="button", the browser's implicit form
+  // submission activates Cancel instead of submitting. This override reproduces
+  // that partner setup; the SDK's built-in react-aria Button already forces
+  // type="button" and would mask the regression.
+  describe('Enter key submits with a native-button component override', () => {
+    const onEvent = vi.fn()
+    const user = userEvent.setup()
+
+    const NativeButton = ({ children, onClick, type, isDisabled }: ButtonProps) => (
+      <button type={type} onClick={onClick} disabled={isDisabled}>
+        {children}
+      </button>
+    )
+
+    beforeEach(() => {
+      onEvent.mockReset()
+      setupApiTestMocks()
+      render(
+        <GustoProvider
+          config={{ baseUrl: API_BASE_URL }}
+          queryClient={createSdkQueryClient()}
+          components={{ Button: NativeButton }}
+        >
+          <StateTaxesForm companyId="company-123" state="GA" onEvent={onEvent} />
+        </GustoProvider>,
+      )
+    })
+
+    it('submits the form when Enter is pressed in a field instead of cancelling', async () => {
+      const taxRateField = await screen.findByLabelText(/Tax Rate/i)
+      await user.click(taxRateField)
+      await user.keyboard('{Enter}')
+
+      await waitFor(() => {
+        expect(onEvent).toHaveBeenCalledWith(componentEvents.COMPANY_STATE_TAX_UPDATED)
+      })
+      expect(onEvent).not.toHaveBeenCalledWith(componentEvents.CANCEL)
     })
   })
 


### PR DESCRIPTION
## Summary

Pressing **Enter** inside a form field while editing State Taxes (or a Location) navigated back to the list view without submitting. The Cancel button was missing `type="button"` and renders first in the form, so for any partner-supplied `Button` that renders a native `<button>` (whose default type is `submit`), the browser's implicit form submission activated Cancel instead of Save — firing `CANCEL` and bouncing to the list without saving.

## Changes

- Add explicit `type="button"` to the Cancel buttons in the State Taxes and Location edit forms, matching the existing pattern in `BankAccountForm/Actions.tsx`.
- Add regression tests for both forms that render with a native-`<button>` component override — the only setup where the bug reproduces, since the built-in react-aria Button always forces `type="button"`.

## Testing

- `npm run test -- --run src/components/Company/StateTaxes/StateTaxesForm/StateTaxesForm.test.tsx src/components/Company/Locations/LocationForm/LocationForm.test.tsx` — 19 passed.
- Confirmed the new regression tests **fail without the fix** (stashed the `Actions.tsx` edits → 2 failures) and pass with it, proving they guard the regression.
- `npx tsc --noEmit` — clean.