### PR TITLE
fix(Employee/OnboardingSummary): show handoff copy when admin invites self-onboarding

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -2614,7 +2614,7 @@ export const EmployeeOnboardingStatus: {
 };
 
 // @public
-export const EmployeeSelfOnboardingStatuses: Set<"self_onboarding_invited" | "self_onboarding_invited_started" | "self_onboarding_invited_overdue">;
+export const EmployeeSelfOnboardingStatuses: Set<string>;
 
 // @public
 export type EmployeeStateTaxesErrorCode = (typeof EmployeeStateTaxesErrorCodes)[keyof typeof EmployeeStateTaxesErrorCodes];

--- a/docs/reference/Translations/index.md
+++ b/docs/reference/Translations/index.md
@@ -3349,6 +3349,8 @@ Translation keys for the `Employee.OnboardingSummary` i18n namespace.
 | ------ | ------ |
 | <a id="property-employeeonboardingsummarydescription"></a> `description` | `"Please complete the following steps in order to continue."` |
 | <a id="property-employeeonboardingsummarydonecta"></a> `doneCta` | `"Done"` |
+| <a id="property-employeeonboardingsummaryhandedoffadmindescription"></a> `handedOffAdminDescription` | `"They'll complete the remaining setup steps on their own."` |
+| <a id="property-employeeonboardingsummaryhandedoffadminsubtitle"></a> `handedOffAdminSubtitle` | `"{{name}}'s invite is on its way"` |
 | <a id="property-employeeonboardingsummarymissingrequirementsdescription"></a> `missingRequirementsDescription` | `"Please complete the following steps in order to continue."` |
 | <a id="property-employeeonboardingsummarymissingrequirementssubtitle"></a> `missingRequirementsSubtitle` | `"Missing requirements"` |
 | <a id="property-employeeonboardingsummarynewhirereportcta"></a> `newHireReportCta` | `"New Hire report"` |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -144,7 +144,7 @@ record. The values mirror the strings returned by the API.
 
 ### EmployeeSelfOnboardingStatuses
 
