### PR TITLE
feat: contractor self-onboarding parity with employee onboarding

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -1271,6 +1271,7 @@ export const componentEvents: {
     readonly RUN_PAYROLL_GROSS_UP_CALCULATED: "runPayroll/grossUp/calculated";
     readonly CONTRACTOR_SELF_ONBOARDING_START: "contractor/selfOnboarding/start";
     readonly CONTRACTOR_SELF_ONBOARDING_DONE: "contractor/selfOnboarding/done";
+    readonly CONTRACTOR_SELF_ONBOARDING_CANCELLED: "contractor/selfOnboarding/cancelled";
     readonly CONTRACTOR_ADDRESS_UPDATED: "contractor/address/updated";
     readonly CONTRACTOR_ADDRESS_DONE: "contractor/address/done";
     readonly CONTRACTOR_PAYMENT_METHOD_UPDATED: "contractor/paymentMethod/updated";

--- a/docs/guides/endpoint-inventory.json
+++ b/docs/guides/endpoint-inventory.json
@@ -1950,6 +1950,11 @@
           "method": "DELETE",
           "path": "/v1/contractors/:contractorUuid",
           "docsUrl": "https://docs.gusto.com/embedded-payroll/v2026-06-15/reference/delete-v1-contractors-contractor_uuid"
+        },
+        {
+          "method": "PUT",
+          "path": "/v1/contractors/:contractorUuid/onboarding_status",
+          "docsUrl": "https://docs.gusto.com/embedded-payroll/v2026-06-15/reference/put-v1-contractors-contractor_uuid-onboarding_status"
         }
       ],
       "variables": [

--- a/docs/guides/endpoint-reference.md
+++ b/docs/guides/endpoint-reference.md
@@ -295,6 +295,7 @@ import inventory from '@gusto/embedded-react-sdk/endpoint-inventory.json'
 |  | GET | [`/v1/contractors/:contractorUuid`](https://docs.gusto.com/embedded-payroll/v2026-06-15/reference/get-v1-contractors-contractor_uuid) |
 | **ContractorOnboarding.ContractorList** | GET | [`/v1/companies/:companyUuid/contractors`](https://docs.gusto.com/embedded-payroll/v2026-06-15/reference/get-v1-companies-company_uuid-contractors) |
 |  | DELETE | [`/v1/contractors/:contractorUuid`](https://docs.gusto.com/embedded-payroll/v2026-06-15/reference/delete-v1-contractors-contractor_uuid) |
+|  | PUT | [`/v1/contractors/:contractorUuid/onboarding_status`](https://docs.gusto.com/embedded-payroll/v2026-06-15/reference/put-v1-contractors-contractor_uuid-onboarding_status) |
 | **ContractorOnboarding.ContractorProfile** | POST | [`/v1/companies/:companyUuid/contractors`](https://docs.gusto.com/embedded-payroll/v2026-06-15/reference/post-v1-companies-company_uuid-contractors) |
 |  | GET | [`/v1/contractors/:contractorUuid`](https://docs.gusto.com/embedded-payroll/v2026-06-15/reference/get-v1-contractors-contractor_uuid) |
 |  | PUT | [`/v1/contractors/:contractorUuid`](https://docs.gusto.com/embedded-payroll/v2026-06-15/reference/put-v1-contractors-contractor_uuid) |

--- a/docs/reference/Translations/index.md
+++ b/docs/reference/Translations/index.md
@@ -1265,6 +1265,7 @@ Translation keys for the `Contractor.ContractorList` i18n namespace.
 | ------ | ------ |
 | <a id="property-contractorcontractorlistaddanothercta"></a> `addAnotherCta` | `"+ Add another contractor"` |
 | <a id="property-contractorcontractorlistaddcontractorcta"></a> `addContractorCta` | `"Add a contractor"` |
+| <a id="property-contractorcontractorlistcancelselfonboardingcta"></a> `cancelSelfOnboardingCta` | `"Cancel self-onboarding"` |
 | <a id="property-contractorcontractorlistcontinuecta"></a> `continueCta` | `"Continue"` |
 | <a id="property-contractorcontractorlistcontractorlistlabel"></a> `contractorListLabel` | `"A list of contractors"` |
 | <a id="property-contractorcontractorlistdeletecta"></a> `deleteCta` | `"Delete"` |

--- a/docs/reference/contractor/onboarding/blocks.md
+++ b/docs/reference/contractor/onboarding/blocks.md
@@ -65,7 +65,7 @@ Props for [Address](#address).
 
 ## ContractorList
 
-Lists a company's contractors with controls to add, edit, delete, and continue onboarding.
+Lists a company's contractors with controls to add, edit, delete, cancel self-onboarding, and continue onboarding.
 
 ### ContractorListProps
 
@@ -89,6 +89,7 @@ _Inherits `children`, `className`, `defaultValues`, `FallbackComponent`, `Loader
 | `contractor/create` | The add-contractor action was triggered. | — |
 | `contractor/update` | A contractor row's edit action was triggered. | `{ contractorId: string }` |
 | `contractor/deleted` | A contractor was successfully deleted. | `{ contractorId: string }` |
+| `contractor/selfOnboarding/cancelled` | A contractor's self-onboarding was cancelled, reverting them to admin onboarding. | The updated `contractorOnboardingStatus` returned by the API. |
 | `contractor/onboarding/continue` | The continue action was triggered to advance onboarding. | — |
 
 ### Endpoints
@@ -97,6 +98,7 @@ _Inherits `children`, `className`, `defaultValues`, `FallbackComponent`, `Loader
 | --- | --- |
 | GET | [`/v1/companies/:companyUuid/contractors`](https://docs.gusto.com/embedded-payroll/v2026-06-15/reference/get-v1-companies-company_uuid-contractors) |
 | DELETE | [`/v1/contractors/:contractorUuid`](https://docs.gusto.com/embedded-payroll/v2026-06-15/reference/delete-v1-contractors-contractor_uuid) |
+| PUT | [`/v1/contractors/:contractorUuid/onboarding_status`](https://docs.gusto.com/embedded-payroll/v2026-06-15/reference/put-v1-contractors-contractor_uuid-onboarding_status) |
 
 <a id="contractorprofile"></a>
 

--- a/docs/reference/contractor/onboarding/index.md
+++ b/docs/reference/contractor/onboarding/index.md
@@ -26,7 +26,7 @@ Flows and blocks for onboarding contractors.
 | Component | Description |
 | --------- | ----------- |
 | [Address](blocks.md#address) | Form for collecting and updating a contractor's mailing address. Renders a business or home address title based on the contractor type. |
-| [ContractorList](blocks.md#contractorlist) | Lists a company's contractors with controls to add, edit, delete, and continue onboarding. |
+| [ContractorList](blocks.md#contractorlist) | Lists a company's contractors with controls to add, edit, delete, cancel self-onboarding, and continue onboarding. |
 | [ContractorProfile](blocks.md#contractorprofile) | Form for creating or editing a contractor profile, supporting both individual and business contractor types. |
 | [ContractorSubmit](blocks.md#contractorsubmit) | Finalizes contractor onboarding by updating the onboarding status, and in the self-onboarding flow can trigger an invitation to the contractor. |
 | [DocumentSigner](blocks.md#documentsigner) | Contractor onboarding step for reading and signing required contractor documents. |

--- a/docs/reference/contractor/onboarding/onboarding-flow.md
+++ b/docs/reference/contractor/onboarding/onboarding-flow.md
@@ -90,7 +90,7 @@ _Inherits `children`, `className`, `dictionary`, `FallbackComponent`, `LoaderCom
 
 | Component | Description |
 | ------ | ------ |
-| [ContractorList](blocks.md#contractorlist) | Lists a company's contractors with controls to add, edit, delete, and continue onboarding. |
+| [ContractorList](blocks.md#contractorlist) | Lists a company's contractors with controls to add, edit, delete, cancel self-onboarding, and continue onboarding. |
 | [ContractorProfile](blocks.md#contractorprofile) | Form for creating or editing a contractor profile, supporting both individual and business contractor types. |
 | [Address](blocks.md#address) | Form for collecting and updating a contractor's mailing address. Renders a business or home address title based on the contractor type. |
 | [PaymentMethod](blocks.md#paymentmethod) | Manages a contractor's payment method, capturing a bank account for direct deposit or recording check as the payment method. |

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -113,6 +113,7 @@ import { componentEvents, EmployeeOnboarding } from '@gusto/embedded-react-sdk'
 | `CONTRACTOR_PAYMENT_VIEW` | `"contractor/payments/view"` |
 | `CONTRACTOR_PAYMENT_VIEW_DETAILS` | `"contractor/payments/view/details"` |
 | `CONTRACTOR_PROFILE_DONE` | `"contractor/profile/done"` |
+| `CONTRACTOR_SELF_ONBOARDING_CANCELLED` | `"contractor/selfOnboarding/cancelled"` |
 | `CONTRACTOR_SELF_ONBOARDING_DONE` | `"contractor/selfOnboarding/done"` |
 | `CONTRACTOR_SELF_ONBOARDING_START` | `"contractor/selfOnboarding/start"` |
 | `CONTRACTOR_SIGN_DOCUMENT` | `"contractor/documents/sign"` |

--- a/src/components/Contractor/ContractorList/ContractorList.test.tsx
+++ b/src/components/Contractor/ContractorList/ContractorList.test.tsx
@@ -1,10 +1,14 @@
-import { beforeEach, describe, expect, it } from 'vitest'
-import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { HttpResponse } from 'msw'
+import { HttpResponse, type HttpResponseResolver } from 'msw'
 import { ContractorList } from './index'
 import { server } from '@/test/mocks/server'
-import { handleGetContractorsList } from '@/test/mocks/apis/contractors'
+import {
+  handleGetContractorsList,
+  handleUpdateContractorOnboardingStatus,
+} from '@/test/mocks/apis/contractors'
+import { contractorEvents, ContractorOnboardingStatus } from '@/shared/constants'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
 
 const baseContractor = {
@@ -80,5 +84,76 @@ describe('ContractorList hamburger menu edit/review CTA', () => {
     await user.click(screen.getByRole('button', { name: 'Edit' }))
 
     expect(await screen.findByRole('menuitem', { name: 'Edit' })).toBeTruthy()
+  })
+})
+
+describe('ContractorList cancel self-onboarding action', () => {
+  it.each(['self_onboarding_invited', 'self_onboarding_started'])(
+    'offers "Cancel self-onboarding" for %s',
+    async status => {
+      mockContractorWithStatus(status)
+
+      const user = userEvent.setup()
+      renderWithProviders(<ContractorList companyId="company-123" onEvent={() => {}} />)
+
+      await screen.findByText('Ada Lovelace')
+      await user.click(screen.getByRole('button', { name: 'Edit' }))
+
+      expect(await screen.findByRole('menuitem', { name: 'Cancel self-onboarding' })).toBeTruthy()
+    },
+  )
+
+  it.each(['admin_onboarding_incomplete', 'self_onboarding_not_invited', 'self_onboarding_review'])(
+    'does not offer "Cancel self-onboarding" for %s',
+    async status => {
+      mockContractorWithStatus(status)
+
+      const user = userEvent.setup()
+      renderWithProviders(<ContractorList companyId="company-123" onEvent={() => {}} />)
+
+      await screen.findByText('Ada Lovelace')
+      await user.click(screen.getByRole('button', { name: /Edit|Review/ }))
+
+      await screen.findByRole('menuitem', { name: /Edit|Review/ })
+      expect(
+        screen.queryByRole('menuitem', { name: 'Cancel self-onboarding' }),
+      ).not.toBeInTheDocument()
+    },
+  )
+
+  it('reverts the contractor to admin onboarding and emits the status-updated event', async () => {
+    mockContractorWithStatus('self_onboarding_invited')
+
+    let requestBody: Record<string, unknown> | null = null
+    const cancelResolver = vi.fn<HttpResponseResolver>(async ({ request }) => {
+      requestBody = (await request.json()) as Record<string, unknown>
+      return HttpResponse.json({
+        uuid: 'contractor-123',
+        onboarding_status: ContractorOnboardingStatus.ADMIN_ONBOARDING_INCOMPLETE,
+        onboarding_steps: [],
+      })
+    })
+    server.use(handleUpdateContractorOnboardingStatus(cancelResolver))
+
+    const onEvent = vi.fn()
+    const user = userEvent.setup()
+    renderWithProviders(<ContractorList companyId="company-123" onEvent={onEvent} />)
+
+    await screen.findByText('Ada Lovelace')
+    await user.click(screen.getByRole('button', { name: 'Edit' }))
+    await user.click(await screen.findByRole('menuitem', { name: 'Cancel self-onboarding' }))
+
+    await waitFor(() => {
+      expect(cancelResolver).toHaveBeenCalledTimes(1)
+    })
+    expect(requestBody).toMatchObject({
+      onboarding_status: ContractorOnboardingStatus.ADMIN_ONBOARDING_INCOMPLETE,
+    })
+    expect(onEvent).toHaveBeenCalledWith(
+      contractorEvents.CONTRACTOR_SELF_ONBOARDING_CANCELLED,
+      expect.objectContaining({
+        onboardingStatus: ContractorOnboardingStatus.ADMIN_ONBOARDING_INCOMPLETE,
+      }),
+    )
   })
 })

--- a/src/components/Contractor/ContractorList/index.tsx
+++ b/src/components/Contractor/ContractorList/index.tsx
@@ -1,6 +1,7 @@
 import { type Contractor } from '@gusto/embedded-api/models/components/contractor'
 import { useTranslation } from 'react-i18next'
 import { useContractorsDeleteMutation } from '@gusto/embedded-api/react-query/contractorsDelete'
+import { useContractorsUpdateOnboardingStatusMutation } from '@gusto/embedded-api/react-query/contractorsUpdateOnboardingStatus'
 import { useContractors } from './useContractorList'
 import { ActionsLayout, DataView, EmptyData, Flex, useDataView } from '@/components/Common'
 import { firstLastName } from '@/helpers/formattedStrings'
@@ -12,6 +13,7 @@ import { useI18n, useComponentDictionary } from '@/i18n'
 import { BaseComponent, useBase, type BaseComponentInterface } from '@/components/Base'
 import { componentEvents, CONTRACTOR_TYPE, ContractorOnboardingStatus } from '@/shared/constants'
 import TrashCanSvg from '@/assets/icons/trashcan.svg?react'
+import XCircleSvg from '@/assets/icons/x-circle.svg?react'
 
 interface HeadProps {
   count: number
@@ -63,7 +65,7 @@ export interface ContractorListProps extends BaseComponentInterface<'Contractor.
 }
 
 /**
- * Lists a company's contractors with controls to add, edit, delete, and continue onboarding.
+ * Lists a company's contractors with controls to add, edit, delete, cancel self-onboarding, and continue onboarding.
  *
  * @events
  * | Event | Description | Data |
@@ -71,6 +73,7 @@ export interface ContractorListProps extends BaseComponentInterface<'Contractor.
  * | `contractor/create` | The add-contractor action was triggered. | — |
  * | `contractor/update` | A contractor row's edit action was triggered. | `{ contractorId: string }` |
  * | `contractor/deleted` | A contractor was successfully deleted. | `{ contractorId: string }` |
+ * | `contractor/selfOnboarding/cancelled` | A contractor's self-onboarding was cancelled, reverting them to admin onboarding. | The updated `contractorOnboardingStatus` returned by the API. |
  * | `contractor/onboarding/continue` | The continue action was triggered to advance onboarding. | — |
  *
  * @param props - See {@link ContractorListProps}.
@@ -105,6 +108,8 @@ function Root({ companyId, className, dictionary, successMessage }: ContractorLi
   } = useContractors({ companyUuid: companyId })
   const { mutateAsync: deleteContractorMutation, isPending: isPendingDelete } =
     useContractorsDeleteMutation()
+  const { mutateAsync: updateOnboardingStatusMutation, isPending: isPendingCancel } =
+    useContractorsUpdateOnboardingStatusMutation()
 
   const dataViewProps = useDataView<Contractor>({
     columns: [
@@ -130,27 +135,43 @@ function Root({ companyId, className, dictionary, successMessage }: ContractorLi
       const isAwaitingSelfOnboardingReview =
         contractor.onboardingStatus === ContractorOnboardingStatus.SELF_ONBOARDING_REVIEW
       const editLabel = isAwaitingSelfOnboardingReview ? t('reviewCta') : t('editCta')
+      const canCancelSelfOnboarding =
+        contractor.onboardingStatus === ContractorOnboardingStatus.SELF_ONBOARDING_INVITED ||
+        contractor.onboardingStatus === ContractorOnboardingStatus.SELF_ONBOARDING_STARTED
+
+      const menuItems = [
+        {
+          label: editLabel,
+          icon: <PencilSvg aria-hidden />,
+          onClick: () => {
+            handleEdit(contractor.uuid)
+          },
+        },
+      ]
+
+      if (canCancelSelfOnboarding) {
+        menuItems.push({
+          label: t('cancelSelfOnboardingCta'),
+          icon: <XCircleSvg aria-hidden />,
+          onClick: () => {
+            void handleCancelSelfOnboarding(contractor.uuid)
+          },
+        })
+      }
+
+      menuItems.push({
+        label: t('deleteCta'),
+        icon: <TrashCanSvg aria-hidden />,
+        onClick: () => {
+          void handleDelete(contractor.uuid)
+        },
+      })
 
       return (
         <HamburgerMenu
-          items={[
-            {
-              label: editLabel,
-              icon: <PencilSvg aria-hidden />,
-              onClick: () => {
-                handleEdit(contractor.uuid)
-              },
-            },
-            {
-              label: t('deleteCta'),
-              icon: <TrashCanSvg aria-hidden />,
-              onClick: () => {
-                void handleDelete(contractor.uuid)
-              },
-            },
-          ]}
+          items={menuItems}
           triggerLabel={editLabel}
-          isLoading={isPendingDelete}
+          isLoading={isPendingDelete || isPendingCancel}
         />
       )
     },
@@ -187,6 +208,24 @@ function Root({ companyId, className, dictionary, successMessage }: ContractorLi
       })
 
       onEvent(componentEvents.CONTRACTOR_DELETED, { contractorId: payload })
+    })
+  }
+
+  const handleCancelSelfOnboarding = async (uuid: string) => {
+    await baseSubmitHandler(uuid, async payload => {
+      const response = await updateOnboardingStatusMutation({
+        request: {
+          contractorUuid: payload,
+          contractorOnboardingStatusUpdateRequestBody: {
+            onboardingStatus: ContractorOnboardingStatus.ADMIN_ONBOARDING_INCOMPLETE,
+          },
+        },
+      })
+
+      onEvent(
+        componentEvents.CONTRACTOR_SELF_ONBOARDING_CANCELLED,
+        response.contractorOnboardingStatus,
+      )
     })
   }
 

--- a/src/components/Contractor/Profile/ContractorProfile.test.tsx
+++ b/src/components/Contractor/Profile/ContractorProfile.test.tsx
@@ -82,6 +82,154 @@ describe('Contractor profile component behavior', () => {
       expect(screen.queryByLabelText('Social Security Number')).not.toBeInTheDocument()
     })
 
+    it('shows SSN for an individual under admin review of self-onboarding, with no toggle', async () => {
+      server.use(
+        handleGetContractor(() =>
+          HttpResponse.json({
+            uuid: 'contractor_id',
+            version: 'version-1',
+            type: 'Individual',
+            wage_type: 'Fixed',
+            start_date: '2024-01-01',
+            first_name: 'John',
+            last_name: 'Doe',
+            email: 'john.doe@example.com',
+            has_ssn: false,
+            has_ein: false,
+            is_active: true,
+            file_new_hire_report: false,
+            onboarding_status: 'self_onboarding_review',
+          }),
+        ),
+      )
+
+      renderWithProviders(
+        <ContractorProfile companyId={companyId} contractorId="contractor_id" onEvent={vi.fn()} />,
+      )
+
+      await screen.findByText('Contractor profile')
+      expect(screen.getByLabelText(/Social Security Number/)).toBeInTheDocument()
+      expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+    })
+
+    it('shows EIN for a business under admin review of self-onboarding, with no toggle', async () => {
+      server.use(
+        handleGetContractor(() =>
+          HttpResponse.json({
+            uuid: 'contractor_id',
+            version: 'version-1',
+            type: 'Business',
+            wage_type: 'Fixed',
+            start_date: '2024-01-01',
+            business_name: 'Acme LLC',
+            email: 'billing@acme.com',
+            has_ssn: false,
+            has_ein: false,
+            is_active: true,
+            file_new_hire_report: false,
+            onboarding_status: 'self_onboarding_review',
+          }),
+        ),
+      )
+
+      renderWithProviders(
+        <ContractorProfile companyId={companyId} contractorId="contractor_id" onEvent={vi.fn()} />,
+      )
+
+      await screen.findByText('Contractor profile')
+      expect(screen.getByLabelText(/EIN/)).toBeInTheDocument()
+      expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+    })
+
+    it('hides SSN and the toggle for an admin viewing an invited self-onboarding contractor', async () => {
+      server.use(
+        handleGetContractor(() =>
+          HttpResponse.json({
+            uuid: 'contractor_id',
+            version: 'version-1',
+            type: 'Individual',
+            wage_type: 'Fixed',
+            start_date: '2024-01-01',
+            first_name: 'John',
+            last_name: 'Doe',
+            email: 'john.doe@example.com',
+            has_ssn: false,
+            has_ein: false,
+            is_active: true,
+            file_new_hire_report: false,
+            onboarding_status: 'self_onboarding_invited',
+          }),
+        ),
+      )
+
+      renderWithProviders(
+        <ContractorProfile companyId={companyId} contractorId="contractor_id" onEvent={vi.fn()} />,
+      )
+
+      await screen.findByText('Contractor profile')
+      expect(screen.getByLabelText('First Name')).toBeInTheDocument()
+      expect(screen.queryByLabelText(/Social Security Number/)).not.toBeInTheDocument()
+      expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+    })
+
+    it('shows SSN for an individual under admin onboarding review, with no toggle', async () => {
+      server.use(
+        handleGetContractor(() =>
+          HttpResponse.json({
+            uuid: 'contractor_id',
+            version: 'version-1',
+            type: 'Individual',
+            wage_type: 'Fixed',
+            start_date: '2024-01-01',
+            first_name: 'John',
+            last_name: 'Doe',
+            has_ssn: false,
+            has_ein: false,
+            is_active: true,
+            file_new_hire_report: false,
+            onboarding_status: 'admin_onboarding_review',
+          }),
+        ),
+      )
+
+      renderWithProviders(
+        <ContractorProfile companyId={companyId} contractorId="contractor_id" onEvent={vi.fn()} />,
+      )
+
+      await screen.findByText('Contractor profile')
+      expect(screen.getByLabelText(/Social Security Number/)).toBeInTheDocument()
+      expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+    })
+
+    it('shows EIN for a business once onboarding is complete, with no toggle', async () => {
+      server.use(
+        handleGetContractor(() =>
+          HttpResponse.json({
+            uuid: 'contractor_id',
+            version: 'version-1',
+            type: 'Business',
+            wage_type: 'Fixed',
+            start_date: '2024-01-01',
+            business_name: 'Acme LLC',
+            has_ssn: false,
+            has_ein: true,
+            is_active: true,
+            onboarded: true,
+            file_new_hire_report: false,
+            onboarding_status: 'onboarding_completed',
+          }),
+        ),
+      )
+
+      renderWithProviders(
+        <ContractorProfile companyId={companyId} contractorId="contractor_id" onEvent={vi.fn()} />,
+      )
+
+      await screen.findByText('Contractor profile')
+      expect(screen.getByLabelText(/EIN/)).toBeInTheDocument()
+      expect(screen.queryByRole('switch')).not.toBeInTheDocument()
+    })
+
     it('blocks submission and surfaces errors when required individual fields are empty', async () => {
       const user = userEvent.setup()
       const createResolver = vi.fn<HttpResponseResolver>(() =>

--- a/src/components/Contractor/Profile/ContractorProfile.tsx
+++ b/src/components/Contractor/Profile/ContractorProfile.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useWatch } from 'react-hook-form'
+import { type Contractor } from '@gusto/embedded-api/models/components/contractor'
 import classNames from 'classnames'
 import {
   useContractorDetailsForm,
@@ -20,6 +21,19 @@ import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentCon
 import { useI18n } from '@/i18n'
 import { useComponentDictionary } from '@/i18n/I18n'
 import { componentEvents, ContractorOnboardingStatus } from '@/shared/constants'
+
+// Once the contractor has finished self-onboarding (or the record is otherwise
+// under admin review / completed), the admin needs to view and edit SSN/EIN even
+// though the self-onboarding toggle stays on. Mirrors the Employee AdminProfile
+// `checkHasCompletedSelfOnboarding` override.
+function hasCompletedSelfOnboarding(contractor?: Contractor | null): boolean {
+  return (
+    contractor?.onboarded === true ||
+    contractor?.onboardingStatus === ContractorOnboardingStatus.ONBOARDING_COMPLETED ||
+    contractor?.onboardingStatus === ContractorOnboardingStatus.SELF_ONBOARDING_REVIEW ||
+    contractor?.onboardingStatus === ContractorOnboardingStatus.ADMIN_ONBOARDING_REVIEW
+  )
+}
 
 // The admin form restores the contractor profile's product requiredness on top
 // of the hook's API-aligned baseline (which leaves ssn/ein optional and
@@ -219,8 +233,12 @@ function ContractorProfileReady({
   const { Fields } = contractor.form
   const mode = contractor.status.mode
 
+  // SSN/EIN are hidden while collection is delegated to the contractor, but must
+  // reappear once they've finished so the admin can review/edit them.
+  const completedSelfOnboarding = hasCompletedSelfOnboarding(contractor.data.contractor)
+  const showTaxId = !watchedSelfOnboarding || completedSelfOnboarding
+
   const handleSubmit = async () => {
-    const onboardingStatus = contractor.data.contractor?.onboardingStatus
     const result = await contractor.actions.onSubmit()
     if (!result) return
 
@@ -233,9 +251,7 @@ function ContractorProfileReady({
 
     onEvent(componentEvents.CONTRACTOR_PROFILE_DONE, {
       contractorId: result.data.uuid,
-      selfOnboarding:
-        watchedSelfOnboarding &&
-        onboardingStatus !== ContractorOnboardingStatus.ADMIN_ONBOARDING_REVIEW,
+      selfOnboarding: watchedSelfOnboarding && !completedSelfOnboarding,
     })
   }
 
@@ -298,7 +314,7 @@ function ContractorProfileReady({
                       INVALID_NAME: t('validations.lastNameFormat'),
                     }}
                   />
-                  {Fields.Ssn && !watchedSelfOnboarding && (
+                  {Fields.Ssn && showTaxId && (
                     <Fields.Ssn
                       label={t('fields.ssn.label')}
                       validationMessages={{
@@ -316,7 +332,7 @@ function ContractorProfileReady({
                     label={t('fields.businessName.label')}
                     validationMessages={{ REQUIRED: t('validations.businessName') }}
                   />
-                  {Fields.Ein && !watchedSelfOnboarding && (
+                  {Fields.Ein && showTaxId && (
                     <Fields.Ein
                       label={t('fields.ein.label')}
                       validationMessages={{

--- a/src/i18n/en/Contractor.ContractorList.json
+++ b/src/i18n/en/Contractor.ContractorList.json
@@ -5,6 +5,7 @@
   "editCta": "Edit",
   "reviewCta": "Review",
   "deleteCta": "Delete",
+  "cancelSelfOnboardingCta": "Cancel self-onboarding",
   "emptyTableDescription": "Add contractors to get them setup for payroll.",
   "emptyTableTitle": "You haven't added any contractors yet",
   "listHeaders": {

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -1753,6 +1753,8 @@ export namespace Translations {
     reviewCta: string
     /** @defaultValue `"Delete"` */
     deleteCta: string
+    /** @defaultValue `"Cancel self-onboarding"` */
+    cancelSelfOnboardingCta: string
     /** @defaultValue `"Add contractors to get them setup for payroll."` */
     emptyTableDescription: string
     /** @defaultValue `"You haven't added any contractors yet"` */

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -220,6 +220,7 @@ export const companyEvents = {
 export const contractorEvents = {
   CONTRACTOR_SELF_ONBOARDING_START: 'contractor/selfOnboarding/start',
   CONTRACTOR_SELF_ONBOARDING_DONE: 'contractor/selfOnboarding/done',
+  CONTRACTOR_SELF_ONBOARDING_CANCELLED: 'contractor/selfOnboarding/cancelled',
   CONTRACTOR_ADDRESS_UPDATED: 'contractor/address/updated',
   CONTRACTOR_ADDRESS_DONE: 'contractor/address/done',
   CONTRACTOR_PAYMENT_METHOD_UPDATED: 'contractor/paymentMethod/updated',

--- a/src/test/mocks/apis/contractors.ts
+++ b/src/test/mocks/apis/contractors.ts
@@ -28,6 +28,10 @@ export function handleGetContractorsList(resolver: HttpResponseResolver) {
   return http.get(`${API_BASE_URL}/v1/companies/:company_uuid/contractors`, resolver)
 }
 
+export function handleUpdateContractorOnboardingStatus(resolver: HttpResponseResolver) {
+  return http.put(`${API_BASE_URL}/v1/contractors/:contractor_uuid/onboarding_status`, resolver)
+}
+
 const contractorFixture = {
   uuid: 'contractor-123',
   company_uuid: '123',


### PR DESCRIPTION
## Summary

Brings the contractor onboarding admin experience to parity with the employee onboarding experience for self-onboarding.

- **Fix SSN/EIN visibility during admin review** (`ContractorProfile.tsx`): previously the tax IDs were hidden whenever the self-onboarding toggle was on, which wrongly hid them during **admin review** of a completed self-onboarding (and admin-review/completed states). Added a local `hasCompletedSelfOnboarding` predicate (mirroring the employee `AdminProfile` seam) and gate the fields on `showTaxId = !watchedSelfOnboarding || completedSelfOnboarding`, so an admin can view/edit SSN/EIN during review. Also generalized the `contractor/profile/done` routing guard to `watchedSelfOnboarding && !completedSelfOnboarding`.
- **Add "Cancel self-onboarding" row action** (`ContractorList/index.tsx`): shown only for `self_onboarding_invited` / `self_onboarding_started` contractors (matching the employee gating). It reverts the contractor to `admin_onboarding_incomplete` and emits a dedicated `contractor/selfOnboarding/cancelled` event. Uses the `x-circle` icon to visually distinguish it from Edit/Delete.
- **i18n**: added `cancelSelfOnboardingCta` and regenerated translation types.

### Target behavior (mirrors employee)

| State | Toggle | SSN/EIN | List action |
| ----- | ------ | ------- | ----------- |
| Admin on profile (`admin_onboarding_incomplete` / `self_onboarding_not_invited` / create) | shown | hidden when toggled on | — |
| Invite sent (`self_onboarding_invited` / `self_onboarding_started`) | hidden | hidden | **Cancel self-onboarding** |
| Admin review (`self_onboarding_review` / `admin_onboarding_review` / `onboarding_completed`) | hidden | **visible & editable** | Review |

### Notes / decisions

- Kept the visibility seam at the component level (consumer owns UX policy; the `useContractorDetailsForm` hook stays a thin API helper), consistent with the employee pattern.
- Used a **dedicated, scoped** `contractor/selfOnboarding/cancelled` event rather than reusing `contractor/onboardingStatus/updated` (owned by `ContractorSubmit`), per the "scoped, unique events" convention.
- Employee onboarding uses the pencil icon for edit/cancel/review alike; the contractor cancel action intentionally uses `x-circle` for clearer semantics.

## Test plan

- [x] `npm run test -- --run src/components/Contractor/Profile/ContractorProfile.test.tsx` (18 passed) — covers SSN/EIN visible for `self_onboarding_review`, `admin_onboarding_review`, `onboarding_completed`; hidden for `self_onboarding_invited`; toggle hidden in all review states.
- [x] `npm run test -- --run src/components/Contractor/ContractorList/ContractorList.test.tsx` (10 passed) — cancel item appears only for invited/started, calls the mutation with `admin_onboarding_incomplete`, and emits `contractor/selfOnboarding/cancelled` (asserts request body + event payload).
- [x] `npm run i18n:generate` and `npm run lint:check` (0 errors).
- [ ] Manual check in sdk-app across the three states.

### Cancel self onboarding

https://github.com/user-attachments/assets/5b6d26cc-021a-414f-b456-f6e9b9f082bf

### EIN/SSN hidden when self onboarding toggled

https://github.com/user-attachments/assets/2cb8a9a6-851d-454d-a217-35b7fd8bf0a4

### EIN/SSN visible after onboarding complete

https://github.com/user-attachments/assets/6a381002-8c03-409e-9e56-0e9a1228a367

Made with [Cursor](https://cursor.com)