### PR TITLE
feat: show "Review" CTA for self-onboarding contractors awaiting admin review

### DIFF
--- a/docs/reference/Translations/index.md
+++ b/docs/reference/Translations/index.md
@@ -1275,6 +1275,7 @@ Translation keys for the `Contractor.ContractorList` i18n namespace.
 | `listHeaders.name` | `"Name"` |
 | `listHeaders.status` | `"Status"` |
 | <a id="property-contractorcontractorlistprogressbarcta"></a> `progressBarCta` | `"Back to contractors"` |
+| <a id="property-contractorcontractorlistreviewcta"></a> `reviewCta` | `"Review"` |
 | <a id="property-contractorcontractorlisttitle"></a> `title` | `"Contractors"` |
 
 ***

--- a/src/components/Contractor/ContractorList/ContractorList.test.tsx
+++ b/src/components/Contractor/ContractorList/ContractorList.test.tsx
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HttpResponse } from 'msw'
+import { ContractorList } from './index'
+import { server } from '@/test/mocks/server'
+import { handleGetContractorsList } from '@/test/mocks/apis/contractors'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+
+const baseContractor = {
+  uuid: 'contractor-123',
+  company_uuid: 'company-123',
+  type: 'Individual',
+  first_name: 'Ada',
+  last_name: 'Lovelace',
+  wage_type: 'Hourly',
+  hourly_rate: '50.00',
+  start_date: '2024-01-01',
+  is_active: true,
+  version: 'version-123',
+  onboarded: false,
+}
+
+function mockContractorWithStatus(onboardingStatus: string, onboarded = false) {
+  server.use(
+    handleGetContractorsList(() =>
+      HttpResponse.json([{ ...baseContractor, onboarding_status: onboardingStatus, onboarded }], {
+        headers: { 'x-total-pages': '1', 'x-total-count': '1' },
+      }),
+    ),
+  )
+}
+
+describe('ContractorList hamburger menu edit/review CTA', () => {
+  beforeEach(() => {
+    mockContractorWithStatus('admin_onboarding_incomplete')
+  })
+
+  it('labels the menu action "Edit" while onboarding is still incomplete', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<ContractorList companyId="company-123" onEvent={() => {}} />)
+
+    await screen.findByText('Ada Lovelace')
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Edit' })).toBeTruthy()
+  })
+
+  it('labels the menu action "Review" when the contractor is awaiting self-onboarding review', async () => {
+    mockContractorWithStatus('self_onboarding_review')
+
+    const user = userEvent.setup()
+    renderWithProviders(<ContractorList companyId="company-123" onEvent={() => {}} />)
+
+    await screen.findByText('Ada Lovelace')
+    await user.click(screen.getByRole('button', { name: 'Review' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Review' })).toBeTruthy()
+  })
+
+  it('labels the menu action "Edit" for admin-facilitated onboarding review (admin entered the data)', async () => {
+    mockContractorWithStatus('admin_onboarding_review')
+
+    const user = userEvent.setup()
+    renderWithProviders(<ContractorList companyId="company-123" onEvent={() => {}} />)
+
+    await screen.findByText('Ada Lovelace')
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Edit' })).toBeTruthy()
+  })
+
+  it('labels the menu action "Edit" once onboarding is complete', async () => {
+    mockContractorWithStatus('onboarding_completed', true)
+
+    const user = userEvent.setup()
+    renderWithProviders(<ContractorList companyId="company-123" onEvent={() => {}} />)
+
+    await screen.findByText('Ada Lovelace')
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Edit' })).toBeTruthy()
+  })
+})

--- a/src/components/Contractor/ContractorList/index.tsx
+++ b/src/components/Contractor/ContractorList/index.tsx
@@ -10,7 +10,7 @@ import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentCon
 import { ContractorOnboardingStatusBadge } from '@/components/Common/OnboardingStatusBadge'
 import { useI18n, useComponentDictionary } from '@/i18n'
 import { BaseComponent, useBase, type BaseComponentInterface } from '@/components/Base'
-import { componentEvents, CONTRACTOR_TYPE } from '@/shared/constants'
+import { componentEvents, CONTRACTOR_TYPE, ContractorOnboardingStatus } from '@/shared/constants'
 import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
 
 interface HeadProps {
@@ -126,28 +126,34 @@ function Root({ companyId, className, dictionary, successMessage }: ContractorLi
       },
     ],
     data: contractors,
-    itemMenu: contractor => (
-      <HamburgerMenu
-        items={[
-          {
-            label: t('editCta'),
-            icon: <PencilSvg aria-hidden />,
-            onClick: () => {
-              handleEdit(contractor.uuid)
+    itemMenu: contractor => {
+      const isAwaitingSelfOnboardingReview =
+        contractor.onboardingStatus === ContractorOnboardingStatus.SELF_ONBOARDING_REVIEW
+      const editLabel = isAwaitingSelfOnboardingReview ? t('reviewCta') : t('editCta')
+
+      return (
+        <HamburgerMenu
+          items={[
+            {
+              label: editLabel,
+              icon: <PencilSvg aria-hidden />,
+              onClick: () => {
+                handleEdit(contractor.uuid)
+              },
             },
-          },
-          {
-            label: t('deleteCta'),
-            icon: <TrashCanSvg aria-hidden />,
-            onClick: () => {
-              void handleDelete(contractor.uuid)
+            {
+              label: t('deleteCta'),
+              icon: <TrashCanSvg aria-hidden />,
+              onClick: () => {
+                void handleDelete(contractor.uuid)
+              },
             },
-          },
-        ]}
-        triggerLabel={t('editCta')}
-        isLoading={isPendingDelete}
-      />
-    ),
+          ]}
+          triggerLabel={editLabel}
+          isLoading={isPendingDelete}
+        />
+      )
+    },
     emptyState: () => <EmptyDataContractorsList handleAdd={handleAdd} />,
     pagination: {
       handleNextPage,

--- a/src/i18n/en/Contractor.ContractorList.json
+++ b/src/i18n/en/Contractor.ContractorList.json
@@ -3,6 +3,7 @@
   "addAnotherCta": "+ Add another contractor",
   "contractorListLabel": "A list of contractors",
   "editCta": "Edit",
+  "reviewCta": "Review",
   "deleteCta": "Delete",
   "emptyTableDescription": "Add contractors to get them setup for payroll.",
   "emptyTableTitle": "You haven't added any contractors yet",

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -1749,6 +1749,8 @@ export namespace Translations {
     contractorListLabel: string
     /** @defaultValue `"Edit"` */
     editCta: string
+    /** @defaultValue `"Review"` */
+    reviewCta: string
     /** @defaultValue `"Delete"` */
     deleteCta: string
     /** @defaultValue `"Add contractors to get them setup for payroll."` */


### PR DESCRIPTION
## Summary

In the contractor list hamburger menu, the per-row action is now labeled **"Review"** instead of **"Edit"** when a contractor is in the `self_onboarding_review` state. All other states keep **"Edit"**. This makes contractor onboarding consistent with employee onboarding, where a self-onboarded worker's row surfaces a "Review" action for the admin.

### Why only `self_onboarding_review`

There are two "review" onboarding statuses. I verified their behavior against the live API (driving contractors through onboarding via the SDK dev-app proxy):

- **`self_onboarding_review`** — the *contractor* entered their own data; this is an **expected, durable resting state** where the admin reviews someone else's submitted info before finishing onboarding. → **"Review"**
- **`admin_onboarding_review`** — the *admin* entered all the data themselves. This is a **transient** state you only rest in if the admin fills every required field but abandons before hitting Submit; the happy path blows straight through it to `onboarding_completed`. "Edit" (finish your own entry) reads more naturally here. → **"Edit"**

Both statuses auto-advance from the backend once all required steps (`basic_details`, `add_address`, `compensation_details`) are complete; the only difference is the `self_onboarding` flag.

## Changes

- `ContractorList/index.tsx` — compute the menu/trigger label from `onboardingStatus`
- `Contractor.ContractorList.json` — add `reviewCta: "Review"` (+ regenerated `i18n/types.d.ts`)
- `ContractorList.test.tsx` — new tests covering incomplete → Edit, self-onboarding review → Review, admin-onboarding review → Edit, completed → Edit

## Test plan

- [x] `npm run test -- --run src/components/Contractor/ContractorList/ContractorList.test.tsx` (4/4 pass)
- [x] Manually verify in the SDK dev app: a `self_onboarding_review` contractor's row menu shows "Review"; an `admin_onboarding_incomplete` / completed contractor shows "Edit"

https://github.com/user-attachments/assets/6af4caea-a2c8-41d5-9c0c-5de47d546f06

Made with [Cursor](https://cursor.com)