### PR TITLE
fix: keep StateTaxes editable after the "done" event

### DIFF
--- a/src/components/Company/StateTaxes/StateTaxes.test.tsx
+++ b/src/components/Company/StateTaxes/StateTaxes.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { StateTaxes } from './StateTaxes'
+import { GustoTestProvider } from '@/test/GustoTestApiProvider'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { componentEvents } from '@/shared/constants'
+
+describe('StateTaxes', () => {
+  it('remains editable after the "done" event instead of getting stuck on the list view', async () => {
+    setupApiTestMocks()
+    const onEvent = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <GustoTestProvider>
+        <StateTaxes companyId="company-123" onEvent={onEvent} />
+      </GustoTestProvider>,
+    )
+
+    const continueButton = await screen.findByRole('button', { name: 'Continue' })
+    await user.click(continueButton)
+
+    expect(onEvent).toHaveBeenCalledWith(componentEvents.COMPANY_STATE_TAX_DONE, undefined)
+
+    const editButton = await screen.findByText('Edit')
+    await user.click(editButton)
+
+    expect(onEvent).toHaveBeenCalledWith(componentEvents.COMPANY_STATE_TAX_EDIT, {
+      state: 'CA',
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Save/i })).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/Company/StateTaxes/stateTaxesStateMachine.tsx
+++ b/src/components/Company/StateTaxes/stateTaxesStateMachine.tsx
@@ -1,4 +1,4 @@
-import { reduce, state, state as final, transition } from 'robot3'
+import { reduce, state, transition } from 'robot3'
 import type { ComponentType } from 'react'
 import type { StateTaxesContextInterface } from './StateTaxesComponents'
 import { StateTaxesFormContextual, StateTaxesListContextual } from './StateTaxesComponents'
@@ -27,7 +27,6 @@ export const stateTaxesStateMachine = {
         }),
       ),
     ),
-    transition(componentEvents.COMPANY_STATE_TAX_DONE, 'done'),
   ),
   editStateTaxes: state<MachineTransition>(
     transition(
@@ -54,5 +53,4 @@ export const stateTaxesStateMachine = {
       })),
     ),
   ),
-  done: final(),
 }


### PR DESCRIPTION
## Summary

The `StateTaxes` component's local FSM transitioned the `company/stateTaxes/done` event (fired on "Continue") into a `robot3` final state with no outgoing transitions. Once that happened, the local machine could never leave `done`, so any later "Edit"/"Start setup" click was silently dropped — users got permanently stuck on the list view.

## Changes

- Remove the `done` transition/final state from `stateTaxesStateMachine.tsx` so `company/stateTaxes/done` bubbles to `onEvent` (for outer flows like onboarding) without freezing the local machine — matching the existing `Locations` component pattern.
- Add `StateTaxes.test.tsx`, an end-to-end regression test covering Continue → Edit that fails against the old machine and passes with the fix.

## Related

## Testing

- `npm run test -- --run src/components/Company/StateTaxes` — 4 files, 32 tests pass.
- Verified the new test fails against the pre-fix machine (reverted the FSM change locally, confirmed the "Edit" click after "Continue" no longer opens the form) and passes with the fix restored.
- `npx eslint` and `npx tsc --noEmit` clean on changed files.