### PR TITLE
fix(Contractor/DocumentsList): key signature status off signedAt and guard unpreparable W-9s

### DIFF
--- a/docs/reference/Translations/index.md
+++ b/docs/reference/Translations/index.md
@@ -1294,6 +1294,8 @@ Translation keys for the `Contractor.DocumentsList` i18n namespace.
 | <a id="property-contractordocumentslistdocumentlistlabel"></a> `documentListLabel` | `"Documents"` |
 | <a id="property-contractordocumentslistemptytitle"></a> `emptyTitle` | `"No documents found"` |
 | <a id="property-contractordocumentslisterrortitle"></a> `errorTitle` | `"Could not load your documents, try again later."` |
+| <a id="property-contractordocumentslistnotreadybody"></a> `notReadyBody` | `"The W-9 form hasn't been fully generated yet. Please check back later, or contact support if the problem continues."` |
+| <a id="property-contractordocumentslistnotreadytitle"></a> `notReadyTitle` | `"W-9 isn't ready to sign yet"` |
 | <a id="property-contractordocumentslistnotsigned"></a> `notSigned` | `"Not signed"` |
 | <a id="property-contractordocumentslistsigndocumentcta"></a> `signDocumentCta` | `"Sign document"` |
 | <a id="property-contractordocumentslistsigned"></a> `signed` | `"Complete"` |

--- a/docs/reference/contractor/onboarding/blocks.md
+++ b/docs/reference/contractor/onboarding/blocks.md
@@ -227,7 +227,9 @@ Lists a contractor's documents and lets the contractor open each one for signing
 
 Fetches the contractor's documents via [useContractorDocumentsList](../hooks/use-contractor-documents-list.md#usecontractordocumentslist) and
 renders them in a table. The Continue action is disabled until every document
