### PR TITLE
fix: remove unprocessed payroll status badge

### DIFF
--- a/docs/reference/Translations/index.md
+++ b/docs/reference/Translations/index.md
@@ -3867,7 +3867,6 @@ Translation keys for the `Payroll.Common` i18n namespace.
 | `status.processing` |
 | `status.readyToSubmit` |
 | `status.submitted` |
-| `status.unprocessed` |
 | `status.waitingForWireIn` |
 
 ***

--- a/src/components/Payroll/PayrollList/PayrollStatusShowcase.stories.tsx
+++ b/src/components/Payroll/PayrollList/PayrollStatusShowcase.stories.tsx
@@ -160,14 +160,6 @@ export const AllStatusesShowcase = () => {
 
     // Priority 4: Fallback Statuses
     {
-      ...createBasePayroll('unprocessed'),
-      payPeriod: {
-        ...createBasePayroll('unprocessed').payPeriod,
-        startDate: '2025-11-12',
-        endDate: '2025-11-26',
-      },
-    },
-    {
       ...createBasePayroll('pending'),
       processed: true,
       checkDate: sevenDaysFromNow.toISOString(),
@@ -399,9 +391,6 @@ export const Priority4_FallbackStatuses = () => {
   const yesterday = new Date(now - 24 * 60 * 60 * 1000)
 
   const payrolls: (Payroll & { payrollType: 'Regular' })[] = [
-    {
-      ...createBasePayroll('unprocessed'),
-    },
     {
       ...createBasePayroll('pending'),
       processed: true,

--- a/src/components/Payroll/PayrollStatusBadges/payrollStatusConfig.ts
+++ b/src/components/Payroll/PayrollStatusBadges/payrollStatusConfig.ts
@@ -5,7 +5,6 @@ import { normalizeToDate, getHoursUntil, getDaysUntil } from '@/helpers/dateForm
 /** @internal */
 export type PayrollStatusTranslationKey =
   | 'processed'
-  | 'unprocessed'
   | 'calculating'
   | 'readyToSubmit'
   | 'processing'
@@ -254,7 +253,7 @@ export const STATUS_CONFIG: StatusConfig[] = [
       const daysDiff = getDaysUntil(payroll.payrollDeadline)
       if (hoursDiff === null || daysDiff === null) return false
 
-      return hoursDiff > 0 && hoursDiff >= 24 && Math.ceil(daysDiff) <= 30
+      return hoursDiff > 0 && hoursDiff >= 24 && Math.ceil(daysDiff) <= 14
     },
   },
   {
@@ -279,13 +278,5 @@ export const STATUS_CONFIG: StatusConfig[] = [
       translationKey: 'pending',
     },
     condition: payroll => !!payroll.processed,
-  },
-  {
-    name: 'unprocessed',
-    badge: {
-      variant: 'info',
-      translationKey: 'unprocessed',
-    },
-    condition: payroll => !payroll.processed && !payroll.processingRequest?.status,
   },
 ]

--- a/src/components/Payroll/PayrollStatusBadges/usePayrollStatusBadges.test.ts
+++ b/src/components/Payroll/PayrollStatusBadges/usePayrollStatusBadges.test.ts
@@ -254,7 +254,7 @@ describe('usePayrollStatusBadges', () => {
       expect(result.badges[0]!.variant).toBe('info')
     })
 
-    it('handles deadline beyond 30 days', () => {
+    it('handles deadline beyond 14 days', () => {
       const futureTime = new Date(Date.now() + 45 * 24 * 60 * 60 * 1000)
       const payroll = {
         processed: false,

--- a/src/components/Payroll/PayrollStatusBadges/usePayrollStatusBadges.test.ts
+++ b/src/components/Payroll/PayrollStatusBadges/usePayrollStatusBadges.test.ts
@@ -113,7 +113,7 @@ describe('usePayrollStatusBadges', () => {
       const wireInRequest = { status: 'awaiting_funds', paymentUuid: 'payroll-1' }
       const result = getPayrollStatusBadges(payroll, wireInRequest)
 
-      expect(result.badges[0]!.variant).toBe('info')
+      expect(result.badges).toHaveLength(0)
     })
   })
 
@@ -172,14 +172,6 @@ describe('usePayrollStatusBadges', () => {
   })
 
   describe('fallback statuses', () => {
-    it('returns Unprocessed for unprocessed payrolls without deadline', () => {
-      const payroll = { processed: false }
-      const result = getPayrollStatusBadges(payroll)
-
-      expect(result.badges[0]!.variant).toBe('info')
-      expect(result.badges[0]!.translationKey).toBe('unprocessed')
-    })
-
     it('returns Complete for processed payrolls with past check date', () => {
       const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
       const payroll = { processed: true, checkDate: pastDate }
@@ -241,7 +233,7 @@ describe('usePayrollStatusBadges', () => {
       }
       const result = getPayrollStatusBadges(payroll)
 
-      expect(result.badges[0]!.variant).toBe('info')
+      expect(result.badges).toHaveLength(0)
     })
 
     it('handles wire request with undefined status', () => {
@@ -270,7 +262,7 @@ describe('usePayrollStatusBadges', () => {
       }
       const result = getPayrollStatusBadges(payroll)
 
-      expect(result.badges[0]!.variant).toBe('info')
+      expect(result.badges).toHaveLength(0)
     })
 
     it('handles Date objects for checkDate', () => {

--- a/src/i18n/en/Payroll.Common.json
+++ b/src/i18n/en/Payroll.Common.json
@@ -1,7 +1,6 @@
 {
   "status": {
     "processed": "Processed",
-    "unprocessed": "Unprocessed",
     "calculating": "Calculating...",
     "readyToSubmit": "Ready to submit",
     "processing": "Processing",

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -5605,8 +5605,6 @@ export namespace Translations {
     status: {
       /** @defaultValue `"Processed"` */
       processed: string
-      /** @defaultValue `"Unprocessed"` */
-      unprocessed: string
       /** @defaultValue `"Calculating..."` */
       calculating: string
       /** @defaultValue `"Ready to submit"` */


### PR DESCRIPTION
## Summary
Removes the "Unprocessed" badge from the payroll list per product feedback. Payrolls with no active processing request and no upcoming deadline now show no badge. Also tightens the "Due in X days" window from 30 days to 14 days.

## Changes
- Removed `unprocessed` status rule, translation string, and type entry
- Tightened `dueInDays` condition from ≤ 30 days to ≤ 14 days
- Updated tests and Storybook stories to reflect both changes

## Demo

<img width="1193" height="539" alt="Screenshot 2026-07-17 at 2 39 00 PM" src="https://github.com/user-attachments/assets/17448925-5a04-4ea1-bda0-00e1f0e6e7c0" />


## Testing
- `npm run test -- --run src/components/Payroll/PayrollStatusBadges/usePayrollStatusBadges.test.ts` — 31 tests pass
- Storybook: `Domain/Payroll/Status Showcase` → `Priority4 Fallback Statuses` (unprocessed row removed)