### PR TITLE
fix(payroll): apply and surface default date range in payroll filters

### DIFF
--- a/docs/reference/Translations/index.md
+++ b/docs/reference/Translations/index.md
@@ -4463,8 +4463,12 @@ Translation keys for the `Payroll.PayrollHistory` i18n namespace.
 | `dateFilter.startDate` | `"From"` |
 | `dateFilter.trigger` | `"Filter by date"` |
 | <a id="property-payrollpayrollhistoryemptystate"></a> `emptyState` | |
-| `emptyState.description` | `"When you run payrolls, they'll appear here for easy reference."` |
-| `emptyState.title` | `"No payroll history"` |
+| `emptyState.default` | |
+| `emptyState.default.description` | `"When you run payrolls, they'll appear here for easy reference."` |
+| `emptyState.default.title` | `"No payroll history"` |
+| `emptyState.filtered` | |
+| `emptyState.filtered.description` | `"Try adjusting the date filter to see more payrolls."` |
+| `emptyState.filtered.title` | `"No payrolls in this date range"` |
 | <a id="property-payrollpayrollhistorylabels"></a> `labels` | |
 | `labels.noAmount` | `"—"` |
 | <a id="property-payrollpayrollhistorymenu"></a> `menu` | |
@@ -4526,7 +4530,12 @@ Translation keys for the `Payroll.PayrollList` i18n namespace.
 | `deletePayrollDialog.confirmCta` | `"Yes, cancel payroll"` |
 | `deletePayrollDialog.title` | `"Cancel {{payPeriod}} payroll?"` |
 | <a id="property-payrollpayrolllistdeletesuccessalert"></a> `deleteSuccessAlert` | `"Payroll cancelled"` |
-| <a id="property-payrollpayrolllistemptystate"></a> `emptyState` | `"All payrolls have been processed"` |
+| <a id="property-payrollpayrolllistemptystate"></a> `emptyState` | |
+| `emptyState.default` | |
+| `emptyState.default.title` | `"All payrolls have been processed"` |
+| `emptyState.filtered` | |
+| `emptyState.filtered.description` | `"Try adjusting the date filter to see more payrolls."` |
+| `emptyState.filtered.title` | `"No payrolls in this date range"` |
 | <a id="property-payrollpayrolllistoffcyclecta"></a> `offCycleCta` | |
 | `offCycleCta.button` | `"Run off-cycle payroll"` |
 | `offCycleCta.description` | `"You can pay an employee outside of your normal payroll schedule by running an off-cycle payroll."` |

--- a/docs/reference/payroll/blocks.md
+++ b/docs/reference/payroll/blocks.md
@@ -439,9 +439,9 @@ Displays historical payroll records with filtering and management capabilities.
 ### Remarks
 
 Lists processed regular, off-cycle, and external payrolls for a company and supports filtering by
-check date (3 months, 6 months, or 1 year), viewing payroll summaries and receipts, and
-cancelling processed payrolls when they remain within the cancellation window. Each row shows
-the pay period, payroll type, pay date, status, and total pay amount.
+pay period, viewing payroll summaries and receipts, and cancelling processed payrolls when they
+remain within the cancellation window. Each row shows the pay period, payroll type, pay date,
+status, and total pay amount.
 
 <br />
 

