### PR TITLE
fix(forms): clear API-derived field errors on user input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1159,6 +1159,37 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.0.tgz",
+      "integrity": "sha512-DPp6hkUjvwIivxbkrTiLXeRswNv1A/4GFA2X6scXma0AMa9632V3TwxmrlkUIEtUktiM3Ln+RrSH2xlP3/jUTw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
@@ -10959,6 +10990,21 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/argue-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+      "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.0",

--- a/src/partner-hook-utils/form/SDKFormProvider.test.tsx
+++ b/src/partner-hook-utils/form/SDKFormProvider.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { useForm, useFormContext, useFormState } from 'react-hook-form'
+import type { FieldMetadata } from '../types'
+import { SDKFormProvider } from './SDKFormProvider'
+import type { SDKError, SDKFieldError } from '@/types/sdkError'
+
+type TestFormValues = { street1: string; city: string }
+
+function fieldError(field: string, message: string): SDKFieldError {
+  return { field, message, category: 'invalid_attribute_value' }
+}
+
+function apiError(fieldErrors: SDKFieldError[]): SDKError {
+  return {
+    category: 'api_error',
+    message: 'We found some errors',
+    httpStatus: 422,
+    fieldErrors,
+  }
+}
+
+function TextInput({ name, label }: { name: keyof TestFormValues; label: string }) {
+  const { register } = useFormContext<TestFormValues>()
+  return <input aria-label={label} {...register(name)} />
+}
+
+function ErrorProbe() {
+  const { errors } = useFormState<TestFormValues>()
+  return (
+    <>
+      <span data-testid="error-street1">{errors.street1?.message ?? ''}</span>
+      <span data-testid="error-city">{errors.city?.message ?? ''}</span>
+    </>
+  )
+}
+
+function Harness({ errors }: { errors: SDKError[] }) {
+  const [renderCount, forceRender] = useState(0)
+  const formMethods = useForm<TestFormValues>({ defaultValues: { street1: '', city: '' } })
+
+  const fieldsMetadata: Record<'street1' | 'city', FieldMetadata> = {
+    street1: { name: 'street1' },
+    city: { name: 'city' },
+  }
+
+  const formHookResult = {
+    errorHandling: { errors },
+    form: {
+      fieldsMetadata,
+      hookFormInternals: { formMethods },
+    },
+  }
+
+  return (
+    <SDKFormProvider formHookResult={formHookResult}>
+      {errors.length > 0 && <div data-testid="banner">{errors[0]!.message}</div>}
+      <TextInput name="street1" label="Street" />
+      <TextInput name="city" label="City" />
+      <ErrorProbe />
+      <button
+        type="button"
+        onClick={() => {
+          forceRender(count => count + 1)
+        }}
+      >
+        rerender {renderCount}
+      </button>
+    </SDKFormProvider>
+  )
+}
+
+describe('SDKFormProvider field-error syncing', () => {
+  it('applies API field errors to their fields', async () => {
+    render(<Harness errors={[apiError([fieldError('street1', 'Street is invalid')])]} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-street1')).toHaveTextContent('Street is invalid')
+    })
+  })
+
+  it('clears a field error when the user changes that field, leaving the banner intact', async () => {
+    const user = userEvent.setup()
+    render(<Harness errors={[apiError([fieldError('street1', 'Street is invalid')])]} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-street1')).toHaveTextContent('Street is invalid')
+    })
+
+    await user.type(screen.getByLabelText('Street'), 'a')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-street1')).toHaveTextContent('')
+    })
+    expect(screen.getByTestId('banner')).toHaveTextContent('We found some errors')
+  })
+
+  it('only clears the changed field, leaving other fields errors intact', async () => {
+    const user = userEvent.setup()
+    render(
+      <Harness
+        errors={[
+          apiError([
+            fieldError('street1', 'Street is invalid'),
+            fieldError('city', 'City is invalid'),
+          ]),
+        ]}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-street1')).toHaveTextContent('Street is invalid')
+      expect(screen.getByTestId('error-city')).toHaveTextContent('City is invalid')
+    })
+
+    await user.type(screen.getByLabelText('Street'), 'a')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-street1')).toHaveTextContent('')
+    })
+    expect(screen.getByTestId('error-city')).toHaveTextContent('City is invalid')
+  })
+
+  it('does not re-apply a cleared error on an unrelated re-render', async () => {
+    const user = userEvent.setup()
+    render(<Harness errors={[apiError([fieldError('street1', 'Street is invalid')])]} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-street1')).toHaveTextContent('Street is invalid')
+    })
+
+    await user.type(screen.getByLabelText('Street'), 'a')
+    await waitFor(() => {
+      expect(screen.getByTestId('error-street1')).toHaveTextContent('')
+    })
+
+    await user.click(screen.getByRole('button', { name: /rerender/i }))
+
+    // The fresh-array-every-render instability must not resurrect the cleared error.
+    expect(screen.getByTestId('error-street1')).toHaveTextContent('')
+  })
+})

