### PR TITLE
chore(docs-site): emit the standard PageViewed analytics event

### DIFF
--- a/docs-site/src/analytics/PageViewedEvent.ts
+++ b/docs-site/src/analytics/PageViewedEvent.ts
@@ -1,14 +1,9 @@
 import type { AnalyticsEvent } from '@site/types'
 
 /**
- * Tracks a page view. `name` should be the page title.
+ * Tracks a page view.
  */
-export class PageViewedEvent implements AnalyticsEvent<{ name: string }> {
+export class PageViewedEvent implements AnalyticsEvent {
   readonly eventCategory = 'Page'
   readonly eventName = 'Viewed'
-  readonly data: { name: string }
-
-  constructor(name: string) {
-    this.data = { name }
-  }
 }

--- a/docs-site/src/analytics/PageViewedEvent.ts
+++ b/docs-site/src/analytics/PageViewedEvent.ts
@@ -1,7 +1,9 @@
 import type { AnalyticsEvent } from '@site/types'
 
 /**
- * Tracks a page view.
+ * Tracks a page view. GustoAnalytics enriches all events with page
+ * context (url, path, and title) automatically so no additional data
+ * is required.
  */
 export class PageViewedEvent implements AnalyticsEvent {
   readonly eventCategory = 'Page'

--- a/docs-site/src/analytics/PageViewedEvent.ts
+++ b/docs-site/src/analytics/PageViewedEvent.ts
@@ -1,10 +1,14 @@
-// A page-view analytics event: a typed object emitted through ./trackEvent rather than a
-// raw call against the client. Page views are the only event the docs site emits; widen
-// ./trackEvent to a union when more events are added.
-export class PageViewedEvent {
-  readonly name: string
+import type { AnalyticsEvent } from '@site/types'
+
+/**
+ * Tracks a page view. `name` should be the page title.
+ */
+export class PageViewedEvent implements AnalyticsEvent<{ name: string }> {
+  readonly eventCategory = 'Page'
+  readonly eventName = 'Viewed'
+  readonly data: { name: string }
 
   constructor(name: string) {
-    this.name = name
+    this.data = { name }
   }
 }

--- a/docs-site/src/analytics/listeners.ts
+++ b/docs-site/src/analytics/listeners.ts
@@ -1,9 +1,10 @@
 import { PageViewedEvent } from './PageViewedEvent'
 import { trackEvent } from './trackEvent'
 
-// Emits a page view for the current document. The wrapper exposes it; the host wires it to
-// its router (here, Docusaurus' onRouteDidUpdate and the OneTrust consent bridge in
-// ../clientModules).
+/**
+ * Emits a page view for the current document; should be called whenever the
+ * top-level page changes.
+ */
 export function routeChangeListener(): void {
   trackEvent(new PageViewedEvent(document.title || window.location.pathname))
 }

--- a/docs-site/src/analytics/listeners.ts
+++ b/docs-site/src/analytics/listeners.ts
@@ -6,5 +6,5 @@ import { trackEvent } from './trackEvent'
  * top-level page changes.
  */
 export function routeChangeListener(): void {
-  trackEvent(new PageViewedEvent(document.title || window.location.pathname))
+  trackEvent(new PageViewedEvent())
 }

--- a/docs-site/src/analytics/loadAnalytics.ts
+++ b/docs-site/src/analytics/loadAnalytics.ts
@@ -1,19 +1,32 @@
-import type { GustoAnalyticsClient } from '@site/types'
+import type { AnalyticsEvent } from '@site/types'
 import { CONFIG } from '../config'
 
-// Loads the analytics client for a client-side-only site: publish window.gustoAC config,
-// install a preload stub that queues calls, then inject the CDN bundle, which replays the
-// queued calls once it loads. Kept separate from the event wrapper (./trackEvent) so the
-// wrapper only ever emits; how the client gets on the page is a distinct concern.
+/**
+ * Loads the Gusto Analytics client for this client-side-only docs site and emits events
+ * through it.
+ *
+ * The CDN bundle is a UMD build. Loaded via a plain `<script>`, its wrapper runs
+ * `window.GustoAnalytics = {}` the instant it executes, clobbering anything we put there —
+ * so the library's documented preload-stub queue is never drained (its own drain reads the
+ * empty object the wrapper installed). Rather than fight that, we don't install a stub: we
+ * buffer events fired before the bundle loads and replay them ourselves once it does.
+ * Direct calls on the loaded client are what reliably emit.
+ */
 
-// The CDN bundle is injected at most once, on first consented page view.
+/** Whether the CDN bundle has been injected. Injection happens once, on the first consented event. */
 let analyticsScriptInjected = false
 
-// Publishes config and installs the preload stub. The stub is a Proxy over an array:
-// any method call (e.g. track()) is queued until the CDN bundle loads and replaces
-// window.GustoAnalytics with the loaded client, which then replays the queue.
-export function installAnalyticsStub(): void {
-  // The client reads this config on load; set it before the bundle loads.
+/** Whether the bundle load has resolved (loaded or failed). Until then, events are buffered. */
+let bundleSettled = false
+
+/** Events fired before the bundle settled, replayed in order once it does. */
+const pendingEvents: AnalyticsEvent[] = []
+
+/**
+ * Publishes the client configuration on `window.gustoAC`. The bundle reads this when it
+ * loads, so this must run before {@link trackWhenReady} injects the bundle.
+ */
+export function configureAnalytics(): void {
   window.gustoAC = {
     snowplowEnabled: true,
     snowplowAppId: CONFIG.ANALYTICS.SNOWPLOW_APP_ID,
@@ -21,30 +34,51 @@ export function installAnalyticsStub(): void {
     snowplowTrackingUrl: CONFIG.ANALYTICS.SNOWPLOW_TRACKING_URL,
     snowplowCollectorMode: 'dual_send',
     serverSideEligibleProviders: ['amplitude'],
-    // We fire page views manually on each route change, so disable automatic page events.
+    /** Emits legacy view on initial page load only */
     autoPageEvent: false,
   }
-
-  const queue: unknown[] = []
-  window.GustoAnalytics = new Proxy(queue, {
-    get(target, prop, receiver) {
-      if (prop in target) return Reflect.get(target, prop, receiver)
-      return (...args: unknown[]) => {
-        target.push([prop, ...args])
-        return window.GustoAnalytics
-      }
-    },
-  }) as unknown as GustoAnalyticsClient
 }
 
-// Deferred until consent so no trackers or cookies are set before the reader opts in;
-// idempotent so repeated page views inject the bundle only once.
-export function ensureAnalyticsLoaded(): void {
+/** Sends one event to the loaded client; a no-op if the bundle failed to load. */
+function emit(event: AnalyticsEvent): void {
+  window.GustoAnalytics?.track({
+    eventCategory: event.eventCategory,
+    eventName: event.eventName,
+    data: event.data,
+  })
+}
+
+/**
+ * Emits an analytics event, injecting the CDN bundle on first use. Events fired before the
+ * bundle finishes loading are buffered and replayed once it settles.
+ */
+export function trackWhenReady(event: AnalyticsEvent): void {
+  ensureAnalyticsLoaded()
+  if (bundleSettled) {
+    emit(event)
+  } else {
+    pendingEvents.push(event)
+  }
+}
+
+/**
+ * Injects the CDN bundle exactly once. Reached only after the consent gate in
+ * `trackEvent`, so no trackers or cookies are set before the reader opts in. The
+ * buffer is flushed whether the bundle loads or fails, so it never grows unbounded.
+ */
+function ensureAnalyticsLoaded(): void {
   if (analyticsScriptInjected) return
   analyticsScriptInjected = true
+
+  const settle = (): void => {
+    bundleSettled = true
+    for (const event of pendingEvents.splice(0)) emit(event)
+  }
 
   const script = document.createElement('script')
   script.src = CONFIG.ANALYTICS.SCRIPT_URL
   script.defer = true
+  script.onload = settle
+  script.onerror = settle
   document.head.appendChild(script)
 }

--- a/docs-site/src/analytics/loadAnalytics.ts
+++ b/docs-site/src/analytics/loadAnalytics.ts
@@ -10,7 +10,7 @@ import { CONFIG } from '../config'
 let analyticsScriptInjected = false
 
 // Publishes config and installs the preload stub. The stub is a Proxy over an array:
-// any method call (e.g. page()) is queued until the CDN bundle loads and replaces
+// any method call (e.g. track()) is queued until the CDN bundle loads and replaces
 // window.GustoAnalytics with the loaded client, which then replays the queue.
 export function installAnalyticsStub(): void {
   // The client reads this config on load; set it before the bundle loads.
@@ -20,6 +20,7 @@ export function installAnalyticsStub(): void {
     snowplowTrackerName: CONFIG.ANALYTICS.SNOWPLOW_TRACKER_NAME,
     snowplowTrackingUrl: CONFIG.ANALYTICS.SNOWPLOW_TRACKING_URL,
     snowplowCollectorMode: 'dual_send',
+    serverSideEligibleProviders: ['amplitude'],
     // We fire page views manually on each route change, so disable automatic page events.
     autoPageEvent: false,
   }

--- a/docs-site/src/analytics/trackEvent.ts
+++ b/docs-site/src/analytics/trackEvent.ts
@@ -1,6 +1,6 @@
 import type { AnalyticsEvent } from '@site/types'
 import { hasPerformanceConsent } from '../cookieConsent'
-import { ensureAnalyticsLoaded } from './loadAnalytics'
+import { trackWhenReady } from './loadAnalytics'
 
 /**
  * Single entry point for emitting analytics. Consent is enforced here so no call site
@@ -10,10 +10,5 @@ import { ensureAnalyticsLoaded } from './loadAnalytics'
  */
 export function trackEvent(event: AnalyticsEvent): void {
   if (!hasPerformanceConsent()) return
-  ensureAnalyticsLoaded()
-  window.GustoAnalytics?.track({
-    eventCategory: event.eventCategory,
-    eventName: event.eventName,
-    data: event.data,
-  })
+  trackWhenReady(event)
 }

--- a/docs-site/src/analytics/trackEvent.ts
+++ b/docs-site/src/analytics/trackEvent.ts
@@ -1,13 +1,19 @@
+import type { AnalyticsEvent } from '@site/types'
 import { hasPerformanceConsent } from '../cookieConsent'
 import { ensureAnalyticsLoaded } from './loadAnalytics'
-import type { PageViewedEvent } from './PageViewedEvent'
 
-// Single entry point for emitting analytics. Consent is enforced here so no call site can
-// emit before the reader opts in; the CDN bundle is loaded lazily on the first consented
-// event.
-export function trackEvent(event: PageViewedEvent): void {
+/**
+ * Single entry point for emitting analytics. Consent is enforced here so no call site
+ * can emit before the reader opts in.
+ *
+ * CDN bundle is loaded lazily on the first consented event.
+ */
+export function trackEvent(event: AnalyticsEvent): void {
   if (!hasPerformanceConsent()) return
   ensureAnalyticsLoaded()
-  // Queued by the preload stub if the bundle is still loading; fired live once it has.
-  window.GustoAnalytics?.page({ name: event.name })
+  window.GustoAnalytics?.track({
+    eventCategory: event.eventCategory,
+    eventName: event.eventName,
+    data: event.data,
+  })
 }

--- a/docs-site/src/clientModules/gustoAnalytics.ts
+++ b/docs-site/src/clientModules/gustoAnalytics.ts
@@ -1,5 +1,5 @@
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment'
-import { installAnalyticsStub } from '../analytics/loadAnalytics'
+import { configureAnalytics } from '../analytics/loadAnalytics'
 import { routeChangeListener } from '../analytics/listeners'
 import { hasPerformanceConsent } from '../cookieConsent'
 
@@ -38,7 +38,7 @@ function emitLandingViewWhenConsentResolves(attemptsRemaining: number): void {
 }
 
 if (ExecutionEnvironment.canUseDOM) {
-  installAnalyticsStub()
+  configureAnalytics()
 
   // Bridge OneTrust consent into analytics: OptanonWrapper handles later consent changes,
   // and the poll handles the landing view on load/reload (see note above).

--- a/docs-site/src/clientModules/gustoAnalytics.ts
+++ b/docs-site/src/clientModules/gustoAnalytics.ts
@@ -3,7 +3,7 @@ import { installAnalyticsStub } from '../analytics/loadAnalytics'
 import { routeChangeListener } from '../analytics/listeners'
 import { hasPerformanceConsent } from '../cookieConsent'
 
-// OneTrust re-invokes OptanonWrapper several times per load, so the landing page view is
+// OneTrust re-invokes OptanonWrapper on every consent change, so the landing page view is
 // guarded to fire once; SPA navigations go through onRouteDidUpdate.
 let landingPageViewSent = false
 
@@ -13,14 +13,37 @@ function handleConsent(): void {
   routeChangeListener()
 }
 
+// OneTrust loads asynchronously and can finish after this module hydrates, so its
+// on-load OptanonWrapper invocation may fire before we assign our handler (and it does
+// not re-fire on a reload where consent is unchanged). Poll until OneTrust publishes its
+// groups, then evaluate consent once — otherwise the landing view is lost on reload and
+// only actual consent changes emit. ~5s budget (25 × 200ms); OneTrust is normally ready
+// well within it, and if it never loads we simply stop.
+const CONSENT_POLL_INTERVAL_MS = 200
+const CONSENT_POLL_ATTEMPTS = 25
+
+function emitLandingViewWhenConsentResolves(attemptsRemaining: number): void {
+  if (landingPageViewSent) return
+  // A groups string means OneTrust has resolved consent (granted or not) — evaluate now.
+  // If not yet granted, a later OptanonWrapper consent-change call emits the view instead.
+  if (typeof window.OnetrustActiveGroups === 'string') {
+    handleConsent()
+    return
+  }
+  if (attemptsRemaining <= 0) return
+  window.setTimeout(
+    () => emitLandingViewWhenConsentResolves(attemptsRemaining - 1),
+    CONSENT_POLL_INTERVAL_MS,
+  )
+}
+
 if (ExecutionEnvironment.canUseDOM) {
   installAnalyticsStub()
 
-  // Bridge OneTrust consent into analytics. OneTrust re-invokes OptanonWrapper on load
-  // and on every consent change; the trailing catch-up call covers the case where
-  // consent had already resolved before this module ran.
+  // Bridge OneTrust consent into analytics: OptanonWrapper handles later consent changes,
+  // and the poll handles the landing view on load/reload (see note above).
   window.OptanonWrapper = handleConsent
-  handleConsent()
+  emitLandingViewWhenConsentResolves(CONSENT_POLL_ATTEMPTS)
 }
 
 // react-helmet-async flushes the new <title> on an animation frame after the route

--- a/docs-site/src/config.ts
+++ b/docs-site/src/config.ts
@@ -12,7 +12,7 @@ const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 export const CONFIG = {
   ANALYTICS: {
     /** gusto-analytics CDN bundle (page-view-only usage). */
-    SCRIPT_URL: 'https://static.gusto.com/analytics/gusto-analytics-15.11.4.min.js',
+    SCRIPT_URL: 'https://static.gusto.com/analytics/gusto-analytics-15.11.6.min.js',
 
     SNOWPLOW_APP_ID: 'gusto',
     SNOWPLOW_TRACKER_NAME: 'gusto_sdk_docs',

--- a/docs-site/src/config.ts
+++ b/docs-site/src/config.ts
@@ -15,7 +15,7 @@ export const CONFIG = {
     SCRIPT_URL: 'https://static.gusto.com/analytics/gusto-analytics-15.11.6.min.js',
 
     SNOWPLOW_APP_ID: 'gusto',
-    SNOWPLOW_TRACKER_NAME: 'gusto_sdk_docs',
+    SNOWPLOW_TRACKER_NAME: 'embedded-sdk-docs',
     SNOWPLOW_TRACKING_URL: IS_PRODUCTION ? 'snowplow.gusto.com' : 'snowplow.gusto-staging.com',
   },
 

--- a/docs-site/types.d.ts
+++ b/docs-site/types.d.ts
@@ -1,5 +1,11 @@
+export interface AnalyticsEvent<Data extends Record<string, unknown> = Record<string, unknown>> {
+  eventCategory: string
+  eventName: string
+  data?: Data
+}
+
 export interface GustoAnalyticsClient {
-  page: (prop: { name: string; data?: Record<string, unknown> }) => void
+  track: (event: AnalyticsEvent) => void
 }
 
 declare global {


### PR DESCRIPTION
## What

Records docs-site page views under the current `PageViewed` analytics event so they land in analytics as `PageViewed` rather than the legacy page-view event.

- Bump the analytics CDN bundle `15.11.4 → 15.11.6` (latest available).
- Opt the docs site into server-side provider delivery for page views (`serverSideEligibleProviders: ['amplitude']`), set before the bundle loads.
- Emit the standard `Page`/`Viewed` event via `track` instead of the legacy auto page-view call.
- Introduce a small `AnalyticsEvent` type; the event owns its identity (`eventCategory`/`eventName`/`data`) and the emitter reads it off the event, so adding future events is a one-line union.

## Why

The legacy page-view path is recorded under the old event name. Emitting the standard `Page`/`Viewed` event records page views under the current `PageViewed` name.

## Notes

A server-side allowlist entry is also required for these events to be delivered end-to-end; that change lives outside this repo and is tracked separately.

## Testing

- `tsc --noEmit` clean for the changed files.
- Verify after deploy: page views emit `Page`/`Viewed` with a non-empty `server_side_eligible_providers`, and appear downstream as `PageViewed`.

The page view event includes this context (decoded):

```json
{
    "referrer": "http://localhost:3000/docs/getting-started/proxy-security-partner-guidance?cache_reset=1783539989654",
    "path": "/",
    "url": "http://localhost:3000/",
    "title": "Gusto Embedded"
}
```
