### PR TITLE
ci: add Lokalise translation workflows for i18n strings

### DIFF
--- a/.github/workflows/check-manual-translations.yaml
+++ b/.github/workflows/check-manual-translations.yaml
@@ -1,0 +1,19 @@
+name: 'Check for manual translations'
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - "src/i18n/es_US/**.json"
+jobs:
+  check-for-manual-translations:
+    runs-on:
+      group: gusto-ubuntu-default
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Run manual translations check
+        uses: Gusto/embedded-i18n-actions/manual_translations_check@main
+        with:
+          file_patterns: |
+            **/i18n/es_US/**

--- a/.github/workflows/check-manual-translations.yaml
+++ b/.github/workflows/check-manual-translations.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     paths:
-      - "src/i18n/es_US/**.json"
+      - 'src/i18n/es_US/**.json'
 jobs:
   check-for-manual-translations:
     runs-on:

--- a/.github/workflows/pull-translations.yaml
+++ b/.github/workflows/pull-translations.yaml
@@ -1,0 +1,18 @@
+name: Pull Translations
+on:
+  workflow_dispatch:
+jobs:
+  pull-translations:
+    runs-on:
+      group: gusto-ubuntu-default
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Pull translations
+        uses: Gusto/embedded-i18n-actions/pull_translations@main
+        with:
+          lokalise_project_id: ${{ vars.LOKALISE_PROJECT_ID }}
+          lokalise_api_token: ${{ secrets.LOKALISE_API_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          file_format: json

--- a/.github/workflows/push-sources.yaml
+++ b/.github/workflows/push-sources.yaml
@@ -1,0 +1,21 @@
+name: Push Sources
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "src/i18n/en/**.json"
+jobs:
+  push-sources:
+    runs-on:
+      group: gusto-ubuntu-default
+    permissions:
+      contents: read
+    steps:
+      - name: Push sources
+        uses: Gusto/embedded-i18n-actions/push_sources@main
+        with:
+          lokalise_project_id: ${{ vars.LOKALISE_PROJECT_ID }}
+          lokalise_api_token: ${{ secrets.LOKALISE_API_TOKEN }}
+          locale_paths: |
+            src/i18n/en

--- a/.github/workflows/push-sources.yaml
+++ b/.github/workflows/push-sources.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - "src/i18n/en/**.json"
+      - 'src/i18n/en/**.json'
 jobs:
   push-sources:
     runs-on:


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflows to route this SDK's `src/i18n/en/*.json` strings through Gusto Embedded's shared Lokalise translation pipeline, replicating the pattern already used by gws-flows and zenpayroll via the reusable `Gusto/embedded-i18n-actions` actions.

## Changes

- `push-sources.yaml` — pushes `src/i18n/en/*.json` to Lokalise on `main` pushes touching those files, or manual dispatch
- `pull-translations.yaml` — manually pulls reviewed `es_US` translations from Lokalise and opens a PR (`file_format: json`, since the action defaults to Rails-style `ruby_yml`)
- `check-manual-translations.yaml` — blocks PRs that hand-edit `src/i18n/es_US/*.json` outside the Lokalise pull-PR flow


## Related

- Reference: [Gusto/embedded-i18n-actions](https://github.com/Gusto/embedded-i18n-actions)

## Testing
TBD