### PR TITLE
chore: [prototype] move additional earnings above time off in payroll edit employee

### DIFF
--- a/sdk-app/src/design/components/payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.tsx
+++ b/sdk-app/src/design/components/payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.tsx
@@ -838,6 +838,18 @@ export const PayrollEditEmployeePresentation = ({
               })}
             </div>
           )}
+          {primaryEarningRows.length > 0 && (
+            <div className={styles.fieldGroup}>
+              <Box header={<BoxHeader title={t('additionalEarningsTitle')} />} withPadding={false}>
+                <FixedAmountsDataView
+                  rows={primaryEarningRows}
+                  label={t('additionalEarningsTitle')}
+                  isWorkweekSplit={isWorkweekSplit}
+                  workweeks={workweeks}
+                />
+              </Box>
+            </div>
+          )}
           {timeOff.length > 0 && (
             <div className={styles.fieldGroup}>
               <Box
@@ -881,18 +893,7 @@ export const PayrollEditEmployeePresentation = ({
               </Box>
             </div>
           )}
-          {primaryEarningRows.length > 0 && (
-            <div className={styles.fieldGroup}>
-              <Box header={<BoxHeader title={t('additionalEarningsTitle')} />} withPadding={false}>
-                <FixedAmountsDataView
-                  rows={primaryEarningRows}
-                  label={t('additionalEarningsTitle')}
-                  isWorkweekSplit={isWorkweekSplit}
-                  workweeks={workweeks}
-                />
-              </Box>
-            </div>
-          )}
+
           {otherEarningRows.length > 0 && (
             <div className={styles.fieldGroup}>
               <Box header={<BoxHeader title="Other" />} withPadding={false}>


### PR DESCRIPTION
## Summary

Reorders sections in the `PayrollEditEmployeePresentation` prototype so "Additional Earnings" appears before "Time Off" rather than after it.

## Changes

- Moved the `primaryEarningRows` (Additional Earnings) block above the `timeOff` block in the payroll edit employee presentation

## Testing

- Visual review in sdk-app (`npm run sdk-app`) on the payroll edit employee screen
- No logic changes; section order only