### PR TITLE
feat: prototype state taxes with future effective dated rates

### DIFF
--- a/sdk-app/src/design/components/company/onboarding/StateTaxesWithFutureRates/AddTaxRateDialog.tsx
+++ b/sdk-app/src/design/components/company/onboarding/StateTaxesWithFutureRates/AddTaxRateDialog.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { FormProvider, useForm, useFormContext, useWatch } from 'react-hook-form'
+import type { TaxRequirement } from '@gusto/embedded-api/models/components/taxrequirement'
+import type { TaxRequirementSet } from '@gusto/embedded-api/models/components/taxrequirementset'
+import { Flex, SelectField } from '@/components/Common'
+import { QuestionInput } from '@/components/Common/TaxInputs/TaxInputs'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { ThemeContext } from '@/contexts/ThemeProvider/useTheme'
+import { useDateFormatter } from '@/hooks/useDateFormatter'
+
+export interface TaxRateSubmission {
+  effectiveFrom: string
+  values: Record<string, string | number | boolean>
+}
+
+interface AddTaxRateDialogProps {
+  isOpen: boolean
+  state: string
+  availableEffectiveDates: string[]
+  requirementTemplate: TaxRequirementSet | null
+  isSubmitting?: boolean
+  onClose: () => void
+  onSubmit: (submission: TaxRateSubmission) => void | Promise<void>
+}
+
+const PIPE_PLACEHOLDER = '__PIPE__'
+const toRhfKey = (key: string): string => key.replaceAll('|', PIPE_PLACEHOLDER)
+const fromRhfKey = (key: string): string => key.replaceAll(PIPE_PLACEHOLDER, '|')
+
+interface FormShape {
+  effectiveFrom: string
+  fields: Record<string, string | number | boolean | undefined>
+}
+
+function isRequirementApplicable(
+  requirement: TaxRequirement,
+  values: Record<string, string | number | boolean | undefined>,
+): boolean {
+  const constraints = requirement.applicableIf
+  if (!constraints || constraints.length === 0) return true
+  return constraints.every(({ key, value }) => {
+    if (!key) return true
+    return values[toRhfKey(key)] === value
+  })
+}
+
+function DynamicFields({ requirements }: { requirements: TaxRequirement[] }) {
+  const { control } = useFormContext<FormShape>()
+  const watched = useWatch({ control, name: 'fields' })
+
+  return (
+    <>
+      {requirements.flatMap(req => {
+        if (!req.key || req.editable === false) return []
+        if (!isRequirementApplicable(req, watched)) return []
+        return [
+          <QuestionInput
+            key={req.key}
+            requirement={{ ...req, key: `fields.${toRhfKey(req.key)}` }}
+            questionType={req.metadata?.type ?? 'text'}
+          />,
+        ]
+      })}
+    </>
+  )
+}
+
+export function AddTaxRateDialog({
+  isOpen,
+  state,
+  availableEffectiveDates,
+  requirementTemplate,
+  isSubmitting = false,
+  onClose,
+  onSubmit,
+}: AddTaxRateDialogProps) {
+  const Components = useComponentContext()
+  const dateFormatter = useDateFormatter()
+  const dialogContainerRef = useRef<HTMLElement | null>(null)
+
+  const editableRequirements = useMemo(
+    () => (requirementTemplate?.requirements ?? []).filter(r => r.editable !== false && r.key),
+    [requirementTemplate],
+  )
+
+  const defaultValues = useMemo<FormShape>(
+    () => ({
+      effectiveFrom: availableEffectiveDates[0] ?? '',
+      fields: {},
+    }),
+    [availableEffectiveDates],
+  )
+
+  const methods = useForm<FormShape>({ defaultValues })
+
+  useEffect(() => {
+    if (isOpen) methods.reset(defaultValues)
+  }, [isOpen, defaultValues, methods])
+
+  const handleSubmit = methods.handleSubmit(async data => {
+    const values: Record<string, string | number | boolean> = {}
+    Object.entries(data.fields).forEach(([rhfKey, raw]) => {
+      if (raw === undefined || raw === '') return
+      values[fromRhfKey(rhfKey)] = raw
+    })
+    await onSubmit({ effectiveFrom: data.effectiveFrom, values })
+  })
+
+  return (
+    <Components.Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      onPrimaryActionClick={() => {
+        void handleSubmit()
+      }}
+      isPrimaryActionLoading={isSubmitting}
+      primaryActionLabel="Save tax rate"
+      closeActionLabel="Cancel"
+      title={`Add tax rate for ${state}`}
+    >
+      <ThemeContext.Provider value={{ container: dialogContainerRef }}>
+        <div
+          ref={el => {
+            dialogContainerRef.current = el
+          }}
+        >
+          <FormProvider {...methods}>
+            <Flex flexDirection="column" gap={20} alignItems="stretch">
+              <Components.Text size="sm">
+                Schedule a new tax configuration to take effect on a future date.
+              </Components.Text>
+
+              <SelectField
+                name="effectiveFrom"
+                label="Effective date"
+                placeholder="Select an effective date"
+                isRequired
+                isDisabled={availableEffectiveDates.length === 0}
+                options={availableEffectiveDates.map(date => ({
+                  value: date,
+                  label: dateFormatter.formatLongWithYear(date),
+                }))}
+              />
+
+              {editableRequirements.length > 0 ? (
+                <DynamicFields requirements={editableRequirements} />
+              ) : (
+                <Components.Alert status="info" label="No editable fields">
+                  This state does not expose editable effective-dated tax requirements.
+                </Components.Alert>
+              )}
+            </Flex>
+          </FormProvider>
+        </div>
+      </ThemeContext.Provider>
+    </Components.Dialog>
+  )
+}

