### PR TITLE
chore(SDK-1054): enforce API Extractor release-tag rules at error level

### DIFF
--- a/.reports/config/api-extractor.json
+++ b/.reports/config/api-extractor.json
@@ -38,20 +38,20 @@
   "messages": {
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
-        "logLevel": "none",
-        "addToApiReportFile": true
+        "logLevel": "error",
+        "addToApiReportFile": false
       },
       "ae-forgotten-export": {
-        "logLevel": "none",
-        "addToApiReportFile": true
+        "logLevel": "error",
+        "addToApiReportFile": false
       },
       "ae-unresolved-link": {
         "logLevel": "none",
         "addToApiReportFile": false
       },
       "ae-incompatible-release-tags": {
-        "logLevel": "none",
-        "addToApiReportFile": true
+        "logLevel": "error",
+        "addToApiReportFile": false
       }
     }
   }


### PR DESCRIPTION
Final PR of the SDK-1054 stack (draft). Base is **PR3** (#2366); merge order 1→2→3→4.
Stack: PR1 (tooling) → PR2 (shrink surface) → PR3 (grow surface) → **PR4 (this: enforce)**.

## What

Flip `ae-missing-release-tag`, `ae-forgotten-export`, and `ae-incompatible-release-tags` from `logLevel: "none"` to `"error"` (and `addToApiReportFile: false`) now that the tooling (PR1), the shrunk surface (PR2), and the expanded surface (PR3) satisfy them.

Turns the doc-coverage gate on: an undocumented or mistagged export now fails the build. Validated locally — API Extractor passes against the full stacked surface with enforcement at `error`.

Diff is `.reports/config/api-extractor.json` only.

## Verified the gate actually blocks merge

Pushed a temporary commit adding an untagged public export (`export const __ciReleaseTagCanary = '…'`, no `@public`/`@internal` tag), then reverted it. The `derive-check-dist` CI job failed as expected, which failed the required `derive` aggregate check and marked the PR `UNSTABLE` (merge blocked):

```
> api-extractor run --local --config .reports/config/api-extractor.json && node ./build/collapseApiReportTranslations.mjs
api-extractor 7.58.9  - https://api-extractor.com/
Warning: You have changed the API signature for this project. Updating .reports/embedded-react-sdk.api.md
Error: dist/index.d.ts:66:22 - (ae-missing-release-tag) "__ciReleaseTagCanary" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
API Extractor completed with errors
##[error]Process completed with exit code 1.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