--- a/src/partner-hook-utils/form/SDKFormProvider.tsx
+++ b/src/partner-hook-utils/form/SDKFormProvider.tsx
@@ -1,5 +1,5 @@
-import { type ReactNode, useEffect } from 'react'
-import type { FieldPath, FieldValues } from 'react-hook-form'
+import { type ReactNode, useEffect, useRef } from 'react'
+import type { FieldPath, FieldValues, UseFormReturn } from 'react-hook-form'
 import { FormProvider } from 'react-hook-form'
 import type { FieldMetadata, FieldMetadataWithOptions, HookFormInternals } from '../types'
 import { FormFieldsMetadataProvider } from './FormFieldsMetadataProvider'
@@ -8,34 +8,89 @@ import type { FieldElementRegistry } from '@/components/Common/Fields/hooks/fiel
 import { normalizeErrorKeyForForm } from '@/helpers/formattedStrings'
 import type { SDKError, SDKFieldError } from '@/types/sdkError'
 
-function useSyncFieldErrors<
-  TFormData extends FieldValues,
-  TFieldsMetadata extends {
-    [K in keyof TFieldsMetadata]: FieldMetadata | FieldMetadataWithOptions
-  },
->(
+interface ApplicableFieldError {
+  /** Field name normalized to the form-side dotted path (e.g. `homeAddress.street1`). */
+  name: string
+  message: string
+}
+
+/**
+ * Produces a referentially-stable list of API field errors that apply to this
+ * form — normalized to form-side keys and filtered to known fields.
+ *
+ * The array reference only changes when the error content changes. `fieldErrors`
+ * is a fresh array on every render (`collectErrors` + `flatMap`), so keying an
+ * effect on it directly would re-run every render and re-apply an error the user
+ * just cleared. Following React's guidance to depend on a primitive rather than a
+ * freshly-created object, we derive a content key and swap the returned reference
+ * only when that key changes. The list is sorted first so the key is order-agnostic,
+ * and `JSON.stringify` avoids delimiter collisions.
+ */
+function useApplicableFieldErrors(
   fieldErrors: SDKFieldError[],
-  form: {
-    fieldsMetadata: TFieldsMetadata
-    hookFormInternals: HookFormInternals<TFormData>
-  },
+  fieldsMetadata: Record<string, unknown>,
+): ApplicableFieldError[] {
+  const knownFields = new Set(Object.keys(fieldsMetadata))
+  const applicable = fieldErrors
+    .filter(
+      fieldError =>
+        fieldError.message && knownFields.has(normalizeErrorKeyForForm(fieldError.field)),
+    )
+    .map(fieldError => ({
+      name: normalizeErrorKeyForForm(fieldError.field),
+      message: fieldError.message,
+    }))
+    .sort((a, b) =>
+      a.name === b.name ? a.message.localeCompare(b.message) : a.name.localeCompare(b.name),
+    )
+
+  const key = JSON.stringify(applicable)
+  const stableRef = useRef<{ key: string; value: ApplicableFieldError[] }>({
+    key,
+    value: applicable,
+  })
+  if (stableRef.current.key !== key) {
+    stableRef.current = { key, value: applicable }
+  }
+  return stableRef.current.value
+}
+
+/**
+ * Applies API-derived field errors to their fields and clears each one as soon
+ * as the user changes that field's value.
+ *
+ * In the absence of client-side validation for these fields, a server field
+ * error would otherwise persist until the next submit. A single `watch(callback)`
+ * subscription reacts to the changed field by name — no value comparison, no
+ * re-renders — clearing the error so a fresh submit can surface a fresh result.
+ * The top-level error alert is intentionally left untouched.
+ */
+function useSyncFieldErrors<TFormData extends FieldValues>(
+  applicableFieldErrors: ApplicableFieldError[],
+  formMethods: UseFormReturn<TFormData>,
 ) {
-  const { fieldsMetadata } = form
-  const { setError } = form.hookFormInternals.formMethods
+  const { setError, clearErrors, watch } = formMethods
 
   useEffect(() => {
-    if (!fieldErrors.length) return
-    const knownFields = new Set(Object.keys(fieldsMetadata))
-    for (const fieldError of fieldErrors) {
-      const normalizedField = normalizeErrorKeyForForm(fieldError.field)
-      if (knownFields.has(normalizedField)) {
-        setError(normalizedField as FieldPath<TFormData>, {
-          type: 'custom',
-          message: fieldError.message,
-        })
-      }
+    if (!applicableFieldErrors.length) return
+
+    const apiErrorFields = new Set<string>()
+    for (const { name, message } of applicableFieldErrors) {
+      setError(name as FieldPath<TFormData>, { type: 'custom', message })
+      apiErrorFields.add(name)
     }
-  }, [fieldErrors, setError, fieldsMetadata])
+
+    const subscription = watch((_values, { name }) => {
+      if (name && apiErrorFields.has(name)) {
+        clearErrors(name)
+        apiErrorFields.delete(name)
+      }
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [applicableFieldErrors, watch, setError, clearErrors])
 }
 
 /**
@@ -100,7 +155,8 @@ export function SDKFormProvider<
 >({ formHookResult, children }: SDKFormProviderProps<TFormData, TFieldsMetadata>) {
   const { errorHandling, form } = formHookResult
   const allFieldErrors = errorHandling.errors.flatMap(e => e.fieldErrors)
-  useSyncFieldErrors(allFieldErrors, form)
+  const applicableFieldErrors = useApplicableFieldErrors(allFieldErrors, form.fieldsMetadata)
+  useSyncFieldErrors(applicableFieldErrors, form.hookFormInternals.formMethods)
 
   return (
     <FormFieldsMetadataProvider metadata={form.fieldsMetadata} errors={errorHandling.errors}>


### PR DESCRIPTION
## Summary

Field-level errors synced from API 422 responses previously persisted on the field until the next submit, even after the user corrected the input — forcing a resubmit just to see whether the fix was accepted. `SDKFormProvider` now clears a field's server-derived error the moment its value changes, so every form built on the provider gets this behavior automatically.

- **`useSyncFieldErrors`** applies API field errors, then subscribes via react-hook-form's imperative `watch(callback)` to clear each field's error on the first change to that field. The subscription does **not** trigger re-renders; clearing is scoped to the one field (via a closure `Set`) and hands the field back to RHF's own validation afterward.
- **`useApplicableFieldErrors`** is a render-phase stabilizer: it filters/normalizes the errors and keys a referentially-stable array on a primitive content signature (sorted `JSON.stringify`). This prevents the fresh-array-every-render churn (`collectErrors` + `flatMap`) from re-applying an error the user just cleared on an unrelated re-render.
- The top-level error alert is intentionally left untouched — only inline field errors clear.

Scope is deliberately limited to the SDK form infrastructure plus its tests; no consumer/prototype churn.

## Test plan

- [x] `npm run test -- --run src/partner-hook-utils/form/SDKFormProvider.test.tsx` — 4 new tests: errors apply to fields, changed field clears while banner persists, only the changed field clears, and a cleared error is not resurrected by an unrelated re-render.
- [x] Regression suites green: `src/components/Company/PaySchedule/`, `src/components/Employee/Profile/`, `src/partner-hook-utils/form/` (244 tests).
- [x] No new type or lint errors in the touched files.

### Pay Schedule

https://github.com/user-attachments/assets/8a066956-079f-4761-9435-d8edd9c5af47

### Employee onboarding

https://github.com/user-attachments/assets/1f306567-6a68-4df3-860b-4dd72811af29

Also smoke tested all forms in contractor and employee onboarding to verify no regressions


Made with [Cursor](https://cursor.com)