--- a/sdk-app/src/design/components/company/onboarding/StateTaxesWithFutureRates/StateTaxesListView.tsx
+++ b/sdk-app/src/design/components/company/onboarding/StateTaxesWithFutureRates/StateTaxesListView.tsx
@@ -1,0 +1,116 @@
+import {
+  SetupStatus,
+  type TaxRequirementStatesList,
+} from '@gusto/embedded-api/models/components/taxrequirementstateslist'
+import { DataView, EmptyData, Flex, HamburgerMenu, useDataView } from '@/components/Common'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+type BadgeStatus = 'success' | 'warning' | 'info'
+
+const badgeStatusMap: Record<SetupStatus, BadgeStatus> = {
+  [SetupStatus.NotStarted]: 'info',
+  [SetupStatus.InProgress]: 'warning',
+  [SetupStatus.Complete]: 'success',
+}
+
+const badgeLabelMap: Record<SetupStatus, string> = {
+  [SetupStatus.NotStarted]: 'Not started',
+  [SetupStatus.InProgress]: 'In progress',
+  [SetupStatus.Complete]: 'Complete',
+}
+
+const editCtaLabelMap: Record<SetupStatus, string> = {
+  [SetupStatus.NotStarted]: 'Start setup',
+  [SetupStatus.InProgress]: 'Continue setup',
+  [SetupStatus.Complete]: 'Edit current tax rate',
+}
+
+function getSetupStatus(req: TaxRequirementStatesList): SetupStatus {
+  return req.setupStatus ?? SetupStatus.InProgress
+}
+
+interface StateTaxesListViewProps {
+  stateTaxRequirements: TaxRequirementStatesList[]
+  onEditCurrent: (state: string) => void
+  onManageRates: (state: string) => void
+}
+
+export function StateTaxesListView({
+  stateTaxRequirements,
+  onEditCurrent,
+  onManageRates,
+}: StateTaxesListViewProps) {
+  const Components = useComponentContext()
+
+  const { ...dataViewProps } = useDataView<TaxRequirementStatesList>({
+    data: stateTaxRequirements,
+    columns: [
+      {
+        key: 'state',
+        title: 'State',
+        render: requirement => (
+          <Flex flexDirection="column" gap={4}>
+            <Components.Text as="span">{requirement.state}</Components.Text>
+            {requirement.defaultRatesApplied && (
+              <Components.Text size="sm">Default rates applied</Components.Text>
+            )}
+          </Flex>
+        ),
+      },
+      {
+        key: 'status',
+        title: 'Status',
+        render: requirement => {
+          const status = getSetupStatus(requirement)
+          return (
+            <Flex gap={8} alignItems="center" flexWrap="wrap">
+              <Components.Badge status={badgeStatusMap[status]}>
+                {badgeLabelMap[status]}
+              </Components.Badge>
+              {requirement.readyToRunPayroll && (
+                <Components.Badge status="success">Ready to run payroll</Components.Badge>
+              )}
+            </Flex>
+          )
+        },
+      },
+    ],
+    itemMenu: requirement => {
+      const status = getSetupStatus(requirement)
+      const state = requirement.state
+      if (!state) return null
+      return (
+        <HamburgerMenu
+          triggerLabel={`Actions for ${state}`}
+          items={[
+            {
+              label: editCtaLabelMap[status],
+              onClick: () => {
+                onEditCurrent(state)
+              },
+            },
+            {
+              label: 'Manage tax rates',
+              onClick: () => {
+                onManageRates(state)
+              },
+            },
+          ]}
+        />
+      )
+    },
+    emptyState: () => (
+      <EmptyData
+        title="No state tax requirements yet"
+        description="Add a work address to a state to see its tax requirements here."
+      />
+    ),
+  })
+
+  return (
+    <Flex flexDirection="column" gap={16} alignItems="stretch">
+      <Components.Heading as="h2">State tax setup</Components.Heading>
+      <DataView label="State tax requirements" {...dataViewProps} />
+    </Flex>
+  )
+}

