### PR TITLE
chore: release 0.51.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.51.2](https://github.com/Gusto/embedded-react-sdk/compare/v0.51.1...v0.51.2) (2026-07-07)
+
+### Fixes
+
+- **Company:** prevent Enter key from cancelling State Taxes and Location edit forms ([#2361](https://github.com/Gusto/embedded-react-sdk/issues/2361)) ([343c78f](https://github.com/Gusto/embedded-react-sdk/commit/343c78f96ce8972cfe40eec992990bd7703411cb))
+- **Contractor/DocumentsList:** key signature status off signedAt and guard unpreparable W-9s ([#2362](https://github.com/Gusto/embedded-react-sdk/issues/2362)) ([8191e91](https://github.com/Gusto/embedded-react-sdk/commit/8191e910885613cbb7e754f7227603986f4c8640))
+
 ## [0.51.1](https://github.com/Gusto/embedded-react-sdk/compare/v0.51.0...v0.51.1) (2026-07-07)
 
 ### Features & Enhancements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-react-sdk",
-      "version": "0.51.1",
+      "version": "0.51.2",
       "license": "MIT",
       "dependencies": {
         "@gusto/embedded-api": "npm:@gusto/embedded-api-v-2026-02-01@^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.51.1",
+  "version": "0.51.2",
   "homepage": "https://github.com/Gusto/embedded-react-sdk",
   "bugs": {
     "url": "https://github.com/Gusto/embedded-react-sdk/issues"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Release version 0.51.2

## Changes

This patch release includes two bug fixes:

### Fixes

- **Company:** prevent Enter key from cancelling State Taxes and Location edit forms ([#2361](https://github.com/Gusto/embedded-react-sdk/issues/2361))
- **Contractor/DocumentsList:** key signature status off signedAt and guard unpreparable W-9s ([#2362](https://github.com/Gusto/embedded-react-sdk/issues/2362))

---

**Version:** 0.51.2  
**Previous version:** 0.51.1  
**Release date:** 2026-07-07
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://gustohq.slack.com/archives/D0BAH4JV151/p1783462841613939?thread_ts=1783462841.613939&cid=D0BAH4JV151)

<div><a href="https://cursor.com/agents/bc-f06a42b3-0817-5955-94b5-775ebda3d023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f06a42b3-0817-5955-94b5-775ebda3d023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

