### PR TITLE
fix: disable continue button when direct deposit has no bank accounts

### DIFF
--- a/src/components/Employee/PaymentMethod/onboarding/ListView.tsx
+++ b/src/components/Employee/PaymentMethod/onboarding/ListView.tsx
@@ -205,7 +205,13 @@ function ListViewReady({
                   {bankAccounts.length > 0 ? t('addAnotherCta') : t('addBankAccountCta')}
                 </Components.Button>
               )}
-              <Components.Button type="submit" isLoading={paymentMethodForm.status.isPending}>
+              <Components.Button
+                type="submit"
+                isLoading={paymentMethodForm.status.isPending}
+                isDisabled={
+                  watchedType === PAYMENT_METHODS.directDeposit && bankAccounts.length === 0
+                }
+              >
                 {t('submitCta')}
               </Components.Button>
             </ActionsLayout>


### PR DESCRIPTION
## Summary
- Disables the Continue button on the payment method onboarding screen when Direct Deposit is selected but no bank accounts have been added
- Prevents a confusing backend error ("Splits is required if type is Direct Deposit") from surfacing to the user

## Test plan
- [ ] Select Direct Deposit with no bank accounts — Continue button should be disabled
- [ ] Add a bank account — Continue button should become enabled
- [ ] Select Check with no bank accounts — Continue button should remain enabled
- [ ] Existing happy paths unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)