### PR TITLE
chore(sdk-app): clean up comment thread UI

### DIFF
--- a/sdk-app/src/design/comments/CommentThread.tsx
+++ b/sdk-app/src/design/comments/CommentThread.tsx
@@ -59,21 +59,9 @@ export function CommentThread({ comment }: { comment: SandboxComment }) {
 
       <div className={styles.footer}>
         {comment.resolved ? (
-          <div className={styles.formRow}>
-            <span className={styles.resolvedTag}>
-              Resolved{comment.resolved_by ? ` by ${comment.resolved_by.name}` : ''}
-            </span>
-            <span className={styles.spacer} />
-            {canWrite ? (
-              <button
-                type="button"
-                className={`${styles.button} ${styles.buttonGhost}`}
-                onClick={() => void toggleResolve(comment)}
-              >
-                Reopen
-              </button>
-            ) : null}
-          </div>
+          <span className={styles.resolvedTag}>
+            Resolved{comment.resolved_by ? ` by ${comment.resolved_by.name}` : ''}
+          </span>
         ) : null}
 
         {replying ? (
@@ -100,16 +88,14 @@ export function CommentThread({ comment }: { comment: SandboxComment }) {
               >
                 Reply
               </button>
+              <button
+                type="button"
+                className={`${styles.button} ${styles.buttonGhost}`}
+                onClick={() => void toggleResolve(comment)}
+              >
+                {comment.resolved ? 'Reopen' : 'Resolve'}
+              </button>
               <span className={styles.spacer} />
-              {!comment.resolved ? (
-                <button
-                  type="button"
-                  className={`${styles.button} ${styles.buttonGhost}`}
-                  onClick={() => void toggleResolve(comment)}
-                >
-                  Resolve
-                </button>
-              ) : null}
               {isAuthor ? (
                 <button
                   type="button"

--- a/sdk-app/src/design/comments/comments.module.scss
+++ b/sdk-app/src/design/comments/comments.module.scss
@@ -555,6 +555,9 @@ $shadow: 0 8px 30px rgba(20, 20, 40, 0.18);
 /* Mentions */
 .composer {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .mentionAnchor {

--- a/sdk-app/src/design/comments/comments.module.scss
+++ b/sdk-app/src/design/comments/comments.module.scss
@@ -189,7 +189,7 @@ $shadow: 0 8px 30px rgba(20, 20, 40, 0.18);
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-top: 8px;
+  margin-top: 12px;
 }
 
 .select {

--- a/sdk-app/src/design/comments/comments.module.scss
+++ b/sdk-app/src/design/comments/comments.module.scss
@@ -164,6 +164,9 @@ $shadow: 0 8px 30px rgba(20, 20, 40, 0.18);
   border-top: 1px solid $border;
   padding: 10px 14px;
   background: #fafafe;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .textarea {
@@ -189,7 +192,6 @@ $shadow: 0 8px 30px rgba(20, 20, 40, 0.18);
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-top: 12px;
 }
 
 .select {


### PR DESCRIPTION
## Summary
- Regroup comment thread actions so non-destructive controls (Reply, Resolve/Reopen) sit together on the left and Delete stays on the right
- Move the "Resolved by X" tag to its own line above the action row
- Small footer/composer flex tweaks for spacing

## Test plan
- [ ] Open a comment thread in sdk-app design mode and confirm the action row shows Reply + Resolve on the left, Delete on the right
- [ ] Resolve a comment and confirm the resolved tag renders above the action row with Reopen in the Resolve slot
- [ ] Verify the read-only state still shows the sign-in hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)