### PR TITLE
fix: correct off-by-one date bugs across DatePicker defaults and serialization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,27 @@ All user-facing text uses i18next. Run `npm run i18n:generate` after changing tr
 
 Exported headless hooks build `errorHandling` with **`composeErrorHandler`** (not a React hook). For multi-form screens, **`composeSubmitHandler`** coordinates validation + ordered submits and returns `{ handleSubmit, errorHandling }` aggregated across those forms. The result plugs back into `composeErrorHandler` when partners need extra `@gusto/embedded-api` queries or screen-level submit state in the same error surface.
 
+### Date handling
+
+The API models calendar dates without a time component (birthdays, effective dates, deadlines) as plain `YYYY-MM-DD` strings. Two raw JS APIs silently corrupt them by conflating UTC and local time — this caused real off-by-one bugs across the SDK (see #2429, #2430):
+
+- `new Date("YYYY-MM-DD")` parses the string as **UTC midnight**. Formatting or reading it back with local date components (`.getMonth()`, `date.toLocaleDateString()`, a default `Intl.DateTimeFormat` with no `timeZone`) rolls the displayed day back by one in any timezone behind UTC (all of the US).
+- `someLocalDate.toISOString()` converts a local-midnight `Date` (e.g. from a `DatePickerField`) to UTC, which shifts the serialized day back by one in any timezone ahead of UTC (most of Europe, Asia, Africa, Australia).
+
+**Never call `new Date(dateOnlyString)` or `date.toISOString().split('T')[0]` on a date-only value.** Always go through `src/helpers/dateFormatting.ts`: `normalizeToDate()` to parse a `YYYY-MM-DD` string into a `Date`, `formatDateToStringDate()` to serialize a `Date` back to `YYYY-MM-DD`, or the locale-aware wrappers via `useDateFormatter()` for display. This applies equally to one-off `zod` preprocessors/transforms on a `Date` field (e.g. `coerceToISODate` in `partner-hook-utils/form/preprocessors.ts`) — route through the same helpers rather than reimplementing with `toISOString()`.
+
+```tsx
+// BAD — new Date(str) parses as UTC midnight; toISOString() re-converts to UTC.
+// Both silently shift the calendar day by one in some timezone.
+const date = new Date(existingRecord.effectiveDate)
+const wireValue = pickedDate.toISOString().split('T')[0]
+
+// GOOD — routes through the timezone-safe helpers used everywhere else in the SDK.
+import { normalizeToDate, formatDateToStringDate } from '@/helpers/dateFormatting'
+const date = normalizeToDate(existingRecord.effectiveDate)
+const wireValue = formatDateToStringDate(pickedDate)
+```
+
 ### Component & Feature Conventions
 
 Durable conventions that apply SDK-wide to any component or feature:

--- a/src/components/Common/UI/CalendarPreview/CalendarPreview.tsx
+++ b/src/components/Common/UI/CalendarPreview/CalendarPreview.tsx
@@ -13,7 +13,7 @@ import { useMemo } from 'react'
 import { CalendarLegend } from './CalendarLegend'
 import type { CalendarPreviewProps } from './CalendarPreviewTypes'
 import styles from './CalendarPreview.module.scss'
-import { formatDateToStringDate } from '@/helpers/dateFormatting'
+import { formatDateToStringDate, normalizeToDate } from '@/helpers/dateFormatting'
 import { Flex } from '@/components/Common/Flex'
 
 /**
@@ -36,7 +36,8 @@ export const CalendarPreview = ({ dateRange, highlightDates }: CalendarPreviewPr
   }, [highlightDates])
 
   const isInRange = (date: DateValue) => {
-    const comparisonDate = new Date(date.toString())
+    const comparisonDate = normalizeToDate(date.toString())
+    if (!comparisonDate) return false
     const { start, end } = dateRange
     return comparisonDate >= start && comparisonDate <= end
   }

--- a/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatory.tsx
+++ b/src/components/Company/AssignSignatory/CreateSignatory/CreateSignatory.tsx
@@ -18,7 +18,7 @@ import { useI18n } from '@/i18n'
 import { useBase, BaseComponent, type BaseComponentInterface } from '@/components/Base'
 import { Flex } from '@/components/Common'
 import { companyEvents } from '@/shared/constants'
-import { formatDateToStringDate } from '@/helpers/dateFormatting'
+import { formatDateToStringDate, normalizeToDate } from '@/helpers/dateFormatting'
 import { commonMasks, useMaskedTransform } from '@/helpers/mask'
 
 /**
@@ -81,7 +81,7 @@ function Root({
   const updateSignatoryMutation = useSignatoriesUpdateMutation()
   const deleteSignatoryMutation = useSignatoriesDeleteMutation()
 
-  const defaultBirthday = currentSignatory?.birthday ?? defaultValues?.birthday
+  const defaultBirthday = normalizeToDate(currentSignatory?.birthday ?? defaultValues?.birthday)
 
   const createSignatoryDefaultValues = {
     firstName: currentSignatory?.firstName ?? defaultValues?.firstName ?? '',
@@ -95,7 +95,7 @@ function Root({
     city: currentSignatory?.homeAddress?.city ?? defaultValues?.city,
     state: currentSignatory?.homeAddress?.state ?? defaultValues?.state,
     zip: currentSignatory?.homeAddress?.zip ?? defaultValues?.zip,
-    ...(defaultBirthday ? { birthday: new Date(defaultBirthday) } : {}),
+    ...(defaultBirthday ? { birthday: defaultBirthday } : {}),
   }
 
   const formMethods = useForm<CreateSignatoryInputs>({

--- a/src/components/Company/PaySchedule/PaySchedule.test.tsx
+++ b/src/components/Company/PaySchedule/PaySchedule.test.tsx
@@ -778,6 +778,33 @@ describe('PaySchedule', () => {
       expect(screen.getByRole('grid')).toBeInTheDocument()
     })
 
+    it('shows the pay period start date without an off-by-one shift', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <GustoProvider config={{ baseUrl: API_BASE_URL }}>
+          <PaySchedule companyId="123" onEvent={() => {}} />
+        </GustoProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Weekly Schedule')).toBeInTheDocument()
+      })
+
+      const actionsButton = screen.getByRole('button', { name: /actions/i })
+      await user.click(actionsButton)
+      await user.click(screen.getByRole('menuitem', { name: /edit/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('application')).toBeInTheDocument()
+      })
+
+      // Fixture's first pay period starts 2024-01-01. Parsing that as UTC and
+      // formatting in a timezone behind UTC would render "December 2023" instead.
+      expect(screen.getAllByText('January 2024').length).toBeGreaterThan(0)
+      expect(screen.queryByText('December 2023')).not.toBeInTheDocument()
+    })
+
     it('shows highlighted dates for payday and payroll deadline', async () => {
       const user = userEvent.setup()
 

--- a/src/components/Company/PaySchedule/PayScheduleForm.tsx
+++ b/src/components/Company/PaySchedule/PayScheduleForm.tsx
@@ -11,10 +11,16 @@ import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentCon
 import { useDateFormatter } from '@/hooks/useDateFormatter'
 import { componentEvents, type EventType } from '@/shared/constants'
 import type { OnEventType } from '@/components/Base/useBase'
+import { normalizeToDate } from '@/helpers/dateFormatting'
 
 interface PayScheduleFormProps extends UsePayScheduleFormProps {
   onEvent: OnEventType<EventType, unknown>
 }
+
+// Pay period preview dates are RFCDate (`YYYY-MM-DD`) instances; normalizeToDate parses
+// them as local midnight instead of new Date's UTC midnight, which CalendarPreview would
+// otherwise roll back a day for timezones behind UTC. The format is always valid here.
+const toLocalDate = (rfcDate: { toString(): string }): Date => normalizeToDate(rfcDate.toString())!
 
 /** @internal */
 export function PayScheduleForm({ onEvent, ...hookProps }: PayScheduleFormProps) {
@@ -159,25 +165,19 @@ function PayScheduleFormRoot({ onEvent, ...hookProps }: PayScheduleFormProps) {
                       <Components.CalendarPreview
                         key={selectedPayPeriodIndex}
                         dateRange={{
-                          start: new Date(
-                            payPeriodPreview[selectedPayPeriodIndex].startDate.toString(),
-                          ),
-                          end: new Date(
-                            payPeriodPreview[selectedPayPeriodIndex].endDate.toString(),
-                          ),
+                          start: toLocalDate(payPeriodPreview[selectedPayPeriodIndex].startDate),
+                          end: toLocalDate(payPeriodPreview[selectedPayPeriodIndex].endDate),
                           label: t('payPreview.payPeriod') || 'Pay Period',
                         }}
                         highlightDates={[
                           {
-                            date: new Date(
-                              payPeriodPreview[selectedPayPeriodIndex].checkDate.toString(),
-                            ),
+                            date: toLocalDate(payPeriodPreview[selectedPayPeriodIndex].checkDate),
                             highlightColor: 'primary',
                             label: t('payPreview.payday') || 'Payday',
                           },
                           {
-                            date: new Date(
-                              payPeriodPreview[selectedPayPeriodIndex].runPayrollBy.toString(),
+                            date: toLocalDate(
+                              payPeriodPreview[selectedPayPeriodIndex].runPayrollBy,
                             ),
                             highlightColor: 'secondary',
                             label: t('payPreview.payrollDeadline') || 'Payroll Deadline',

--- a/src/components/Employee/Documents/onboarding/DocumentSigner/EmploymentEligibility/EmploymentEligibility.test.tsx
+++ b/src/components/Employee/Documents/onboarding/DocumentSigner/EmploymentEligibility/EmploymentEligibility.test.tsx
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
 import { EmploymentEligibility } from './EmploymentEligibility'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
 import { setupApiTestMocks } from '@/test/mocks/apiServer'
 import { server } from '@/test/mocks/server'
 import { getI9Authorization } from '@/test/mocks/apis/i9_authorization'
 import { componentEvents } from '@/shared/constants'
+import { API_BASE_URL } from '@/test/constants'
 
 describe('EmploymentEligibility', () => {
   beforeEach(() => {
@@ -280,6 +282,29 @@ describe('EmploymentEligibility', () => {
 
       const alert = await screen.findByRole('alert')
       expect(alert).toHaveTextContent(/citizen is someone who was born or naturalized/i)
+    })
+
+    it('pre-populates the expiration date without an off-by-one shift', async () => {
+      server.use(
+        http.get(`${API_BASE_URL}/v1/employees/:employee_id/i9_authorization`, () => {
+          return HttpResponse.json({
+            uuid: 'i9-auth-uuid-123',
+            version: 'abc123version',
+            authorization_status: 'alien',
+            expiration_date: '2026-01-01',
+            employer_signed: false,
+            employee_signed: false,
+          })
+        }),
+      )
+      renderWithProviders(<EmploymentEligibility {...defaultProps} />)
+
+      const dateGroup = await screen.findByRole('group', { name: /authorized to work until/i })
+      expect(within(dateGroup).getByRole('spinbutton', { name: /^month/i })).toHaveTextContent('1')
+      expect(within(dateGroup).getByRole('spinbutton', { name: /^day/i })).toHaveTextContent('1')
+      expect(within(dateGroup).getByRole('spinbutton', { name: /^year/i })).toHaveTextContent(
+        '2026',
+      )
     })
   })
 

--- a/src/components/Employee/Documents/onboarding/DocumentSigner/EmploymentEligibility/EmploymentEligibility.tsx
+++ b/src/components/Employee/Documents/onboarding/DocumentSigner/EmploymentEligibility/EmploymentEligibility.tsx
@@ -11,6 +11,7 @@ import { BaseComponent } from '@/components/Base/Base'
 import { useBase } from '@/components/Base'
 import { useComponentDictionary, useI18n } from '@/i18n'
 import { componentEvents } from '@/shared/constants'
+import { normalizeToDate } from '@/helpers/dateFormatting'
 
 /**
  * Props for {@link EmploymentEligibility}.
@@ -101,9 +102,7 @@ const Root = ({ employeeId, dictionary }: EmploymentEligibilityProps) => {
     ? {
         authorizationStatus: existingAuth.authorizationStatus,
         documentType: existingAuth.documentType ?? undefined,
-        expirationDate: existingAuth.expirationDate
-          ? new Date(existingAuth.expirationDate)
-          : undefined,
+        expirationDate: normalizeToDate(existingAuth.expirationDate) ?? undefined,
         country: existingAuth.country ?? undefined,
       }
     : {}

--- a/src/components/Employee/Documents/onboarding/DocumentSigner/EmploymentEligibility/EmploymentEligibilitySchema.ts
+++ b/src/components/Employee/Documents/onboarding/DocumentSigner/EmploymentEligibility/EmploymentEligibilitySchema.ts
@@ -3,6 +3,7 @@ import {
   AuthorizationStatus,
   DocumentType as I9AuthorizationDocumentType,
 } from '@gusto/embedded-api/models/components/i9authorization'
+import { formatDateToStringDate } from '@/helpers/dateFormatting'
 
 const isValidUscisNumber = (value: string) => /^[Aa]?\d{7,9}$/.test(value)
 const isValidI94Number = (value: string) => /^\d{9} ?[A-Za-z\d]\d$/.test(value)
@@ -16,7 +17,7 @@ export const generateEmploymentEligibilitySchema = (hasDocumentNumber?: boolean 
       documentNumber: z.string().optional(),
       expirationDate: z
         .date()
-        .transform(date => date.toISOString().split('T')[0])
+        .transform(date => formatDateToStringDate(date) ?? undefined)
         .optional(),
       country: z.string().optional(),
     })

--- a/src/components/Employee/StateTaxes/shared/useEmployeeStateTaxesForm/useEmployeeStateTaxesForm.tsx
+++ b/src/components/Employee/StateTaxes/shared/useEmployeeStateTaxesForm/useEmployeeStateTaxesForm.tsx
@@ -18,6 +18,7 @@ import type { StateTaxFields } from './fields'
 import { createStateFields } from './fields'
 import { getQuestionVariant } from './fieldMapping'
 import { snakeCaseToCamelCase } from '@/helpers/formattedStrings'
+import { normalizeToDate, formatDateToStringDate } from '@/helpers/dateFormatting'
 import { useDeriveFieldsMetadata } from '@/partner-hook-utils/form/useDeriveFieldsMetadata'
 import { createGetFormSubmissionValues } from '@/partner-hook-utils/form/getFormSubmissionValues'
 import { useHookFormInternals } from '@/partner-hook-utils/form/useHookFormInternals'
@@ -309,8 +310,7 @@ function resolveDefaultForQuestion(
       if (typeof wireValue === 'string') {
         const trimmed = wireValue.trim()
         if (trimmed === '') return undefined
-        const parsed = new Date(trimmed)
-        return Number.isNaN(parsed.getTime()) ? undefined : parsed
+        return normalizeToDate(trimmed) ?? undefined
       }
       return wireValue
     }
@@ -364,11 +364,7 @@ function serializeStatesPayload(
       } else if (typeof formValue === 'number' && Number.isNaN(formValue)) {
         serializedValue = ''
       } else if (formValue instanceof Date) {
-        if (Number.isNaN(formValue.getTime())) {
-          serializedValue = ''
-        } else {
-          serializedValue = formValue.toISOString().split('T')[0] ?? ''
-        }
+        serializedValue = formatDateToStringDate(formValue) ?? ''
       } else {
         serializedValue = formValue as string | number | boolean
       }

--- a/src/components/Employee/Terminations/TerminateEmployee/TerminateEmployee.test.tsx
+++ b/src/components/Employee/Terminations/TerminateEmployee/TerminateEmployee.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { http, HttpResponse } from 'msw'
+import { http, HttpResponse, type HttpResponseResolver } from 'msw'
 import { TerminateEmployee } from './TerminateEmployee'
 import { server } from '@/test/mocks/server'
 import { componentEvents } from '@/shared/constants'
@@ -291,6 +291,27 @@ describe('TerminateEmployee', () => {
       })
     })
 
+    it('sends the exact date selected by the user without a timezone shift', async () => {
+      const createTerminationResolver = vi.fn<HttpResponseResolver>(async ({ request }) => {
+        const body = (await request.json()) as { effective_date: string }
+        expect(body.effective_date).toBe('2026-06-15')
+        return HttpResponse.json(mockTerminationCancelable, { status: 201 })
+      })
+      server.use(
+        http.post(
+          `${API_BASE_URL}/v1/employees/:employee_id/terminations`,
+          createTerminationResolver,
+        ),
+      )
+
+      renderWithProviders(<TerminateEmployee {...defaultProps} />)
+      await fillDateAndSubmit()
+
+      await waitFor(() => {
+        expect(createTerminationResolver).toHaveBeenCalledTimes(1)
+      })
+    })
+
     it('emits EMPLOYEE_TERMINATION_DONE without payrollUuid when regular payroll is selected', async () => {
       renderWithProviders(<TerminateEmployee {...defaultProps} />)
 
@@ -317,6 +338,25 @@ describe('TerminateEmployee', () => {
           }),
         )
       })
+    })
+  })
+
+  describe('editing an existing termination', () => {
+    it('pre-populates the last day of work without an off-by-one shift', async () => {
+      server.use(
+        http.get(`${API_BASE_URL}/v1/employees/:employee_id/terminations`, () => {
+          return HttpResponse.json([{ ...mockTerminationCancelable, effective_date: '2026-01-01' }])
+        }),
+      )
+
+      renderWithProviders(<TerminateEmployee {...defaultProps} />)
+
+      const dateGroup = await screen.findByRole('group', { name: /last day of work/i })
+      expect(within(dateGroup).getByRole('spinbutton', { name: /^month/i })).toHaveTextContent('1')
+      expect(within(dateGroup).getByRole('spinbutton', { name: /^day/i })).toHaveTextContent('1')
+      expect(within(dateGroup).getByRole('spinbutton', { name: /^year/i })).toHaveTextContent(
+        '2026',
+      )
     })
   })
 

--- a/src/components/Employee/Terminations/TerminateEmployee/TerminateEmployee.tsx
+++ b/src/components/Employee/Terminations/TerminateEmployee/TerminateEmployee.tsx
@@ -22,6 +22,7 @@ import { useBase } from '@/components/Base/useBase'
 import { componentEvents } from '@/shared/constants'
 import { useComponentDictionary, useI18n } from '@/i18n'
 import { firstLastName } from '@/helpers/formattedStrings'
+import { formatDateToStringDate } from '@/helpers/dateFormatting'
 
 /**
  * Props for {@link TerminateEmployee}.
@@ -142,7 +143,7 @@ const Root = ({ employeeId, companyId, dictionary }: TerminateEmployeeProps) => 
 
   const handleSubmit = async (formData: TerminateEmployeeFormData) => {
     const { lastDayOfWork, payrollOption } = formData
-    const effectiveDate = lastDayOfWork.toISOString().split('T')[0]!
+    const effectiveDate = formatDateToStringDate(lastDayOfWork)!
 
     await baseSubmitHandler({ effectiveDate, payrollOption }, async () => {
       const runTerminationPayroll = payrollOption === 'dismissalPayroll'

--- a/src/components/Employee/Terminations/TerminateEmployee/TerminateEmployeePresentation.tsx
+++ b/src/components/Employee/Terminations/TerminateEmployee/TerminateEmployeePresentation.tsx
@@ -9,6 +9,7 @@ import { Flex, ActionsLayout, DatePickerField, RadioGroupField } from '@/compone
 import { Form as HtmlForm } from '@/components/Common/Form'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
+import { normalizeToDate } from '@/helpers/dateFormatting'
 
 interface TerminateEmployeePresentationProps {
   employeeName: string
@@ -45,9 +46,7 @@ export function TerminateEmployeePresentation({
   }
 
   const initialValues: Partial<TerminateEmployeeFormData> = {
-    lastDayOfWork: existingTermination?.effectiveDate
-      ? new Date(existingTermination.effectiveDate)
-      : undefined,
+    lastDayOfWork: normalizeToDate(existingTermination?.effectiveDate) ?? undefined,
     payrollOption: existingTermination
       ? getPayrollOptionFromTermination(existingTermination)
       : 'dismissalPayroll',

--- a/src/components/Payroll/ConfirmWireDetails/ConfirmWireDetailsForm/ConfirmWireDetailsForm.tsx
+++ b/src/components/Payroll/ConfirmWireDetails/ConfirmWireDetailsForm/ConfirmWireDetailsForm.tsx
@@ -21,6 +21,7 @@ import { DatePickerField, NumberInputField, TextInputField } from '@/components/
 import { TextAreaField } from '@/components/Common/Fields/TextAreaField'
 import type { OnEventType } from '@/components/Base/useBase'
 import { useDateFormatter } from '@/hooks/useDateFormatter'
+import { formatDateToStringDate } from '@/helpers/dateFormatting'
 
 interface ConfirmWireDetailsFormProps extends BaseComponentInterface<'Payroll.ConfirmWireDetailsForm'> {
   wireInId: string
@@ -44,7 +45,7 @@ const transformFormDataToPayload = (
 ): PutWireInRequestsWireInRequestUuidRequest['wireInRequestUpdateRequestBody'] => {
   return {
     amountSent: String(data.amountSent),
-    dateSent: data.dateSent.toISOString().split('T')[0] || '',
+    dateSent: formatDateToStringDate(data.dateSent) ?? '',
     bankName: data.bankName,
     additionalNotes: data.additionalNotes || undefined,
   }

--- a/src/hooks/useDateRangeFilter/useDateRangeFilter.test.ts
+++ b/src/hooks/useDateRangeFilter/useDateRangeFilter.test.ts
@@ -85,7 +85,7 @@ describe('useDateRangeFilter', () => {
       const { result } = renderHook(() => useDateRangeFilter())
 
       act(() => {
-        result.current.handleStartDateChange(new Date('2025-03-15'))
+        result.current.handleStartDateChange(new Date(2025, 2, 15))
       })
 
       const params = result.current.getApiDateParams()
@@ -97,8 +97,8 @@ describe('useDateRangeFilter', () => {
       const { result } = renderHook(() => useDateRangeFilter())
 
       act(() => {
-        result.current.handleStartDateChange(new Date('2025-01-01'))
-        result.current.handleEndDateChange(new Date('2025-06-30'))
+        result.current.handleStartDateChange(new Date(2025, 0, 1))
+        result.current.handleEndDateChange(new Date(2025, 5, 30))
       })
 
       const params = result.current.getApiDateParams()

--- a/src/hooks/useDateRangeFilter/useDateRangeFilter.ts
+++ b/src/hooks/useDateRangeFilter/useDateRangeFilter.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { formatDateToStringDate } from '@/helpers/dateFormatting'
 
 const MAX_RANGE_MONTHS = 12
 
@@ -29,7 +30,7 @@ export interface UseDateRangeFilterResult {
   getMinStartDate: () => Date | undefined
 }
 
-const toISODateString = (date: Date): string => date.toISOString().split('T')[0]!
+const toISODateString = (date: Date): string => formatDateToStringDate(date) ?? ''
 
 const addMonths = (date: Date, months: number): Date => {
   const result = new Date(date)

--- a/src/partner-hook-utils/form/preprocessors.test.ts
+++ b/src/partner-hook-utils/form/preprocessors.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { coerceNaN, coerceStringBoolean, coerceToISODate } from './preprocessors'
+
+describe('coerceToISODate', () => {
+  it('serializes a Date using its local calendar day, not the UTC day', () => {
+    // A DatePicker always produces local-midnight Dates. Serializing via
+    // toISOString() would shift this to '2025-12-31' in any timezone ahead of UTC.
+    expect(coerceToISODate(new Date(2026, 0, 1))).toBe('2026-01-01')
+  })
+
+  it('passes through non-Date values unchanged', () => {
+    expect(coerceToISODate('2026-01-01')).toBe('2026-01-01')
+  })
+
+  it('returns null for empty input', () => {
+    expect(coerceToISODate(null)).toBeNull()
+    expect(coerceToISODate(undefined)).toBeNull()
+    expect(coerceToISODate('')).toBeNull()
+  })
+
+  it('returns null for an invalid Date instead of throwing', () => {
+    expect(coerceToISODate(new Date('invalid'))).toBeNull()
+  })
+})
+
+describe('coerceNaN', () => {
+  it('substitutes the fallback for null, undefined, and NaN', () => {
+    expect(coerceNaN(0)(null)).toBe(0)
+    expect(coerceNaN(0)(undefined)).toBe(0)
+    expect(coerceNaN(0)(NaN)).toBe(0)
+  })
+
+  it('passes through valid numbers unchanged', () => {
+    expect(coerceNaN(0)(5)).toBe(5)
+  })
+})
+
+describe('coerceStringBoolean', () => {
+  it('converts the string "true" to boolean true', () => {
+    expect(coerceStringBoolean('true')).toBe(true)
+  })
+
+  it('converts any other string to boolean false', () => {
+    expect(coerceStringBoolean('false')).toBe(false)
+    expect(coerceStringBoolean('anything')).toBe(false)
+  })
+
+  it('passes through non-string values unchanged', () => {
+    expect(coerceStringBoolean(true)).toBe(true)
+    expect(coerceStringBoolean(undefined)).toBeUndefined()
+  })
+})

--- a/src/partner-hook-utils/form/preprocessors.ts
+++ b/src/partner-hook-utils/form/preprocessors.ts
@@ -1,3 +1,5 @@
+import { formatDateToStringDate } from '@/helpers/dateFormatting'
+
 /**
  * Builds a `z.preprocess` transform that replaces `null`, `undefined`, and `NaN`
  * numeric input with the provided fallback before validation.
@@ -20,12 +22,12 @@ export function coerceNaN(fallback: number) {
  * (`YYYY-MM-DD`) or `null`.
  *
  * @param val - Raw value from a date picker — a `Date`, ISO string, or empty.
- * @returns The date portion of a `Date`'s ISO string, `null` for empty input,
- *   or the value cast to `string` otherwise.
+ * @returns The `YYYY-MM-DD` string for a `Date`'s local calendar day, `null`
+ *   for empty or unparseable input, or the value cast to `string` otherwise.
  * @internal
  */
 export function coerceToISODate(val: unknown): string | null {
-  if (val instanceof Date) return val.toISOString().split('T')[0]!
+  if (val instanceof Date) return formatDateToStringDate(val)
   if (val === null || val === '' || val === undefined) return null
   return val as string
 }


### PR DESCRIPTION
## Summary

Follow-up to #2429. That fix corrected one case of a UTC-vs-local off-by-one in `StateTaxes` `Form.tsx`. This PR sweeps the rest of the SDK for the same bug class in both directions:

- **Parsing**: an API date-only string (`YYYY-MM-DD`) parsed with `new Date(str)` reads as UTC midnight; formatting or reading it back with local date components rolls the displayed date back a day in timezones behind UTC.
- **Serializing**: a DatePicker-selected `Date` (local midnight) converted back to a wire string via `.toISOString()` shifts to the previous day in timezones ahead of UTC.

## Changes

- **Parsing bugs** (DatePicker defaults showing the wrong day): `TerminateEmployee` (last day of work), `EmploymentEligibility` (I-9 expiration), `CreateSignatory` (birthday), employee state tax date-variant questions, and the PaySchedule preview calendar (month header, highlighted payday/deadline, and the selected range itself — traced through `PayScheduleForm.tsx` → `CalendarPreview.tsx`).
- **Serialization bugs** (wrong date sent to the API): the shared `coerceToISODate` preprocessor — used by the Contractor details, Compensation, Job, and PaySchedule form schemas — plus `TerminateEmployee`'s submit handler, `EmploymentEligibility`'s schema transform, employee state tax submission, `useDateRangeFilter`'s API query params, and `ConfirmWireDetailsForm`.
- All fixes route through the existing `normalizeToDate`/`formatDateToStringDate` helpers in `dateFormatting.ts`, which already handle this correctly elsewhere in the codebase (e.g. `CompensationCard`).
- Payroll domain was also audited (deadlines, pay periods, compensation dates) and came back clean — those call sites are either full timestamps or internally-consistent same-anchor comparisons.

## Testing

- Added/extended regression tests pinning the fix in `TerminateEmployee.test.tsx` (default value + exact submitted date), `EmploymentEligibility.test.tsx` (default value), `PaySchedule.test.tsx` (calendar month header), `useDateRangeFilter.test.ts`, and a new `preprocessors.test.ts` for `coerceToISODate`.
- Verified each new test actually catches the regression by temporarily reverting the corresponding fix and confirming the test fails, then restoring it.
- `npm run test -- --run` — full suite passes.
- `npx tsc --noEmit` and `npx eslint` clean on changed files.

Not included: `ConfirmWireDetailsForm.tsx` has no existing test file (none added elsewhere in the codebase either); the fix there is a one-line change onto the same well-tested `formatDateToStringDate` helper. Also out of scope: a separate, lower-severity pattern of computing "today" via `new Date().toISOString()` for default filter ranges (e.g. `PayrollList`, `PaymentsList`) — only wrong within a few hours of UTC midnight, not tied to a specific date-only field being corrupted.