### PR TITLE
chore(SDK-1054): deterministic union sort + @internal typeof const expansion in expandDtsTypeof

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -678,7 +678,7 @@ export const BankFormErrorCodes: {
 };
 
 // @public
-export type BankFormField = "name" | "accountNumber" | "routingNumber" | "accountType";
+export type BankFormField = "accountNumber" | "accountType" | "name" | "routingNumber";
 
 // @public
 export interface BankFormFields {
@@ -894,7 +894,7 @@ export type ChildSupportGarnishmentAmountFieldProps = HookFieldProps<NumberInput
 export type ChildSupportGarnishmentAmountValidation = ChildSupportGarnishmentRequiredValidation | ChildSupportGarnishmentPercentValidation;
 
 // @public
-export type ChildSupportGarnishmentFormData = { state: string; fipsCode: string; caseNumber: string; orderNumber: string; remittanceNumber: string; payPeriodMaximum: number; amount: number; paymentPeriod: "Every week" | "Every other week" | "Twice per month" | "Monthly"; };
+export type ChildSupportGarnishmentFormData = { state: string; fipsCode: string; caseNumber: string; orderNumber: string; remittanceNumber: string; payPeriodMaximum: number; amount: number; paymentPeriod: "Every other week" | "Every week" | "Monthly" | "Twice per month"; };
 
 // @public
 export type ChildSupportGarnishmentFormErrorCode = (typeof ChildSupportGarnishmentFormErrorCodes)[keyof typeof ChildSupportGarnishmentFormErrorCodes];
@@ -919,7 +919,7 @@ export interface ChildSupportGarnishmentFormFields {
 }
 
 // @public
-export type ChildSupportGarnishmentFormFieldsMetadata = { state: FieldMetadataWithOptions<StateFieldEntry>; fipsCode: FieldMetadataWithOptions<CountyEntry>; caseNumber: FieldMetadata; orderNumber: FieldMetadata; remittanceNumber: FieldMetadata; payPeriodMaximum: FieldMetadata; amount: FieldMetadata; paymentPeriod: FieldMetadataWithOptions<"Every week" | "Every other week" | "Twice per month" | "Monthly">; };
+export type ChildSupportGarnishmentFormFieldsMetadata = { state: FieldMetadataWithOptions<StateFieldEntry>; fipsCode: FieldMetadataWithOptions<CountyEntry>; caseNumber: FieldMetadata; orderNumber: FieldMetadata; remittanceNumber: FieldMetadata; payPeriodMaximum: FieldMetadata; amount: FieldMetadata; paymentPeriod: FieldMetadataWithOptions<"Every other week" | "Every week" | "Monthly" | "Twice per month">; };
 
 // @public
 export type ChildSupportGarnishmentNegativeAmountValidation = typeof ChildSupportGarnishmentFormErrorCodes.NEGATIVE_AMOUNT;
@@ -1101,7 +1101,7 @@ export type CompensationFieldsMetadata = { title: FieldMetadata; effectiveDate: 
 export type CompensationFormData = {
     title: string
     flsaStatus: "Exempt" | "Salaried Nonexempt" | "Nonexempt" | "Owner" | "Commission Only Exempt" | "Commission Only Nonexempt" | undefined
-    paymentUnit: "Hour" | "Week" | "Month" | "Year" | "Paycheck"
+    paymentUnit: "Hour" | "Month" | "Paycheck" | "Week" | "Year"
     rate: number
     effectiveDate: string | null
     adjustForMinimumWage: boolean
@@ -1120,7 +1120,7 @@ export interface CompensationFormFields {
 }
 
 // @public
-export type CompensationOptionalFieldsToRequire = { create?: ("title" | "minimumWageId")[] | undefined; update?: ("title" | "flsaStatus" | "paymentUnit" | "rate" | "effectiveDate" | "minimumWageId")[] | undefined; };
+export type CompensationOptionalFieldsToRequire = { create?: ("minimumWageId" | "title")[] | undefined; update?: ("effectiveDate" | "flsaStatus" | "minimumWageId" | "paymentUnit" | "rate" | "title")[] | undefined; };
 
 // @public
 interface CompensationProps extends BaseComponentInterface<'Employee.Compensation'> {
@@ -1518,10 +1518,10 @@ export const ContractorAddressErrorCodes: {
 };
 
 // @public
-export type ContractorAddressField = "street1" | "street2" | "city" | "state" | "zip";
+export type ContractorAddressField = "city" | "state" | "street1" | "street2" | "zip";
 
 // @public
-export type ContractorAddressFieldsMetadata = { street1: FieldMetadata; street2: FieldMetadata; city: FieldMetadata; state: FieldMetadataWithOptions<"AL" | "AK" | "AZ" | "AR" | "CA" | "CO" | "CT" | "DE" | "DC" | "FL" | "GA" | "HI" | "ID" | "IL" | "IN" | "IA" | "KS" | "KY" | "LA" | "ME" | "MD" | "MA" | "MI" | "MN" | "MS" | "MO" | "MT" | "NE" | "NV" | "NH" | "NJ" | "NM" | "NY" | "NC" | "ND" | "OH" | "OK" | "OR" | "PA" | "RI" | "SC" | "SD" | "TN" | "TX" | "UT" | "VT" | "VA" | "WA" | "WV" | "WI" | "WY">; zip: FieldMetadata; };
+export type ContractorAddressFieldsMetadata = { street1: FieldMetadata; street2: FieldMetadata; city: FieldMetadata; state: FieldMetadataWithOptions<"AK" | "AL" | "AR" | "AZ" | "CA" | "CO" | "CT" | "DC" | "DE" | "FL" | "GA" | "HI" | "IA" | "ID" | "IL" | "IN" | "KS" | "KY" | "LA" | "MA" | "MD" | "ME" | "MI" | "MN" | "MO" | "MS" | "MT" | "NC" | "ND" | "NE" | "NH" | "NJ" | "NM" | "NV" | "NY" | "OH" | "OK" | "OR" | "PA" | "RI" | "SC" | "SD" | "TN" | "TX" | "UT" | "VA" | "VT" | "WA" | "WI" | "WV" | "WY">; zip: FieldMetadata; };
 
 // @public
 export type ContractorAddressFormData = { street1: string; street2: string; city: string; state: string; zip: string; };
@@ -1536,7 +1536,7 @@ export interface ContractorAddressFormFields {
 }
 
 // @public
-export type ContractorAddressOptionalFieldsToRequire = { create?: ("street1" | "street2" | "city" | "state" | "zip")[] | undefined; update?: ("street1" | "street2" | "city" | "state" | "zip")[] | undefined; };
+export type ContractorAddressOptionalFieldsToRequire = { create?: ("city" | "state" | "street1" | "street2" | "zip")[] | undefined; update?: ("city" | "state" | "street1" | "street2" | "zip")[] | undefined; };
 
 // @public
 export type ContractorAddressRequiredValidation = typeof ContractorAddressErrorCodes.REQUIRED;
@@ -1587,7 +1587,7 @@ export type ContractorBankAccountFieldsMetadata = { name: FieldMetadata; routing
 export type ContractorBankAccountFormData = { name: string; routingNumber: string; accountNumber: string; accountType: "Checking" | "Savings"; };
 
 // @public
-export type ContractorBankAccountFormField = "name" | "accountNumber" | "routingNumber" | "accountType";
+export type ContractorBankAccountFormField = "accountNumber" | "accountType" | "name" | "routingNumber";
 
 // @public
 export interface ContractorBankAccountFormFields {
@@ -1640,7 +1640,7 @@ export const ContractorDetailsErrorCodes: {
 };
 
 // @public
-export type ContractorDetailsFieldsMetadata = { type: FieldMetadataWithOptions<"Business" | "Individual">; wageType: FieldMetadataWithOptions<"Fixed" | "Hourly">; startDate: FieldMetadata; hourlyRate: FieldMetadata; selfOnboarding: FieldMetadata; fileNewHireReport: FieldMetadata; email: FieldMetadata; firstName: FieldMetadata; lastName: FieldMetadata; middleInitial: FieldMetadata; businessName: FieldMetadata; ssn: FieldMetadata; ein: FieldMetadata; workState: FieldMetadataWithOptions<"AL" | "AK" | "AZ" | "AR" | "CA" | "CO" | "CT" | "DE" | "DC" | "FL" | "GA" | "HI" | "ID" | "IL" | "IN" | "IA" | "KS" | "KY" | "LA" | "ME" | "MD" | "MA" | "MI" | "MN" | "MS" | "MO" | "MT" | "NE" | "NV" | "NH" | "NJ" | "NM" | "NY" | "NC" | "ND" | "OH" | "OK" | "OR" | "PA" | "RI" | "SC" | "SD" | "TN" | "TX" | "UT" | "VT" | "VA" | "WA" | "WV" | "WI" | "WY">; };
+export type ContractorDetailsFieldsMetadata = { type: FieldMetadataWithOptions<"Business" | "Individual">; wageType: FieldMetadataWithOptions<"Fixed" | "Hourly">; startDate: FieldMetadata; hourlyRate: FieldMetadata; selfOnboarding: FieldMetadata; fileNewHireReport: FieldMetadata; email: FieldMetadata; firstName: FieldMetadata; lastName: FieldMetadata; middleInitial: FieldMetadata; businessName: FieldMetadata; ssn: FieldMetadata; ein: FieldMetadata; workState: FieldMetadataWithOptions<"AK" | "AL" | "AR" | "AZ" | "CA" | "CO" | "CT" | "DC" | "DE" | "FL" | "GA" | "HI" | "IA" | "ID" | "IL" | "IN" | "KS" | "KY" | "LA" | "MA" | "MD" | "ME" | "MI" | "MN" | "MO" | "MS" | "MT" | "NC" | "ND" | "NE" | "NH" | "NJ" | "NM" | "NV" | "NY" | "OH" | "OK" | "OR" | "PA" | "RI" | "SC" | "SD" | "TN" | "TX" | "UT" | "VA" | "VT" | "WA" | "WI" | "WV" | "WY">; };
 
 // @public
 export type ContractorDetailsFormData = { type: "Business" | "Individual"; wageType: "Fixed" | "Hourly"; startDate: string; hourlyRate: number; selfOnboarding: boolean; fileNewHireReport: boolean; email: string; firstName: string; lastName: string; middleInitial: string; businessName: string; workState: string; ssn: string; ein: string; };
@@ -1667,7 +1667,7 @@ export interface ContractorDetailsFormFields {
 export type ContractorDetailsNameValidation = (typeof ContractorDetailsErrorCodes)['REQUIRED' | 'INVALID_NAME'];
 
 // @public
-export type ContractorDetailsOptionalFieldsToRequire = { create?: ("ssn" | "ein" | "email" | "middleInitial")[] | undefined; update?: ("hourlyRate" | "businessName" | "ssn" | "ein" | "startDate" | "email" | "firstName" | "lastName" | "middleInitial" | "workState")[] | undefined; };
+export type ContractorDetailsOptionalFieldsToRequire = { create?: ("ein" | "email" | "middleInitial" | "ssn")[] | undefined; update?: ("businessName" | "ein" | "email" | "firstName" | "hourlyRate" | "lastName" | "middleInitial" | "ssn" | "startDate" | "workState")[] | undefined; };
 
 // @public
 export type ContractorDetailsRequiredValidation = typeof ContractorDetailsErrorCodes.REQUIRED;
@@ -1863,7 +1863,7 @@ export type ContractorSignatureExemptionFromFatcaFieldProps = HookFieldProps<Tex
 export type ContractorSignatureExemptPayeeCodeFieldProps = HookFieldProps<TextInputHookFieldProps<ContractorSignatureRequiredValidation>>;
 
 // @public
-export type ContractorSignatureFieldsMetadata = { name: FieldMetadata; businessName: FieldMetadata; taxClassification: FieldMetadataWithOptions<"other" | "individual_proprietor" | "c_corporation" | "s_corporation" | "partnership" | "trust_estate" | "limited_liability_company">; llcClassificationCode: FieldMetadataWithOptions<"c" | "s" | "p">; otherText: FieldMetadata; foreignPartners: FieldMetadata; exemptPayeeCode: FieldMetadata; exemptionFromFatca: FieldMetadata; homeAddressStreet1: FieldMetadata; homeAddressStreet2: FieldMetadata; homeAddressCity: FieldMetadata; homeAddressState: FieldMetadata; homeAddressZip: FieldMetadata; accountNumber: FieldMetadata; companyName: FieldMetadata; ssn: FieldMetadata; ein: FieldMetadata; signatureText: FieldMetadata; agree: FieldMetadata; };
+export type ContractorSignatureFieldsMetadata = { name: FieldMetadata; businessName: FieldMetadata; taxClassification: FieldMetadataWithOptions<"c_corporation" | "individual_proprietor" | "limited_liability_company" | "other" | "partnership" | "s_corporation" | "trust_estate">; llcClassificationCode: FieldMetadataWithOptions<"c" | "p" | "s">; otherText: FieldMetadata; foreignPartners: FieldMetadata; exemptPayeeCode: FieldMetadata; exemptionFromFatca: FieldMetadata; homeAddressStreet1: FieldMetadata; homeAddressStreet2: FieldMetadata; homeAddressCity: FieldMetadata; homeAddressState: FieldMetadata; homeAddressZip: FieldMetadata; accountNumber: FieldMetadata; companyName: FieldMetadata; ssn: FieldMetadata; ein: FieldMetadata; signatureText: FieldMetadata; agree: FieldMetadata; };
 
 // @public
 export type ContractorSignatureForeignPartnersFieldProps = HookFieldProps<CheckboxHookFieldProps>;
@@ -1947,7 +1947,7 @@ export type ContractorSignatureLlcClassificationCodeFieldProps = HookFieldProps<
 export type ContractorSignatureNameFieldProps = HookFieldProps<TextInputHookFieldProps<ContractorSignatureRequiredValidation>>;
 
 // @public
-export type ContractorSignatureOptionalFieldsToRequire = { create?: ("businessName" | "llcClassificationCode" | "otherText" | "foreignPartners" | "exemptPayeeCode" | "exemptionFromFatca" | "homeAddressStreet2" | "accountNumber" | "companyName")[] | undefined; update?: ("businessName" | "llcClassificationCode" | "otherText" | "foreignPartners" | "exemptPayeeCode" | "exemptionFromFatca" | "homeAddressStreet2" | "accountNumber" | "companyName")[] | undefined; };
+export type ContractorSignatureOptionalFieldsToRequire = { create?: ("accountNumber" | "businessName" | "companyName" | "exemptPayeeCode" | "exemptionFromFatca" | "foreignPartners" | "homeAddressStreet2" | "llcClassificationCode" | "otherText")[] | undefined; update?: ("accountNumber" | "businessName" | "companyName" | "exemptPayeeCode" | "exemptionFromFatca" | "foreignPartners" | "homeAddressStreet2" | "llcClassificationCode" | "otherText")[] | undefined; };
 
 // @public
 export type ContractorSignatureOtherTextFieldProps = HookFieldProps<TextInputHookFieldProps<ContractorSignatureRequiredValidation>>;
@@ -2159,7 +2159,7 @@ export type DeductionFormAmountValidation = DeductionFormRequiredValidation | De
 export type DeductionFormCapValidation = DeductionFormNegativeAmountValidation;
 
 // @public
-export type DeductionFormData = { description: string; recurring: boolean; deductAsPercentage: boolean; amount: number; totalAmount: number; annualMaximum: number; garnishmentType: "child_support" | "federal_tax_lien" | "state_tax_lien" | "student_loan" | "creditor_garnishment" | "federal_loan" | "other_garnishment"; };
+export type DeductionFormData = { description: string; recurring: boolean; deductAsPercentage: boolean; amount: number; totalAmount: number; annualMaximum: number; garnishmentType: "child_support" | "creditor_garnishment" | "federal_loan" | "federal_tax_lien" | "other_garnishment" | "state_tax_lien" | "student_loan"; };
 
 // @public
 export type DeductionFormErrorCode = (typeof DeductionFormErrorCodes)[keyof typeof DeductionFormErrorCodes];
@@ -2188,7 +2188,7 @@ export type DeductionFormFieldsMetadata = { description: FieldMetadata; recurrin
 export type DeductionFormNegativeAmountValidation = typeof DeductionFormErrorCodes.NEGATIVE_AMOUNT;
 
 // @public
-export type DeductionFormOptionalFieldsToRequire = { create?: ("totalAmount" | "annualMaximum")[] | undefined; update?: ("totalAmount" | "annualMaximum")[] | undefined; };
+export type DeductionFormOptionalFieldsToRequire = { create?: ("annualMaximum" | "totalAmount")[] | undefined; update?: ("annualMaximum" | "totalAmount")[] | undefined; };
 
 // @public
 export type DeductionFormRequiredValidation = typeof DeductionFormErrorCodes.REQUIRED;
@@ -2412,7 +2412,7 @@ export const EmployeeDetailsErrorCodes: {
 };
 
 // @public
-export type EmployeeDetailsField = "ssn" | "email" | "firstName" | "lastName" | "middleInitial" | "dateOfBirth";
+export type EmployeeDetailsField = "dateOfBirth" | "email" | "firstName" | "lastName" | "middleInitial" | "ssn";
 
 // @public
 export type EmployeeDetailsFieldsMetadata = { firstName: FieldMetadata; middleInitial: FieldMetadata; lastName: FieldMetadata; email: FieldMetadata; dateOfBirth: FieldMetadata; ssn: FieldMetadata; selfOnboarding: FieldMetadata; };
@@ -2432,7 +2432,7 @@ export interface EmployeeDetailsFormFields {
 }
 
 // @public
-export type EmployeeDetailsOptionalFieldsToRequire = { create?: ("ssn" | "email" | "middleInitial" | "dateOfBirth")[] | undefined; update?: ("ssn" | "email" | "firstName" | "lastName" | "middleInitial" | "dateOfBirth")[] | undefined; };
+export type EmployeeDetailsOptionalFieldsToRequire = { create?: ("dateOfBirth" | "email" | "middleInitial" | "ssn")[] | undefined; update?: ("dateOfBirth" | "email" | "firstName" | "lastName" | "middleInitial" | "ssn")[] | undefined; };
 
 // @public
 export type EmployeeDetailsRequiredValidation = typeof EmployeeDetailsErrorCodes.REQUIRED;
@@ -2752,10 +2752,10 @@ export const FederalTaxesErrorCodes: {
 };
 
 // @public
-export type FederalTaxesField = "filingStatus" | "twoJobs" | "dependentsAmount" | "otherIncome" | "deductions" | "extraWithholding";
+export type FederalTaxesField = "deductions" | "dependentsAmount" | "extraWithholding" | "filingStatus" | "otherIncome" | "twoJobs";
 
 // @public
-export type FederalTaxesFieldsMetadata = { filingStatus: FieldMetadataWithOptions<"Single" | "Married" | "Head of Household" | "Exempt from withholding">; twoJobs: FieldMetadataWithOptions<boolean>; dependentsAmount: FieldMetadata; otherIncome: FieldMetadata; deductions: FieldMetadata; extraWithholding: FieldMetadata; };
+export type FederalTaxesFieldsMetadata = { filingStatus: FieldMetadataWithOptions<"Exempt from withholding" | "Head of Household" | "Married" | "Single">; twoJobs: FieldMetadataWithOptions<boolean>; dependentsAmount: FieldMetadata; otherIncome: FieldMetadata; deductions: FieldMetadata; extraWithholding: FieldMetadata; };
 
 // @public
 export type FederalTaxesFormData = { filingStatus: string; twoJobs: boolean; dependentsAmount: number; otherIncome: number; deductions: number; extraWithholding: number; };
@@ -2771,7 +2771,7 @@ export interface FederalTaxesFormFields {
 }
 
 // @public
-export type FederalTaxesOptionalFieldsToRequire = { create?: ("twoJobs" | "dependentsAmount" | "otherIncome" | "deductions" | "extraWithholding")[] | undefined; update?: ("twoJobs" | "dependentsAmount" | "otherIncome" | "deductions" | "extraWithholding")[] | undefined; };
+export type FederalTaxesOptionalFieldsToRequire = { create?: ("deductions" | "dependentsAmount" | "extraWithholding" | "otherIncome" | "twoJobs")[] | undefined; update?: ("deductions" | "dependentsAmount" | "extraWithholding" | "otherIncome" | "twoJobs")[] | undefined; };
 
 // @public
 interface FederalTaxesProps extends BaseComponentInterface<'Employee.FederalTaxes'> {
@@ -3077,10 +3077,10 @@ export const HomeAddressErrorCodes: {
 };
 
 // @public
-export type HomeAddressField = "street1" | "street2" | "city" | "state" | "zip" | "effectiveDate" | "courtesyWithholding";
+export type HomeAddressField = "city" | "courtesyWithholding" | "effectiveDate" | "state" | "street1" | "street2" | "zip";
 
 // @public
-export type HomeAddressFieldsMetadata = { street1: FieldMetadata; street2: FieldMetadata; city: FieldMetadata; state: FieldMetadataWithOptions<"AL" | "AK" | "AZ" | "AR" | "CA" | "CO" | "CT" | "DE" | "DC" | "FL" | "GA" | "HI" | "ID" | "IL" | "IN" | "IA" | "KS" | "KY" | "LA" | "ME" | "MD" | "MA" | "MI" | "MN" | "MS" | "MO" | "MT" | "NE" | "NV" | "NH" | "NJ" | "NM" | "NY" | "NC" | "ND" | "OH" | "OK" | "OR" | "PA" | "RI" | "SC" | "SD" | "TN" | "TX" | "UT" | "VT" | "VA" | "WA" | "WV" | "WI" | "WY">; zip: FieldMetadata; courtesyWithholding: FieldMetadata; effectiveDate: FieldMetadata; };
+export type HomeAddressFieldsMetadata = { street1: FieldMetadata; street2: FieldMetadata; city: FieldMetadata; state: FieldMetadataWithOptions<"AK" | "AL" | "AR" | "AZ" | "CA" | "CO" | "CT" | "DC" | "DE" | "FL" | "GA" | "HI" | "IA" | "ID" | "IL" | "IN" | "KS" | "KY" | "LA" | "MA" | "MD" | "ME" | "MI" | "MN" | "MO" | "MS" | "MT" | "NC" | "ND" | "NE" | "NH" | "NJ" | "NM" | "NV" | "NY" | "OH" | "OK" | "OR" | "PA" | "RI" | "SC" | "SD" | "TN" | "TX" | "UT" | "VA" | "VT" | "WA" | "WI" | "WV" | "WY">; zip: FieldMetadata; courtesyWithholding: FieldMetadata; effectiveDate: FieldMetadata; };
 
 // @public
 export type HomeAddressFormData = { street1: string; street2: string; city: string; state: string; zip: string; courtesyWithholding: boolean; effectiveDate: string; };
@@ -3258,7 +3258,7 @@ export interface JobFormFields {
 }
 
 // @public
-export type JobOptionalFieldsToRequire = { create?: ("twoPercentShareholder" | "stateWcCovered" | "stateWcClassCode")[] | undefined; update?: ("title" | "hireDate" | "twoPercentShareholder" | "stateWcCovered" | "stateWcClassCode")[] | undefined; };
+export type JobOptionalFieldsToRequire = { create?: ("stateWcClassCode" | "stateWcCovered" | "twoPercentShareholder")[] | undefined; update?: ("hireDate" | "stateWcClassCode" | "stateWcCovered" | "title" | "twoPercentShareholder")[] | undefined; };
 
 // @public
 export type JobRequiredValidation = typeof JobErrorCodes.REQUIRED;
@@ -3674,10 +3674,8 @@ interface OnboardingExecutionFlowProps {
     withEmployeeI9?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "INITIAL_COMPONENT_MAP" needs to be exported by the entry point index.d.ts
-//
 // @public
-type OnboardingExecutionInitialState = keyof typeof INITIAL_COMPONENT_MAP;
+type OnboardingExecutionInitialState = "employeeProfile";
 
 // @public
 const OnboardingFlow: (input: OnboardingFlowProps) => JSX;
@@ -4142,13 +4140,13 @@ export const PayScheduleErrorCodes: {
 };
 
 // @public
-export type PayScheduleField = "customName" | "frequency" | "customTwicePerMonth" | "anchorPayDate" | "anchorEndOfPayPeriod" | "day1" | "day2";
+export type PayScheduleField = "anchorEndOfPayPeriod" | "anchorPayDate" | "customName" | "customTwicePerMonth" | "day1" | "day2" | "frequency";
 
 // @public
-export type PayScheduleFieldsMetadata = { customName: FieldMetadata; frequency: FieldMetadataWithOptions<"Every week" | "Every other week" | "Twice per month" | "Monthly">; customTwicePerMonth: FieldMetadataWithOptions<string>; anchorPayDate: FieldMetadata; anchorEndOfPayPeriod: FieldMetadata; day1: FieldMetadata; day2: FieldMetadata; };
+export type PayScheduleFieldsMetadata = { customName: FieldMetadata; frequency: FieldMetadataWithOptions<"Every other week" | "Every week" | "Monthly" | "Twice per month">; customTwicePerMonth: FieldMetadataWithOptions<string>; anchorPayDate: FieldMetadata; anchorEndOfPayPeriod: FieldMetadata; day1: FieldMetadata; day2: FieldMetadata; };
 
 // @public
-export type PayScheduleFormData = { customName: string; frequency: "Every week" | "Every other week" | "Twice per month" | "Monthly"; customTwicePerMonth: string; anchorPayDate: string | null; anchorEndOfPayPeriod: string | null; day1: number; day2: number; };
+export type PayScheduleFormData = { customName: string; frequency: "Every other week" | "Every week" | "Monthly" | "Twice per month"; customTwicePerMonth: string; anchorPayDate: string | null; anchorEndOfPayPeriod: string | null; day1: number; day2: number; };
 
 // @public
 export interface PayScheduleFormFields {
@@ -4162,7 +4160,7 @@ export interface PayScheduleFormFields {
 }
 
 // @public
-export type PayScheduleFrequency = "Every week" | "Every other week" | "Twice per month" | "Monthly";
+export type PayScheduleFrequency = "Every other week" | "Every week" | "Monthly" | "Twice per month";
 
 // @public
 export type PayScheduleOptionalFieldsToRequire = { create?: ("customTwicePerMonth" | "day1" | "day2")[] | undefined; update?: ("customTwicePerMonth" | "day1" | "day2")[] | undefined; };
@@ -4910,7 +4908,7 @@ export const SignCompanyFormErrorCodes: {
 };
 
 // @public
-export type SignCompanyFormField = "signature" | "confirmSignature";
+export type SignCompanyFormField = "confirmSignature" | "signature";
 
 // @public
 export interface SignCompanyFormFields {
@@ -4937,7 +4935,7 @@ export type SignEmployeeBaseFieldsMetadata = {
 export type SignEmployeeFormConfirmSignatureFieldProps = HookFieldProps<CheckboxHookFieldProps<SignEmployeeFormRequiredValidation>>;
 
 // @public
-export type SignEmployeeFormData = { signature: string; confirmSignature: boolean; usedPreparer: "yes" | "no"; preparerFirstName: string; preparerLastName: string; preparerStreet1: string; preparerStreet2: string; preparerCity: string; preparerState: string; preparerZip: string; preparerSignature: string; preparerAgree: boolean; preparer2FirstName: string; preparer2LastName: string; preparer2Street1: string; preparer2Street2: string; preparer2City: string; preparer2State: string; preparer2Zip: string; preparer2Signature: string; preparer2Agree: boolean; preparer3FirstName: string; preparer3LastName: string; preparer3Street1: string; preparer3Street2: string; preparer3City: string; preparer3State: string; preparer3Zip: string; preparer3Signature: string; preparer3Agree: boolean; preparer4FirstName: string; preparer4LastName: string; preparer4Street1: string; preparer4Street2: string; preparer4City: string; preparer4State: string; preparer4Zip: string; preparer4Signature: string; preparer4Agree: boolean; };
+export type SignEmployeeFormData = { signature: string; confirmSignature: boolean; usedPreparer: "no" | "yes"; preparerFirstName: string; preparerLastName: string; preparerStreet1: string; preparerStreet2: string; preparerCity: string; preparerState: string; preparerZip: string; preparerSignature: string; preparerAgree: boolean; preparer2FirstName: string; preparer2LastName: string; preparer2Street1: string; preparer2Street2: string; preparer2City: string; preparer2State: string; preparer2Zip: string; preparer2Signature: string; preparer2Agree: boolean; preparer3FirstName: string; preparer3LastName: string; preparer3Street1: string; preparer3Street2: string; preparer3City: string; preparer3State: string; preparer3Zip: string; preparer3Signature: string; preparer3Agree: boolean; preparer4FirstName: string; preparer4LastName: string; preparer4Street1: string; preparer4Street2: string; preparer4City: string; preparer4State: string; preparer4Zip: string; preparer4Signature: string; preparer4Agree: boolean; };
 
 // @public
 export type SignEmployeeFormErrorCode = (typeof SignEmployeeFormErrorCodes)[keyof typeof SignEmployeeFormErrorCodes];
@@ -4948,7 +4946,7 @@ export const SignEmployeeFormErrorCodes: {
 };
 
 // @public
-export type SignEmployeeFormField = "signature" | "confirmSignature" | "usedPreparer" | "preparerFirstName" | "preparerLastName" | "preparerStreet1" | "preparerStreet2" | "preparerCity" | "preparerState" | "preparerZip" | "preparerSignature" | "preparerAgree" | "preparer2FirstName" | "preparer2LastName" | "preparer2Street1" | "preparer2Street2" | "preparer2City" | "preparer2State" | "preparer2Zip" | "preparer2Signature" | "preparer2Agree" | "preparer3FirstName" | "preparer3LastName" | "preparer3Street1" | "preparer3Street2" | "preparer3City" | "preparer3State" | "preparer3Zip" | "preparer3Signature" | "preparer3Agree" | "preparer4FirstName" | "preparer4LastName" | "preparer4Street1" | "preparer4Street2" | "preparer4City" | "preparer4State" | "preparer4Zip" | "preparer4Signature" | "preparer4Agree";
+export type SignEmployeeFormField = "confirmSignature" | "preparer2Agree" | "preparer2City" | "preparer2FirstName" | "preparer2LastName" | "preparer2Signature" | "preparer2State" | "preparer2Street1" | "preparer2Street2" | "preparer2Zip" | "preparer3Agree" | "preparer3City" | "preparer3FirstName" | "preparer3LastName" | "preparer3Signature" | "preparer3State" | "preparer3Street1" | "preparer3Street2" | "preparer3Zip" | "preparer4Agree" | "preparer4City" | "preparer4FirstName" | "preparer4LastName" | "preparer4Signature" | "preparer4State" | "preparer4Street1" | "preparer4Street2" | "preparer4Zip" | "preparerAgree" | "preparerCity" | "preparerFirstName" | "preparerLastName" | "preparerSignature" | "preparerState" | "preparerStreet1" | "preparerStreet2" | "preparerZip" | "signature" | "usedPreparer";
 
 // @public
 export interface SignEmployeeFormFields {
@@ -5031,7 +5029,7 @@ export const SplitPaymentsFormErrorCodes: {
 };
 
 // @public
-export type SplitPaymentsFormField = "splitBy" | "splitAmount" | "priority";
+export type SplitPaymentsFormField = "priority" | "splitAmount" | "splitBy";
 
 // @public
 export interface SplitPaymentsFormFields {

--- a/build/expandDtsTypeof.test.ts
+++ b/build/expandDtsTypeof.test.ts
@@ -58,7 +58,7 @@ export type FormFields = keyof typeof validators;
     )
     expect(processSourceFile(sf, checker)).not.toBeNull()
     expect(sf.getText()).toMatchInlineSnapshot(`
-      "export type FormFields = "title" | "age";
+      "export type FormFields = "age" | "title";
       "
     `)
   })
@@ -235,7 +235,7 @@ export type BankFormField = keyof typeof fieldValidators;
     expect(processSourceFile(sf, checker)).not.toBeNull()
     expect(sf.getText()).toMatchInlineSnapshot(`
       "import { z } from 'zod';
-      export type BankFormField = "name" | "accountType";
+      export type BankFormField = "accountType" | "name";
       "
     `)
   })
@@ -278,7 +278,7 @@ export type BankFormData = {
     expect(() => processSourceFile(sf, checker)).not.toThrow()
     expect(sf.getText()).toMatchInlineSnapshot(`
       "import { z } from 'zod';
-      export type BankFormField = "name" | "accountType";
+      export type BankFormField = "accountType" | "name";
       export type BankFormData = { name: string; accountType: "Checking" | "Savings"; };
       "
     `)
@@ -430,7 +430,7 @@ describe('processSourceFile — jobSchema before/after', () => {
             stateWcClassCode: string
           };
       export type JobFormOutputs = JobFormData;
-      export type JobOptionalFieldsToRequire = { create?: ("twoPercentShareholder" | "stateWcCovered")[] | undefined; update?: ("title" | "hireDate" | "twoPercentShareholder" | "stateWcCovered")[] | undefined; };
+      export type JobOptionalFieldsToRequire = { create?: ("stateWcCovered" | "twoPercentShareholder")[] | undefined; update?: ("hireDate" | "stateWcCovered" | "title" | "twoPercentShareholder")[] | undefined; };
       export {};
       "
     `)
@@ -478,5 +478,96 @@ export type FormInputs = { a: string };
     )
     expect(processSourceFile(sf, checker)).toBeNull()
     expect(sf.getText()).toContain('export type FormInputs = { a: string }')
+  })
+})
+
+// ── References to @internal consts (exported / imported) ─────────────────────
+// A @public alias referencing an @internal const via `typeof` leaks it as
+// ae-incompatible-release-tags. Expand the alias to a concrete type; leave the
+// @internal declaration (a real export) in place, and drop an orphaned import.
+
+describe('processSourceFile — references to @internal consts', () => {
+  it('expands keyof typeof over an exported @internal const, leaving the declaration', () => {
+    const { sf, checker } = setup(
+      'internal-exported-const.d.ts',
+      `/** @internal */
+export declare const INITIAL_COMPONENT_MAP: {
+    readonly employeeProfile: () => number;
+};
+/** @public */
+export type OnboardingExecutionInitialState = keyof typeof INITIAL_COMPONENT_MAP;
+`,
+    )
+    expect(processSourceFile(sf, checker)).not.toBeNull()
+    const out = sf.getText()
+    expect(out).toContain('export type OnboardingExecutionInitialState = "employeeProfile";')
+    // The @internal declaration is a real export — it stays put.
+    expect(out).toContain('export declare const INITIAL_COMPONENT_MAP:')
+  })
+
+  it('expands an indexed access over an imported @internal const and prunes the dead import', () => {
+    const project = new Project({
+      tsConfigFilePath: join(ROOT, 'tsconfig.json'),
+      skipAddingFilesFromTsConfig: true,
+    })
+    project.createSourceFile(
+      join(FIXTURE_DIR, 'shared/constants.d.ts'),
+      `/** @internal */
+export declare const PAYMENT_METHODS: {
+    readonly check: "Check";
+    readonly directDeposit: "Direct Deposit";
+};
+`,
+      { overwrite: true },
+    )
+    const sf = project.createSourceFile(
+      join(FIXTURE_DIR, 'schema.d.ts'),
+      `import { PAYMENT_METHODS } from './shared/constants';
+/** @public */
+export type ContractorPaymentMethodFormType = (typeof PAYMENT_METHODS)[keyof typeof PAYMENT_METHODS];
+`,
+      { overwrite: true },
+    )
+    const checker = project.getTypeChecker().compilerObject
+    expect(processSourceFile(sf, checker)).not.toBeNull()
+    const out = sf.getText()
+    expect(out).toContain(
+      'export type ContractorPaymentMethodFormType = "Check" | "Direct Deposit";',
+    )
+    // The now-unused import of the @internal const is removed.
+    expect(out).not.toContain('PAYMENT_METHODS')
+  })
+
+  it('keeps an imported @internal const when another export still references it', () => {
+    const project = new Project({
+      tsConfigFilePath: join(ROOT, 'tsconfig.json'),
+      skipAddingFilesFromTsConfig: true,
+    })
+    project.createSourceFile(
+      join(FIXTURE_DIR, 'shared/constants2.d.ts'),
+      `/** @internal */
+export declare const PAYMENT_METHODS: {
+    readonly check: "Check";
+    readonly directDeposit: "Direct Deposit";
+};
+`,
+      { overwrite: true },
+    )
+    const sf = project.createSourceFile(
+      join(FIXTURE_DIR, 'schema2.d.ts'),
+      `import { PAYMENT_METHODS } from './shared/constants2';
+/** @public */
+export type Kind = (typeof PAYMENT_METHODS)[keyof typeof PAYMENT_METHODS];
+/** @internal */
+export declare function getDefault(): typeof PAYMENT_METHODS;
+`,
+      { overwrite: true },
+    )
+    const checker = project.getTypeChecker().compilerObject
+    expect(processSourceFile(sf, checker)).not.toBeNull()
+    const out = sf.getText()
+    expect(out).toContain('export type Kind = "Check" | "Direct Deposit";')
+    // Still referenced by getDefault — the import must remain.
+    expect(out).toContain("import { PAYMENT_METHODS } from './shared/constants2'")
   })
 })

--- a/build/expandDtsTypeof.ts
+++ b/build/expandDtsTypeof.ts
@@ -17,12 +17,93 @@
  */
 import {
   Node,
+  Project,
   ts,
   type SourceFile,
   type TypeAliasDeclaration,
+  type UnionTypeNode,
   type VariableStatement,
 } from 'ts-morph'
 import { relative } from 'path'
+
+// TypeScript's `typeToString` emits union members in a checker-internal order
+// that is not stable across builds, producing spurious reordering in the tracked
+// API report. Union member order is semantically irrelevant, so we sort every
+// union alphabetically to make the output deterministic. Parsing/sorting happens
+// in an isolated in-memory project so it never perturbs the build's type checker.
+let sortProject: Project | undefined
+function getSortProject(): Project {
+  sortProject ??= new Project({ useInMemoryFileSystem: true })
+  return sortProject
+}
+
+// Collects the outermost union nodes in a subtree — unions not nested inside
+// another union of the set. Nested unions are handled by recursion instead, so
+// reordering one union never invalidates another's text offsets.
+function collectOutermostUnions(root: Node): UnionTypeNode[] {
+  if (Node.isUnionTypeNode(root)) return [root]
+  const unions: UnionTypeNode[] = []
+  const visit = (node: Node): void => {
+    if (Node.isUnionTypeNode(node)) {
+      unions.push(node)
+      return
+    }
+    node.forEachChild(visit)
+  }
+  root.forEachChild(visit)
+  return unions
+}
+
+// A union is only reordered when every member is a string- or number-literal.
+// Those are the `keyof`- and template-literal-derived unions whose order the
+// checker emits non-deterministically. Unions mixing keywords (`string | null`,
+// `boolean`, `T[] | undefined`) keep their given order — it's already stable and
+// reordering it would churn the report without cause.
+function isReorderableUnion(union: UnionTypeNode): boolean {
+  return union.getTypeNodes().every(member => {
+    if (!Node.isLiteralTypeNode(member)) return false
+    const literal = member.getLiteral()
+    return Node.isStringLiteral(literal) || Node.isNumericLiteral(literal)
+  })
+}
+
+// Returns the node's text with the members of every all-literal union sorted
+// alphabetically at every nesting depth, leaving all other syntax (generics,
+// function types, object shapes, keyword unions, whitespace) byte-for-byte intact.
+function sortUnionsInNode(node: Node): string {
+  const unions = collectOutermostUnions(node)
+  if (unions.length === 0) return node.getText()
+
+  const base = node.getStart()
+  const replacements = unions.map(union => {
+    const members = union.getTypeNodes().map(member => sortUnionsInNode(member))
+    if (isReorderableUnion(union)) members.sort()
+    return { start: union.getStart() - base, end: union.getEnd() - base, text: members.join(' | ') }
+  })
+
+  let text = node.getText()
+  for (const replacement of replacements.sort((a, b) => b.start - a.start)) {
+    text = text.slice(0, replacement.start) + replacement.text + text.slice(replacement.end)
+  }
+  return text
+}
+
+// Sorts union members in a resolved type string. Falls back to the input
+// unchanged if it can't be parsed as a type (never throws).
+function sortUnionMembers(typeText: string): string {
+  try {
+    const sourceFile = getSortProject().createSourceFile(
+      '__union_sort__.ts',
+      `type __T = ${typeText}`,
+      {
+        overwrite: true,
+      },
+    )
+    return sortUnionsInNode(sourceFile.getTypeAliasOrThrow('__T').getTypeNodeOrThrow())
+  } catch {
+    return typeText
+  }
+}
 
 function buildTypeofPattern(names: Set<string>): RegExp {
   const escaped = [...names].map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
@@ -68,10 +149,12 @@ function buildTypeWithPropertyJsDocs(
   for (const prop of props) {
     const isOptional = (prop.flags & ts.SymbolFlags.Optional) !== 0
     const propType = checker.getTypeOfSymbolAtLocation(prop, contextNode)
-    const propTypeText = checker.typeToString(
-      propType,
-      contextNode,
-      ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.InTypeAlias,
+    const propTypeText = sortUnionMembers(
+      checker.typeToString(
+        propType,
+        contextNode,
+        ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.InTypeAlias,
+      ),
     )
     const jsdoc = propJsDocs.get(prop.getName())
     if (jsdoc) lines.push(`  ${jsdoc}`)
@@ -82,8 +165,22 @@ function buildTypeWithPropertyJsDocs(
 }
 
 // Returns true when the declaration carries an `@internal` JSDoc tag.
-function hasInternalTag(node: TypeAliasDeclaration): boolean {
+function hasInternalTag(node: TypeAliasDeclaration | VariableStatement): boolean {
   return node.getJsDocs().some(doc => doc.getTags().some(tag => tag.getTagName() === 'internal'))
+}
+
+// Returns true when an imported binding resolves to a variable declaration in
+// another module that carries an `@internal` JSDoc tag. Requires the target
+// module's .d.ts to be in the program (all dist files are, during build).
+function importedBindingIsInternal(nameNode: Node): boolean {
+  const symbol = nameNode.getSymbol()
+  if (!symbol) return false
+  const target = symbol.getAliasedSymbol() ?? symbol
+  return target.getDeclarations().some(decl => {
+    if (!Node.isVariableDeclaration(decl)) return false
+    const stmt = decl.getVariableStatement()
+    return stmt ? hasInternalTag(stmt) : false
+  })
 }
 
 // Within an exported type alias, rewrites references to `@internal` type aliases
@@ -143,7 +240,11 @@ function expandInternalTypeRefs(
     // Bail rather than emit a degraded type that still leaks an internal name or
     // loses concrete union information to `any`.
     if (/\bany\b/.test(resolved) || internalPattern.test(resolved)) return null
-    replacements.push({ start: node.getStart() - base, end: node.getEnd() - base, text: resolved })
+    replacements.push({
+      start: node.getStart() - base,
+      end: node.getEnd() - base,
+      text: sortUnionMembers(resolved),
+    })
   }
 
   // Apply right-to-left so earlier offsets stay valid as text length changes.
@@ -190,7 +291,33 @@ export function processSourceFile(sourceFile: SourceFile, checker: ts.TypeChecke
     if (hasInternalTag(typeAlias)) internalTypeNames.add(typeAlias.getName())
   }
 
-  if (unexportedTypeofNames.size === 0 && internalTypeNames.size === 0) return null
+  // Consts tagged @internal leak as ae-incompatible-release-tags when a @public
+  // alias references them via `typeof`. Unlike unexported consts we can't delete
+  // the declaration — an exported const is a real runtime export, an imported one
+  // belongs to another module — so we expand the referencing alias to a concrete
+  // type and, for imports, drop the now-orphaned import specifier afterward.
+  const internalTypeofConstNames = new Set<string>()
+  const internalImportedNames = new Set<string>()
+  for (const stmt of sourceFile.getVariableStatements()) {
+    if (!hasInternalTag(stmt)) continue
+    for (const decl of stmt.getDeclarations()) internalTypeofConstNames.add(decl.getName())
+  }
+  for (const importDecl of sourceFile.getImportDeclarations()) {
+    for (const spec of importDecl.getNamedImports()) {
+      const localName = spec.getAliasNode()?.getText() ?? spec.getName()
+      if (importedBindingIsInternal(spec.getNameNode())) {
+        internalTypeofConstNames.add(localName)
+        internalImportedNames.add(localName)
+      }
+    }
+  }
+
+  if (
+    unexportedTypeofNames.size === 0 &&
+    internalTypeNames.size === 0 &&
+    internalTypeofConstNames.size === 0
+  )
+    return null
 
   // For each unexported const with a TypeLiteralNode type, collect JSDoc for
   // each property so we can re-attach them after expansion.
@@ -214,8 +341,13 @@ export function processSourceFile(sourceFile: SourceFile, checker: ts.TypeChecke
     }
   }
 
-  const unexportedTypeofPattern =
-    unexportedTypeofNames.size > 0 ? buildTypeofPattern(unexportedTypeofNames) : null
+  // Whole-alias expansion applies to unexported consts/functions and to
+  // @internal consts alike. The declaration-pruning passes below stay scoped to
+  // the unexported names only, so @internal exports/imports are expanded but
+  // never deleted.
+  const expandableTypeofNames = new Set([...unexportedTypeofNames, ...internalTypeofConstNames])
+  const expandableTypeofPattern =
+    expandableTypeofNames.size > 0 ? buildTypeofPattern(expandableTypeofNames) : null
 
   // Two-pass approach: resolve all types first (using the original checker
   // against the unmodified AST), then apply mutations. Mutating mid-loop via
@@ -239,7 +371,7 @@ export function processSourceFile(sourceFile: SourceFile, checker: ts.TypeChecke
     // Path 2: when the alias doesn't reference an unexported `typeof` const but
     // does reference an @internal type alias, rewrite just those references to
     // their concrete types in place and leave the rest of the alias unchanged.
-    if (!unexportedTypeofPattern || !unexportedTypeofPattern.test(typeNode.getText())) {
+    if (!expandableTypeofPattern || !expandableTypeofPattern.test(typeNode.getText())) {
       if (internalTypeNames.size > 0 && !hasInternalTag(typeAlias)) {
         const expanded = expandInternalTypeRefs(
           typeNode,
@@ -285,8 +417,8 @@ export function processSourceFile(sourceFile: SourceFile, checker: ts.TypeChecke
       )
       continue
     }
-    // Skip if the resolved text still references an unexported const.
-    if (unexportedTypeofPattern && unexportedTypeofPattern.test(resolvedText)) {
+    // Skip if the resolved text still references a const we meant to expand out.
+    if (expandableTypeofPattern && expandableTypeofPattern.test(resolvedText)) {
       console.warn(
         `[expand-dts-typeof] ${rel(sourceFile.getFilePath())}: ${typeAlias.getName()} resolved type still contains unexported typeof — skipping`,
         `\n  resolved: ${truncate(resolvedText, 200)}`,
@@ -306,8 +438,10 @@ export function processSourceFile(sourceFile: SourceFile, checker: ts.TypeChecke
     }
 
     // If the resolved type is an object type and we have property JSDoc for
-    // the referenced const, build a multi-line type with the comments preserved.
-    let finalResolvedText = resolvedText
+    // the referenced const, build a multi-line type with the comments preserved
+    // (which sorts unions per-property itself). Otherwise sort the flat text so
+    // union member order is deterministic across builds.
+    let finalResolvedText = sortUnionMembers(resolvedText)
     if (resolvedText.startsWith('{')) {
       const referencedConst = findSingleReferencedConst(typeNode.getText(), unexportedVarNames)
       const propJsDocs = referencedConst ? constPropJsDocs.get(referencedConst) : undefined
@@ -366,6 +500,34 @@ export function processSourceFile(sourceFile: SourceFile, checker: ts.TypeChecke
       console.log(
         `[expand-dts-typeof] ${rel(sourceFile.getFilePath())}: removed orphaned declare function ${name}`,
       )
+    }
+  }
+
+  // Remove import specifiers for @internal bindings whose only remaining
+  // reference is the import itself (e.g. `import { PAYMENT_METHODS }` after the
+  // sole alias referencing it was expanded). The exporting module is untouched;
+  // only this file's now-dead import is pruned.
+  if (internalImportedNames.size > 0) {
+    const afterExpansion = sourceFile.getFullText()
+    for (const importDecl of sourceFile.getImportDeclarations()) {
+      for (const spec of importDecl.getNamedImports()) {
+        const localName = spec.getAliasNode()?.getText() ?? spec.getName()
+        if (!internalImportedNames.has(localName)) continue
+        const occurrences = afterExpansion.match(new RegExp(`\\b${localName}\\b`, 'g'))?.length ?? 0
+        if (occurrences <= 1) {
+          spec.remove()
+          console.log(
+            `[expand-dts-typeof] ${rel(sourceFile.getFilePath())}: removed orphaned import ${localName}`,
+          )
+        }
+      }
+      if (
+        importDecl.getNamedImports().length === 0 &&
+        !importDecl.getDefaultImport() &&
+        !importDecl.getNamespaceImport()
+      ) {
+        importDecl.remove()
+      }
     }
   }
 


### PR DESCRIPTION
First of a 4-PR stack splitting the SDK-1054 doc-coverage work for reviewability. Stack: **PR1 (this)** → PR2 (shrink surface) → PR3 (grow surface) → PR4 (enforce).

## What

Two independent enhancements to the `.d.ts` post-processor, both prerequisites for turning API Extractor release-tag enforcement on (PR4):

- **Deterministic union sort** — sort all-literal union members alphabetically at every nesting depth. The checker's `typeToString` emits union order non-deterministically, churning the tracked API report; member order is semantically irrelevant. Sorting runs in an isolated in-memory project so it never perturbs the build's type checker. Keyword unions (`string | null`, `T[] | undefined`) keep their given order.
- **`@internal typeof <const>` expansion** — resolve `typeof` references to `@internal` consts (exported-local and imported) to their concrete types, leaving declarations in place and pruning now-orphaned import specifiers, so `@public` aliases no longer trip `ae-incompatible-release-tags`.

## Scope

Tooling only (`build/expandDtsTypeof.ts` + tests). No change to the published API surface. Safe to land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)