### PR TITLE
ci: authenticate publish workflows to Cloudsmith via OIDC

### DIFF
--- a/.github/workflows/publish-rc.yaml
+++ b/.github/workflows/publish-rc.yaml
@@ -60,10 +60,17 @@ jobs:
             exit 1
           fi
 
+      - name: Authenticate with Cloudsmith via OIDC
+        uses: cloudsmith-io/cloudsmith-cli-action@v2
+        with:
+          oidc-namespace: "gusto"
+          oidc-service-slug: "gusto-cloudsmith-write-svc-01"
+          oidc-auth-only: "true"
+
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://cloudsmith.io/gusto/gusto'
 
       - name: Restore node_modules cache
         id: cache-node-modules
@@ -169,7 +176,7 @@ jobs:
       - name: Publish RC version
         run: npm publish --access public --tag rc
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ env.CLOUDSMITH_API_KEY }}
 
       - name: Output published version
         run: |

--- a/.github/workflows/publish-rc.yaml
+++ b/.github/workflows/publish-rc.yaml
@@ -63,9 +63,9 @@ jobs:
       - name: Authenticate with Cloudsmith via OIDC
         uses: cloudsmith-io/cloudsmith-cli-action@v2
         with:
-          oidc-namespace: "gusto"
-          oidc-service-slug: "gusto-cloudsmith-write-svc-01"
-          oidc-auth-only: "true"
+          oidc-namespace: 'gusto'
+          oidc-service-slug: 'gusto-cloudsmith-write-svc-01'
+          oidc-auth-only: 'true'
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,10 +21,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Authenticate with Cloudsmith via OIDC
+        uses: cloudsmith-io/cloudsmith-cli-action@v2
+        with:
+          oidc-namespace: "gusto"
+          oidc-service-slug: "gusto-cloudsmith-write-svc-01"
+          oidc-auth-only: "true"
+
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://cloudsmith.io/gusto/gusto'
 
       - name: Restore node_modules cache
         id: cache-node-modules
@@ -81,7 +88,7 @@ jobs:
       - name: Publish to NPM
         run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ env.CLOUDSMITH_API_KEY }}
 
       - name: Read SDK version
         id: version

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,9 +24,9 @@ jobs:
       - name: Authenticate with Cloudsmith via OIDC
         uses: cloudsmith-io/cloudsmith-cli-action@v2
         with:
-          oidc-namespace: "gusto"
-          oidc-service-slug: "gusto-cloudsmith-write-svc-01"
-          oidc-auth-only: "true"
+          oidc-namespace: 'gusto'
+          oidc-service-slug: 'gusto-cloudsmith-write-svc-01'
+          oidc-auth-only: 'true'
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/unpublish-rc.yaml
+++ b/.github/workflows/unpublish-rc.yaml
@@ -34,9 +34,9 @@ jobs:
       - name: Authenticate with Cloudsmith via OIDC
         uses: cloudsmith-io/cloudsmith-cli-action@v2
         with:
-          oidc-namespace: "gusto"
-          oidc-service-slug: "gusto-cloudsmith-write-svc-01"
-          oidc-auth-only: "true"
+          oidc-namespace: 'gusto'
+          oidc-service-slug: 'gusto-cloudsmith-write-svc-01'
+          oidc-auth-only: 'true'
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/unpublish-rc.yaml
+++ b/.github/workflows/unpublish-rc.yaml
@@ -31,10 +31,16 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
+      - name: Authenticate with Cloudsmith via OIDC
+        uses: cloudsmith-io/cloudsmith-cli-action@v2
+        with:
+          oidc-namespace: "gusto"
+          oidc-service-slug: "gusto-cloudsmith-write-svc-01"
+          oidc-auth-only: "true"
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://cloudsmith.io/gusto/gusto'
 
       - name: Validate confirmation
         run: |
@@ -176,7 +182,7 @@ jobs:
             fi
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ env.CLOUDSMITH_API_KEY }}
 
       - name: Summary
         run: |

--- a/.github/workflows/unpublish.yaml
+++ b/.github/workflows/unpublish.yaml
@@ -16,9 +16,9 @@ jobs:
       - name: Authenticate with Cloudsmith via OIDC
         uses: cloudsmith-io/cloudsmith-cli-action@v2
         with:
-          oidc-namespace: "gusto"
-          oidc-service-slug: "gusto-cloudsmith-write-svc-01"
-          oidc-auth-only: "true"
+          oidc-namespace: 'gusto'
+          oidc-service-slug: 'gusto-cloudsmith-write-svc-01'
+          oidc-auth-only: 'true'
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/unpublish.yaml
+++ b/.github/workflows/unpublish.yaml
@@ -13,10 +13,16 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
+      - name: Authenticate with Cloudsmith via OIDC
+        uses: cloudsmith-io/cloudsmith-cli-action@v2
+        with:
+          oidc-namespace: "gusto"
+          oidc-service-slug: "gusto-cloudsmith-write-svc-01"
+          oidc-auth-only: "true"
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://cloudsmith.io/gusto/gusto'
       - run: npm unpublish @gusto/embedded-react-sdk@${{ github.event.inputs.version }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ env.CLOUDSMITH_API_KEY }}


### PR DESCRIPTION
## What
Migrates all four npm publish/unpublish workflows off `registry.npmjs.org` and onto our internal Cloudsmith instance (`https://cloudsmith.io/gusto/gusto`), authenticating via GitHub OIDC instead of a static `NPM_TOKEN` secret.

Each workflow now:
1. Adds a `cloudsmith-io/cloudsmith-cli-action@v2` step (`oidc-auth-only: "true"`) before `actions/setup-node`, which exchanges the job's GitHub OIDC token for a Cloudsmith token and exports it as `CLOUDSMITH_API_KEY` in the job env.
2. Points `actions/setup-node`'s `registry-url` at `https://cloudsmith.io/gusto/gusto`.
3. Swaps `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` for `NODE_AUTH_TOKEN: ${{ env.CLOUDSMITH_API_KEY }}` on the publish/unpublish step.
4. Adds `id-token: write` to the job's `permissions` block (all four jobs already had a `permissions` block with other entries, which are left untouched).

## Files touched
- `.github/workflows/publish.yaml`
- `.github/workflows/publish-rc.yaml`
- `.github/workflows/unpublish.yaml`
- `.github/workflows/unpublish-rc.yaml`

## Precedent
This is the same OIDC auth pattern already merged/open for RubyGems in Gusto/virtuous-pdf#452 and Gusto/fixture_kit#70, adapted here for npm (registry-url + `NODE_AUTH_TOKEN` instead of a gem credentials file).

## Status / caveats
Draft PR. The Cloudsmith npm endpoint format (`https://cloudsmith.io/gusto/gusto`) has only been confirmed for RubyGems repos so far — it has **not** been runtime-verified against npm publish/unpublish yet. Holding as draft until a real publish/unpublish run against this workflow confirms the registry URL and auth handshake work for the npm package type. `secrets.NPM_TOKEN` references have been fully removed from all four files since nothing else in this repo depends on them.