### PR TITLE
feat: add showContinueButton prop to StateTaxes and StateTaxesList

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -5079,6 +5079,7 @@ function StateTaxesList(props: StateTaxesListProps): JSX;
 // @public
 interface StateTaxesListProps extends BaseComponentInterface<'Company.StateTaxes'> {
     companyId: string;
+    showContinueButton?: boolean;
 }
 
 // @public
@@ -5095,6 +5096,7 @@ interface StateTaxesProps_2 extends BaseComponentInterface<'Employee.Management.
 // @public
 interface StateTaxesProps_3 extends BaseComponentInterface<'Company.StateTaxes'> {
     companyId: string;
+    showContinueButton?: boolean;
 }
 
 // @public

--- a/docs/reference/company/onboarding/blocks.md
+++ b/docs/reference/company/onboarding/blocks.md
@@ -610,11 +610,12 @@ For finer-grained control over navigation, use the standalone [StateTaxesList](#
 
 Props for the [StateTaxes](#statetaxes) flow.
 
-| Property | Type | Description |
-| ------ | ------ | ------ |
-| `companyId` | `string` | UUID of the company whose state taxes are being managed. |
-| `onEvent` | [`OnEventType`](../../events.md#oneventtype)\<[`EventType`](../../events.md#eventtype), `unknown`\> | Callback invoked each time the component emits an event — user interactions, successful API responses, step transitions, or errors. Receives the event type constant and an optional payload whose shape varies by event. See the [Event Handling guide](https://docs.gusto.com/embedded-payroll/docs/event-handling) and each component's event table for the full list of emitted events. |
-| `dictionary?` | `Record`\<`"en"`, [`DeepPartial`](../../Translations/index.md#deeppartial)\<[`CompanyStateTaxes`](../../Translations/index.md#companystatetaxes)\>\> | Overrides for the component's i18n strings. Supply a partial object whose keys match the component's resource namespace — any omitted keys fall back to SDK defaults. See the [Translation guide](https://docs.gusto.com/embedded-payroll/docs/translation) for details. |
+| Property | Type | Default value | Description |
+| ------ | ------ | ------ | ------ |
+| `companyId` | `string` | | UUID of the company whose state taxes are being managed. |
+| `onEvent` | [`OnEventType`](../../events.md#oneventtype)\<[`EventType`](../../events.md#eventtype), `unknown`\> | | Callback invoked each time the component emits an event — user interactions, successful API responses, step transitions, or errors. Receives the event type constant and an optional payload whose shape varies by event. See the [Event Handling guide](https://docs.gusto.com/embedded-payroll/docs/event-handling) and each component's event table for the full list of emitted events. |
+| `dictionary?` | `Record`\<`"en"`, [`DeepPartial`](../../Translations/index.md#deeppartial)\<[`CompanyStateTaxes`](../../Translations/index.md#companystatetaxes)\>\> | | Overrides for the component's i18n strings. Supply a partial object whose keys match the component's resource namespace — any omitted keys fall back to SDK defaults. See the [Translation guide](https://docs.gusto.com/embedded-payroll/docs/translation) for details. |
+| `showContinueButton?` | `boolean` | `true` | Controls visibility of the Continue button below the state tax list. When `false`, hides the Continue button. Use this when the flow is embedded as one step inside a larger flow that provides its own navigation. |
 
 _Inherits `children`, `className`, `defaultValues`, `FallbackComponent`, `LoaderComponent` from [BaseComponentInterface](../../index.md#basecomponentinterface)._
 
@@ -707,11 +708,12 @@ Standalone building block used internally by the orchestrated `StateTaxes` compo
 
 Props for the [StateTaxesList](#statetaxeslist) component.
 
-| Property | Type | Description |
-| ------ | ------ | ------ |
-| `companyId` | `string` | The associated company identifier. |
-| `onEvent` | [`OnEventType`](../../events.md#oneventtype)\<[`EventType`](../../events.md#eventtype), `unknown`\> | Callback invoked each time the component emits an event — user interactions, successful API responses, step transitions, or errors. Receives the event type constant and an optional payload whose shape varies by event. See the [Event Handling guide](https://docs.gusto.com/embedded-payroll/docs/event-handling) and each component's event table for the full list of emitted events. |
-| `dictionary?` | `Record`\<`"en"`, [`DeepPartial`](../../Translations/index.md#deeppartial)\<[`CompanyStateTaxes`](../../Translations/index.md#companystatetaxes)\>\> | Overrides for the component's i18n strings. Supply a partial object whose keys match the component's resource namespace — any omitted keys fall back to SDK defaults. See the [Translation guide](https://docs.gusto.com/embedded-payroll/docs/translation) for details. |
+| Property | Type | Default value | Description |
+| ------ | ------ | ------ | ------ |
+| `companyId` | `string` | | The associated company identifier. |
+| `onEvent` | [`OnEventType`](../../events.md#oneventtype)\<[`EventType`](../../events.md#eventtype), `unknown`\> | | Callback invoked each time the component emits an event — user interactions, successful API responses, step transitions, or errors. Receives the event type constant and an optional payload whose shape varies by event. See the [Event Handling guide](https://docs.gusto.com/embedded-payroll/docs/event-handling) and each component's event table for the full list of emitted events. |
+| `dictionary?` | `Record`\<`"en"`, [`DeepPartial`](../../Translations/index.md#deeppartial)\<[`CompanyStateTaxes`](../../Translations/index.md#companystatetaxes)\>\> | | Overrides for the component's i18n strings. Supply a partial object whose keys match the component's resource namespace — any omitted keys fall back to SDK defaults. See the [Translation guide](https://docs.gusto.com/embedded-payroll/docs/translation) for details. |
+| `showContinueButton?` | `boolean` | `true` | Controls visibility of the Continue button below the state tax list. When `false`, hides the Continue button. Use this when the list is embedded as one step inside a larger flow that provides its own navigation. |
 
 _Inherits `children`, `className`, `defaultValues`, `FallbackComponent`, `LoaderComponent` from [BaseComponentInterface](../../index.md#basecomponentinterface)._
 

--- a/src/components/Company/StateTaxes/StateTaxes.tsx
+++ b/src/components/Company/StateTaxes/StateTaxes.tsx
@@ -15,6 +15,15 @@ import { useComponentDictionary } from '@/i18n/I18n'
 export interface StateTaxesProps extends BaseComponentInterface<'Company.StateTaxes'> {
   /** UUID of the company whose state taxes are being managed. */
   companyId: string
+  /**
+   * Controls visibility of the Continue button below the state tax list.
+   *
+   * When `false`, hides the Continue button. Use this when the flow is embedded
+   * as one step inside a larger flow that provides its own navigation.
+   *
+   * @defaultValue `true`
+   */
+  showContinueButton?: boolean
 }
 
 /**
@@ -37,7 +46,12 @@ export interface StateTaxesProps extends BaseComponentInterface<'Company.StateTa
  * @returns The rendered state taxes flow.
  * @public
  */
-export function StateTaxes({ companyId, onEvent, dictionary }: StateTaxesProps) {
+export function StateTaxes({
+  companyId,
+  onEvent,
+  dictionary,
+  showContinueButton = true,
+}: StateTaxesProps) {
   useComponentDictionary('Company.StateTaxes', dictionary)
   const manageStateTaxes = useMemo(
     () =>
@@ -48,9 +62,10 @@ export function StateTaxes({ companyId, onEvent, dictionary }: StateTaxesProps) 
           ...initialContext,
           component: StateTaxesListContextual,
           companyId,
+          showContinueButton,
         }),
       ),
-    [companyId],
+    [companyId, showContinueButton],
   )
   return <Flow machine={manageStateTaxes} onEvent={onEvent} />
 }

--- a/src/components/Company/StateTaxes/StateTaxesComponents.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesComponents.tsx
@@ -11,12 +11,20 @@ export interface StateTaxesContextInterface extends FlowContextInterface {
   state?: string
   /** Current step component rendered by the flow machine. */
   component: React.ComponentType | null
+  /** Controls visibility of the Continue button in the state tax list. */
+  showContinueButton: boolean
 }
 
 /** @internal */
 export function StateTaxesListContextual() {
-  const { companyId, onEvent } = useFlow<StateTaxesContextInterface>()
-  return <StateTaxesList onEvent={onEvent} companyId={ensureRequired(companyId)} />
+  const { companyId, onEvent, showContinueButton } = useFlow<StateTaxesContextInterface>()
+  return (
+    <StateTaxesList
+      onEvent={onEvent}
+      companyId={ensureRequired(companyId)}
+      showContinueButton={showContinueButton}
+    />
+  )
 }
 
 /** @internal */

--- a/src/components/Company/StateTaxes/StateTaxesList/StateTaxesList.test.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesList/StateTaxesList.test.tsx
@@ -60,6 +60,23 @@ describe('StateTaxesList', () => {
   })
 })
 
+describe('showContinueButton', () => {
+  it('hides the Continue button when showContinueButton is false', async () => {
+    setupApiTestMocks()
+    render(
+      <GustoTestProvider>
+        <StateTaxesList companyId="company-123" onEvent={vi.fn()} showContinueButton={false} />
+      </GustoTestProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('California')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument()
+  })
+})
+
 function renderWithSingleState(state: object, onEvent = vi.fn()) {
   setupApiTestMocks()
   server.use(

--- a/src/components/Company/StateTaxes/StateTaxesList/StateTaxesList.tsx
+++ b/src/components/Company/StateTaxes/StateTaxesList/StateTaxesList.tsx
@@ -18,6 +18,15 @@ import { useBase } from '@/components/Base'
 export interface StateTaxesListProps extends BaseComponentInterface<'Company.StateTaxes'> {
   /** The associated company identifier. */
   companyId: string
+  /**
+   * Controls visibility of the Continue button below the state tax list.
+   *
+   * When `false`, hides the Continue button. Use this when the list is embedded
+   * as one step inside a larger flow that provides its own navigation.
+   *
+   * @defaultValue `true`
+   */
+  showContinueButton?: boolean
 }
 
 /**
@@ -44,7 +53,7 @@ export function StateTaxesList(props: StateTaxesListProps) {
   )
 }
 
-function Root({ className, children, companyId }: StateTaxesListProps) {
+function Root({ className, children, companyId, showContinueButton = true }: StateTaxesListProps) {
   useI18n('Company.StateTaxes')
   const { onEvent } = useBase()
   const { data } = useTaxRequirementsGetAllSuspense({ companyUuid: companyId })
@@ -75,7 +84,7 @@ function Root({ className, children, companyId }: StateTaxesListProps) {
             <>
               <Head />
               <List />
-              <Actions />
+              {showContinueButton && <Actions />}
             </>
           )}
         </Flex>


### PR DESCRIPTION
## Summary

Adds a `showContinueButton` prop to `StateTaxes` and `StateTaxesList`, letting integrators hide the Continue button when either component is embedded as a step inside a larger flow that provides its own navigation. Defaults to `true`, preserving current behavior. Mirrors the existing `showContinueButton` pattern used by `EmployeeList`/`OnboardingFlow`.

## Changes

- Added `showContinueButton?: boolean` (default `true`) to `StateTaxesProps` and `StateTaxesListProps`
- Threaded the flag through `StateTaxesContextInterface` and `StateTaxesListContextual` so the orchestrated `StateTaxes` flow can control it
- `StateTaxesList` now conditionally renders its `Actions` (Continue button) based on the prop

## Testing

- `npm run test -- --run src/components/Company/StateTaxes` — 31/31 tests pass, including a new test asserting the Continue button is hidden when `showContinueButton={false}`
- `npx tsc --noEmit -p .` — clean
- `npm run lint` — no new errors/warnings introduced
- `npx prettier --check` — clean