--- a/sdk-app/src/design/components/company/onboarding/StateTaxesWithFutureRates/TaxRatesHistoryView.tsx
+++ b/sdk-app/src/design/components/company/onboarding/StateTaxesWithFutureRates/TaxRatesHistoryView.tsx
@@ -1,0 +1,183 @@
+import { useMemo, useState } from 'react'
+import type { TaxRequirementSet } from '@gusto/embedded-api/models/components/taxrequirementset'
+import type { TaxRequirement } from '@gusto/embedded-api/models/components/taxrequirement'
+import { AddTaxRateDialog, type TaxRateSubmission } from './AddTaxRateDialog'
+import { DataView, EmptyData, Flex, useDataView } from '@/components/Common'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { useDateFormatter } from '@/hooks/useDateFormatter'
+import CaretLeftIcon from '@/assets/icons/caret-left.svg?react'
+
+export interface TaxRateRow {
+  id: string
+  effectiveFrom: string
+  isCurrent: boolean
+  isFuture: boolean
+  isHistorical: boolean
+  values: Record<string, string>
+}
+
+interface TaxRatesHistoryViewProps {
+  state: string
+  requirementSets: TaxRequirementSet[]
+  availableFutureDates: string[]
+  onBack: () => void
+  onAddTaxRate: (submission: TaxRateSubmission) => Promise<boolean>
+}
+
+function isEffectiveDated(
+  set: TaxRequirementSet,
+): set is TaxRequirementSet & { effectiveFrom: string } {
+  return typeof set.effectiveFrom === 'string' && set.effectiveFrom.length > 0
+}
+
+function extractRequirementColumns(sets: TaxRequirementSet[]): TaxRequirement[] {
+  const seen = new Map<string, TaxRequirement>()
+  for (const set of sets) {
+    for (const req of set.requirements ?? []) {
+      if (req.key && !seen.has(req.key) && req.editable !== false) {
+        seen.set(req.key, req)
+      }
+    }
+  }
+  return Array.from(seen.values())
+}
+
+function toRows(sets: (TaxRequirementSet & { effectiveFrom: string })[]): TaxRateRow[] {
+  const today = new Date().toISOString().slice(0, 10)
+  const sorted = [...sets].sort((a, b) => a.effectiveFrom.localeCompare(b.effectiveFrom))
+  const currentIndex = sorted.reduce((acc, set, idx) => {
+    if (set.effectiveFrom <= today) return idx
+    return acc
+  }, -1)
+
+  return sorted.map((set, idx) => {
+    const values: Record<string, string> = {}
+    for (const req of set.requirements ?? []) {
+      if (req.key) {
+        values[req.key] = req.value === null || req.value === undefined ? '—' : String(req.value)
+      }
+    }
+    return {
+      id: `${set.key ?? 'set'}-${set.effectiveFrom}-${idx}`,
+      effectiveFrom: set.effectiveFrom,
+      isCurrent: idx === currentIndex,
+      isFuture: idx > currentIndex,
+      isHistorical: idx < currentIndex && currentIndex !== -1,
+      values,
+    }
+  })
+}
+
+export function TaxRatesHistoryView({
+  state,
+  requirementSets,
+  availableFutureDates,
+  onBack,
+  onAddTaxRate,
+}: TaxRatesHistoryViewProps) {
+  const Components = useComponentContext()
+  const dateFormatter = useDateFormatter()
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const effectiveDatedSets = useMemo(
+    () => requirementSets.filter(isEffectiveDated),
+    [requirementSets],
+  )
+  const requirementColumns = useMemo(
+    () => extractRequirementColumns(effectiveDatedSets),
+    [effectiveDatedSets],
+  )
+  const rows = useMemo(() => toRows(effectiveDatedSets), [effectiveDatedSets])
+
+  const templateSet = useMemo<TaxRequirementSet | null>(() => {
+    if (effectiveDatedSets.length === 0) return null
+    const sorted = [...effectiveDatedSets].sort((a, b) =>
+      a.effectiveFrom.localeCompare(b.effectiveFrom),
+    )
+    return sorted[sorted.length - 1] ?? null
+  }, [effectiveDatedSets])
+
+  const { ...dataViewProps } = useDataView<TaxRateRow>({
+    data: rows,
+    columns: [
+      {
+        key: 'effectiveFrom',
+        title: 'Effective date',
+        render: row => dateFormatter.formatLongWithYear(row.effectiveFrom),
+      },
+      {
+        key: 'status',
+        title: '',
+        render: row => (
+          <>
+            {row.isCurrent && <Components.Badge status="success">Current</Components.Badge>}
+            {row.isFuture && <Components.Badge status="info">Scheduled</Components.Badge>}
+            {row.isHistorical && <Components.Badge status="warning">Historical</Components.Badge>}
+          </>
+        ),
+      },
+      ...requirementColumns.map(req => ({
+        key: req.key as string,
+        title: req.label ?? req.key ?? '',
+        render: (row: TaxRateRow) => row.values[req.key as string] ?? '—',
+      })),
+    ],
+    emptyState: () => (
+      <EmptyData
+        title="No effective-dated rates yet"
+        description="Add a tax rate to schedule an effective-dated configuration for this state."
+      />
+    ),
+  })
+
+  return (
+    <Flex flexDirection="column" gap={24} alignItems="stretch">
+      <Flex justifyContent="space-between" alignItems="center" gap={16}>
+        <Flex flexDirection="column" gap={32}>
+          <Components.Button variant="secondary" onClick={onBack}>
+            <CaretLeftIcon /> Back to states
+          </Components.Button>
+          <Flex flexDirection="column" gap={4}>
+            <Components.Heading as="h2">Tax rates for {state}</Components.Heading>
+            <Components.Text size="sm">
+              Effective-dated tax rate history and scheduled future rates.
+            </Components.Text>
+          </Flex>
+        </Flex>
+        <Components.Button
+          variant="primary"
+          onClick={() => {
+            setIsDialogOpen(true)
+          }}
+          isDisabled={availableFutureDates.length === 0 || templateSet === null}
+        >
+          Add tax rate
+        </Components.Button>
+      </Flex>
+
+      <DataView label={`Tax rates for ${state}`} {...dataViewProps} />
+
+      <AddTaxRateDialog
+        isOpen={isDialogOpen}
+        state={state}
+        availableEffectiveDates={availableFutureDates}
+        requirementTemplate={templateSet}
+        isSubmitting={isSubmitting}
+        onClose={() => {
+          if (isSubmitting) return
+          setIsDialogOpen(false)
+        }}
+        onSubmit={async submission => {
+          setIsSubmitting(true)
+          try {
+            const success = await onAddTaxRate(submission)
+            if (success) setIsDialogOpen(false)
+          } finally {
+            setIsSubmitting(false)
+          }
+        }}
+      />
+    </Flex>
+  )
+}

