### PR TITLE
fix: keep BankAccount, DocumentSigner, and PaySchedule editable after the "done" event

### DIFF
--- a/src/components/Company/BankAccount/BankAccount.test.tsx
+++ b/src/components/Company/BankAccount/BankAccount.test.tsx
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BankAccount } from './BankAccount'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { server } from '@/test/mocks/server'
+import { getCompanyBankAccounts } from '@/test/mocks/apis/company_bank_accounts'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import { companyEvents } from '@/shared/constants'
+
+describe('BankAccount', () => {
+  beforeEach(() => {
+    setupApiTestMocks()
+    server.use(getCompanyBankAccounts)
+  })
+
+  it('remains editable after the "done" event instead of getting stuck on the list view', async () => {
+    const user = userEvent.setup()
+    const onEvent = vi.fn()
+
+    renderWithProviders(<BankAccount companyId="company-123" onEvent={onEvent} />)
+
+    const continueButton = await screen.findByRole('button', { name: 'Continue' })
+    await user.click(continueButton)
+    expect(onEvent).toHaveBeenCalledWith(companyEvents.COMPANY_BANK_ACCOUNT_DONE, undefined)
+
+    const changeButton = await screen.findByRole('button', { name: 'Change bank account' })
+    await user.click(changeButton)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Routing number')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/Company/BankAccount/stateMachine.ts
+++ b/src/components/Company/BankAccount/stateMachine.ts
@@ -1,4 +1,4 @@
-import { state, transition, reduce, state as final } from 'robot3'
+import { state, transition, reduce } from 'robot3'
 import type { BankAccountContextInterface, EventPayloads } from './BankAccountComponents'
 import {
   BankAccountFormContextual,
@@ -29,7 +29,6 @@ export const bankAccountStateMachine = {
         showVerifiedMessage: false,
       })),
     ),
-    transition(componentEvents.COMPANY_BANK_ACCOUNT_DONE, 'done'),
   ),
   addBankAccount: state<MachineTransition>(
     transition(
@@ -80,5 +79,4 @@ export const bankAccountStateMachine = {
       })),
     ),
   ),
-  done: final(),
 }

--- a/src/components/Company/DocumentSigner/DocumentSigner.test.tsx
+++ b/src/components/Company/DocumentSigner/DocumentSigner.test.tsx
@@ -1,0 +1,61 @@
+import { HttpResponse } from 'msw'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DocumentSigner } from './DocumentSigner'
+import { setupApiTestMocks } from '@/test/mocks/apiServer'
+import { companyEvents } from '@/shared/constants'
+import { handleGetAllSignatories } from '@/test/mocks/apis/company_signatories'
+import { handleGetAllCompanyForms } from '@/test/mocks/apis/company_forms'
+import { server } from '@/test/mocks/server'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+
+describe('DocumentSigner', () => {
+  beforeEach(() => {
+    setupApiTestMocks()
+    server.use(
+      handleGetAllSignatories(() =>
+        HttpResponse.json([
+          {
+            uuid: 'signatory-123',
+            first_name: 'John',
+            last_name: 'Doe',
+            email: 'john.doe@example.com',
+            title: 'CEO',
+          },
+        ]),
+      ),
+      handleGetAllCompanyForms(() =>
+        HttpResponse.json([
+          {
+            uuid: 'form-123',
+            title: 'Test Form',
+            name: 'test name',
+            description: 'test description',
+            requires_signing: true,
+          },
+        ]),
+      ),
+    )
+  })
+
+  it('remains editable after the "done" event instead of getting stuck on the list view', async () => {
+    const user = userEvent.setup()
+    const onEvent = vi.fn()
+
+    renderWithProviders(
+      <DocumentSigner companyId="company-123" signatoryId="signatory-123" onEvent={onEvent} />,
+    )
+
+    const continueButton = await screen.findByRole('button', { name: 'Continue' })
+    await user.click(continueButton)
+    expect(onEvent).toHaveBeenCalledWith(companyEvents.COMPANY_FORMS_DONE, undefined)
+
+    const signButton = await screen.findByRole('button', { name: 'Sign document' })
+    await user.click(signButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Sign form' })).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/Company/DocumentSigner/stateMachine.ts
+++ b/src/components/Company/DocumentSigner/stateMachine.ts
@@ -32,7 +32,6 @@ export const documentSignerMachine = {
         component: AssignSignatory,
       })),
     ),
-    transition(companyEvents.COMPANY_FORMS_DONE, 'final'),
   ),
   assignSignatory: assignSignatoryState,
   signatureForm: state<MachineTransition>(
@@ -53,5 +52,4 @@ export const documentSignerMachine = {
       })),
     ),
   ),
-  final: state<MachineTransition>(),
 }

