### PR TITLE
fix: add U.S. person definition copy to W-9 certification section

### DIFF
--- a/docs/reference/Translations/index.md
+++ b/docs/reference/Translations/index.md
@@ -1769,6 +1769,7 @@ Translation keys for the `Contractor.SignatureForm` i18n namespace.
 | `certificationPoints.fatca` | `"The FATCA code(s) entered on this form (if any) indicating that I am exempt from FATCA reporting is correct."` |
 | `certificationPoints.taxpayerId` | `"The number shown on this form is my correct taxpayer identification number (or I am waiting for a number to be issued to me);"` |
 | `certificationPoints.usPerson` | `"I am a U.S. citizen or other U.S. person (defined below);"` |
+| `certificationPoints.usPersonDefinition` | `"For federal tax purposes, you are considered a U.S. person if you are: an individual who is a U.S. citizen or U.S. resident alien; a partnership, corporation, company, or association created or organized in the United States or under the laws of the United States; an estate (other than a foreign estate); or a domestic trust (as defined in Regulations section 301.7701-7)."` |
 | <a id="property-contractorsignatureformdownloadprompt"></a> `downloadPrompt` | `"<downloadLink>Download document</downloadLink>"` |
 | <a id="property-contractorsignatureformfields"></a> `fields` | |
 | `fields.account_number` | |

--- a/src/components/Contractor/Documents/SignatureForm/SignatureForm.tsx
+++ b/src/components/Contractor/Documents/SignatureForm/SignatureForm.tsx
@@ -374,16 +374,23 @@ function CertificationDeclaration() {
   return (
     <Flex flexDirection="column" gap={8}>
       <Components.Text weight="medium">{t('certificationIntro')}</Components.Text>
-      <Components.OrderedList
-        items={[
-          <Components.Text key="taxpayerId">{t('certificationPoints.taxpayerId')}</Components.Text>,
-          <Components.Text key="backupWithholding">
-            {t('certificationPoints.backupWithholding')}
-          </Components.Text>,
-          <Components.Text key="usPerson">{t('certificationPoints.usPerson')}</Components.Text>,
-          <Components.Text key="fatca">{t('certificationPoints.fatca')}</Components.Text>,
-        ]}
-      />
+      <Flex flexDirection="column" gap={16}>
+        <Components.OrderedList
+          items={[
+            <Components.Text key="taxpayerId">
+              {t('certificationPoints.taxpayerId')}
+            </Components.Text>,
+            <Components.Text key="backupWithholding">
+              {t('certificationPoints.backupWithholding')}
+            </Components.Text>,
+            <Components.Text key="usPerson">{t('certificationPoints.usPerson')}</Components.Text>,
+            <Components.Text key="fatca">{t('certificationPoints.fatca')}</Components.Text>,
+          ]}
+        />
+        <Components.Text variant="supporting" size="sm">
+          {t('certificationPoints.usPersonDefinition')}
+        </Components.Text>
+      </Flex>
     </Flex>
   )
 }

--- a/src/i18n/en/Contractor.SignatureForm.json
+++ b/src/i18n/en/Contractor.SignatureForm.json
@@ -20,6 +20,7 @@
     "taxpayerId": "The number shown on this form is my correct taxpayer identification number (or I am waiting for a number to be issued to me);",
     "backupWithholding": "I am not subject to backup withholding because (a) I am exempt from backup withholding, or (b) I have not been notified by the Internal Revenue Service (IRS) that I am subject to backup withholding as a result of a failure to report all interest or dividends, or (c) the IRS has notified me that I am no longer subject to backup withholding;",
     "usPerson": "I am a U.S. citizen or other U.S. person (defined below);",
+    "usPersonDefinition": "For federal tax purposes, you are considered a U.S. person if you are: an individual who is a U.S. citizen or U.S. resident alien; a partnership, corporation, company, or association created or organized in the United States or under the laws of the United States; an estate (other than a foreign estate); or a domestic trust (as defined in Regulations section 301.7701-7).",
     "fatca": "The FATCA code(s) entered on this form (if any) indicating that I am exempt from FATCA reporting is correct."
   },
   "fields": {

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -2494,6 +2494,8 @@ export namespace Translations {
       backupWithholding: string
       /** @defaultValue `"I am a U.S. citizen or other U.S. person (defined below);"` */
       usPerson: string
+      /** @defaultValue `"For federal tax purposes, you are considered a U.S. person if you are: an individual who is a U.S. citizen or U.S. resident alien; a partnership, corporation, company, or association created or organized in the United States or under the laws of the United States; an estate (other than a foreign estate); or a domestic trust (as defined in Regulations section 301.7701-7)."` */
+      usPersonDefinition: string
       /** @defaultValue `"The FATCA code(s) entered on this form (if any) indicating that I am exempt from FATCA reporting is correct."` */
       fatca: string
     }


### PR DESCRIPTION
## Summary
- Adds the "U.S. person" definition footnote to the W-9 certification section in `SignatureForm`
- Wraps the ordered list and definition in a `Flex` column to give proper spacing
- Adds the `usPersonDefinition` translation key and regenerates i18n types

## Demo

<img width="1245" height="576" alt="Screenshot 2026-07-10 at 3 29 08 PM" src="https://github.com/user-attachments/assets/b10ae111-9920-4cc0-9c5f-f44ebcbbebec" />

## Test plan
- [x] Verify the W-9 `CertificationDeclaration` renders the definition text below the ordered list
- [x] Confirm no TypeScript errors on `t('certificationPoints.usPersonDefinition')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)