### PR TITLE
docs(SDK-1072): restore and reorganize the hooks overview guide

### DIFF
--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -51,6 +51,17 @@ const sidebars: SidebarsConfig = {
             'guides/component-adapter/component-adapter-faq',
           ],
         },
+        {
+          type: 'category',
+          label: 'Hooks',
+          link: { type: 'doc', id: 'guides/hooks/overview' },
+          items: [
+            'guides/hooks/configuring-form-fields',
+            'guides/hooks/handling-hook-errors',
+            'guides/hooks/composing-multiple-hooks',
+            'guides/hooks/jobs-and-compensations',
+          ],
+        },
         'guides/workflows-overview',
         'guides/endpoint-reference',
       ],

--- a/docs/guides/hooks/composing-multiple-hooks.md
+++ b/docs/guides/hooks/composing-multiple-hooks.md
@@ -1,0 +1,303 @@
+---
+title: Composing multiple hooks
+description: Coordinate several SDK hooks on one screen — combining error state with composeErrorHandler and ordered submits with composeSubmitHandler.
+order: 3
+---
+
+A screen that combines multiple SDK hooks, or mixes SDK hooks with additional `@gusto/embedded-api-v-2026-02-01` queries, produces multiple `errorHandling` objects and (for form screens) multiple submit flows. Two small helpers stitch them together:
+
+- **`composeErrorHandler([sources])`** — merges many error sources into a single `HookErrorHandling`.
+- **`composeSubmitHandler([forms], onAllValid)`** — coordinates validation and ordered submits across forms, and returns `{ handleSubmit, errorHandling }` where `errorHandling` is built from those forms via `composeErrorHandler` under the hood.
+
+## Combining data fetches with `composeErrorHandler`
+
+Use `composeErrorHandler` to produce a single `errorHandling` bag for any screen that reads from multiple sources. It accepts any mix of:
+
+- **SDK hook results** — objects with an `errorHandling` property (e.g., `useEmployeeDetailsForm`, `useCompensationForm`, or the return value of `composeSubmitHandler`).
+- **`@gusto/embedded-api-v-2026-02-01` React Query results** — objects with `error` and `refetch` properties.
+
+```tsx
+import { composeErrorHandler, useEmployeeDetailsForm } from '@gusto/embedded-react-sdk'
+import { useEmployeeFormsList } from '@gusto/embedded-api-v-2026-02-01/react-query/employeeFormsList'
+
+function EmployeeProfileView({ companyId, employeeId }: { companyId: string; employeeId: string }) {
+  const employeeDetails = useEmployeeDetailsForm({ companyId, employeeId })
+  const formsListQuery = useEmployeeFormsList({ employeeId })
+
+  const errorHandling = composeErrorHandler([employeeDetails, formsListQuery])
+
+  if (errorHandling.errors.length > 0) {
+    return (
+      <div role="alert">
+        {errorHandling.errors.map((error, i) => (
+          <p key={i}>{error.message}</p>
+        ))}
+        <button onClick={errorHandling.retryQueries}>Retry</button>
+      </div>
+    )
+  }
+
+  // ...render
+}
+```
+
+`employeeDetails` is an SDK hook result (its `errorHandling` is delegated into), while `formsListQuery` is a raw `@gusto/embedded-api-v-2026-02-01` query (its `error` is normalized and its `refetch` is wired into `retryQueries`). The same call works for any combination of the two shapes.
+
+The returned `errorHandling` has the same shape as any SDK hook's `errorHandling`:
+
+- `errors: SDKError[]` — fetch errors from all sources.
+- `retryQueries()` — refetches every failed query and delegates into nested hooks so their retries fire too.
+- `clearSubmitError()` — clears submit errors across any nested hook results passed in.
+
+## Combining forms with `composeSubmitHandler`
+
+When multiple forms sit on the same page (e.g., employee details and compensation side by side), use `composeSubmitHandler` to coordinate validation, focus, and ordered submission across all of them. It returns both pieces you typically need:
+
+- **`handleSubmit`** — a form event handler that validates every form in parallel, focuses the first invalid field across forms (in array order) if any fail, and calls your `onAllValid` callback only when every form passes.
+- **`errorHandling`** — a combined `HookErrorHandling` built from the forms via `composeErrorHandler` internally. No need to call `composeErrorHandler` yourself for the common case.
+
+```tsx
+const { handleSubmit, errorHandling } = composeSubmitHandler(
+  [employeeDetails, compensation],
+  async () => {
+    await employeeDetails.actions.onSubmit()
+    await compensation.actions.onSubmit()
+  },
+)
+```
+
+If the same screen also has extra `@gusto/embedded-api-v-2026-02-01` queries that should feed the same error banner, pass the `composeSubmitHandler` result back into `composeErrorHandler` alongside those queries — the result already satisfies `composeErrorHandler`'s input shape:
+
+```tsx
+const submitResult = composeSubmitHandler([employeeDetails, compensation], onAllValid)
+
+const errorHandling = composeErrorHandler([submitResult, extraQuery])
+```
+
+## Setup
+
+Each form hook must be initialized with `shouldFocusError: false` so that react-hook-form's per-form focus is disabled and `composeSubmitHandler` can manage cross-form focus instead.
+
+Both connection approaches work with composition. Choose the one that fits your layout.
+
+### Grouped layout with `SDKFormProvider`
+
+When fields from each hook are grouped into their own sections, `SDKFormProvider` keeps things clean:
+
+```tsx
+import {
+  useEmployeeDetailsForm,
+  useCompensationForm,
+  composeSubmitHandler,
+  SDKFormProvider,
+} from '@gusto/embedded-react-sdk'
+
+function OnboardingPage({ companyId, employeeId }: { companyId: string; employeeId: string }) {
+  const employeeDetails = useEmployeeDetailsForm({
+    companyId,
+    employeeId,
+    shouldFocusError: false,
+  })
+
+  const compensation = useCompensationForm({
+    employeeId,
+    shouldFocusError: false,
+  })
+
+  if (employeeDetails.isLoading || compensation.isLoading) {
+    return <LoadingSpinner />
+  }
+
+  const EmployeeDetailsFields = employeeDetails.form.Fields
+  const CompensationFields = compensation.form.Fields
+
+  const { handleSubmit, errorHandling } = composeSubmitHandler(
+    [employeeDetails, compensation],
+    async () => {
+      await employeeDetails.actions.onSubmit()
+      await compensation.actions.onSubmit()
+    },
+  )
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {errorHandling.errors.length > 0 && (
+        <div role="alert">
+          {errorHandling.errors.map((error, i) => (
+            <p key={i}>{error.message}</p>
+          ))}
+        </div>
+      )}
+
+      <SDKFormProvider formHookResult={employeeDetails}>
+        <h2>Employee Details</h2>
+        <EmployeeDetailsFields.FirstName label="First name" />
+        <EmployeeDetailsFields.LastName label="Last name" />
+      </SDKFormProvider>
+
+      <SDKFormProvider formHookResult={compensation}>
+        <h2>Compensation</h2>
+        <CompensationFields.JobTitle label="Job title" />
+        <CompensationFields.Rate label="Pay rate" />
+      </SDKFormProvider>
+
+      <button type="submit">Save All</button>
+    </form>
+  )
+}
+```
+
+Each `SDKFormProvider` scopes field metadata and error syncing to its respective hook. The outer `<form>` element uses the composed submit handler, and the combined `errorHandling` drives a single banner covering fetch failures from either hook and submit failures from any of the `onSubmit` calls.
+
+### Interleaved layout with `formHookResult` prop
+
+When you want to mix fields from different hooks in any order — for example, placing job title next to first name, or grouping fields by theme rather than domain — use the `formHookResult` prop. There are no provider boundaries to manage, so fields can go anywhere:
+
+```tsx
+import {
+  useEmployeeDetailsForm,
+  useCompensationForm,
+  useWorkAddressForm,
+  composeSubmitHandler,
+} from '@gusto/embedded-react-sdk'
+
+function OnboardingPage({ companyId, employeeId }: { companyId: string; employeeId: string }) {
+  const employeeDetails = useEmployeeDetailsForm({
+    companyId,
+    employeeId,
+    shouldFocusError: false,
+  })
+
+  const compensation = useCompensationForm({
+    employeeId,
+    shouldFocusError: false,
+  })
+
+  const workAddress = useWorkAddressForm({
+    companyId,
+    employeeId,
+    shouldFocusError: false,
+  })
+
+  if (employeeDetails.isLoading || compensation.isLoading || workAddress.isLoading) {
+    return <LoadingSpinner />
+  }
+
+  const EmployeeDetailsFields = employeeDetails.form.Fields
+  const CompensationFields = compensation.form.Fields
+  const WorkAddressFields = workAddress.form.Fields
+
+  const { handleSubmit, errorHandling } = composeSubmitHandler(
+    [employeeDetails, compensation, workAddress],
+    async () => {
+      await employeeDetails.actions.onSubmit()
+      await compensation.actions.onSubmit()
+      await workAddress.actions.onSubmit()
+    },
+  )
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {errorHandling.errors.length > 0 && (
+        <div role="alert">
+          {errorHandling.errors.map((error, i) => (
+            <p key={i}>{error.message}</p>
+          ))}
+        </div>
+      )}
+
+      <section>
+        <h2>Who</h2>
+        <EmployeeDetailsFields.FirstName label="First name" formHookResult={employeeDetails} />
+        <EmployeeDetailsFields.LastName label="Last name" formHookResult={employeeDetails} />
+        <EmployeeDetailsFields.Email label="Email" formHookResult={employeeDetails} />
+        <CompensationFields.StartDate label="Start date" formHookResult={compensation} />
+      </section>
+
+      <section>
+        <h2>Role and Location</h2>
+        <CompensationFields.JobTitle label="Job title" formHookResult={compensation} />
+        <WorkAddressFields.Location label="Work address" formHookResult={workAddress} />
+        <CompensationFields.Rate label="Pay rate" formHookResult={compensation} />
+        <CompensationFields.PaymentUnit label="Pay frequency" formHookResult={compensation} />
+      </section>
+
+      <button type="submit">Save All</button>
+    </form>
+  )
+}
+```
+
+Fields from `employeeDetails`, `compensation`, and `workAddress` are freely interleaved — each field knows which hook it belongs to via its `formHookResult` prop. Validation, error handling, and submission all work identically to the provider-based approach.
+
+## Composing Job + Compensation
+
+Jobs and compensations are separate entities in the Gusto API, and most product flows compose both hooks on the same screen. See [Working with Jobs and Compensations](./jobs-and-compensations.md) for the full onboarding stub-fill and steady-state-edit patterns; the sections below cover the essentials.
+
+---
+
+## Submit-time entity ID resolution
+
+In a create flow, the employee doesn't exist yet — so `useCompensationForm` and `useWorkAddressForm` can't receive an `employeeId` at init time. Both hooks accept `employeeId` as optional in their props and allow it to be provided at submit time via the `options` parameter:
+
+```tsx
+function CreateOnboardingPage({ companyId }: { companyId: string }) {
+  const employeeDetails = useEmployeeDetailsForm({
+    companyId,
+    shouldFocusError: false,
+  })
+
+  const compensation = useCompensationForm({
+    shouldFocusError: false,
+  })
+
+  const workAddress = useWorkAddressForm({
+    companyId,
+    shouldFocusError: false,
+  })
+
+  // ...loading checks...
+
+  const { handleSubmit } = composeSubmitHandler(
+    [employeeDetails, compensation, workAddress],
+    async () => {
+      const employeeResult = await employeeDetails.actions.onSubmit()
+      if (!employeeResult) return
+
+      const newEmployeeId = employeeResult.data.uuid
+
+      await compensation.actions.onSubmit({ employeeId: newEmployeeId })
+      await workAddress.actions.onSubmit(undefined, { employeeId: newEmployeeId })
+    },
+  )
+
+  // ...render forms...
+}
+```
+
+When `employeeId` is omitted from props, the hooks skip data fetching and render in create mode with empty defaults. The ID is resolved at submit time, avoiding re-render cycles that would tear down the form UI.
+
+## Handling submission failures
+
+`composeSubmitHandler` takes care of client-side validation — your `onAllValid` callback only runs when every form passes. However, API mutations inside the callback can still fail. When they do, `onSubmit` returns `undefined` (it never throws) and the error is automatically captured in `errorHandling.errors` for display.
+
+Early return when a subsequent call depends on data from a prior call:
+
+```tsx
+const { handleSubmit, errorHandling } = composeSubmitHandler(
+  [employeeDetails, compensation, workAddress],
+  async () => {
+    const employeeResult = await employeeDetails.actions.onSubmit()
+    if (!employeeResult) return
+
+    const newEmployeeId = employeeResult.data.uuid
+
+    await compensation.actions.onSubmit({ employeeId: newEmployeeId })
+    await workAddress.actions.onSubmit(undefined, { employeeId: newEmployeeId })
+  },
+)
+```
+
+Here `compensation` and `workAddress` both need the employee ID, so if employee creation fails there's nothing to pass and no reason to continue. The user will see the error from `errorHandling.errors` and can retry.
+
+For independent submissions where one doesn't depend on the other's result, continuing after a failure is a valid choice — it depends on your product requirements.