--- a/sdk-app/src/design/prototypes/company-onboarding/StateTaxesWithFutureRates/StateTaxesWithFutureRates.tsx
+++ b/sdk-app/src/design/prototypes/company-onboarding/StateTaxesWithFutureRates/StateTaxesWithFutureRates.tsx
@@ -1,0 +1,163 @@
+import { Suspense, useMemo, useState } from 'react'
+import { useTaxRequirementsGetAllSuspense } from '@gusto/embedded-api/react-query/taxRequirementsGetAll'
+import { useTaxRequirementsGetSuspense } from '@gusto/embedded-api/react-query/taxRequirementsGet'
+import { useTaxRequirementsUpdateStateMutation } from '@gusto/embedded-api/react-query/taxRequirementsUpdateState'
+import type { TaxRequirementSet } from '@gusto/embedded-api/models/components/taxrequirementset'
+import { StateTaxesListView } from '../../../components/company/onboarding/StateTaxesWithFutureRates/StateTaxesListView'
+import { TaxRatesHistoryView } from '../../../components/company/onboarding/StateTaxesWithFutureRates/TaxRatesHistoryView'
+import type { TaxRateSubmission } from '../../../components/company/onboarding/StateTaxesWithFutureRates/AddTaxRateDialog'
+import { BaseComponent, useBase } from '@/components/Base'
+import { Flex } from '@/components/Common'
+
+export interface StateTaxesWithFutureRatesProps {
+  companyId: string
+}
+
+type View = { name: 'list' } | { name: 'history'; state: string }
+
+function stringifyRequirementValue(value: unknown): string {
+  if (value === undefined || value === null) return ''
+  if (typeof value === 'number') return isNaN(value) ? '' : String(value)
+  if (typeof value === 'string') return value
+  if (typeof value === 'boolean') return String(value)
+  return ''
+}
+
+function ListRoot({
+  companyId,
+  onManageRates,
+}: {
+  companyId: string
+  onManageRates: (state: string) => void
+}) {
+  const { data } = useTaxRequirementsGetAllSuspense({ companyUuid: companyId })
+  const stateTaxRequirements = data.taxRequirementStatesList ?? []
+  return (
+    <StateTaxesListView
+      stateTaxRequirements={stateTaxRequirements}
+      onEditCurrent={() => {}}
+      onManageRates={onManageRates}
+    />
+  )
+}
+
+function HistoryRoot({
+  companyId,
+  state,
+  onBack,
+}: {
+  companyId: string
+  state: string
+  onBack: () => void
+}) {
+  const currentQuery = useTaxRequirementsGetSuspense({ companyUuid: companyId, state })
+  const schedulingQuery = useTaxRequirementsGetSuspense({
+    companyUuid: companyId,
+    state,
+    scheduling: true,
+  })
+  const { mutateAsync: updateStateTax } = useTaxRequirementsUpdateStateMutation()
+  const { baseSubmitHandler } = useBase()
+
+  const apiSets = useMemo(
+    () => currentQuery.data.taxRequirementsState?.requirementSets ?? [],
+    [currentQuery.data.taxRequirementsState?.requirementSets],
+  )
+  const schedulingSets = useMemo(
+    () => schedulingQuery.data.taxRequirementsState?.requirementSets ?? [],
+    [schedulingQuery.data.taxRequirementsState?.requirementSets],
+  )
+
+  const availableFutureDates = useMemo(() => {
+    const existing = new Set(
+      apiSets
+        .map(s => s.effectiveFrom)
+        .filter((d): d is string => typeof d === 'string' && d.length > 0),
+    )
+    return schedulingSets
+      .map(s => s.effectiveFrom)
+      .filter((d): d is string => typeof d === 'string' && d.length > 0 && !existing.has(d))
+      .sort()
+  }, [schedulingSets, apiSets])
+
+  const templateSet = useMemo<TaxRequirementSet | null>(() => {
+    if (schedulingSets.length > 0) return schedulingSets[0] ?? null
+    const effectiveDated = apiSets.filter(
+      s => typeof s.effectiveFrom === 'string' && s.effectiveFrom.length > 0,
+    )
+    return effectiveDated[effectiveDated.length - 1] ?? null
+  }, [schedulingSets, apiSets])
+
+  const handleAddTaxRate = async (submission: TaxRateSubmission): Promise<boolean> => {
+    if (!templateSet || !templateSet.key) return false
+    let success = false
+    await baseSubmitHandler(submission, async payload => {
+      const applicableRequirements = (templateSet.requirements ?? [])
+        .filter(req => req.editable !== false && req.key)
+        .map(req => ({
+          key: req.key as string,
+          value: stringifyRequirementValue(payload.values[req.key as string]),
+        }))
+        .filter(r => r.value.length > 0)
+
+      await updateStateTax({
+        request: {
+          companyUuid: companyId,
+          state,
+          requestBody: {
+            requirementSets: [
+              {
+                state,
+                key: templateSet.key as string,
+                effectiveFrom: payload.effectiveFrom,
+                requirements: applicableRequirements,
+              },
+            ],
+          },
+        },
+      })
+      success = true
+    })
+    return success
+  }
+
+  return (
+    <TaxRatesHistoryView
+      state={state}
+      requirementSets={apiSets}
+      availableFutureDates={availableFutureDates}
+      onBack={onBack}
+      onAddTaxRate={handleAddTaxRate}
+    />
+  )
+}
+
+export function StateTaxesWithFutureRates({ companyId }: StateTaxesWithFutureRatesProps) {
+  const [view, setView] = useState<View>({ name: 'list' })
+
+  return (
+    <BaseComponent onEvent={() => {}}>
+      <Flex flexDirection="column" gap={32} alignItems="stretch">
+        <Suspense fallback={<div>Loading...</div>}>
+          {view.name === 'list' && (
+            <ListRoot
+              companyId={companyId}
+              onManageRates={state => {
+                setView({ name: 'history', state })
+              }}
+            />
+          )}
+          {view.name === 'history' && (
+            <HistoryRoot
+              companyId={companyId}
+              state={view.state}
+              onBack={() => {
+                setView({ name: 'list' })
+              }}
+            />
+          )}
+        </Suspense>
+      </Flex>
+    </BaseComponent>
+  )
+}