--- a/src/components/Company/PaySchedule/PaySchedule.test.tsx
+++ b/src/components/Company/PaySchedule/PaySchedule.test.tsx
@@ -387,6 +387,32 @@ describe('PaySchedule', () => {
       expect(onEvent).toHaveBeenCalledWith(componentEvents.PAY_SCHEDULE_DONE, undefined)
     })
 
+    it('remains editable after the "done" event instead of getting stuck on the list view', async () => {
+      const user = userEvent.setup()
+      const onEvent = vi.fn()
+
+      render(
+        <GustoProvider config={{ baseUrl: API_BASE_URL }}>
+          <PaySchedule companyId="123" onEvent={onEvent} />
+        </GustoProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+      expect(onEvent).toHaveBeenCalledWith(componentEvents.PAY_SCHEDULE_DONE, undefined)
+
+      const actionsButton = screen.getByRole('button', { name: /actions/i })
+      await user.click(actionsButton)
+      await user.click(screen.getByRole('menuitem', { name: /edit/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /edit pay schedule/i })).toBeInTheDocument()
+      })
+    })
+
     it('propagates navigation events when transitioning between views', async () => {
       const user = userEvent.setup()
       const onEvent = vi.fn()

--- a/src/components/Company/PaySchedule/payScheduleStateMachine.ts
+++ b/src/components/Company/PaySchedule/payScheduleStateMachine.ts
@@ -1,4 +1,4 @@
-import { reduce, state, state as final, transition } from 'robot3'
+import { reduce, state, transition } from 'robot3'
 import type { ComponentType } from 'react'
 import type { PayScheduleContextInterface } from './PayScheduleComponents'
 import { PayScheduleFormContextual, PayScheduleListContextual } from './PayScheduleComponents'
@@ -43,7 +43,6 @@ export const payScheduleStateMachine = {
         }),
       ),
     ),
-    transition(componentEvents.PAY_SCHEDULE_DONE, 'done'),
   ),
   addSchedule: state<MachineTransition>(
     transition(componentEvents.PAY_SCHEDULE_CREATED, 'listSchedules', toList),
@@ -53,5 +52,4 @@ export const payScheduleStateMachine = {
     transition(componentEvents.PAY_SCHEDULE_UPDATED, 'listSchedules', toList),
     transition(componentEvents.CANCEL, 'listSchedules', toList),
   ),
-  done: final(),
 }

--- a/src/components/Contractor/Documents/DocumentSigner/stateMachine.ts
+++ b/src/components/Contractor/Documents/DocumentSigner/stateMachine.ts
@@ -1,4 +1,4 @@
-import { state, transition, reduce, state as final } from 'robot3'
+import { state, transition, reduce } from 'robot3'
 import type { DocumentSignerContextInterface, EventPayloads } from './documentSignerStateMachine'
 import { SignatureFormContextual, DocumentsListContextual } from './documentSignerStateMachine'
 import { componentEvents } from '@/shared/constants'
@@ -24,7 +24,6 @@ export const documentSignerMachine = {
         }),
       ),
     ),
-    transition(componentEvents.CONTRACTOR_DOCUMENTS_DONE, 'done'),
   ),
   signatureForm: state<MachineTransition>(
     transition(
@@ -46,5 +45,4 @@ export const documentSignerMachine = {
       })),
     ),
   ),
-  done: final(),
 }


### PR DESCRIPTION
## Summary

Fixes the same class of bug patched in #2416 for `StateTaxes`, found in 3 more components while auditing every `robot3` state machine for it. Each affected component's local FSM transitioned its "done" event into a `final()` state with no outgoing transitions, permanently freezing the machine — so a later Edit/Change/Sign click on the same screen was silently dropped once "Continue" had been clicked.

## Changes

- Removed the `_DONE → final` transition and the dead-end `final`/`done` state from the local state machines for `Company/BankAccount`, `Company/DocumentSigner`, and `Company/PaySchedule`, so the "done" event bubbles to `onEvent` without moving the local machine anywhere — matching the existing correct pattern in `Locations`.
- Added/extended regression tests for each: fire the done event via "Continue," then confirm the Edit/Change/Sign action on the same screen still works.
- Also fixed the identical dead-end in `Contractor/Documents/DocumentSigner`'s state machine for consistency, but did not add a matching regression test there — its "Continue" button is gated on every signable document already being signed, so there's no UI path where a sign action coexists with "Continue" being clickable; the fix is defensive/structural rather than closing an observed repro.

## Related

- #2416 (the original StateTaxes fix this follows)

## Testing

- `npm run test -- --run src/components/Company/PaySchedule src/components/Company/BankAccount src/components/Company/DocumentSigner src/components/Contractor/Documents/DocumentSigner` — 12 files, 99 tests pass.
- `npm run test -- --run` (full suite) — 285 files, 3424 pass, 1 pre-existing expected fail (same baseline as #2416).
- `npx tsc --noEmit` — clean.
- `npx eslint` on changed files — clean (only pre-existing, unrelated warnings elsewhere in touched directories).