--- a/docs/guides/hooks/configuring-form-fields.md
+++ b/docs/guides/hooks/configuring-form-fields.md
@@ -1,0 +1,148 @@
+---
+title: Configuring form fields
+description: Tune form-hook field behavior — required fields, default values, and validation messages.
+order: 1
+---
+
+Form hooks expose several ways to control field behavior — which fields are required, what values they start with, and how validation errors read.
+
+## Required Fields
+
+Hooks let you declare which form fields are required beyond the built-in defaults. Each hook has built-in requiredness rules based on the form mode (create vs. update), and you can override optional fields to be required.
+
+The API varies by hook. Some hooks use `requiredFields` (flat array or per-mode object), while newer hooks use `optionalFieldsToRequire` with type-safe, mode-aware overrides.
+
+### `requiredFields` (useEmployeeDetailsForm, useWorkAddressForm)
+
+Pass a flat array (applies to both modes) or an object with per-mode arrays:
+
+```tsx
+// Flat array: same requirements for both create and update
+useEmployeeDetailsForm({
+  companyId,
+  requiredFields: ['email', 'dateOfBirth'],
+})
+
+// Per-mode object: different requirements per mode
+useEmployeeDetailsForm({
+  companyId,
+  requiredFields: {
+    create: ['email'],
+    update: ['ssn', 'dateOfBirth'],
+  },
+})
+```
+
+### `optionalFieldsToRequire` (useJobForm, useCompensationForm)
+
+Override specific fields that are optional in a given mode to be required. The type constrains which fields can be listed per mode — only fields that are actually optional in that mode are allowed:
+
+```tsx
+useJobForm({
+  employeeId,
+  jobId,
+  optionalFieldsToRequire: {
+    update: ['title'],
+  },
+})
+
+useCompensationForm({
+  employeeId,
+  jobId,
+  compensationId,
+  optionalFieldsToRequire: {
+    update: ['rate'],
+  },
+})
+```
+
+Each hook's reference page documents which fields are available to require and which are required by default in each mode. See:
+
+- [useEmployeeDetailsForm required fields](../../reference/employee/hooks/use-employee-details-form.md)
+- [useJobForm configurable required fields](../../reference/employee/hooks/use-job-form.md)
+- [useCompensationForm configurable required fields](../../reference/employee/hooks/use-compensation-form.md)
+- [useWorkAddressForm required fields](../../reference/employee/hooks/use-work-address-form.md)
+- [usePayScheduleForm configurable required fields](../../reference/company/hooks/use-pay-schedule-form.md)
+
+---
+
+## Default Values
+
+All form hooks accept a `defaultValues` prop to pre-fill the form. Pass a partial object matching the hook's form data shape — any fields you omit use built-in fallbacks (typically empty strings or `false`).
+
+```tsx
+useEmployeeDetailsForm({
+  companyId,
+  defaultValues: {
+    firstName: 'Jane',
+    email: 'jane@acme.com',
+  },
+})
+
+useJobForm({
+  employeeId,
+  defaultValues: {
+    title: 'Software Engineer',
+    hireDate: '2025-01-15',
+  },
+})
+
+useCompensationForm({
+  defaultValues: {
+    rate: 85000,
+    paymentUnit: 'Year',
+    flsaStatus: 'Exempt',
+    effectiveDate: '2025-01-15',
+  },
+})
+```
+
+### Resolution order
+
+In **create mode** (no existing entity), `defaultValues` populate the form directly. In **update mode**, server data always takes precedence — `defaultValues` only fill in fields the server doesn't provide.
+
+Each hook's reference page documents the full form data shape accepted by `defaultValues`:
+
+- [useEmployeeDetailsForm form data](../../reference/employee/hooks/use-employee-details-form.md)
+- [useJobForm form data](../../reference/employee/hooks/use-job-form.md)
+- [useCompensationForm form data](../../reference/employee/hooks/use-compensation-form.md)
+- [useWorkAddressForm form data](../../reference/employee/hooks/use-work-address-form.md)
+- [usePayScheduleForm form data](../../reference/company/hooks/use-pay-schedule-form.md)
+- [useSignCompanyForm form data](../../reference/company/hooks/use-sign-company-form.md)
+
+---
+
+## Validation Messages
+
+Each field component accepts a `validationMessages` prop that maps error codes to human-readable strings. Error codes are defined as typed constants, and TypeScript enforces that you provide a message for every code the field can produce.
+
+```tsx
+import { EmployeeDetailsErrorCodes } from '@gusto/embedded-react-sdk'
+
+<Fields.FirstName
+  label="First name"
+  validationMessages={{
+    REQUIRED: 'First name is required',
+    INVALID_NAME: 'Enter a valid first name',
+  }}
+/>
+
+<Fields.Email
+  label="Email"
+  validationMessages={{
+    REQUIRED: 'Email is required',
+    INVALID_EMAIL: 'Please enter a valid email address',
+  }}
+/>
+```
+
+If you omit `validationMessages`, validation still runs and the field is marked as invalid, but the displayed text falls back to the raw error code (e.g., `REQUIRED`, `INVALID_EMAIL`, `INVALID_AMOUNT`). Always supply `validationMessages` for production UI so you control the user-facing copy.
+
+Error codes for each hook are exported alongside the hook:
+
+- `EmployeeDetailsErrorCodes` — see [useEmployeeDetailsForm field reference](../../reference/employee/hooks/use-employee-details-form.md#fields)
+- `JobErrorCodes` — see [useJobForm field reference](../../reference/employee/hooks/use-job-form.md#fields)
+- `CompensationErrorCodes` — see [useCompensationForm field reference](../../reference/employee/hooks/use-compensation-form.md#fields)
+- `WorkAddressErrorCodes` — see [useWorkAddressForm field reference](../../reference/employee/hooks/use-work-address-form.md#fields)
+- `PayScheduleErrorCodes` — see [usePayScheduleForm field reference](../../reference/company/hooks/use-pay-schedule-form.md#fields)
+- `SignCompanyFormErrorCodes` — see [useSignCompanyForm field reference](../../reference/company/hooks/use-sign-company-form.md#fields)

--- a/docs/guides/hooks/handling-hook-errors.md
+++ b/docs/guides/hooks/handling-hook-errors.md
@@ -1,0 +1,106 @@
+---
+title: Handling hook errors
+description: The error surface returned by every hook — surfacing query and submit errors, retries, and recovery actions.
+order: 2
+---
+
+All hooks return an `errorHandling` object in **both** loading and ready states. This ensures you can always display errors and offer recovery actions, even when data never loaded.
+
+```typescript
+interface HookErrorHandling {
+  errors: SDKError[]
+  retryQueries: () => void
+  clearSubmitError: () => void
+}
+```
+
+## Multi-hook screens
+
+When a screen pulls from more than one SDK hook (or mixes SDK hooks with additional `@gusto/embedded-api-v-2026-02-01` queries), combine their error state into one banner and one retry/dismiss flow using `composeErrorHandler` / `composeSubmitHandler`. See [Composing Multiple Hooks](./composing-multiple-hooks.md).
+
+## SDKError shape
+
+```typescript
+interface SDKError {
+  category: 'api_error' | 'validation_error' | 'network_error' | 'internal_error'
+  message: string
+  httpStatus?: number
+  fieldErrors: SDKFieldError[]
+  raw?: unknown
+}
+
+interface SDKFieldError {
+  field: string
+  category: string
+  message: string
+  metadata?: Record<string, unknown>
+}
+```
+
+## Error categories and recommended actions
+
+| Category           | What happened                                                    | What you should do                                                                                                                                         |
+| ------------------ | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api_error`        | HTTP error from the Gusto API (422, 404, 409, etc.)              | Display `error.message`. For 422 responses, check `error.fieldErrors` for inline field-level messages. For 404/409, show a contextual message to the user. |
+| `validation_error` | Client-side schema validation failed before the request was sent | This is likely an SDK bug. Display a generic error and report to Gusto.                                                                                    |
+| `network_error`    | Network connectivity failure (timeout, connection refused)       | Show retry UI using `errorHandling.retryQueries()`. Suggest the user check their connection.                                                               |
+| `internal_error`   | Unexpected SDK runtime error                                     | Display a generic error and report to Gusto.                                                                                                               |
+
+## Recovery actions
+
+- **`retryQueries()`** — Retries all failed data-fetching queries. Dependent queries automatically re-trigger when their dependencies resolve.
+- **`clearSubmitError()`** — Clears the most recent form submission error from state.
+
+Explicit **`query` vs `submit` labels** on each `SDKError` are not part of the type today; infer recovery from **`retryQueries`** (fetch) vs **`clearSubmitError`** (submit). A future revision may add structured discrimination.
+
+## Example: error display with retry
+
+```tsx
+function EmployeeForm({ companyId }: { companyId: string }) {
+  const employeeDetails = useEmployeeDetailsForm({ companyId })
+
+  if (employeeDetails.isLoading) {
+    const { errors, retryQueries } = employeeDetails.errorHandling
+
+    if (errors.length > 0) {
+      return (
+        <div>
+          <p>Failed to load employee data.</p>
+          <ul>
+            {errors.map((error, i) => (
+              <li key={i}>{error.message}</li>
+            ))}
+          </ul>
+          <button onClick={retryQueries}>Retry</button>
+        </div>
+      )
+    }
+
+    return <LoadingSpinner />
+  }
+
+  // ... render form
+}
+```
+
+## Handling submit errors
+
+Submit errors (from API mutations) are also collected into `errorHandling.errors`. After a failed submission, you can display the error and let the user correct their input:
+
+```tsx
+const { errors, clearSubmitError } = employeeDetails.errorHandling
+
+{
+  errors.length > 0 && (
+    <div role="alert">
+      {errors.map((error, i) => (
+        <p key={i}>{error.message}</p>
+      ))}
+    </div>
+  )
+}
+```
+
+Field-level API errors (e.g., 422 responses with `fieldErrors`) are automatically synced to the corresponding form fields so they appear inline alongside client-side validation errors. When using `SDKFormProvider`, the provider handles this syncing via context. When using the `formHookResult` prop, each field resolves errors directly from `formHookResult.errorHandling.errors` — no provider is needed.
+
+For a deeper look at the SDK's error architecture, see [Error Handling in the React SDK](../integration-guide/error-handling.md) and [Observability](../integration-guide/observability.md).

--- a/docs/guides/hooks/jobs-and-compensations.md
+++ b/docs/guides/hooks/jobs-and-compensations.md
@@ -1,0 +1,210 @@
+---
+title: Working with Jobs and Compensations
+description: Patterns for composing useJobForm and useCompensationForm on the same screen — onboarding stub-fill and steady-state edits via composeSubmitHandler.
+order: 4
+---
+
+# Working with Jobs and Compensations
+
+Jobs and compensations are separate entities in the Gusto API:
+
+- A **job** (`POST /v1/employees/:id/jobs`, `PUT /v1/jobs/:id`) carries title, hire date, S-Corp 2% shareholder flag, and Washington state workers' comp fields. Modeled by [`useJobForm`](../../reference/employee/hooks/use-job-form.md).
+- A **compensation** (`POST /v1/jobs/:jobId/compensations`, `PUT /v1/compensations/:id`) carries FLSA status, pay rate, payment unit, and effective date. Modeled by [`useCompensationForm`](../../reference/employee/hooks/use-compensation-form.md).
+
+Most product flows compose both hooks on the same screen. This page covers the two patterns you'll reach for and how to wire them up with [`composeSubmitHandler`](./composing-multiple-hooks.md).
+
+---
+
+## Onboarding stub-fill (POST job → PUT auto-created stub)
+
+When a job is created, the API auto-creates a stub compensation with `rate: 0`. Onboarding flows replace that stub with the real values via PUT. `useCompensationForm.actions.onSubmit` accepts `{ jobId, compensationId, compensationVersion }` for this exact case:
+
+```tsx
+import {
+  useJobForm,
+  useCompensationForm,
+  composeSubmitHandler,
+  SDKFormProvider,
+} from '@gusto/embedded-react-sdk'
+
+function OnboardingCompensationPage({ employeeId }: { employeeId: string }) {
+  const jobForm = useJobForm({ employeeId, shouldFocusError: false })
+  const compensationForm = useCompensationForm({ employeeId, shouldFocusError: false })
+
+  if (jobForm.isLoading || compensationForm.isLoading) return <LoadingSpinner />
+
+  const JobFields = jobForm.form.Fields
+  const CompFields = compensationForm.form.Fields
+
+  const { handleSubmit, errorHandling } = composeSubmitHandler(
+    [jobForm, compensationForm],
+    async () => {
+      const jobResult = await jobForm.actions.onSubmit()
+      if (!jobResult || jobResult.mode !== 'create') return
+
+      const job = jobResult.data
+      const compensationId = job.currentCompensationUuid
+      const stub = job.compensations?.find(c => c.uuid === compensationId)
+
+      await compensationForm.actions.onSubmit({
+        jobId: job.uuid,
+        compensationId,
+        compensationVersion: stub?.version,
+      })
+    },
+  )
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {errorHandling.errors.length > 0 && (
+        <div role="alert">
+          {errorHandling.errors.map((e, i) => (
+            <p key={i}>{e.message}</p>
+          ))}
+        </div>
+      )}
+
+      <SDKFormProvider formHookResult={jobForm}>
+        <JobFields.Title label="Job title" validationMessages={{ REQUIRED: 'Required' }} />
+        <JobFields.HireDate label="Hire date" validationMessages={{ REQUIRED: 'Required' }} />
+        {JobFields.TwoPercentShareholder && (
+          <JobFields.TwoPercentShareholder label="2% S-Corp shareholder" />
+        )}
+        {JobFields.StateWcCovered && <JobFields.StateWcCovered label="WA workers' comp covered" />}
+        {JobFields.StateWcClassCode && (
+          <JobFields.StateWcClassCode
+            label="Risk class code"
+            validationMessages={{ REQUIRED: 'Required' }}
+          />
+        )}
+      </SDKFormProvider>
+
+      <SDKFormProvider formHookResult={compensationForm}>
+        {CompFields.FlsaStatus && (
+          <CompFields.FlsaStatus
+            label="Employee type"
+            validationMessages={{ REQUIRED: 'Required' }}
+          />
+        )}
+        <CompFields.Rate
+          label="Compensation amount"
+          validationMessages={{
+            REQUIRED: 'Required',
+            RATE_MINIMUM: 'Must be at least $1.00',
+            RATE_EXEMPT_THRESHOLD: 'Must clear the FLSA salary threshold',
+          }}
+        />
+        <CompFields.PaymentUnit
+          label="Per"
+          validationMessages={{
+            REQUIRED: 'Required',
+            PAYMENT_UNIT_OWNER: 'Owners must use Paycheck',
+            PAYMENT_UNIT_COMMISSION: 'Commission-only must use Year',
+          }}
+        />
+        <CompFields.EffectiveDate
+          label="Effective date"
+          validationMessages={{
+            REQUIRED: 'Required',
+            EFFECTIVE_DATE_BEFORE_HIRE: 'Cannot precede hire date',
+          }}
+        />
+        {CompFields.AdjustForMinimumWage && (
+          <CompFields.AdjustForMinimumWage label="Adjust for minimum wage" />
+        )}
+        {CompFields.MinimumWageId && (
+          <CompFields.MinimumWageId
+            label="Minimum wage"
+            validationMessages={{ REQUIRED: 'Required' }}
+          />
+        )}
+      </SDKFormProvider>
+
+      <button type="submit">Save</button>
+    </form>
+  )
+}
+```
+
+`composeSubmitHandler` validates both forms in parallel — if either fails, the chain short-circuits before any network I/O. Inside `onAllValid`, thread the new IDs and the stub's version into `useCompensationForm` to PUT it.
+
+### Driving hireDate / effectiveDate from external context
+
+To submit `hireDate` and `effectiveDate` without rendering input fields for them, set `withHireDateField: false` and `withEffectiveDateField: false` and supply the values via submit options. The schemas drop those fields from validation and `Fields.HireDate` / `Fields.EffectiveDate` become `undefined`, so the TypeScript build flags any accidental renders.
+
+```tsx
+const jobForm = useJobForm({
+  employeeId,
+  withHireDateField: false,
+  shouldFocusError: false,
+})
+const compensationForm = useCompensationForm({
+  employeeId,
+  withEffectiveDateField: false,
+  shouldFocusError: false,
+})
+
+const { handleSubmit } = composeSubmitHandler([jobForm, compensationForm], async () => {
+  const jobResult = await jobForm.actions.onSubmit({ employeeId, hireDate: startDate })
+  if (!jobResult) return
+
+  const job = jobResult.data
+  const stub = job.compensations?.find(c => c.uuid === job.currentCompensationUuid)
+  await compensationForm.actions.onSubmit({
+    jobId: job.uuid,
+    compensationId: job.currentCompensationUuid ?? undefined,
+    compensationVersion: stub?.version,
+    effectiveDate: startDate,
+  })
+})
+```
+
+When `withEffectiveDateField: false`, `useCompensationForm` is strictly options-only — `effective_date` is omitted from the PUT body unless you supply it via submit options. Omit `effectiveDate` from the options entirely to leave the existing date untouched.
+
+---
+
+## Steady-state edit (job + compensation already exist)
+
+When both records exist (a page that edits the current compensation), pass IDs to both hooks and submit them in parallel. The hooks own their own version handling:
+
+```tsx
+function CompensationEditPage({
+  employeeId,
+  jobId,
+  compensationId,
+}: {
+  employeeId: string
+  jobId: string
+  compensationId: string
+}) {
+  const jobForm = useJobForm({ employeeId, jobId, shouldFocusError: false })
+  const compensationForm = useCompensationForm({
+    employeeId,
+    jobId,
+    compensationId,
+    shouldFocusError: false,
+  })
+
+  if (jobForm.isLoading || compensationForm.isLoading) return <LoadingSpinner />
+
+  const { handleSubmit, errorHandling } = composeSubmitHandler(
+    [jobForm, compensationForm],
+    async () => {
+      await jobForm.actions.onSubmit()
+      await compensationForm.actions.onSubmit()
+    },
+  )
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {compensationForm.status.willDeleteSecondaryJobs && (
+        <Alert status="warning">Saving will delete this employee's secondary jobs.</Alert>
+      )}
+
+      {/* ...fields, errorHandling banner, submit button */}
+    </form>
+  )
+}
+```
+
+`compensationForm.status.willDeleteSecondaryJobs` is a reactive flag that flips to `true` when the form is positioned on the carve-out branch: update mode, loaded compensation is `Nonexempt`, the form's `flsaStatus` was just changed to a non-`Nonexempt` value, and the employee has at least one secondary job. While the flag is on, the hook also locks the `effectiveDate` field — it forces the form value to today and renders the field disabled (via `fieldsMetadata.effectiveDate.isDisabled`). Reverting `flsaStatus` back to `Nonexempt` restores the prior date. You can render the disabled `Fields.EffectiveDate` as-is or skip it entirely and rely on the inline warning. The hook tracks form state via `useWatch` internally — a render-time read of the flag is enough. See [derived helpers](../../reference/employee/hooks/use-compensation-form.md) for the full breakdown.

--- a/docs/guides/hooks/overview.md
+++ b/docs/guides/hooks/overview.md
@@ -1,0 +1,359 @@
+---
+title: Hooks overview
+description: Headless form and data hooks that handle data fetching, validation, submission, and error handling — you supply the layout and presentation.
+order: 3
+---
+
+# Hooks
+
+Hooks let you own the layout while the SDK manages data fetching, validation, submission, and error handling. **Form hooks** return pre-bound field components, metadata, and actions for rendering a form — you supply the layout and labels. **Data hooks** return fetched, decorated data plus the actions valid for it — you supply the presentation. Both share the same loading/error/`HookErrorHandling` conventions.
+
+## Getting Started
+
+All hooks are exported from `@gusto/embedded-react-sdk`. Your app must be wrapped in `GustoProvider`.
+
+```tsx
+import { GustoProvider, useEmployeeDetailsForm } from '@gusto/embedded-react-sdk'
+
+function App() {
+  return (
+    <GustoProvider config={{ apiToken: '...' }}>
+      <EmployeeForm companyId="company-uuid" />
+    </GustoProvider>
+  )
+}
+
+function EmployeeForm({ companyId }: { companyId: string }) {
+  const employeeDetails = useEmployeeDetailsForm({ companyId })
+
+  if (employeeDetails.isLoading) {
+    return <div>Loading...</div>
+  }
+
+  const { Fields } = employeeDetails.form
+
+  return (
+    <form
+      onSubmit={async e => {
+        e.preventDefault()
+        await employeeDetails.actions.onSubmit()
+      }}
+    >
+      <Fields.FirstName label="First name" formHookResult={employeeDetails} />
+      <Fields.LastName label="Last name" formHookResult={employeeDetails} />
+      <button type="submit">Save</button>
+    </form>
+  )
+}
+```
+
+### Key concepts
+
+1. **Call the hook** with the required identifiers (`companyId`, `employeeId`, etc.)
+2. **Check `isLoading`** — the hook fetches server data before the form is ready
+3. **Connect fields** — pass `formHookResult` as a prop to each field, or wrap fields in `SDKFormProvider` for context-based connection (see [Connecting Fields to the Form](#connecting-fields-to-the-form))
+4. **Render `Fields`** — each field is a pre-bound component that handles validation, error display, and metadata automatically
+5. **Call `onSubmit`** — the hook handles API mutations, error normalization, and returns the saved entity
+
+---
+
+## Connecting Fields to the Form
+
+Every Field component needs access to form state — react-hook-form's control, field metadata (required/disabled), and error messages. There are two ways to provide this connection:
+
+### Option A: `formHookResult` prop (explicit)
+
+Pass the hook result directly to each field. No wrapper component needed.
+
+```tsx
+const { Fields } = employeeDetails.form
+
+<Fields.FirstName label="First name" formHookResult={employeeDetails} />
+<Fields.LastName label="Last name" formHookResult={employeeDetails} />
+<Fields.Email label="Email" formHookResult={employeeDetails} />
+```
+
+Each field reads metadata, form control, and error state directly from the prop. This is the most flexible approach — fields can be placed anywhere in your component tree and interleaved freely with fields from other hooks.
+
+### Option B: `SDKFormProvider` (context)
+
+Wrap fields in `SDKFormProvider` and they pick up form state from context automatically.
+
+```tsx
+import { SDKFormProvider } from '@gusto/embedded-react-sdk'
+
+function EmployeeFormSection() {
+  // ...employeeDetails from useEmployeeDetailsForm
+
+  const { Fields } = employeeDetails.form
+
+  return (
+    <SDKFormProvider formHookResult={employeeDetails}>
+      <Fields.FirstName label="First name" />
+      <Fields.LastName label="Last name" />
+      <Fields.Email label="Email" />
+    </SDKFormProvider>
+  )
+}
+```
+
+Fields inside an `SDKFormProvider` don't need the `formHookResult` prop — the provider injects form state via React context. This is convenient when all fields from a single hook are grouped together.
+
+### Choosing an approach
+
+Both approaches produce identical validation, API payloads, and behavior. The difference is purely in how fields discover their form state.
+
+| Aspect                | `formHookResult` prop                                               | `SDKFormProvider`                               |
+| --------------------- | ------------------------------------------------------------------- | ----------------------------------------------- |
+| **Best for**          | Interleaving fields from multiple hooks; maximum layout flexibility | Grouping fields from a single hook together     |
+| **Boilerplate**       | Each field receives the prop                                        | One wrapper, fields are clean                   |
+| **Interleaving**      | Fields from different hooks can be placed in any order              | Fields must stay within their provider boundary |
+| **API error syncing** | Handled automatically per-field                                     | Handled automatically via the provider          |
+
+#### Side-by-side: two hooks on one screen
+
+The same `employeeDetails` + `compensation` form, written each way:
+
+```tsx
+// Option A: formHookResult prop — fields can be interleaved freely
+const EmployeeDetailsFields = employeeDetails.form.Fields
+const CompensationFields = compensation.form.Fields
+
+<EmployeeDetailsFields.FirstName label="First name" formHookResult={employeeDetails} />
+<EmployeeDetailsFields.LastName label="Last name" formHookResult={employeeDetails} />
+<CompensationFields.JobTitle label="Job title" formHookResult={compensation} />
+<CompensationFields.Rate label="Pay rate" formHookResult={compensation} />
+```
+
+```tsx
+// Option B: SDKFormProvider — one wrapper per hook, fields stay grouped
+<SDKFormProvider formHookResult={employeeDetails}>
+  <EmployeeDetailsFields.FirstName label="First name" />
+  <EmployeeDetailsFields.LastName label="Last name" />
+</SDKFormProvider>
+
+<SDKFormProvider formHookResult={compensation}>
+  <CompensationFields.JobTitle label="Job title" />
+  <CompensationFields.Rate label="Pay rate" />
+</SDKFormProvider>
+```
+
+You can also mix approaches on the same page — for example, `SDKFormProvider` for one hook's fields that are grouped together, and `formHookResult` props for another hook's fields that are scattered. See [Composing multiple hooks](./composing-multiple-hooks.md) for the full submit-handler wiring around either layout.
+
+> **Avoid passing `formHookResult` to fields via props that are already inside an `SDKFormProvider`.** When both are present on the same field, the prop takes precedence and the provider's context is ignored, which may lead to unexpected behavior.
+
+---
+
+## Field Rendering and Custom UI
+
+### Component Adapter integration
+
+By default, every field component renders through the SDK's [Component Adapter](../component-adapter/component-adapter.md). If you've configured a Component Adapter for your app (e.g., mapping to your own design system), hook fields will automatically render using your custom components. If no adapter is configured, fields render using the SDK's built-in React Aria-driven components.
+
+This means hooks inherit whatever UI customization you've already set up at the `GustoProvider` level -- no extra configuration needed.
+
+### Overriding a single field with `FieldComponent`
+
+If you need a specific field to render differently without changing your global Component Adapter, most fields accept a `FieldComponent` prop. This lets you swap the UI for a single field by providing your own component that conforms to the expected props interface.
+
+The `FieldComponent` receives the same props the underlying UI primitive expects (`TextInputProps`, `SelectProps`, `NumberInputProps`, etc.) -- including `value`, `onChange`, `onBlur`, error state, and accessibility attributes. You don't need any react-hook-form knowledge; the hook field handles all form binding and passes clean UI props to your component.
+
+```tsx
+import type { TextInputProps } from '@gusto/embedded-react-sdk'
+
+function MyCustomTextInput(props: TextInputProps) {
+  return (
+    <div className="my-field-wrapper">
+      <label>{props.label}</label>
+      <input
+        value={props.value}
+        onChange={e => props.onChange?.(e.target.value)}
+        onBlur={props.onBlur}
+        disabled={props.isDisabled}
+        required={props.isRequired}
+      />
+      {props.errorMessage && <span className="error">{props.errorMessage}</span>}
+    </div>
+  )
+}
+
+// Then in your form:
+;<Fields.FirstName
+  label="First name"
+  FieldComponent={MyCustomTextInput}
+  validationMessages={{ REQUIRED: 'First name is required' }}
+/>
+```
+
+This is useful when you want to use a third-party input library for one field, add custom styling, or render a completely different control while still getting the hook's validation, error handling, and form binding for free.
+
+The `FieldComponent` prop is available on all field types: `TextInputProps`, `SelectProps`, `NumberInputProps`, `CheckboxProps`, `DatePickerProps`, `RadioGroupProps`, and `SwitchProps`. Import the corresponding prop type from `@gusto/embedded-react-sdk` for type-safe implementations.
+
+---
+
+## Data
+
+Every form hook returns a `data` object when ready. This contains the entities fetched by the hook — the primary entity being edited plus any supporting data needed for the form.
+
+```tsx
+if (!employeeDetails.isLoading) {
+  const { employee } = employeeDetails.data
+  // employee is the loaded Employee entity (or null in create mode)
+}
+```
+
+The shape of `data` varies by hook — see each hook's reference page for details:
+
+- `useEmployeeDetailsForm` — `{ employee }`
+- `useJobForm` — `{ currentJob, jobs, employee, currentWorkAddress, showTwoPercentShareholder, showStateWc }`
+- `useCompensationForm` — `{ compensation, currentJob, minimumWages, minimumEffectiveDate, maximumEffectiveDate, hasPendingFutureCompensation }` (plus `status.willDeleteSecondaryJobs` for the reactive carve-out flag)
+- `useWorkAddressForm` — `{ workAddress, workAddresses, companyLocations }`
+- `usePayScheduleForm` — `{ paySchedule, payPeriodPreview, payPreviewLoading, paymentSpeedDays }`
+- `useSignCompanyForm` — `{ companyForm, pdfUrl }`
+
+---
+
+## Loading States
+
+Every hook returns a discriminated union on `isLoading`. While server data is being fetched, only `isLoading` and `errorHandling` are available:
+
+```tsx
+const employeeDetails = useEmployeeDetailsForm({ companyId, employeeId })
+
+// Loading branch — no form data yet
+if (employeeDetails.isLoading) {
+  return <LoadingSpinner />
+}
+
+// Ready branch — TypeScript narrows to the full return type
+const { data, form, actions, status, errorHandling } = employeeDetails
+```
+
+The loading state is also where you first encounter errors — if a data-fetching query fails, the hook stays in the loading branch but `errorHandling.errors` will be populated. See [Handling hook errors](./handling-hook-errors.md).
+
+---
+
+## Submit Handler
+
+Each hook's `actions.onSubmit` is an async function that validates the form, calls the appropriate API mutations, and returns the result.
+
+```typescript
+interface HookSubmitResult<T> {
+  mode: 'create' | 'update'
+  data: T
+}
+```
+
+`onSubmit` accepts optional callbacks that fire after each mutation step. This is useful for telemetry logging or reacting to individual API call results:
+
+```tsx
+const result = await employeeDetails.actions.onSubmit({
+  onEmployeeCreated: employee => {
+    console.log('Created:', employee.uuid)
+  },
+  onEmployeeUpdated: employee => {
+    console.log('Updated:', employee.uuid)
+  },
+})
+
+if (result) {
+  // result.mode is 'create' or 'update'
+  // result.data is the saved Employee entity
+  navigate(`/employees/${result.data.uuid}`)
+}
+```
+
+If validation fails, `onSubmit` returns `undefined` and the form fields display their error messages. If a mutation fails, the error is captured in `errorHandling.errors`.
+
+### Checking pending state and mode
+
+Use `status.isPending` to disable the submit button while mutations are in flight, and `status.mode` to adapt your UI based on whether the hook is creating or updating:
+
+```tsx
+<h2>{employeeDetails.status.mode === 'create' ? 'Add Employee' : 'Edit Employee'}</h2>
+
+<button type="submit" disabled={employeeDetails.status.isPending}>
+  {employeeDetails.status.isPending ? 'Saving...' : 'Save'}
+</button>
+```
+
+`status.mode` is `'create'` when no existing entity was loaded (e.g., no `employeeId` was provided) and `'update'` when editing an existing record.
+
+---
+
+## Reading Form Values
+
+Each hook exposes `form.getFormSubmissionValues()` — a synchronous function that returns the current form values parsed through the hook's Zod validation schema. The returned object matches exactly what `onSubmit` would receive: all preprocessing transforms (e.g., string-to-number coercion) are applied.
+
+Returns `undefined` when the current form state is invalid (empty required fields, failed cross-field rules, etc.). It never throws.
+
+```tsx
+const values = employeeDetails.form.getFormSubmissionValues()
+
+if (values) {
+  console.log(values.firstName, values.lastName)
+}
+```
+
+This is particularly useful when you need to share values across form submissions. For example, when the work address form captures an effective date that the compensation form needs as its start date, you can read the value from one form and pass it to the other's submit options:
+
+```tsx
+const workAddress = useWorkAddressForm({ companyId, shouldFocusError: false })
+const compensation = useCompensationForm({
+  withStartDateField: false,
+  shouldFocusError: false,
+})
+
+// ...loading checks...
+
+const { handleSubmit } = composeSubmitHandler(
+  [employeeDetails, workAddress, compensation],
+  async () => {
+    const employeeResult = await employeeDetails.actions.onSubmit()
+    if (!employeeResult) return
+
+    const newEmployeeId = employeeResult.data.uuid
+    const workAddressValues = workAddress.form.getFormSubmissionValues()
+
+    await workAddress.actions.onSubmit(undefined, { employeeId: newEmployeeId })
+    await compensation.actions.onSubmit({
+      employeeId: newEmployeeId,
+      startDate: workAddressValues?.effectiveDate,
+    })
+  },
+)
+```
+
+`getFormSubmissionValues` has no side effects — it doesn't trigger re-renders, mutate form state, or update validation errors. It's a pure read from react-hook-form's internal store followed by Zod schema parsing.
+
+---
+
+## Advanced: Hook Form Internals
+
+Each hook exposes `form.hookFormInternals` which provides direct access to the underlying react-hook-form `formMethods` (`UseFormReturn`). This is an escape hatch for advanced use cases that aren't covered by the hook's built-in API.
+
+```tsx
+const { formMethods } = employeeDetails.form.hookFormInternals
+
+formMethods.watch('email')
+formMethods.setValue('firstName', 'Jane')
+formMethods.trigger('ssn')
+```
+
+Use this when you need to:
+
+- Watch specific fields for reactive UI updates outside of the SDK fields
+- Programmatically set or reset field values
+- Trigger validation on specific fields manually
+- Access form state like `isDirty`, `isValid`, or `dirtyFields`
+
+In most cases the built-in Fields, `onSubmit`, and `getFormSubmissionValues` are sufficient. Reach for `hookFormInternals` only when you need fine-grained form control that the hook doesn't expose directly.
+
+---
+
+## Further reading
+
+- [Configuring form fields](./configuring-form-fields.md) — required fields, default values, and validation messages
+- [Handling hook errors](./handling-hook-errors.md) — the `HookErrorHandling` surface, retries, and submit errors
+- [Composing multiple hooks](./composing-multiple-hooks.md) — coordinating several hooks on one screen with `composeSubmitHandler` / `composeErrorHandler`
+- [Working with jobs and compensations](./jobs-and-compensations.md) — onboarding stub-fill and steady-state edit patterns


### PR DESCRIPTION
## Summary

Restores the hooks overview content that was accidentally removed when the `docs/hooks/` directory was deleted, reorganized under `docs/guides/hooks/` with a cleaner structure.

## Changes

- Five new guide pages under `docs/guides/hooks/`: overview, configuring form fields, handling hook errors, composing multiple hooks, and jobs & compensations
- Relinks deleted per-hook pages to their reference equivalents
- Nests the set under Guides → Hooks in the sidebar
- Drops hand-maintained hook index tables (to be generated from the reference instead)

<img width="1604" height="1041" alt="Screenshot 2026-07-13 at 3 41 58 PM" src="https://github.com/user-attachments/assets/e6f7df2c-9aa8-4a75-aea6-a51ab29808d6" />
<img width="1604" height="1041" alt="Screenshot 2026-07-13 at 3 42 01 PM" src="https://github.com/user-attachments/assets/118281ec-8358-4f2b-9c3c-456ecc1917a1" />
<img width="1604" height="1041" alt="Screenshot 2026-07-13 at 3 42 05 PM" src="https://github.com/user-attachments/assets/2dfb5619-0ade-4a36-b83d-f5e046d20c70" />


## Related

- Jira: [SDK-1072](https://gustohq.atlassian.net/browse/SDK-1072)

## Testing

Docs-only change. Verify with the docs-site dev server that:
- Guides → Hooks section appears in the sidebar with all five pages
- Internal links resolve correctly

[SDK-1072]: https://gustohq.atlassian.net/browse/SDK-1072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