--- a/sdk-app/src/design/prototypes/company-onboarding/StateTaxesWithFutureRates/index.tsx
+++ b/sdk-app/src/design/prototypes/company-onboarding/StateTaxesWithFutureRates/index.tsx
@@ -1,0 +1,31 @@
+import { useOutletContext } from 'react-router-dom'
+import type { EntityIds } from '../../../../useEntities'
+import { ComponentStatesPage } from '../../ComponentStatesPage'
+import { StateTaxesWithFutureRates } from './StateTaxesWithFutureRates'
+import { components } from './states'
+import { Flex } from '@/components/Common'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+
+const BASE_PATH = '/design/state-taxes-with-future-rates'
+
+export function StateTaxesWithFutureRatesPrototype() {
+  const { entities } = useOutletContext<{ entities: EntityIds }>()
+  const Components = useComponentContext()
+
+  if (!entities.companyId) {
+    return (
+      <Flex flexDirection="column" gap={16} alignItems="stretch">
+        <Components.Heading as="h2">State taxes with future rates</Components.Heading>
+        <Components.Alert label="Missing company ID" status="warning">
+          Set a company ID in Settings (top right) to load real data.
+        </Components.Alert>
+      </Flex>
+    )
+  }
+
+  return <StateTaxesWithFutureRates companyId={entities.companyId} />
+}
+
+export function StateTaxesWithFutureRatesStates() {
+  return <ComponentStatesPage basePath={`${BASE_PATH}/component-states`} components={components} />
+}