-> `const` **EmployeeSelfOnboardingStatuses**: `Set`\<`"self_onboarding_invited"` \| `"self_onboarding_invited_started"` \| `"self_onboarding_invited_overdue"`\>
+> `const` **EmployeeSelfOnboardingStatuses**: `Set`\<`string`\>
 
 Set of [EmployeeOnboardingStatus](#employeeonboardingstatus) values that indicate the employee is
 completing self-onboarding.

--- a/src/components/Employee/Documents/onboarding/EmployeeDocuments/EmployeeDocuments.tsx
+++ b/src/components/Employee/Documents/onboarding/EmployeeDocuments/EmployeeDocuments.tsx
@@ -65,8 +65,7 @@ const Root = ({ employeeId, dictionary }: EmployeeDocumentsProps) => {
   const currentI9Status = employee?.onboardingDocumentsConfig?.i9Document ?? false
 
   const isEmployeeSelfOnboarding = employee?.onboardingStatus
-    ? // @ts-expect-error: onboarding_status during runtime can be one of self onboarding statuses
-      EmployeeSelfOnboardingStatuses.has(employee.onboardingStatus) ||
+    ? EmployeeSelfOnboardingStatuses.has(employee.onboardingStatus) ||
       employee.onboardingStatus === EmployeeOnboardingStatus.SELF_ONBOARDING_PENDING_INVITE
     : false
 

--- a/src/components/Employee/EmployeeList/shared/useEmployeeList.tsx
+++ b/src/components/Employee/EmployeeList/shared/useEmployeeList.tsx
@@ -100,11 +100,7 @@ function deriveAllowedActions(employee: Employee, employeeType?: EmployeeType): 
   }
 
   // Cancel self onboarding - available for employees in self-onboarding flow
-  if (
-    employee.onboardingStatus &&
-    // @ts-expect-error: onboardingStatus during runtime can be one of self onboarding statuses
-    EmployeeSelfOnboardingStatuses.has(employee.onboardingStatus)
-  ) {
+  if (employee.onboardingStatus && EmployeeSelfOnboardingStatuses.has(employee.onboardingStatus)) {
     actions.push('cancel_self_onboarding')
   }
 

--- a/src/components/Employee/OnboardingExecutionFlow/onboardingExecutionStateMachine.ts
+++ b/src/components/Employee/OnboardingExecutionFlow/onboardingExecutionStateMachine.ts
@@ -50,8 +50,6 @@ const employeeDocumentsGuard = (ctx: OnboardingContextInterface) => {
 const selfOnboardingGuard = (ctx: OnboardingContextInterface) =>
   ctx.onboardingStatus
     ? !(
-        // prettier-ignore
-        // @ts-expect-error: onboarding_status during runtime can be one of self onboarding statuses
         EmployeeSelfOnboardingStatuses.has(ctx.onboardingStatus) ||
         ctx.onboardingStatus === EmployeeOnboardingStatus.SELF_ONBOARDING_PENDING_INVITE
       )

--- a/src/components/Employee/OnboardingSummary/OnboardingSummary.test.tsx
+++ b/src/components/Employee/OnboardingSummary/OnboardingSummary.test.tsx
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { OnboardingSummary } from './OnboardingSummary'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { server } from '@/test/mocks/server'
+import { API_BASE_URL } from '@/test/constants'
+import { handleGetEmployee } from '@/test/mocks/apis/employees'
+
+const EMPLOYEE_ID = '4b3f930f-82cd-48a8-b797-798686e12e5e'
+
+const employeeFixture = {
+  uuid: EMPLOYEE_ID,
+  first_name: 'Isom',
+  last_name: 'Jaskolski',
+  company_uuid: 'a007e1ab-3595-43c2-ab4b-af7a5af2e365',
+  version: '1c7ba9d62c8bafbfff998ffccad5d296',
+  terminated: false,
+  two_percent_shareholder: false,
+  onboarded: false,
+  onboarding_status: 'admin_onboarding_incomplete',
+  jobs: [],
+  terminations: [],
+  custom_fields: [],
+  garnishments: [],
+  eligible_paid_time_off: [],
+}
+
+const buildStep = (id: string, completed: boolean) => ({
+  title: id,
+  id,
+  required: true,
+  completed,
+  requirements: [],
+})
+
+const allStepsComplete = [
+  buildStep('personal_details', true),
+  buildStep('compensation_details', true),
+  buildStep('add_work_address', true),
+  buildStep('add_home_address', true),
+  buildStep('federal_tax_setup', true),
+  buildStep('state_tax_setup', true),
+  buildStep('direct_deposit_setup', true),
+  buildStep('employee_form_signing', true),
+]
+
+const employeeStepsIncomplete = [
+  buildStep('personal_details', true),
+  buildStep('compensation_details', true),
+  buildStep('add_work_address', true),
+  buildStep('add_home_address', false),
+  buildStep('federal_tax_setup', false),
+  buildStep('state_tax_setup', false),
+  buildStep('direct_deposit_setup', false),
+  buildStep('employee_form_signing', false),
+]
+
+function setupOnboardingHandlers({
+  status,
+  steps = employeeStepsIncomplete,
+}: {
+  status: string
+  steps?: ReturnType<typeof buildStep>[]
+}) {
+  server.use(
+    handleGetEmployee(() => HttpResponse.json(employeeFixture)),
+    http.get(`${API_BASE_URL}/v1/employees/:employee_id/onboarding_status`, () =>
+      HttpResponse.json({
+        uuid: EMPLOYEE_ID,
+        onboarding_status: status,
+        onboarding_steps: steps,
+      }),
+    ),
+  )
+}
+
+describe('Employee OnboardingSummary', () => {
+  const user = userEvent.setup()
+  const mockOnEvent = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupApiTestMocks()
+  })
+
+  describe('isAdmin=true', () => {
+    it('shows the "ready to get paid" copy when onboarding is fully complete', async () => {
+      setupOnboardingHandlers({
+        status: 'onboarding_completed',
+        steps: allStepsComplete,
+      })
+
+      renderWithProviders(
+        <OnboardingSummary employeeId={EMPLOYEE_ID} isAdmin onEvent={mockOnEvent} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+          /Isom Jaskolski is ready to get paid/i,
+        )
+      })
+      expect(screen.queryByText(/invite is on its way/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Missing requirements/i)).not.toBeInTheDocument()
+    })
+
+    it('shows the handoff copy for SELF_ONBOARDING_PENDING_INVITE', async () => {
+      setupOnboardingHandlers({ status: 'self_onboarding_pending_invite' })
+
+      renderWithProviders(
+        <OnboardingSummary employeeId={EMPLOYEE_ID} isAdmin onEvent={mockOnEvent} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+          /Isom Jaskolski's invite is on its way/i,
+        )
+      })
+      expect(
+        screen.getByText(/They'll complete the remaining setup steps on their own/i),
+      ).toBeInTheDocument()
+      expect(screen.queryByText(/Missing requirements/i)).not.toBeInTheDocument()
+    })
+
+    it('shows the handoff copy for SELF_ONBOARDING_INVITED_STARTED', async () => {
+      setupOnboardingHandlers({ status: 'self_onboarding_invited_started' })
+
+      renderWithProviders(
+        <OnboardingSummary employeeId={EMPLOYEE_ID} isAdmin onEvent={mockOnEvent} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(/invite is on its way/i)
+      })
+      expect(screen.queryByText(/Missing requirements/i)).not.toBeInTheDocument()
+    })
+
+    it('shows the missing-requirements list for ADMIN_ONBOARDING_INCOMPLETE', async () => {
+      setupOnboardingHandlers({
+        status: 'admin_onboarding_incomplete',
+        steps: [
+          buildStep('personal_details', true),
+          buildStep('compensation_details', false),
+          buildStep('add_work_address', false),
+        ],
+      })
+
+      renderWithProviders(
+        <OnboardingSummary employeeId={EMPLOYEE_ID} isAdmin onEvent={mockOnEvent} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Missing requirements/i })).toBeInTheDocument()
+      })
+      expect(screen.getByText(/Job and compensation/i)).toBeInTheDocument()
+      expect(screen.queryByText(/invite is on its way/i)).not.toBeInTheDocument()
+    })
+
+    it('shows the missing-requirements list for SELF_ONBOARDING_AWAITING_ADMIN_REVIEW (admin still owes review)', async () => {
+      setupOnboardingHandlers({
+        status: 'self_onboarding_awaiting_admin_review',
+        steps: [...allStepsComplete, buildStep('admin_review', false)],
+      })
+
+      renderWithProviders(
+        <OnboardingSummary employeeId={EMPLOYEE_ID} isAdmin onEvent={mockOnEvent} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Missing requirements/i })).toBeInTheDocument()
+      })
+      expect(screen.queryByText(/invite is on its way/i)).not.toBeInTheDocument()
+    })
+
+    it('fires EMPLOYEES_LIST when the Done button is clicked in the handoff branch', async () => {
+      setupOnboardingHandlers({ status: 'self_onboarding_pending_invite' })
+
+      renderWithProviders(
+        <OnboardingSummary employeeId={EMPLOYEE_ID} isAdmin onEvent={mockOnEvent} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Done/i })).toBeInTheDocument()
+      })
+      await user.click(screen.getByRole('button', { name: /Done/i }))
+
+      expect(mockOnEvent).toHaveBeenCalledWith('company/employees')
+    })
+  })
+
+  describe('isAdmin=false', () => {
+    it('renders the self-onboarded confirmation copy regardless of status', async () => {
+      setupOnboardingHandlers({ status: 'self_onboarding_completed_by_employee' })
+
+      renderWithProviders(
+        <OnboardingSummary employeeId={EMPLOYEE_ID} isAdmin={false} onEvent={mockOnEvent} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /You've completed setup/i })).toBeInTheDocument()
+      })
+      expect(screen.queryByText(/invite is on its way/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Missing requirements/i)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
+++ b/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
@@ -9,7 +9,11 @@ import { Flex, ActionsLayout } from '@/components/Common'
 import { RequirementsList } from '@/components/Common/RequirementsList/RequirementsList'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
-import { componentEvents, EmployeeOnboardingStatus } from '@/shared/constants'
+import {
+  componentEvents,
+  EmployeeOnboardingStatus,
+  EmployeeSelfOnboardingStatuses,
+} from '@/shared/constants'
 import { useFlow } from '@/components/Flow/useFlow'
 import { useComponentDictionary } from '@/i18n/I18n'
 
@@ -82,6 +86,11 @@ const Root = ({ employeeId, className, isAdmin = false }: OnboardingSummaryProps
     (!hasMissingRequirements &&
       onboardingStatus === EmployeeOnboardingStatus.SELF_ONBOARDING_PENDING_INVITE)
 
+  const isEmployeeCompletingSelfOnboarding =
+    onboardingStatus === EmployeeOnboardingStatus.SELF_ONBOARDING_PENDING_INVITE ||
+    // @ts-expect-error: onboardingStatus during runtime can be one of self onboarding statuses
+    EmployeeSelfOnboardingStatuses.has(onboardingStatus)
+
   const sanitizedFirstName = useMemo(() => DOMPurify.sanitize(firstName), [firstName])
   const sanitizedLastName = useMemo(() => DOMPurify.sanitize(lastName), [lastName])
 
@@ -100,6 +109,18 @@ const Root = ({ employeeId, className, isAdmin = false }: OnboardingSummaryProps
                 </Components.Heading>
                 <Components.Text variant="supporting">
                   {t('onboardedAdminDescription')}
+                </Components.Text>
+              </Flex>
+            ) : isEmployeeCompletingSelfOnboarding ? (
+              <Flex flexDirection="column" gap={4} alignItems="center">
+                <Components.Heading as="h2" textAlign="center">
+                  {t('handedOffAdminSubtitle', {
+                    name: `${sanitizedFirstName} ${sanitizedLastName}`,
+                    interpolation: { escapeValue: false },
+                  })}
+                </Components.Heading>
+                <Components.Text variant="supporting">
+                  {t('handedOffAdminDescription')}
                 </Components.Text>
               </Flex>
             ) : (
@@ -169,7 +190,7 @@ const Root = ({ employeeId, className, isAdmin = false }: OnboardingSummaryProps
           )}
         </Flex>
 
-        {isAdmin && isOnboardingCompleted && (
+        {isAdmin && (isOnboardingCompleted || isEmployeeCompletingSelfOnboarding) && (
           <ActionsLayout justifyContent={'center'}>
             <Components.Button
               variant="secondary"

--- a/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
+++ b/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
@@ -175,7 +175,7 @@ const Root = ({ employeeId, className, isAdmin = false }: OnboardingSummaryProps
                     {t('onboardedSelfDescription')}
                   </Components.Text>
                 </Flex>
-                <ActionsLayout justifyContent={isOnboardingCompleted ? 'center' : 'start'}>
+                <ActionsLayout justifyContent="center">
                   <Components.Button
                     variant="secondary"
                     onClick={() => {

--- a/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
+++ b/src/components/Employee/OnboardingSummary/OnboardingSummary.tsx
@@ -88,8 +88,7 @@ const Root = ({ employeeId, className, isAdmin = false }: OnboardingSummaryProps
 
   const isEmployeeCompletingSelfOnboarding =
     onboardingStatus === EmployeeOnboardingStatus.SELF_ONBOARDING_PENDING_INVITE ||
-    // @ts-expect-error: onboardingStatus during runtime can be one of self onboarding statuses
-    EmployeeSelfOnboardingStatuses.has(onboardingStatus)
+    (onboardingStatus !== undefined && EmployeeSelfOnboardingStatuses.has(onboardingStatus))
 
   const sanitizedFirstName = useMemo(() => DOMPurify.sanitize(firstName), [firstName])
   const sanitizedLastName = useMemo(() => DOMPurify.sanitize(lastName), [lastName])

--- a/src/i18n/en/Employee.OnboardingSummary.json
+++ b/src/i18n/en/Employee.OnboardingSummary.json
@@ -3,6 +3,8 @@
   "description": "Please complete the following steps in order to continue.",
   "onboardedAdminSubtitle": "That's it! {{name}} is ready to get paid!",
   "onboardedAdminDescription": "We'll begin withholding and reporting their taxes.",
+  "handedOffAdminSubtitle": "{{name}}'s invite is on its way",
+  "handedOffAdminDescription": "They'll complete the remaining setup steps on their own.",
   "onboardedSelfSubtitle": "You've completed setup!",
   "onboardedSelfDescription": "Your account will now be reviewed by your company admin.",
   "doneCta": "Done",

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -4930,7 +4930,7 @@ export namespace Translations {
     onboardedAdminDescription: string
     /** @defaultValue `"{{name}}'s invite is on its way"` */
     handedOffAdminSubtitle: string
-    /** @defaultValue `"They'll complete the remaining setup steps on their own. We'll notify you when they're done."` */
+    /** @defaultValue `"They'll complete the remaining setup steps on their own."` */
     handedOffAdminDescription: string
     /** @defaultValue `"You've completed setup!"` */
     onboardedSelfSubtitle: string

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -4928,6 +4928,10 @@ export namespace Translations {
     onboardedAdminSubtitle: string
     /** @defaultValue `"We'll begin withholding and reporting their taxes."` */
     onboardedAdminDescription: string
+    /** @defaultValue `"{{name}}'s invite is on its way"` */
+    handedOffAdminSubtitle: string
+    /** @defaultValue `"They'll complete the remaining setup steps on their own. We'll notify you when they're done."` */
+    handedOffAdminDescription: string
     /** @defaultValue `"You've completed setup!"` */
     onboardedSelfSubtitle: string
     /** @defaultValue `"Your account will now be reviewed by your company admin."` */

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -569,7 +569,7 @@ export const EmployeeOnboardingStatus = {
  *
  * @public
  */
-export const EmployeeSelfOnboardingStatuses = new Set([
+export const EmployeeSelfOnboardingStatuses = new Set<string>([
   EmployeeOnboardingStatus.SELF_ONBOARDING_INVITED,
   EmployeeOnboardingStatus.SELF_ONBOARDING_INVITED_STARTED,
   EmployeeOnboardingStatus.SELF_ONBOARDING_INVITED_OVERDUE,


### PR DESCRIPTION
## Summary

- When an admin adds an employee with self-onboarding enabled, the summary currently shows a misleading "Missing requirements" checklist — the employee-owned steps are unavoidably incomplete, but the imperative copy ("Please complete the following steps in order to continue") is aimed at the wrong person.
- Detect the handoff statuses (`SELF_ONBOARDING_PENDING_INVITE` plus the three `SELF_ONBOARDING_INVITED*` values already grouped in `EmployeeSelfOnboardingStatuses`) and render admin-facing confirmation copy instead of the requirements list.
- `SELF_ONBOARDING_COMPLETED_BY_EMPLOYEE` / `SELF_ONBOARDING_AWAITING_ADMIN_REVIEW` deliberately stay in the missing-requirements branch, since `admin_review` is a real outstanding admin task.

## Test plan

- [x] `npm run test -- --run src/components/Employee/OnboardingSummary/` (7 new tests, all pass)
- [x] `npx tsc --noEmit` clean
- [x] Sibling flow tests (`OnboardingExecutionFlow`, `SelfOnboardingFlow`) still pass
- [ ] Manual verification in `sdk-app` — walk the admin add-employee flow with self-onboarding enabled and confirm the new copy replaces the requirements checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)