--- a/src/components/Common/DateRangeFilter/DateRangeFilter.test.tsx
+++ b/src/components/Common/DateRangeFilter/DateRangeFilter.test.tsx
@@ -17,7 +17,6 @@ const defaultProps = {
   resetLabel: 'Reset',
   selectDatesLabel: 'Select dates',
   triggerLabel: 'Filter by date',
-  isFilterActive: false,
 }
 
 describe('DateRangeFilter', () => {
@@ -59,7 +58,6 @@ describe('DateRangeFilter', () => {
     renderWithProviders(
       <DateRangeFilter
         {...defaultProps}
-        isFilterActive={true}
         startDate={new Date(2025, 2, 10)}
         endDate={new Date(2025, 3, 16)}
         onClear={onClear}
@@ -113,11 +111,10 @@ describe('DateRangeFilter', () => {
     expect(onClear).not.toHaveBeenCalled()
   })
 
-  it('uses secondary variant and shows date range for trigger when filter is active', () => {
+  it('shows the date range on the trigger when both dates are set', () => {
     renderWithProviders(
       <DateRangeFilter
         {...defaultProps}
-        isFilterActive={true}
         startDate={new Date(2025, 2, 10)}
         endDate={new Date(2025, 3, 16)}
       />,
@@ -128,10 +125,11 @@ describe('DateRangeFilter', () => {
     expect(trigger).toHaveTextContent('Mar 10 – Apr 16')
   })
 
-  it('uses secondary variant for trigger when filter is not active', () => {
-    renderWithProviders(<DateRangeFilter {...defaultProps} isFilterActive={false} />)
+  it('shows the selectDatesLabel on the trigger when no dates are set', () => {
+    renderWithProviders(<DateRangeFilter {...defaultProps} />)
 
     const trigger = screen.getByRole('button', { name: 'Filter by date' })
     expect(trigger).toHaveAttribute('data-variant', 'secondary')
+    expect(trigger).toHaveTextContent('Select dates')
   })
 })

--- a/src/components/Common/DateRangeFilter/DateRangeFilter.tsx
+++ b/src/components/Common/DateRangeFilter/DateRangeFilter.tsx
@@ -23,7 +23,6 @@ interface DateRangeFilterProps {
   resetLabel: string
   selectDatesLabel: string
   triggerLabel: string
-  isFilterActive: boolean
   maxEndDate?: Date
   minStartDate?: Date
 }
@@ -42,7 +41,6 @@ export const DateRangeFilter = ({
   resetLabel,
   selectDatesLabel,
   triggerLabel,
-  isFilterActive,
   maxEndDate,
   minStartDate,
 }: DateRangeFilterProps) => {

--- a/src/components/Common/DateRangeFilter/DateRangeFilter.tsx
+++ b/src/components/Common/DateRangeFilter/DateRangeFilter.tsx
@@ -82,9 +82,9 @@ export const DateRangeFilter = ({
   }, [])
 
   const filterDateLabel = useMemo(() => {
-    if (!isFilterActive || !startDate || !endDate) return null
+    if (!startDate || !endDate) return null
     return `${formatFilterDate(startDate)} – ${formatFilterDate(endDate)}`
-  }, [isFilterActive, startDate, endDate])
+  }, [startDate, endDate])
 
   const triggerButton = (
     <Button

--- a/src/components/Payroll/PayrollHistory/PayrollHistory.stories.tsx
+++ b/src/components/Payroll/PayrollHistory/PayrollHistory.stories.tsx
@@ -13,6 +13,8 @@ export default {
 const mockDateRangeFilter: UseDateRangeFilterResult = {
   filterStartDate: null,
   filterEndDate: null,
+  displayStartDate: null,
+  displayEndDate: null,
   isFilterActive: false,
   handleStartDateChange: fn().mockName('handleStartDateChange'),
   handleEndDateChange: fn().mockName('handleEndDateChange'),
@@ -242,6 +244,8 @@ export const WithDateFilter = () => {
   const activeDateRangeFilter: UseDateRangeFilterResult = {
     filterStartDate: startDate,
     filterEndDate: endDate,
+    displayStartDate: startDate,
+    displayEndDate: endDate,
     isFilterActive: startDate !== null || endDate !== null,
     handleStartDateChange: setStartDate,
     handleEndDateChange: setEndDate,

--- a/src/components/Payroll/PayrollHistory/PayrollHistory.stories.tsx
+++ b/src/components/Payroll/PayrollHistory/PayrollHistory.stories.tsx
@@ -11,11 +11,9 @@ export default {
 }
 
 const mockDateRangeFilter: UseDateRangeFilterResult = {
-  filterStartDate: null,
-  filterEndDate: null,
-  displayStartDate: null,
-  displayEndDate: null,
-  isFilterActive: false,
+  startDate: null,
+  endDate: null,
+  isModified: false,
   handleStartDateChange: fn().mockName('handleStartDateChange'),
   handleEndDateChange: fn().mockName('handleEndDateChange'),
   handleClearFilter: fn().mockName('handleClearFilter'),
@@ -242,11 +240,9 @@ export const WithDateFilter = () => {
   }, [])
 
   const activeDateRangeFilter: UseDateRangeFilterResult = {
-    filterStartDate: startDate,
-    filterEndDate: endDate,
-    displayStartDate: startDate,
-    displayEndDate: endDate,
-    isFilterActive: startDate !== null || endDate !== null,
+    startDate,
+    endDate,
+    isModified: startDate !== null || endDate !== null,
     handleStartDateChange: setStartDate,
     handleEndDateChange: setEndDate,
     handleClearFilter: handleClear,

--- a/src/components/Payroll/PayrollHistory/PayrollHistory.test.tsx
+++ b/src/components/Payroll/PayrollHistory/PayrollHistory.test.tsx
@@ -709,7 +709,7 @@ describe('PayrollHistory', () => {
       })
     })
 
-    it('passes default date params (3 months back through today, filtered by check date) to the API', async () => {
+    it('passes default date params (3 months back through today, filtered by pay period) to the API', async () => {
       renderWithProviders(<PayrollHistory {...defaultProps} />)
 
       await waitFor(() => {
@@ -720,7 +720,7 @@ describe('PayrollHistory', () => {
       const endDateParam = capturedPayrollListUrl!.searchParams.get('end_date')
       expect(startDateParam).toBeTruthy()
       expect(endDateParam).toBeTruthy()
-      expect(capturedPayrollListUrl!.searchParams.get('date_filter_by')).toBe('check_date')
+      expect(capturedPayrollListUrl!.searchParams.get('date_filter_by')).toBeNull()
 
       const startDate = new Date(startDateParam!)
       const endDate = new Date(endDateParam!)

--- a/src/components/Payroll/PayrollHistory/PayrollHistory.test.tsx
+++ b/src/components/Payroll/PayrollHistory/PayrollHistory.test.tsx
@@ -709,16 +709,34 @@ describe('PayrollHistory', () => {
       })
     })
 
-    it('does not pass date params to API by default', async () => {
+    it('passes default date params (3 months back through today, filtered by check date) to the API', async () => {
       renderWithProviders(<PayrollHistory {...defaultProps} />)
 
       await waitFor(() => {
         expect(capturedPayrollListUrl).not.toBeNull()
       })
 
-      expect(capturedPayrollListUrl!.searchParams.get('start_date')).toBeNull()
-      expect(capturedPayrollListUrl!.searchParams.get('end_date')).toBeNull()
-      expect(capturedPayrollListUrl!.searchParams.get('date_filter_by')).toBeNull()
+      const startDateParam = capturedPayrollListUrl!.searchParams.get('start_date')
+      const endDateParam = capturedPayrollListUrl!.searchParams.get('end_date')
+      expect(startDateParam).toBeTruthy()
+      expect(endDateParam).toBeTruthy()
+      expect(capturedPayrollListUrl!.searchParams.get('date_filter_by')).toBe('check_date')
+
+      const startDate = new Date(startDateParam!)
+      const endDate = new Date(endDateParam!)
+      const fourMonthsAgo = new Date()
+      fourMonthsAgo.setMonth(fourMonthsAgo.getMonth() - 4)
+      const twoMonthsAgo = new Date()
+      twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2)
+      expect(startDate.getTime()).toBeGreaterThan(fourMonthsAgo.getTime())
+      expect(startDate.getTime()).toBeLessThan(twoMonthsAgo.getTime())
+
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+      const tomorrow = new Date()
+      tomorrow.setDate(tomorrow.getDate() + 1)
+      expect(endDate.getTime()).toBeGreaterThan(yesterday.getTime())
+      expect(endDate.getTime()).toBeLessThan(tomorrow.getTime())
     })
   })
 

--- a/src/components/Payroll/PayrollHistory/PayrollHistory.tsx
+++ b/src/components/Payroll/PayrollHistory/PayrollHistory.tsx
@@ -3,7 +3,6 @@ import { usePayrollsListSuspense } from '@gusto/embedded-api/react-query/payroll
 import { usePayrollsCancelMutation } from '@gusto/embedded-api/react-query/payrollsCancel'
 import { useWireInRequestsListSuspense } from '@gusto/embedded-api/react-query/wireInRequestsList'
 import {
-  DateFilterBy,
   ProcessingStatuses,
   QueryParamPayrollTypes,
   QueryParamSortOrder as SortOrder,
@@ -33,9 +32,9 @@ export interface PayrollHistoryProps extends BaseComponentInterface<'Payroll.Pay
  *
  * @remarks
  * Lists processed regular, off-cycle, and external payrolls for a company and supports filtering by
- * check date (3 months, 6 months, or 1 year), viewing payroll summaries and receipts, and
- * cancelling processed payrolls when they remain within the cancellation window. Each row shows
- * the pay period, payroll type, pay date, status, and total pay amount.
+ * pay period, viewing payroll summaries and receipts, and cancelling processed payrolls when they
+ * remain within the cancellation window. Each row shows the pay period, payroll type, pay date,
+ * status, and total pay amount.
  *
  * @events
  * | Event | Description | Data |
@@ -96,7 +95,6 @@ const Root = ({ onEvent, companyId, dictionary }: PayrollHistoryProps) => {
     sortOrder: SortOrder.Desc,
     startDate: dateFilterParams.startDate,
     endDate: dateFilterParams.endDate,
-    dateFilterBy: DateFilterBy.CheckDate,
     page: currentPage,
     per: itemsPerPage,
   })

--- a/src/components/Payroll/PayrollHistory/PayrollHistory.tsx
+++ b/src/components/Payroll/PayrollHistory/PayrollHistory.tsx
@@ -56,6 +56,16 @@ export function PayrollHistory(props: PayrollHistoryProps) {
   )
 }
 
+const DEFAULT_LOOKBACK_MONTHS = 3
+
+const getDefaultStartDate = (): Date => {
+  const date = new Date()
+  date.setMonth(date.getMonth() - DEFAULT_LOOKBACK_MONTHS)
+  return date
+}
+
+const getDefaultEndDate = (): Date => new Date()
+
 const Root = ({ onEvent, companyId, dictionary }: PayrollHistoryProps) => {
   useComponentDictionary('Payroll.PayrollHistory', dictionary)
   useI18n('Payroll.PayrollHistory')
@@ -65,6 +75,8 @@ const Root = ({ onEvent, companyId, dictionary }: PayrollHistoryProps) => {
   const { currentPage, itemsPerPage, getPaginationProps, resetPage } = usePagination()
 
   const dateRangeFilter = useDateRangeFilter({
+    defaultStartDate: getDefaultStartDate(),
+    defaultEndDate: getDefaultEndDate(),
     onFilterChange: useCallback(() => {
       resetPage()
     }, [resetPage]),
@@ -84,7 +96,7 @@ const Root = ({ onEvent, companyId, dictionary }: PayrollHistoryProps) => {
     sortOrder: SortOrder.Desc,
     startDate: dateFilterParams.startDate,
     endDate: dateFilterParams.endDate,
-    dateFilterBy: dateRangeFilter.isFilterActive ? DateFilterBy.CheckDate : undefined,
+    dateFilterBy: DateFilterBy.CheckDate,
     page: currentPage,
     per: itemsPerPage,
   })

--- a/src/components/Payroll/PayrollHistory/PayrollHistory.tsx
+++ b/src/components/Payroll/PayrollHistory/PayrollHistory.tsx
@@ -75,8 +75,8 @@ const Root = ({ onEvent, companyId, dictionary }: PayrollHistoryProps) => {
   const { currentPage, itemsPerPage, getPaginationProps, resetPage } = usePagination()
 
   const dateRangeFilter = useDateRangeFilter({
-    defaultStartDate: getDefaultStartDate(),
-    defaultEndDate: getDefaultEndDate(),
+    initialStartDate: getDefaultStartDate(),
+    initialEndDate: getDefaultEndDate(),
     onFilterChange: useCallback(() => {
       resetPage()
     }, [resetPage]),

--- a/src/components/Payroll/PayrollHistory/PayrollHistoryPresentation.tsx
+++ b/src/components/Payroll/PayrollHistory/PayrollHistoryPresentation.tsx
@@ -125,8 +125,8 @@ export const PayrollHistoryPresentation = ({
       <Flex justifyContent="space-between" alignItems="center">
         <Heading as="h2">{t('title')}</Heading>
         <DateRangeFilter
-          startDate={dateRangeFilter.filterStartDate}
-          endDate={dateRangeFilter.filterEndDate}
+          startDate={dateRangeFilter.displayStartDate}
+          endDate={dateRangeFilter.displayEndDate}
           onStartDateChange={dateRangeFilter.handleStartDateChange}
           onEndDateChange={dateRangeFilter.handleEndDateChange}
           onClear={dateRangeFilter.handleClearFilter}

--- a/src/components/Payroll/PayrollHistory/PayrollHistoryPresentation.tsx
+++ b/src/components/Payroll/PayrollHistory/PayrollHistoryPresentation.tsx
@@ -125,8 +125,8 @@ export const PayrollHistoryPresentation = ({
       <Flex justifyContent="space-between" alignItems="center">
         <Heading as="h2">{t('title')}</Heading>
         <DateRangeFilter
-          startDate={dateRangeFilter.displayStartDate}
-          endDate={dateRangeFilter.displayEndDate}
+          startDate={dateRangeFilter.startDate}
+          endDate={dateRangeFilter.endDate}
           onStartDateChange={dateRangeFilter.handleStartDateChange}
           onEndDateChange={dateRangeFilter.handleEndDateChange}
           onClear={dateRangeFilter.handleClearFilter}
@@ -137,7 +137,6 @@ export const PayrollHistoryPresentation = ({
           resetLabel={t('dateFilter.reset')}
           selectDatesLabel={t('dateFilter.selectDates')}
           triggerLabel={t('dateFilter.trigger')}
-          isFilterActive={dateRangeFilter.isFilterActive}
           maxEndDate={dateRangeFilter.getMaxEndDate()}
           minStartDate={dateRangeFilter.getMinStartDate()}
         />
@@ -147,7 +146,7 @@ export const PayrollHistoryPresentation = ({
         label={t('dataView.label')}
         pagination={pagination}
         emptyState={() =>
-          dateRangeFilter.isFilterActive ? (
+          dateRangeFilter.isModified ? (
             <EmptyData
               title={t('emptyState.filtered.title')}
               description={t('emptyState.filtered.description')}

--- a/src/components/Payroll/PayrollHistory/PayrollHistoryPresentation.tsx
+++ b/src/components/Payroll/PayrollHistory/PayrollHistoryPresentation.tsx
@@ -146,9 +146,19 @@ export const PayrollHistoryPresentation = ({
       <DataView
         label={t('dataView.label')}
         pagination={pagination}
-        emptyState={() => (
-          <EmptyData title={t('emptyState.title')} description={t('emptyState.description')} />
-        )}
+        emptyState={() =>
+          dateRangeFilter.isFilterActive ? (
+            <EmptyData
+              title={t('emptyState.filtered.title')}
+              description={t('emptyState.filtered.description')}
+            />
+          ) : (
+            <EmptyData
+              title={t('emptyState.default.title')}
+              description={t('emptyState.default.description')}
+            />
+          )
+        }
         columns={[
           {
             title: t('columns.payPeriod'),

--- a/src/components/Payroll/PayrollList/PayrollList.stories.tsx
+++ b/src/components/Payroll/PayrollList/PayrollList.stories.tsx
@@ -15,11 +15,9 @@ const runOffCyclePayrollAction = fn().mockName('run_off_cycle_payroll')
 const dismissAlertAction = fn().mockName('dismiss_alert')
 
 const mockDateRangeFilter: UseDateRangeFilterResult = {
-  filterStartDate: null,
-  filterEndDate: null,
-  displayStartDate: null,
-  displayEndDate: null,
-  isFilterActive: false,
+  startDate: null,
+  endDate: null,
+  isModified: false,
   handleStartDateChange: fn().mockName('handleStartDateChange'),
   handleEndDateChange: fn().mockName('handleEndDateChange'),
   handleClearFilter: fn().mockName('handleClearFilter'),
@@ -375,11 +373,9 @@ export const WithDateFilter = () => {
   }, [])
 
   const activeDateRangeFilter: UseDateRangeFilterResult = {
-    filterStartDate: startDate,
-    filterEndDate: endDate,
-    displayStartDate: startDate,
-    displayEndDate: endDate,
-    isFilterActive: startDate !== null || endDate !== null,
+    startDate,
+    endDate,
+    isModified: startDate !== null || endDate !== null,
     handleStartDateChange: setStartDate,
     handleEndDateChange: setEndDate,
     handleClearFilter: handleClear,

--- a/src/components/Payroll/PayrollList/PayrollList.stories.tsx
+++ b/src/components/Payroll/PayrollList/PayrollList.stories.tsx
@@ -17,6 +17,8 @@ const dismissAlertAction = fn().mockName('dismiss_alert')
 const mockDateRangeFilter: UseDateRangeFilterResult = {
   filterStartDate: null,
   filterEndDate: null,
+  displayStartDate: null,
+  displayEndDate: null,
   isFilterActive: false,
   handleStartDateChange: fn().mockName('handleStartDateChange'),
   handleEndDateChange: fn().mockName('handleEndDateChange'),
@@ -375,6 +377,8 @@ export const WithDateFilter = () => {
   const activeDateRangeFilter: UseDateRangeFilterResult = {
     filterStartDate: startDate,
     filterEndDate: endDate,
+    displayStartDate: startDate,
+    displayEndDate: endDate,
     isFilterActive: startDate !== null || endDate !== null,
     handleStartDateChange: setStartDate,
     handleEndDateChange: setEndDate,

--- a/src/components/Payroll/PayrollList/PayrollList.test.tsx
+++ b/src/components/Payroll/PayrollList/PayrollList.test.tsx
@@ -70,14 +70,23 @@ describe('PayrollList', () => {
     })
   })
 
-  it('does not pass start_date to API by default', async () => {
+  it('passes a default start_date of today to the API', async () => {
     renderWithProviders(<PayrollList {...defaultProps} />)
 
     await waitFor(() => {
       expect(capturedPayrollListUrl).not.toBeNull()
     })
 
-    expect(capturedPayrollListUrl!.searchParams.get('start_date')).toBeNull()
+    const startDateParam = capturedPayrollListUrl!.searchParams.get('start_date')
+    expect(startDateParam).toBeTruthy()
+
+    const startDate = new Date(startDateParam!)
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 1)
+    const tomorrow = new Date()
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    expect(startDate.getTime()).toBeGreaterThan(yesterday.getTime())
+    expect(startDate.getTime()).toBeLessThan(tomorrow.getTime())
   })
 
   it('includes page and per params in the API request', async () => {

--- a/src/components/Payroll/PayrollList/PayrollList.tsx
+++ b/src/components/Payroll/PayrollList/PayrollList.tsx
@@ -93,8 +93,8 @@ const Root = ({ companyId, onEvent }: PayrollListBlockProps) => {
   const [deletingPayrollId, setDeletingPayrollId] = useState<string | null>(null)
 
   const dateRangeFilter = useDateRangeFilter({
-    defaultStartDate: getDefaultStartDate(),
-    defaultEndDate: getDefaultEndDate(),
+    initialStartDate: getDefaultStartDate(),
+    initialEndDate: getDefaultEndDate(),
     onFilterChange: useCallback(() => {
       resetPage()
     }, [resetPage]),

--- a/src/components/Payroll/PayrollList/PayrollList.tsx
+++ b/src/components/Payroll/PayrollList/PayrollList.tsx
@@ -75,10 +75,12 @@ export function PayrollList(props: PayrollListBlockProps) {
 
 const FUTURE_LOOKAHEAD_MONTHS = 3
 
-const getFutureEndDate = (): string => {
-  const endDate = new Date()
-  endDate.setMonth(endDate.getMonth() + FUTURE_LOOKAHEAD_MONTHS)
-  return endDate.toISOString().split('T')[0]!
+const getDefaultStartDate = (): Date => new Date()
+
+const getDefaultEndDate = (): Date => {
+  const date = new Date()
+  date.setMonth(date.getMonth() + FUTURE_LOOKAHEAD_MONTHS)
+  return date
 }
 
 const Root = ({ companyId, onEvent }: PayrollListBlockProps) => {
@@ -91,6 +93,8 @@ const Root = ({ companyId, onEvent }: PayrollListBlockProps) => {
   const [deletingPayrollId, setDeletingPayrollId] = useState<string | null>(null)
 
   const dateRangeFilter = useDateRangeFilter({
+    defaultStartDate: getDefaultStartDate(),
+    defaultEndDate: getDefaultEndDate(),
     onFilterChange: useCallback(() => {
       resetPage()
     }, [resetPage]),
@@ -101,7 +105,7 @@ const Root = ({ companyId, onEvent }: PayrollListBlockProps) => {
     companyId,
     processingStatuses: [ProcessingStatuses.Unprocessed],
     startDate: dateFilterParams.startDate,
-    endDate: dateFilterParams.endDate ?? getFutureEndDate(),
+    endDate: dateFilterParams.endDate,
     payrollTypes: [
       QueryParamPayrollTypes.Regular,
       QueryParamPayrollTypes.OffCycle,

--- a/src/components/Payroll/PayrollList/PayrollListPresentation.test.tsx
+++ b/src/components/Payroll/PayrollList/PayrollListPresentation.test.tsx
@@ -73,11 +73,9 @@ const mockBlockers: ApiPayrollBlocker[] = [
 ]
 
 const mockDateRangeFilter: UseDateRangeFilterResult = {
-  filterStartDate: null,
-  filterEndDate: null,
-  displayStartDate: null,
-  displayEndDate: null,
-  isFilterActive: false,
+  startDate: null,
+  endDate: null,
+  isModified: false,
   handleStartDateChange: vi.fn(),
   handleEndDateChange: vi.fn(),
   handleClearFilter: vi.fn(),

--- a/src/components/Payroll/PayrollList/PayrollListPresentation.test.tsx
+++ b/src/components/Payroll/PayrollList/PayrollListPresentation.test.tsx
@@ -75,6 +75,8 @@ const mockBlockers: ApiPayrollBlocker[] = [
 const mockDateRangeFilter: UseDateRangeFilterResult = {
   filterStartDate: null,
   filterEndDate: null,
+  displayStartDate: null,
+  displayEndDate: null,
   isFilterActive: false,
   handleStartDateChange: vi.fn(),
   handleEndDateChange: vi.fn(),

--- a/src/components/Payroll/PayrollList/PayrollListPresentation.tsx
+++ b/src/components/Payroll/PayrollList/PayrollListPresentation.tsx
@@ -251,8 +251,8 @@ export const PayrollListPresentation = ({
         <Flex justifyContent="space-between" alignItems="center">
           <Heading as="h2">{t('title')}</Heading>
           <DateRangeFilter
-            startDate={dateRangeFilter.filterStartDate}
-            endDate={dateRangeFilter.filterEndDate}
+            startDate={dateRangeFilter.displayStartDate}
+            endDate={dateRangeFilter.displayEndDate}
             onStartDateChange={dateRangeFilter.handleStartDateChange}
             onEndDateChange={dateRangeFilter.handleEndDateChange}
             onClear={dateRangeFilter.handleClearFilter}

--- a/src/components/Payroll/PayrollList/PayrollListPresentation.tsx
+++ b/src/components/Payroll/PayrollList/PayrollListPresentation.tsx
@@ -251,8 +251,8 @@ export const PayrollListPresentation = ({
         <Flex justifyContent="space-between" alignItems="center">
           <Heading as="h2">{t('title')}</Heading>
           <DateRangeFilter
-            startDate={dateRangeFilter.displayStartDate}
-            endDate={dateRangeFilter.displayEndDate}
+            startDate={dateRangeFilter.startDate}
+            endDate={dateRangeFilter.endDate}
             onStartDateChange={dateRangeFilter.handleStartDateChange}
             onEndDateChange={dateRangeFilter.handleEndDateChange}
             onClear={dateRangeFilter.handleClearFilter}
@@ -263,7 +263,6 @@ export const PayrollListPresentation = ({
             resetLabel={t('dateFilter.reset')}
             selectDatesLabel={t('dateFilter.selectDates')}
             triggerLabel={t('dateFilter.trigger')}
-            isFilterActive={dateRangeFilter.isFilterActive}
             maxEndDate={dateRangeFilter.getMaxEndDate()}
             minStartDate={dateRangeFilter.getMinStartDate()}
           />
@@ -273,7 +272,7 @@ export const PayrollListPresentation = ({
           breakAt="large"
           pagination={pagination}
           emptyState={() =>
-            dateRangeFilter.isFilterActive ? (
+            dateRangeFilter.isModified ? (
               <EmptyData
                 title={t('emptyState.filtered.title')}
                 description={t('emptyState.filtered.description')}

--- a/src/components/Payroll/PayrollList/PayrollListPresentation.tsx
+++ b/src/components/Payroll/PayrollList/PayrollListPresentation.tsx
@@ -272,7 +272,16 @@ export const PayrollListPresentation = ({
         <DataView
           breakAt="large"
           pagination={pagination}
-          emptyState={() => <EmptyData title={t('emptyState')} />}
+          emptyState={() =>
+            dateRangeFilter.isFilterActive ? (
+              <EmptyData
+                title={t('emptyState.filtered.title')}
+                description={t('emptyState.filtered.description')}
+              />
+            ) : (
+              <EmptyData title={t('emptyState.default.title')} />
+            )
+          }
           data={payrolls}
           columns={[
             {

--- a/src/components/Payroll/PayrollList/PayrollStatusShowcase.stories.tsx
+++ b/src/components/Payroll/PayrollList/PayrollStatusShowcase.stories.tsx
@@ -9,11 +9,9 @@ export default {
 }
 
 const mockDateRangeFilter: UseDateRangeFilterResult = {
-  filterStartDate: null,
-  filterEndDate: null,
-  displayStartDate: null,
-  displayEndDate: null,
-  isFilterActive: false,
+  startDate: null,
+  endDate: null,
+  isModified: false,
   handleStartDateChange: fn().mockName('handleStartDateChange'),
   handleEndDateChange: fn().mockName('handleEndDateChange'),
   handleClearFilter: fn().mockName('handleClearFilter'),

--- a/src/components/Payroll/PayrollList/PayrollStatusShowcase.stories.tsx
+++ b/src/components/Payroll/PayrollList/PayrollStatusShowcase.stories.tsx
@@ -11,6 +11,8 @@ export default {
 const mockDateRangeFilter: UseDateRangeFilterResult = {
   filterStartDate: null,
   filterEndDate: null,
+  displayStartDate: null,
+  displayEndDate: null,
   isFilterActive: false,
   handleStartDateChange: fn().mockName('handleStartDateChange'),
   handleEndDateChange: fn().mockName('handleEndDateChange'),

--- a/src/hooks/useDateRangeFilter/useDateRangeFilter.test.ts
+++ b/src/hooks/useDateRangeFilter/useDateRangeFilter.test.ts
@@ -3,15 +3,28 @@ import { renderHook, act } from '@testing-library/react'
 import { useDateRangeFilter } from './useDateRangeFilter'
 
 describe('useDateRangeFilter', () => {
-  it('initializes with no active filter', () => {
+  it('initializes with null dates and is not modified', () => {
     const { result } = renderHook(() => useDateRangeFilter())
 
-    expect(result.current.filterStartDate).toBeNull()
-    expect(result.current.filterEndDate).toBeNull()
-    expect(result.current.isFilterActive).toBe(false)
+    expect(result.current.startDate).toBeNull()
+    expect(result.current.endDate).toBeNull()
+    expect(result.current.isModified).toBe(false)
   })
 
-  it('becomes active when start date is set', () => {
+  it('seeds start and end from initialStartDate and initialEndDate', () => {
+    const initialStart = new Date('2025-01-01')
+    const initialEnd = new Date('2025-06-30')
+
+    const { result } = renderHook(() =>
+      useDateRangeFilter({ initialStartDate: initialStart, initialEndDate: initialEnd }),
+    )
+
+    expect(result.current.startDate).toBe(initialStart)
+    expect(result.current.endDate).toBe(initialEnd)
+    expect(result.current.isModified).toBe(false)
+  })
+
+  it('becomes modified when start date is changed', () => {
     const { result } = renderHook(() => useDateRangeFilter())
     const date = new Date('2025-01-15')
 
@@ -19,11 +32,11 @@ describe('useDateRangeFilter', () => {
       result.current.handleStartDateChange(date)
     })
 
-    expect(result.current.filterStartDate).toEqual(date)
-    expect(result.current.isFilterActive).toBe(true)
+    expect(result.current.startDate).toEqual(date)
+    expect(result.current.isModified).toBe(true)
   })
 
-  it('becomes active when end date is set', () => {
+  it('becomes modified when end date is changed', () => {
     const { result } = renderHook(() => useDateRangeFilter())
     const date = new Date('2025-06-15')
 
@@ -31,11 +44,35 @@ describe('useDateRangeFilter', () => {
       result.current.handleEndDateChange(date)
     })
 
-    expect(result.current.filterEndDate).toEqual(date)
-    expect(result.current.isFilterActive).toBe(true)
+    expect(result.current.endDate).toEqual(date)
+    expect(result.current.isModified).toBe(true)
   })
 
-  it('clears both dates when handleClearFilter is called', () => {
+  it('restores initial dates when handleClearFilter is called', () => {
+    const initialStart = new Date('2025-01-01')
+    const initialEnd = new Date('2025-06-30')
+
+    const { result } = renderHook(() =>
+      useDateRangeFilter({ initialStartDate: initialStart, initialEndDate: initialEnd }),
+    )
+
+    act(() => {
+      result.current.handleStartDateChange(new Date('2025-02-01'))
+      result.current.handleEndDateChange(new Date('2025-07-01'))
+    })
+
+    expect(result.current.isModified).toBe(true)
+
+    act(() => {
+      result.current.handleClearFilter()
+    })
+
+    expect(result.current.startDate).toBe(initialStart)
+    expect(result.current.endDate).toBe(initialEnd)
+    expect(result.current.isModified).toBe(false)
+  })
+
+  it('clears to null when no initials are supplied', () => {
     const { result } = renderHook(() => useDateRangeFilter())
 
     act(() => {
@@ -43,15 +80,13 @@ describe('useDateRangeFilter', () => {
       result.current.handleEndDateChange(new Date('2025-06-01'))
     })
 
-    expect(result.current.isFilterActive).toBe(true)
-
     act(() => {
       result.current.handleClearFilter()
     })
 
-    expect(result.current.filterStartDate).toBeNull()
-    expect(result.current.filterEndDate).toBeNull()
-    expect(result.current.isFilterActive).toBe(false)
+    expect(result.current.startDate).toBeNull()
+    expect(result.current.endDate).toBeNull()
+    expect(result.current.isModified).toBe(false)
   })
 
   it('calls onFilterChange when dates change', () => {
@@ -79,6 +114,19 @@ describe('useDateRangeFilter', () => {
       const { result } = renderHook(() => useDateRangeFilter())
 
       expect(result.current.getApiDateParams()).toEqual({})
+    })
+
+    it('returns initial dates as ISO strings on first render', () => {
+      const { result } = renderHook(() =>
+        useDateRangeFilter({
+          initialStartDate: new Date(2025, 0, 1),
+          initialEndDate: new Date(2025, 5, 30),
+        }),
+      )
+
+      const params = result.current.getApiDateParams()
+      expect(params.startDate).toBe('2025-01-01')
+      expect(params.endDate).toBe('2025-06-30')
     })
 
     it('returns startDate as ISO string when set', () => {

--- a/src/hooks/useDateRangeFilter/useDateRangeFilter.ts
+++ b/src/hooks/useDateRangeFilter/useDateRangeFilter.ts
@@ -5,6 +5,8 @@ const MAX_RANGE_MONTHS = 12
 
 interface UseDateRangeFilterOptions {
   onFilterChange?: () => void
+  defaultStartDate?: Date
+  defaultEndDate?: Date
 }
 
 interface DateRangeApiParams {
@@ -21,6 +23,10 @@ interface DateRangeApiParams {
 export interface UseDateRangeFilterResult {
   filterStartDate: Date | null
   filterEndDate: Date | null
+  /** The effective start date for display: user-set value, falling back to `defaultStartDate`. */
+  displayStartDate: Date | null
+  /** The effective end date for display: user-set value, falling back to `defaultEndDate`. */
+  displayEndDate: Date | null
   isFilterActive: boolean
   handleStartDateChange: (date: Date | null) => void
   handleEndDateChange: (date: Date | null) => void
@@ -51,7 +57,7 @@ const addMonths = (date: Date, months: number): Date => {
  * @internal
  */
 export function useDateRangeFilter(options?: UseDateRangeFilterOptions): UseDateRangeFilterResult {
-  const { onFilterChange } = options ?? {}
+  const { onFilterChange, defaultStartDate, defaultEndDate } = options ?? {}
 
   const [filterStartDate, setFilterStartDate] = useState<Date | null>(null)
   const [filterEndDate, setFilterEndDate] = useState<Date | null>(null)
@@ -76,11 +82,13 @@ export function useDateRangeFilter(options?: UseDateRangeFilterOptions): UseDate
 
   const getApiDateParams = (): DateRangeApiParams => {
     const params: DateRangeApiParams = {}
-    if (filterStartDate) {
-      params.startDate = toISODateString(filterStartDate)
+    const effectiveStart = filterStartDate ?? defaultStartDate
+    const effectiveEnd = filterEndDate ?? defaultEndDate
+    if (effectiveStart) {
+      params.startDate = toISODateString(effectiveStart)
     }
-    if (filterEndDate) {
-      params.endDate = toISODateString(filterEndDate)
+    if (effectiveEnd) {
+      params.endDate = toISODateString(effectiveEnd)
     }
     return params
   }
@@ -98,6 +106,8 @@ export function useDateRangeFilter(options?: UseDateRangeFilterOptions): UseDate
   return {
     filterStartDate,
     filterEndDate,
+    displayStartDate: filterStartDate ?? defaultStartDate ?? null,
+    displayEndDate: filterEndDate ?? defaultEndDate ?? null,
     isFilterActive,
     handleStartDateChange,
     handleEndDateChange,

--- a/src/hooks/useDateRangeFilter/useDateRangeFilter.ts
+++ b/src/hooks/useDateRangeFilter/useDateRangeFilter.ts
@@ -1,12 +1,12 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { formatDateToStringDate } from '@/helpers/dateFormatting'
 
 const MAX_RANGE_MONTHS = 12
 
 interface UseDateRangeFilterOptions {
   onFilterChange?: () => void
-  defaultStartDate?: Date
-  defaultEndDate?: Date
+  initialStartDate?: Date | null
+  initialEndDate?: Date | null
 }
 
 interface DateRangeApiParams {
@@ -21,13 +21,10 @@ interface DateRangeApiParams {
  * @internal
  */
 export interface UseDateRangeFilterResult {
-  filterStartDate: Date | null
-  filterEndDate: Date | null
-  /** The effective start date for display: user-set value, falling back to `defaultStartDate`. */
-  displayStartDate: Date | null
-  /** The effective end date for display: user-set value, falling back to `defaultEndDate`. */
-  displayEndDate: Date | null
-  isFilterActive: boolean
+  startDate: Date | null
+  endDate: Date | null
+  /** True when the current dates differ from the initial dates the hook was seeded with. */
+  isModified: boolean
   handleStartDateChange: (date: Date | null) => void
   handleEndDateChange: (date: Date | null) => void
   handleClearFilter: () => void
@@ -45,70 +42,73 @@ const addMonths = (date: Date, months: number): Date => {
 }
 
 /**
- * Manages an optional start/end date range filter, capping the span at 12 months.
+ * Manages a start/end date range filter as a single source of truth, capping the span at 12 months.
  *
  * @remarks
- * `getMaxEndDate` and `getMinStartDate` return bounds for date pickers that keep the
- * selected range within 12 months of the opposite endpoint. `getApiDateParams` returns
- * only the dates that are set, formatted as `YYYY-MM-DD` strings for API requests.
+ * Seed the hook with `initialStartDate` / `initialEndDate` to render a default range on load;
+ * `handleClearFilter` returns to those initial values (not `null`). `getMaxEndDate` and
+ * `getMinStartDate` return bounds for date pickers that keep the selected range within
+ * 12 months of the opposite endpoint. `getApiDateParams` returns only the dates that are set,
+ * formatted as `YYYY-MM-DD` strings for API requests.
  *
  * @param options - Optional configuration; `onFilterChange` fires after any filter mutation.
  * @returns The current filter state and handlers — see {@link UseDateRangeFilterResult}.
  * @internal
  */
 export function useDateRangeFilter(options?: UseDateRangeFilterOptions): UseDateRangeFilterResult {
-  const { onFilterChange, defaultStartDate, defaultEndDate } = options ?? {}
+  const { onFilterChange, initialStartDate = null, initialEndDate = null } = options ?? {}
 
-  const [filterStartDate, setFilterStartDate] = useState<Date | null>(null)
-  const [filterEndDate, setFilterEndDate] = useState<Date | null>(null)
+  const initialRef = useRef<{ start: Date | null; end: Date | null }>({
+    start: initialStartDate,
+    end: initialEndDate,
+  })
 
-  const isFilterActive = filterStartDate !== null || filterEndDate !== null
+  const [startDate, setStartDate] = useState<Date | null>(initialRef.current.start)
+  const [endDate, setEndDate] = useState<Date | null>(initialRef.current.end)
+
+  const isModified = startDate !== initialRef.current.start || endDate !== initialRef.current.end
 
   const handleStartDateChange = (date: Date | null) => {
-    setFilterStartDate(date)
+    setStartDate(date)
     onFilterChange?.()
   }
 
   const handleEndDateChange = (date: Date | null) => {
-    setFilterEndDate(date)
+    setEndDate(date)
     onFilterChange?.()
   }
 
   const handleClearFilter = () => {
-    setFilterStartDate(null)
-    setFilterEndDate(null)
+    setStartDate(initialRef.current.start)
+    setEndDate(initialRef.current.end)
     onFilterChange?.()
   }
 
   const getApiDateParams = (): DateRangeApiParams => {
     const params: DateRangeApiParams = {}
-    const effectiveStart = filterStartDate ?? defaultStartDate
-    const effectiveEnd = filterEndDate ?? defaultEndDate
-    if (effectiveStart) {
-      params.startDate = toISODateString(effectiveStart)
+    if (startDate) {
+      params.startDate = toISODateString(startDate)
     }
-    if (effectiveEnd) {
-      params.endDate = toISODateString(effectiveEnd)
+    if (endDate) {
+      params.endDate = toISODateString(endDate)
     }
     return params
   }
 
   const getMaxEndDate = (): Date | undefined => {
-    if (!filterStartDate) return undefined
-    return addMonths(filterStartDate, MAX_RANGE_MONTHS)
+    if (!startDate) return undefined
+    return addMonths(startDate, MAX_RANGE_MONTHS)
   }
 
   const getMinStartDate = (): Date | undefined => {
-    if (!filterEndDate) return undefined
-    return addMonths(filterEndDate, -MAX_RANGE_MONTHS)
+    if (!endDate) return undefined
+    return addMonths(endDate, -MAX_RANGE_MONTHS)
   }
 
   return {
-    filterStartDate,
-    filterEndDate,
-    displayStartDate: filterStartDate ?? defaultStartDate ?? null,
-    displayEndDate: filterEndDate ?? defaultEndDate ?? null,
-    isFilterActive,
+    startDate,
+    endDate,
+    isModified,
     handleStartDateChange,
     handleEndDateChange,
     handleClearFilter,

--- a/src/i18n/en/Payroll.PayrollHistory.json
+++ b/src/i18n/en/Payroll.PayrollHistory.json
@@ -25,8 +25,14 @@
     "cancelPayroll": "Cancel payroll"
   },
   "emptyState": {
-    "title": "No payroll history",
-    "description": "When you run payrolls, they'll appear here for easy reference."
+    "default": {
+      "title": "No payroll history",
+      "description": "When you run payrolls, they'll appear here for easy reference."
+    },
+    "filtered": {
+      "title": "No payrolls in this date range",
+      "description": "Try adjusting the date filter to see more payrolls."
+    }
   },
   "labels": {
     "noAmount": "—"

--- a/src/i18n/en/Payroll.PayrollList.json
+++ b/src/i18n/en/Payroll.PayrollList.json
@@ -1,5 +1,13 @@
 {
-  "emptyState": "All payrolls have been processed",
+  "emptyState": {
+    "default": {
+      "title": "All payrolls have been processed"
+    },
+    "filtered": {
+      "title": "No payrolls in this date range",
+      "description": "Try adjusting the date filter to see more payrolls."
+    }
+  },
   "title": "Upcoming payroll",
   "dateFilter": {
     "startDate": "From",

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -6459,10 +6459,18 @@ export namespace Translations {
       cancelPayroll: string
     }
     emptyState: {
-      /** @defaultValue `"No payroll history"` */
-      title: string
-      /** @defaultValue `"When you run payrolls, they'll appear here for easy reference."` */
-      description: string
+      default: {
+        /** @defaultValue `"No payroll history"` */
+        title: string
+        /** @defaultValue `"When you run payrolls, they'll appear here for easy reference."` */
+        description: string
+      }
+      filtered: {
+        /** @defaultValue `"No payrolls in this date range"` */
+        title: string
+        /** @defaultValue `"Try adjusting the date filter to see more payrolls."` */
+        description: string
+      }
     }
     labels: {
       /** @defaultValue `"—"` */
@@ -6512,8 +6520,18 @@ export namespace Translations {
   }
   /** Translation keys for the `Payroll.PayrollList` i18n namespace. */
   export interface PayrollPayrollList {
-    /** @defaultValue `"All payrolls have been processed"` */
-    emptyState: string
+    emptyState: {
+      default: {
+        /** @defaultValue `"All payrolls have been processed"` */
+        title: string
+      }
+      filtered: {
+        /** @defaultValue `"No payrolls in this date range"` */
+        title: string
+        /** @defaultValue `"Try adjusting the date filter to see more payrolls."` */
+        description: string
+      }
+    }
     /** @defaultValue `"Upcoming payroll"` */
     title: string
     dateFilter: {


### PR DESCRIPTION
## Summary

- Apply a default date range in `PayrollList` (today → 3 months out) and `PayrollHistory` (3 months back → today), routed through the `useDateRangeFilter` hook so both API queries and the filter UI show the same range on load.
- Display the effective default range in the `DateRangeFilter` trigger and popover instead of the "Select dates" placeholder, so users see what they're seeing before opening the filter.
- Differentiate the empty state in both lists: when the user has actively filtered by date, show "No payrolls in this date range / Try adjusting the date filter to see more payrolls." Otherwise keep the original "no payrolls yet" copy.
- All date serialization goes through the timezone-safe `formatDateToStringDate` / `normalizeToDate` helpers per the SDK date-handling contract.

## Test plan

- [ ] Storybook: `Payroll/PayrollList` and `Payroll/PayrollHistory` — verify the default range appears in the filter trigger on load and that the popover opens pre-populated with the same range.
- [ ] Storybook: verify the empty-state variant renders both "no payrolls" (default range) and "no payrolls in this date range" (after picking a custom range with no matches).
- [ ] Confirm no regressions in existing PayrollList / PayrollHistory tests and stories.