--- a/sdk-app/src/design/prototypes/company-onboarding/StateTaxesWithFutureRates/states.tsx
+++ b/sdk-app/src/design/prototypes/company-onboarding/StateTaxesWithFutureRates/states.tsx
@@ -1,0 +1,402 @@
+/* eslint-disable react-refresh/only-export-components */
+import { useState } from 'react'
+import {
+  SetupStatus,
+  type TaxRequirementStatesList,
+} from '@gusto/embedded-api/models/components/taxrequirementstateslist'
+import type { TaxRequirementSet } from '@gusto/embedded-api/models/components/taxrequirementset'
+import type { TaxRequirement } from '@gusto/embedded-api/models/components/taxrequirement'
+import type { PrototypeComponent } from '../../prototypeTypes'
+import { StateTaxesListView } from '../../../components/company/onboarding/StateTaxesWithFutureRates/StateTaxesListView'
+import { TaxRatesHistoryView } from '../../../components/company/onboarding/StateTaxesWithFutureRates/TaxRatesHistoryView'
+import { AddTaxRateDialog } from '../../../components/company/onboarding/StateTaxesWithFutureRates/AddTaxRateDialog'
+
+const mockStates: TaxRequirementStatesList[] = [
+  {
+    state: 'CA',
+    setupStatus: SetupStatus.Complete,
+    readyToRunPayroll: true,
+    defaultRatesApplied: false,
+  },
+  {
+    state: 'NY',
+    setupStatus: SetupStatus.InProgress,
+    readyToRunPayroll: false,
+    defaultRatesApplied: false,
+  },
+  {
+    state: 'WA',
+    setupStatus: SetupStatus.Complete,
+    readyToRunPayroll: true,
+    defaultRatesApplied: true,
+  },
+  {
+    state: 'TX',
+    setupStatus: SetupStatus.NotStarted,
+    readyToRunPayroll: false,
+    defaultRatesApplied: false,
+  },
+]
+
+const emptyStates: TaxRequirementStatesList[] = []
+
+const waRequirements: TaxRequirement[] = [
+  {
+    key: 'wa_ui_rate',
+    label: 'UI tax rate',
+    description: 'Combined unemployment insurance rate',
+    value: '2.75',
+    editable: true,
+    metadata: { type: 'tax_rate' },
+  },
+  {
+    key: 'wa_eaf_rate',
+    label: 'EAF rate',
+    description: 'Employment administration fund rate',
+    value: '0.03',
+    editable: true,
+    metadata: { type: 'tax_rate' },
+  },
+]
+
+const waRequirementSets: TaxRequirementSet[] = [
+  {
+    state: 'WA',
+    key: 'wa_ui_rates',
+    label: 'UI & EAF rates',
+    effectiveFrom: '2024-01-01',
+    requirements: waRequirements.map(r => ({
+      ...r,
+      value: r.key === 'wa_ui_rate' ? '2.50' : '0.02',
+    })),
+  },
+  {
+    state: 'WA',
+    key: 'wa_ui_rates',
+    label: 'UI & EAF rates',
+    effectiveFrom: '2025-01-01',
+    requirements: waRequirements,
+  },
+  {
+    state: 'WA',
+    key: 'wa_ui_rates',
+    label: 'UI & EAF rates',
+    effectiveFrom: '2026-01-01',
+    requirements: waRequirements.map(r => ({
+      ...r,
+      value: r.key === 'wa_ui_rate' ? '2.90' : '0.03',
+    })),
+  },
+  {
+    state: 'WA',
+    key: 'wa_ui_rates',
+    label: 'UI & EAF rates',
+    effectiveFrom: '2027-01-01',
+    requirements: waRequirements.map(r => ({
+      ...r,
+      value: r.key === 'wa_ui_rate' ? '3.10' : '0.04',
+    })),
+  },
+]
+
+const singleCurrentRateOnly: TaxRequirementSet[] = [
+  {
+    state: 'CA',
+    key: 'ca_sdi',
+    label: 'CA SDI',
+    effectiveFrom: '2025-01-01',
+    requirements: [
+      {
+        key: 'ca_sdi_rate',
+        label: 'SDI rate',
+        value: '1.10',
+        editable: true,
+        metadata: { type: 'tax_rate' },
+      },
+    ],
+  },
+]
+
+function ListPopulatedStory() {
+  return (
+    <StateTaxesListView
+      stateTaxRequirements={mockStates}
+      onEditCurrent={() => {}}
+      onManageRates={() => {}}
+    />
+  )
+}
+
+function ListEmptyStory() {
+  return (
+    <StateTaxesListView
+      stateTaxRequirements={emptyStates}
+      onEditCurrent={() => {}}
+      onManageRates={() => {}}
+    />
+  )
+}
+
+function HistoryPopulatedStory() {
+  const [sets, setSets] = useState<TaxRequirementSet[]>(waRequirementSets)
+  return (
+    <TaxRatesHistoryView
+      state="WA"
+      requirementSets={sets}
+      availableFutureDates={['2028-01-01', '2028-07-01', '2029-01-01']}
+      onBack={() => {}}
+      onAddTaxRate={submission => {
+        setSets(prev => [
+          ...prev,
+          {
+            state: 'WA',
+            key: 'wa_ui_rates',
+            label: 'UI & EAF rates',
+            effectiveFrom: submission.effectiveFrom,
+            requirements: waRequirements.map(r => ({
+              ...r,
+              value: r.key ? (submission.values[r.key] ?? r.value) : r.value,
+            })),
+          },
+        ])
+        return Promise.resolve(true)
+      }}
+    />
+  )
+}
+
+function HistorySingleRateStory() {
+  return (
+    <TaxRatesHistoryView
+      state="CA"
+      requirementSets={singleCurrentRateOnly}
+      availableFutureDates={['2026-01-01', '2026-07-01', '2027-01-01']}
+      onBack={() => {}}
+      onAddTaxRate={() => Promise.resolve(true)}
+    />
+  )
+}
+
+function HistoryEmptyStory() {
+  return (
+    <TaxRatesHistoryView
+      state="TX"
+      requirementSets={[]}
+      availableFutureDates={['2026-01-01', '2027-01-01']}
+      onBack={() => {}}
+      onAddTaxRate={() => Promise.resolve(true)}
+    />
+  )
+}
+
+const caRequirementSet: TaxRequirementSet = {
+  state: 'CA',
+  key: 'ca_ui_rates',
+  label: 'CA UI & ETT rates',
+  effectiveFrom: '2026-01-01',
+  requirements: [
+    {
+      key: 'has_tax_rates',
+      label: 'Have you received your tax rates from your state agency?',
+      value: null,
+      editable: true,
+      metadata: {
+        type: 'radio',
+        options: [
+          { value: 'true', label: 'Yes' },
+          { value: 'false', label: 'No' },
+        ],
+      },
+    },
+    {
+      key: 'ca_ui_rate',
+      label: 'Unemployment tax rate',
+      description: 'The unemployment tax rate assigned to you by the state agency.',
+      value: null,
+      editable: true,
+      metadata: { type: 'tax_rate' },
+      applicableIf: [{ key: 'has_tax_rates', value: 'true' }],
+    },
+    {
+      key: 'ca_ett_rate',
+      label: 'ETT rate',
+      description: 'Most companies are assigned a rate of 0.1%.',
+      value: null,
+      editable: true,
+      metadata: { type: 'tax_rate' },
+      applicableIf: [{ key: 'has_tax_rates', value: 'true' }],
+    },
+  ],
+}
+
+const waRequirementTemplate: TaxRequirementSet = {
+  state: 'WA',
+  key: 'wa_ui_rates',
+  label: 'UI & EAF rates',
+  effectiveFrom: '2027-01-01',
+  requirements: waRequirements,
+}
+
+function AddDialogOpenStory() {
+  const [isOpen, setIsOpen] = useState(true)
+  return (
+    <>
+      <AddTaxRateDialog
+        isOpen={isOpen}
+        state="CA"
+        availableEffectiveDates={['2026-01-01', '2026-07-01', '2027-01-01']}
+        requirementTemplate={caRequirementSet}
+        onClose={() => {
+          setIsOpen(false)
+        }}
+        onSubmit={() => {
+          setIsOpen(false)
+        }}
+      />
+      {!isOpen && (
+        <button
+          onClick={() => {
+            setIsOpen(true)
+          }}
+        >
+          Reopen dialog
+        </button>
+      )}
+    </>
+  )
+}
+
+function AddDialogWaStory() {
+  const [isOpen, setIsOpen] = useState(true)
+  return (
+    <>
+      <AddTaxRateDialog
+        isOpen={isOpen}
+        state="WA"
+        availableEffectiveDates={['2027-01-01', '2027-07-01', '2028-01-01']}
+        requirementTemplate={waRequirementTemplate}
+        onClose={() => {
+          setIsOpen(false)
+        }}
+        onSubmit={() => {
+          setIsOpen(false)
+        }}
+      />
+      {!isOpen && (
+        <button
+          onClick={() => {
+            setIsOpen(true)
+          }}
+        >
+          Reopen dialog
+        </button>
+      )}
+    </>
+  )
+}
+
+function AddDialogNoFieldsStory() {
+  const [isOpen, setIsOpen] = useState(true)
+  return (
+    <>
+      <AddTaxRateDialog
+        isOpen={isOpen}
+        state="FL"
+        availableEffectiveDates={['2027-01-01', '2028-01-01']}
+        requirementTemplate={null}
+        onClose={() => {
+          setIsOpen(false)
+        }}
+        onSubmit={() => {
+          setIsOpen(false)
+        }}
+      />
+      {!isOpen && (
+        <button
+          onClick={() => {
+            setIsOpen(true)
+          }}
+        >
+          Reopen dialog
+        </button>
+      )}
+    </>
+  )
+}
+
+export const components: PrototypeComponent[] = [
+  {
+    slug: 'state-taxes-list',
+    name: 'State taxes list',
+    description:
+      'Duplicated onboarding list with a hamburger menu that includes "Manage tax rates".',
+    configurations: [
+      {
+        slug: 'populated',
+        name: 'Populated',
+        description: 'A mix of complete, in-progress, and not-started states.',
+        render: () => <ListPopulatedStory />,
+      },
+      {
+        slug: 'empty',
+        name: 'Empty',
+        description: 'No states configured yet.',
+        render: () => <ListEmptyStory />,
+      },
+    ],
+  },
+  {
+    slug: 'tax-rates-history',
+    name: 'Tax rates history',
+    description:
+      'DataView showing effective-dated rate configurations for a state, including historical, current, and scheduled future rates.',
+    configurations: [
+      {
+        slug: 'multi-year',
+        name: 'Multi-year timeline',
+        description: 'Historical, current, and future rates in one view — the multi-badge case.',
+        render: () => <HistoryPopulatedStory />,
+      },
+      {
+        slug: 'current-only',
+        name: 'Current rate only',
+        description: 'No history and no future rates yet — just the active configuration.',
+        render: () => <HistorySingleRateStory />,
+      },
+      {
+        slug: 'empty',
+        name: 'Empty',
+        description: 'No rates on record for the state.',
+        render: () => <HistoryEmptyStory />,
+      },
+    ],
+  },
+  {
+    slug: 'add-tax-rate-dialog',
+    name: 'Add tax rate dialog',
+    description:
+      'Dialog for selecting a future effective date and setting dynamic requirement values.',
+    configurations: [
+      {
+        slug: 'ca-with-applicable-if',
+        name: 'CA — with conditional question',
+        description:
+          'The CA case: yes/no gate on "Have you received your tax rates" conditionally reveals Unemployment tax rate and ETT rate.',
+        render: () => <AddDialogOpenStory />,
+      },
+      {
+        slug: 'wa-flat',
+        name: 'WA — flat rate inputs',
+        description: 'A simpler state with no conditional gate — both rate inputs shown directly.',
+        render: () => <AddDialogWaStory />,
+      },
+      {
+        slug: 'no-fields',
+        name: 'No editable fields',
+        description:
+          'A state that has no editable tax requirement fields — dialog degrades gracefully.',
+        render: () => <AddDialogNoFieldsStory />,
+      },
+    ],
+  },
+]

