### PR TITLE
chore: sync package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1159,6 +1159,37 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.0.tgz",
+      "integrity": "sha512-DPp6hkUjvwIivxbkrTiLXeRswNv1A/4GFA2X6scXma0AMa9632V3TwxmrlkUIEtUktiM3Ln+RrSH2xlP3/jUTw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
@@ -11446,6 +11477,21 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/argue-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+      "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.0",


### PR DESCRIPTION
## Summary

- `package-lock.json` was out of sync on `main`. Running `npm install` against the current dependency set produced additive lockfile entries (transitive `@commitlint`-related deps: `conventional-commits-filter`, `conventional-commits-parser`, `argue-cli`).
- This PR commits the resynced lockfile so installs are deterministic and CI/`npm ci` stay green.

## Test plan

- [x] `npm install` completes cleanly and leaves the working tree clean afterward
- [x] Pre-commit hooks (build, format, lint, commitlint) pass

Made with [Cursor](https://cursor.com)