-that requires signing has been signed.
+the contractor can sign has been signed; a document that isn't signable yet
+(e.g. a W-9 whose fields haven't been generated) surfaces a warning instead of
+blocking the flow.
 
 ### DocumentsListProps
 

--- a/src/components/Common/DocumentList/DocumentList.tsx
+++ b/src/components/Common/DocumentList/DocumentList.tsx
@@ -17,7 +17,14 @@ export interface FormData {
 
 interface DocumentListProps {
   forms: FormData[]
-  canSign?: boolean
+  /**
+   * Whether a form can be signed. Pass a boolean to apply the same value to
+   * every row, or a predicate to decide per form (e.g. to block signing a
+   * document that isn't ready). When a signable form resolves to `false`, the
+   * row shows the "not signed" status instead of a sign action. Defaults to
+   * `true`.
+   */
+  canSign?: boolean | ((form: FormData) => boolean)
   onRequestSign?: (form: FormData) => void
   withError?: boolean
   label: string
@@ -65,21 +72,24 @@ function DocumentList({
       },
       {
         title: columnLabels.action,
-        render: (form: FormData) => (
-          <div className={styles.statusCell}>
-            {form.requires_signing ? (
-              canSign ? (
-                <Components.Button variant="secondary" onClick={() => onRequestSign?.(form)}>
-                  {statusLabels.signCta}
-                </Components.Button>
+        render: (form: FormData) => {
+          const formCanSign = typeof canSign === 'function' ? canSign(form) : canSign
+          return (
+            <div className={styles.statusCell}>
+              {form.requires_signing ? (
+                formCanSign ? (
+                  <Components.Button variant="secondary" onClick={() => onRequestSign?.(form)}>
+                    {statusLabels.signCta}
+                  </Components.Button>
+                ) : (
+                  <Components.Badge status="warning">{statusLabels.notSigned}</Components.Badge>
+                )
               ) : (
-                <Components.Badge status="warning">{statusLabels.notSigned}</Components.Badge>
-              )
-            ) : (
-              <Components.Badge status="success">{statusLabels.complete}</Components.Badge>
-            )}
-          </div>
-        ),
+                <Components.Badge status="success">{statusLabels.complete}</Components.Badge>
+              )}
+            </div>
+          )
+        },
       },
     ],
     emptyState: () => <EmptyData title={withError ? errorLabel : emptyStateLabel} />,

--- a/src/components/Contractor/Documents/DocumentsList/DocumentsList.test.tsx
+++ b/src/components/Contractor/Documents/DocumentsList/DocumentsList.test.tsx
@@ -6,6 +6,7 @@ import { DocumentsList } from './DocumentsList'
 import { server } from '@/test/mocks/server'
 import {
   handleGetContractorDocuments,
+  w9DocumentFields,
   W9_DOCUMENT_UUID,
 } from '@/test/mocks/apis/contractor_documents'
 import { setupApiTestMocks } from '@/test/mocks/apiServer'
@@ -31,6 +32,59 @@ describe('Contractor DocumentsList', () => {
     renderWithProviders(<DocumentsList contractorId={contractorId} onEvent={vi.fn()} />)
 
     await screen.findByText('Documents')
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+  })
+
+  it('warns about an unprepared W-9, blocks signing it, but does not trap the user on Continue', async () => {
+    server.use(
+      handleGetContractorDocuments(() =>
+        HttpResponse.json([
+          {
+            uuid: W9_DOCUMENT_UUID,
+            title: 'W-9',
+            name: 'taxpayer_identification_form_w_9',
+            requires_signing: false,
+            signed_at: null,
+            fields: [],
+          },
+        ]),
+      ),
+    )
+    renderWithProviders(<DocumentsList contractorId={contractorId} onEvent={vi.fn()} />)
+
+    await screen.findByText('Documents')
+    // The row still reads as outstanding but offers no sign action...
+    expect(screen.getByText('Not signed')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Sign document' })).not.toBeInTheDocument()
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
+    // ...a warning explains why...
+    expect(screen.getByText("W-9 isn't ready to sign yet")).toBeInTheDocument()
+    // ...and an un-signable document must not block the flow.
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled()
+  })
+
+  it('offers the sign action for an unsigned W-9 that has fields, without warning', async () => {
+    server.use(
+      handleGetContractorDocuments(() =>
+        HttpResponse.json([
+          {
+            uuid: W9_DOCUMENT_UUID,
+            title: 'W-9',
+            name: 'taxpayer_identification_form_w_9',
+            requires_signing: false,
+            signed_at: null,
+            fields: w9DocumentFields,
+          },
+        ]),
+      ),
+    )
+    renderWithProviders(<DocumentsList contractorId={contractorId} onEvent={vi.fn()} />)
+
+    await screen.findByText('Documents')
+    expect(screen.getByRole('button', { name: 'Sign document' })).toBeInTheDocument()
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
+    // A signable, unsigned document has nothing to warn about and still gates Continue.
+    expect(screen.queryByText("W-9 isn't ready to sign yet")).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
   })
 

--- a/src/components/Contractor/Documents/DocumentsList/DocumentsList.tsx
+++ b/src/components/Contractor/Documents/DocumentsList/DocumentsList.tsx
@@ -1,5 +1,9 @@
 import { useTranslation } from 'react-i18next'
 import type { Document } from '@gusto/embedded-api/models/components/document'
+import {
+  W9_DOCUMENT_NAME,
+  getPresentFieldNames,
+} from '../SignatureForm/useContractorSignatureForm/w9Fields'
 import { useContractorDocumentsList } from './useContractorDocumentsList'
 import { BaseComponent, type BaseComponentInterface } from '@/components/Base/Base'
 import { BaseLayout } from '@/components/Base'
@@ -24,11 +28,30 @@ export interface DocumentsListProps extends BaseComponentInterface<'Contractor.D
  * Returns whether a document still needs the contractor's signature.
  *
  * @remarks
- * A document is outstanding when it requires signing and has not yet been
- * signed (`signedAt` is unset).
+ * In the contractor onboarding flow every listed document must be signed, so a
+ * document is outstanding whenever it has not yet been signed (`signedAt` is
+ * unset). We intentionally do not defer to the API's `requiresSigning` flag
+ * here: an unsigned document whose template is not yet prepared comes back with
+ * `requiresSigning: false`, and treating that as "complete" would render an
+ * unsigned document as signed and let the contractor skip it. Keying off
+ * `signedAt` keeps "complete" meaning "actually signed" for this component.
  */
 function requiresSignature(document: Document): boolean {
-  return Boolean(document.requiresSigning) && !document.signedAt
+  return !document.signedAt
+}
+
+/**
+ * Returns whether a document can be signed right now.
+ *
+ * @remarks
+ * A W-9 whose template has not finished preparing comes back with no signable
+ * fields (this is the same signal the signer keys its `hasFields` state off).
+ * Signing it would submit an empty form, so we block the sign action until the
+ * fields are present. Any non-W-9 document is treated as signable here.
+ */
+function canSignDocument(document: Document): boolean {
+  if (document.name !== W9_DOCUMENT_NAME) return true
+  return getPresentFieldNames(document).size > 0
 }
 
 /**
@@ -37,7 +60,9 @@ function requiresSignature(document: Document): boolean {
  * @remarks
  * Fetches the contractor's documents via {@link useContractorDocumentsList} and
  * renders them in a table. The Continue action is disabled until every document
- * that requires signing has been signed.
+ * the contractor can sign has been signed; a document that isn't signable yet
+ * (e.g. a W-9 whose fields haven't been generated) surfaces a warning instead of
+ * blocking the flow.
  *
  * @events
  * | Event | Description | Data |
@@ -72,7 +97,16 @@ function Root({ contractorId, className, dictionary }: DocumentsListProps) {
 
   const { documents } = result.data
   const hasError = result.errorHandling.errors.length > 0
-  const hasSignedAllDocuments = documents.every(document => !requiresSignature(document))
+  // Only a document the contractor can actually sign should gate the flow. A
+  // document that still needs signing but isn't signable yet (e.g. a W-9 whose
+  // fields haven't been generated) must not trap the user — it surfaces the
+  // "not ready" warning below instead of blocking Continue.
+  const hasOutstandingSignature = documents.some(
+    document => requiresSignature(document) && canSignDocument(document),
+  )
+  const hasUnpreparedDocument = documents.some(
+    document => requiresSignature(document) && !canSignDocument(document),
+  )
 
   const handleRequestSign = (uuid: string) => {
     const document = documents.find(candidate => candidate.uuid === uuid)
@@ -95,6 +129,12 @@ function Root({ contractorId, className, dictionary }: DocumentsListProps) {
             <Components.Text>{t('subtitle')}</Components.Text>
           </Flex>
 
+          {hasUnpreparedDocument && (
+            <Components.Alert status="warning" label={t('notReadyTitle')}>
+              <Components.Text>{t('notReadyBody')}</Components.Text>
+            </Components.Alert>
+          )}
+
           <DocumentList
             forms={documents.map(document => ({
               uuid: document.uuid ?? '',
@@ -102,6 +142,10 @@ function Root({ contractorId, className, dictionary }: DocumentsListProps) {
               description: document.description,
               requires_signing: requiresSignature(document),
             }))}
+            canSign={form => {
+              const document = documents.find(candidate => candidate.uuid === form.uuid)
+              return document ? canSignDocument(document) : true
+            }}
             onRequestSign={form => {
               handleRequestSign(form.uuid)
             }}
@@ -121,7 +165,7 @@ function Root({ contractorId, className, dictionary }: DocumentsListProps) {
           />
 
           <ActionsLayout>
-            <Components.Button onClick={handleContinue} isDisabled={!hasSignedAllDocuments}>
+            <Components.Button onClick={handleContinue} isDisabled={hasOutstandingSignature}>
               {t('continueCta')}
             </Components.Button>
           </ActionsLayout>

--- a/src/i18n/en/Contractor.DocumentsList.json
+++ b/src/i18n/en/Contractor.DocumentsList.json
@@ -7,6 +7,8 @@
   "signDocumentCta": "Sign document",
   "notSigned": "Not signed",
   "signed": "Complete",
+  "notReadyTitle": "W-9 isn't ready to sign yet",
+  "notReadyBody": "The W-9 form hasn't been fully generated yet. Please check back later, or contact support if the problem continues.",
   "emptyTitle": "No documents found",
   "errorTitle": "Could not load your documents, try again later.",
   "continueCta": "Continue"

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -1786,6 +1786,10 @@ export namespace Translations {
     notSigned: string
     /** @defaultValue `"Complete"` */
     signed: string
+    /** @defaultValue `"W-9 isn't ready to sign yet"` */
+    notReadyTitle: string
+    /** @defaultValue `"The W-9 form hasn't been fully generated yet. Please check back later, or contact support if the problem continues."` */
+    notReadyBody: string
     /** @defaultValue `"No documents found"` */
     emptyTitle: string
     /** @defaultValue `"Could not load your documents, try again later."` */

--- a/src/test/mocks/apis/contractor_documents.ts
+++ b/src/test/mocks/apis/contractor_documents.ts
@@ -118,6 +118,9 @@ export function buildContractorDocumentsList(overrides?: Array<Record<string, un
         name: 'taxpayer_identification_form_w_9',
         requires_signing: true,
         signed_at: null,
+        // The list endpoint's view extends the document `show` view, so each row
+        // carries the full `fields` array (not just the summary attributes).
+        fields: w9DocumentFields,
       },
       {
         uuid: SIGNED_DOCUMENT_UUID,


### PR DESCRIPTION
## Summary

- An unsigned W-9 whose template hasn't finished preparing comes back from the API with `requiresSigning: false`, which caused the contractor documents list to render a **"Complete"** badge for a document the contractor never signed. The outstanding-signature check now keys off `signedAt`, so "complete" means *actually signed*.
- A W-9 with no generated fields can't be signed (the signer would submit an empty form). `DocumentList.canSign` now accepts a **per-form predicate** so such a document shows a "not signed" badge instead of a sign action.
- An unsignable-but-required W-9 no longer traps the contractor: it surfaces a **warning alert** ("W-9 isn't ready to sign yet") and no longer disables **Continue**, while genuinely signable outstanding documents still gate the flow.

## Details

- `Common/DocumentList`: `canSign` widened from `boolean` to `boolean | ((form) => boolean)`, evaluated per row.
- `Contractor/Documents/DocumentsList`:
  - `requiresSignature` keys off `!document.signedAt` (no longer defers to the API's `requiresSigning`).
  - New `canSignDocument` guard — a W-9 is signable only once it has generated fields.
  - Splits gating into `hasOutstandingSignature` (signable + unsigned → disables Continue) vs. `hasUnpreparedDocument` (unsigned + not-yet-signable → warning alert).
- i18n keys `notReadyTitle` / `notReadyBody` added.
- Mock (`contractor_documents`) updated so the default W-9 row carries `fields` (matching the real list endpoint, whose view extends the document `show` view).

## Test plan

- [x] `DocumentsList.test.tsx` — added coverage: unprepared W-9 shows the warning, keeps Continue enabled, and shows no sign action; a fields-present unsigned W-9 offers the sign action and disables Continue.
- [x] Existing DocumentsList tests pass (6/6).
- [x] Manual: contractor self-onboarding documents step with an unprepared W-9 (verify warning + Continue enabled) and a prepared W-9 (verify sign action + Continue gated).

### With a contractor where the W9 isn't completely generated

<img width="758" height="728" alt="Screenshot 2026-07-07 at 2 50 17 PM" src="https://github.com/user-attachments/assets/a074611d-c992-4b4a-8707-834ace4adc1a" />

### With a contractor where the W9 is completely generated

<img width="1243" height="660" alt="Screenshot 2026-07-07 at 2 53 41 PM" src="https://github.com/user-attachments/assets/542a7fe5-572a-46e1-979d-3745787e7d46" />

Made with [Cursor](https://cursor.com)