--- a/sdk-app/src/design/registry.ts
+++ b/sdk-app/src/design/registry.ts
@@ -20,7 +20,26 @@ export const categorizedRegistry: CategorizedRegistry = {
         'A single page demonstrating SDK components like Button, TextInput, Select, Alert, and more.',
     },
   ],
-  Companies: [],
+  Companies: [
+    {
+      name: 'State Taxes with Future Rates',
+      path: '/design/state-taxes-with-future-rates',
+      description:
+        'Extends the company state tax onboarding component with an effective-dated tax rate history and a dialog for scheduling future rates.',
+      children: [
+        {
+          name: 'Prototype',
+          path: '/design/state-taxes-with-future-rates',
+          description: 'Live prototype against the real API.',
+        },
+        {
+          name: 'Component states',
+          path: '/design/state-taxes-with-future-rates/component-states',
+          description: 'Browse individual components and configurations with mock data.',
+        },
+      ],
+    },
+  ],
   Contractors: [
     {
       name: 'Contractor Management',

--- a/sdk-app/src/main.tsx
+++ b/sdk-app/src/main.tsx
@@ -36,6 +36,10 @@ import {
   CreateHistoricalPaymentPrototype,
   CreateHistoricalPaymentStates,
 } from './design/prototypes/contractor-payments/CreateHistoricalPayment'
+import {
+  StateTaxesWithFutureRatesPrototype,
+  StateTaxesWithFutureRatesStates,
+} from './design/prototypes/company-onboarding/StateTaxesWithFutureRates'
 import './app.scss'
 import '@/styles/sdk.scss'
 
@@ -135,6 +139,22 @@ const router = createBrowserRouter([
                   {
                     path: ':componentSlug/:configSlug',
                     element: <CreateHistoricalPaymentStates />,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            path: 'state-taxes-with-future-rates',
+            children: [
+              { index: true, element: <StateTaxesWithFutureRatesPrototype /> },
+              {
+                path: 'component-states',
+                children: [
+                  { index: true, element: <StateTaxesWithFutureRatesStates /> },
+                  {
+                    path: ':componentSlug/:configSlug',
+                    element: <StateTaxesWithFutureRatesStates />,
                   },
                 ],
               },


### PR DESCRIPTION
## Summary

Design prototype in `sdk-app` that extends the existing state tax onboarding component with per-state effective-dated rate management. Not production code — lives under `sdk-app/src/design/` and is only reachable through the design gallery.

- **List view** — duplicate of the state taxes list with a HamburgerMenu on each row exposing *Edit current tax rate* and *Manage tax rates*.
- **Tax rates history** — DataView showing all effective-dated requirement sets for a state (Effective date + a title-less status column with Current/Scheduled/Historical badges + one column per editable requirement). Registration-type (non-effective-dated) sets are filtered out.
- **Add tax rate dialog** — effective date picker sourced from the API's schedulable set (`taxRequirementsGet` with `scheduling: true`), plus dynamic requirement inputs (`QuestionInput` inside a `FormProvider`) with `applicable_if` handling. Persists via `useTaxRequirementsUpdateStateMutation`; the global mutation invalidation refetches both queries so the new row shows up from the API.
- **Portal fix** — since the SDK's `Modal` uses a native `<dialog>` promoted to the browser top layer, react-aria Select popovers portaled outside the dialog rendered invisibly beneath it. The dialog overrides `ThemeContext` for its subtree so Selects portal into a node inside the dialog.

## Test plan
- [ ] `npm run sdk-app`, visit http://localhost:5200/design/state-taxes-with-future-rates
- [ ] Row menu on any state → *Manage tax rates* → history view renders with correct status badges
- [ ] *Add tax rate* → effective date select opens and populates from API schedulable dates
- [ ] For CA: yes/no gate conditionally reveals UI + ETT rate inputs (`applicable_if`)
- [ ] Save persists — reloading the page shows the new row (real network round-trip)
- [ ] Component states page at `/design/state-taxes-with-future-rates/component-states` renders all mock configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)