### PR TITLE
chore: release 0.52.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.52.1](https://github.com/Gusto/embedded-react-sdk/compare/v0.52.0...v0.52.1) (2026-07-14)
+
+### Features & Enhancements
+
+- Contractor self-onboarding now mirrors the employee self-onboarding experience, giving contractors a guided flow to complete their own profile, address, and signature steps. ([#2385](https://github.com/Gusto/embedded-react-sdk/issues/2385))
+- The Contractor `Submit` step now lets contractors download their signed W-9. ([#2392](https://github.com/Gusto/embedded-react-sdk/issues/2392))
+
+### Fixes
+
+- The contractor new hire report is now only triggered during the initial onboarding pass, so re-editing an already-onboarded contractor no longer re-files the report. ([#2386](https://github.com/Gusto/embedded-react-sdk/issues/2386))
+
+### Chores & Maintenance
+
+- Bump dev dependencies (`storybook` and its addons to 10.5.0, `eslint`, `@eslint/js`, `@typescript-eslint/rule-tester`, `@typescript-eslint/utils`)
+- Bump dependencies (`dompurify`)
+
 ## [0.52.0](https://github.com/Gusto/embedded-react-sdk/compare/v0.51.2...v0.52.0) (2026-07-10)
 
 ### ⚠ Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-react-sdk",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "MIT",
       "dependencies": {
         "@gusto/embedded-api": "npm:@gusto/embedded-api-v-2026-06-15@^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "homepage": "https://github.com/Gusto/embedded-react-sdk",
   "bugs": {
     "url": "https://github.com/Gusto/embedded-react-sdk/issues"


### PR DESCRIPTION
Automated release PR for v0.52.1. Review the changelog and merge to publish.

## Highlights

### Features & Enhancements
- Contractor self-onboarding parity with employee self-onboarding (#2385)
- W-9 download on the Contractor `Submit` step (#2392)

### Fixes
- Contractor new hire report now only fires on the initial onboarding pass (#2386)

### Chores & Maintenance
- Dependency bumps (Storybook 10.5.0 + addons, ESLint, typescript-eslint, dompurify)

Merging this PR triggers the Publish to NPM workflow automatically.

Made with [Cursor](https://cursor.com)