### PR TITLE
fix(ci): force docs refresh on manual trigger

### DIFF
--- a/.github/scripts/sync-snapshot.sh
+++ b/.github/scripts/sync-snapshot.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 #   workflow_run,      minor missing  -> create
 #   workflow_run,      minor present  -> refresh
 #   workflow_dispatch, minor missing  -> create
-#   workflow_dispatch, minor present  -> (no-op — manual runs don't refresh)
+#   workflow_dispatch, minor present  -> refresh (manual dispatch is the recovery path)
 #   push                              -> (no-op — push path never touches snapshots)
 #
 # For the create action the script copies docs/ into the downstream's docs/
@@ -84,7 +84,7 @@ SNAPSHOT_ACTION=none
 if [[ "$TRIGGER" == "workflow_run" ]] || [[ "$TRIGGER" == "workflow_dispatch" ]]; then
   if [[ "$MINOR_IN_VERSIONS" == "false" ]]; then
     SNAPSHOT_ACTION=create
-  elif [[ "$TRIGGER" == "workflow_run" ]]; then
+  else
     SNAPSHOT_ACTION=refresh
   fi
 fi

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -19,9 +19,9 @@ name: Sync Docs Source
 #      Syncs the latest docs source down so /docs/ refreshes. Does not touch
 #      versioned snapshots.
 #   3. workflow_dispatch — manual run. Always allowed; useful for recovery,
-#      end-to-end testing, or bootstrapping the first snapshot on a clean
-#      downstream (it will create the snapshot if missing for the current
-#      package.json minor).
+#      end-to-end testing, or forcing a snapshot refresh (e.g. after a doc
+#      rename that changed the snapshot structure). Creates the snapshot if
+#      missing, refreshes it if it already exists.
 #
 # Snapshot mechanics:
 #   New minor / bootstrap: `npx docusaurus docs:version <X.Y>` runs inside the
@@ -207,7 +207,7 @@ jobs:
           if [ "$TRIGGER" = "workflow_run" ] || [ "$TRIGGER" = "workflow_dispatch" ]; then
             if [ "$MINOR_IN_VERSIONS" = "false" ]; then
               SNAPSHOT_ACTION=create
-            elif [ "$TRIGGER" = "workflow_run" ]; then
+            else
               SNAPSHOT_ACTION=refresh
             fi
           fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1159,6 +1159,37 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.0.tgz",
+      "integrity": "sha512-DPp6hkUjvwIivxbkrTiLXeRswNv1A/4GFA2X6scXma0AMa9632V3TwxmrlkUIEtUktiM3Ln+RrSH2xlP3/jUTw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
@@ -11003,6 +11034,21 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/argue-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+      "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.0",


### PR DESCRIPTION
## Summary

- `workflow_dispatch` was a no-op when the minor version already existed in `versions.json`, causing manually re-dispatched syncs to produce empty commits
- The recovery/manual path should behave like `workflow_run`: refresh when present, create when absent
- Fixed in both `sync-snapshot.sh` (the logic) and `publish-docs.yaml` (the duplicated SNAPSHOT_ACTION derivation used for the commit message)

## Test plan

- [ ] Dispatch the Sync Docs Source workflow manually and confirm it produces a non-empty commit with "refreshed version-X.Y snapshot" in the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)