### PR TITLE
feat(Payroll): redesign Edit payroll UI as card/table sections

### DIFF
--- a/docs/reference/Translations/index.md
+++ b/docs/reference/Translations/index.md
@@ -4434,6 +4434,7 @@ Translation keys for the `Payroll.PayrollEditEmployee` i18n namespace.
 | Property | Default value |
 | ------ | ------ |
 | <a id="property-payrollpayrolleditemployeeadditionalearningstitle"></a> `additionalEarningsTitle` | `"Additional earnings"` |
+| <a id="property-payrollpayrolleditemployeeaddovertimecta"></a> `addOvertimeCta` | `"Add overtime"` |
 | <a id="property-payrollpayrolleditemployeeaddreimbursementcta"></a> `addReimbursementCta` | `"Add one-time reimbursement"` |
 | <a id="property-payrollpayrolleditemployeeaddreimbursementlink"></a> `addReimbursementLink` | `"Add one-time reimbursement"` |
 | <a id="property-payrollpayrolleditemployeebreadcrumblabel"></a> `breadcrumbLabel` | `"{{firstName}} {{lastName}}"` |
@@ -4445,6 +4446,9 @@ Translation keys for the `Payroll.PayrollEditEmployee` i18n namespace.
 | `compensationNames.regularHours` | `"Regular Hours"` |
 | <a id="property-payrollpayrolleditemployeefinalpayoutdescription"></a> `finalPayoutDescription` | `"Enter the unused hours to pay out on the final paycheck. This is separate from time off hours used during the pay period."` |
 | <a id="property-payrollpayrolleditemployeefinalpayouttitle"></a> `finalPayoutTitle` | `"Unused time off payout"` |
+| <a id="property-payrollpayrolleditemployeefixedamountcolumns"></a> `fixedAmountColumns` | |
+| `fixedAmountColumns.amount` | `"Amount"` |
+| `fixedAmountColumns.type` | `"Type"` |
 | <a id="property-payrollpayrolleditemployeefixedcompensationnames"></a> `fixedCompensationNames` | |
 | `fixedCompensationNames.bonus` | `"Bonus"` |
 | `fixedCompensationNames.cashTips` | `"Cash tips"` |
@@ -4454,7 +4458,11 @@ Translation keys for the `Payroll.PayrollEditEmployee` i18n namespace.
 | `fixedCompensationNames.reimbursement` | `"Reimbursement"` |
 | <a id="property-payrollpayrolleditemployeegrosspaylabel"></a> `grossPayLabel` | `"Gross pay (excluding reimbursements)"` |
 | <a id="property-payrollpayrolleditemployeegrosspaylabelmobile"></a> `grossPayLabelMobile` | `"Gross pay: {{grossPay}} (excluding reimbursements)"` |
+| <a id="property-payrollpayrolleditemployeehourscolumns"></a> `hoursColumns` | |
+| `hoursColumns.hours` | `"Hours"` |
+| `hoursColumns.type` | `"Hour type"` |
 | <a id="property-payrollpayrolleditemployeehoursunit"></a> `hoursUnit` | `"Hours"` |
+| <a id="property-payrollpayrolleditemployeeotherearningstitle"></a> `otherEarningsTitle` | `"Other"` |
 | <a id="property-payrollpayrolleditemployeepagetitle"></a> `pageTitle` | `"Edit payroll for {{employeeName}}"` |
 | <a id="property-payrollpayrolleditemployeepaymentmethoddescription"></a> `paymentMethodDescription` | `"Changing the default payment method will only apply to this payroll."` |
 | <a id="property-payrollpayrolleditemployeepaymentmethodlabel"></a> `paymentMethodLabel` | `"Payment method"` |
@@ -4464,7 +4472,7 @@ Translation keys for the `Payroll.PayrollEditEmployee` i18n namespace.
 | <a id="property-payrollpayrolleditemployeepaymentmethodtitle"></a> `paymentMethodTitle` | `"Payment"` |
 | <a id="property-payrollpayrolleditemployeerecurringreimbursementlabel"></a> `recurringReimbursementLabel` | `"{{description}} (recurring reimbursement)"` |
 | <a id="property-payrollpayrolleditemployeerecurringreimbursementtooltip"></a> `recurringReimbursementTooltip` | `"Recurring reimbursements are managed outside of payroll."` |
-| <a id="property-payrollpayrolleditemployeeregularhourstitle"></a> `regularHoursTitle` | `"Regular hours"` |
+| <a id="property-payrollpayrolleditemployeeregularhourstitle"></a> `regularHoursTitle` | `"Regular and overtime hours"` |
 | <a id="property-payrollpayrolleditemployeereimbursementamountcolumn"></a> `reimbursementAmountColumn` | `"Amount"` |
 | <a id="property-payrollpayrolleditemployeereimbursementamountlabel"></a> `reimbursementAmountLabel` | `"Amount"` |
 | <a id="property-payrollpayrolleditemployeereimbursementdescriptioncolumn"></a> `reimbursementDescriptionColumn` | `"Description"` |
@@ -4482,6 +4490,9 @@ Translation keys for the `Payroll.PayrollEditEmployee` i18n namespace.
 | <a id="property-payrollpayrolleditemployeesavereimbursementcta"></a> `saveReimbursementCta` | `"Save reimbursement"` |
 | <a id="property-payrollpayrolleditemployeetimeoffbalance"></a> `timeOffBalance` | |
 | `timeOffBalance.remaining` | `"{{balance}} remaining"` |
+| <a id="property-payrollpayrolleditemployeetimeoffcolumns"></a> `timeOffColumns` | |
+| `timeOffColumns.hours` | `"Hours"` |
+| `timeOffColumns.type` | `"Type"` |
 | <a id="property-payrollpayrolleditemployeetimeofftitle"></a> `timeOffTitle` | `"Time off"` |
 | <a id="property-payrollpayrolleditemployeetimeofftitledismissal"></a> `timeOffTitleDismissal` | `"Time off hours used this pay period"` |
 

--- a/src/components/Payroll/OffCycle/OffCycleExecution.test.tsx
+++ b/src/components/Payroll/OffCycle/OffCycleExecution.test.tsx
@@ -352,7 +352,7 @@ describe('OffCycleExecution - edit employee hours round-trip', () => {
       ).toBeInTheDocument()
     })
 
-    const regularHoursInput = await screen.findByLabelText('Regular Hours')
+    const regularHoursInput = await screen.findByRole('spinbutton', { name: 'Regular Hours' })
     await user.clear(regularHoursInput)
     await user.type(regularHoursInput, '20')
 

--- a/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.module.scss
+++ b/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.module.scss
@@ -18,16 +18,10 @@
 }
 
 .fieldGroup {
-  padding: toRem(32) 0;
-  border-top: 1px solid var(--g-colorBorderSecondary);
   width: 100%;
   display: flex;
   flex-direction: column;
   gap: toRem(16);
-
-  &:first-child {
-    border-top: none;
-  }
 }
 
 .grossPayLabel {

--- a/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.test.tsx
+++ b/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.test.tsx
@@ -473,6 +473,72 @@ describe('PayrollEditEmployeePresentation', () => {
     )
   })
 
+  describe('Overtime', () => {
+    it('hides overtime rows behind an Add overtime button until revealed', async () => {
+      const user = userEvent.setup()
+      const compensationWithZeroOvertime: PayrollEmployeeCompensationsType = {
+        ...mockEmployeeCompensation,
+        hourlyCompensations: [
+          {
+            name: 'Regular Hours',
+            hours: '40.000',
+            flsaStatus: 'Nonexempt',
+            jobUuid: 'job-1',
+            amount: '1000.0',
+            compensationMultiplier: 1.0,
+          },
+          {
+            name: 'Overtime',
+            hours: '0',
+            flsaStatus: 'Nonexempt',
+            jobUuid: 'job-1',
+            amount: '0',
+            compensationMultiplier: 1.5,
+          },
+        ],
+      }
+
+      renderWithProviders(
+        <PayrollEditEmployeePresentation
+          {...defaultProps}
+          employeeCompensation={compensationWithZeroOvertime}
+        />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Regular Hours')).toBeInTheDocument()
+      })
+      expect(screen.queryByLabelText('Overtime')).not.toBeInTheDocument()
+
+      const addOvertimeButton = screen.getByText('Add overtime')
+      await user.click(addOvertimeButton)
+
+      expect(screen.getByLabelText('Overtime')).toBeInTheDocument()
+      expect(screen.queryByText('Add overtime')).not.toBeInTheDocument()
+    })
+
+    it('reveals overtime rows by default when the employee already has overtime hours', async () => {
+      renderWithProviders(<PayrollEditEmployeePresentation {...defaultProps} />)
+
+      expect(await screen.findByLabelText('Overtime')).toBeInTheDocument()
+      expect(screen.queryByText('Add overtime')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Section order', () => {
+    it('renders Additional earnings before Time off', async () => {
+      renderWithProviders(<PayrollEditEmployeePresentation {...defaultProps} />)
+
+      const additionalEarningsHeading = await screen.findByText('Additional earnings')
+      const timeOffHeading = screen.getByText('Time off')
+
+      expect(
+        additionalEarningsHeading.compareDocumentPosition(timeOffHeading) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy()
+    })
+  })
+
   describe('Time Off', () => {
     it('renders time off section when employee has time off data', async () => {
       renderWithProviders(<PayrollEditEmployeePresentation {...defaultProps} />)
@@ -819,6 +885,35 @@ describe('PayrollEditEmployeePresentation', () => {
         expect(screen.getByLabelText('Bonus')).toBeInTheDocument()
         expect(screen.getByLabelText('Commission')).toBeInTheDocument()
       })
+    })
+
+    it('renders cash and paycheck tips under a separate Other section', async () => {
+      const compensationWithTips: PayrollEmployeeCompensationsType = {
+        ...mockEmployeeCompensation,
+        fixedCompensations: [
+          { name: 'Bonus', amount: '500.00', jobUuid: 'job-1' },
+          { name: 'Cash Tips', amount: '20.00', jobUuid: 'job-1' },
+        ],
+      }
+
+      renderWithProviders(
+        <PayrollEditEmployeePresentation
+          {...defaultProps}
+          employeeCompensation={compensationWithTips}
+          fixedCompensationTypes={[{ name: 'Bonus' }, { name: 'Cash Tips' }]}
+        />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText('Additional earnings')).toBeInTheDocument()
+      })
+      expect(screen.getByLabelText('Bonus')).toBeInTheDocument()
+      const otherHeading = screen.getByText('Other')
+      const cashTipsInput = screen.getByLabelText('Cash tips')
+      expect(cashTipsInput).toBeInTheDocument()
+      expect(
+        otherHeading.compareDocumentPosition(cashTipsInput) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy()
     })
 
     it('renders reimbursement rows when present', async () => {

--- a/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.tsx
+++ b/src/components/Payroll/PayrollEditEmployee/PayrollEditEmployeePresentation.tsx
@@ -219,6 +219,125 @@ function TimeOffDataView({ timeOffs, employee, label, Field }: TimeOffDataViewPr
   return <DataView label={label} isWithinBox {...dataViewProps} />
 }
 
+interface HourRow {
+  compensationName: string
+  label: string
+  fieldName: string
+}
+
+interface HoursDataViewProps {
+  rows: HourRow[]
+  label: string
+  title: string
+  isOvertimeRevealed: boolean
+  onAddOvertime: () => void
+}
+
+function HoursDataView({
+  rows,
+  label,
+  title,
+  isOvertimeRevealed,
+  onAddOvertime,
+}: HoursDataViewProps) {
+  const { t } = useTranslation('Payroll.PayrollEditEmployee')
+  const { Box, BoxHeader, Button } = useComponentContext()
+
+  const overtimeRows = rows.filter(
+    r =>
+      r.compensationName === COMPENSATION_NAME_OVERTIME ||
+      r.compensationName === COMPENSATION_NAME_DOUBLE_OVERTIME,
+  )
+  const baseRows = rows.filter(
+    r =>
+      r.compensationName !== COMPENSATION_NAME_OVERTIME &&
+      r.compensationName !== COMPENSATION_NAME_DOUBLE_OVERTIME,
+  )
+  const visibleRows = isOvertimeRevealed ? rows : baseRows
+
+  const dataViewProps = useDataView<HourRow>({
+    data: visibleRows,
+    columns: [
+      { title: t('hoursColumns.type'), key: 'label' },
+      {
+        title: t('hoursColumns.hours'),
+        justify: 'end',
+        render: row => (
+          <div className={styles.inputContainer}>
+            <TextInputField
+              name={row.fieldName}
+              type="number"
+              min={0}
+              adornmentEnd={t('hoursUnit')}
+              isRequired
+              label={row.label}
+              shouldVisuallyHideLabel
+            />
+          </div>
+        ),
+      },
+    ],
+  })
+
+  const showAddOvertimeFooter = overtimeRows.length > 0 && !isOvertimeRevealed
+
+  return (
+    <Box
+      header={<BoxHeader title={title} />}
+      withPadding={false}
+      footer={
+        showAddOvertimeFooter ? (
+          <Button variant="secondary" onClick={onAddOvertime}>
+            {t('addOvertimeCta')}
+          </Button>
+        ) : undefined
+      }
+    >
+      <DataView label={label} isWithinBox {...dataViewProps} />
+    </Box>
+  )
+}
+
+interface FixedAmountRow {
+  name: string
+  label: string
+  fieldName: string
+}
+
+interface FixedAmountsDataViewProps {
+  rows: FixedAmountRow[]
+  label: string
+}
+
+function FixedAmountsDataView({ rows, label }: FixedAmountsDataViewProps) {
+  const { t } = useTranslation('Payroll.PayrollEditEmployee')
+
+  const dataViewProps = useDataView<FixedAmountRow>({
+    data: rows,
+    columns: [
+      { title: t('fixedAmountColumns.type'), key: 'label' },
+      {
+        title: t('fixedAmountColumns.amount'),
+        justify: 'end',
+        render: row => (
+          <div className={styles.inputContainer}>
+            <TextInputField
+              name={row.fieldName}
+              type="number"
+              min={0}
+              adornmentStart="$"
+              isRequired
+              label={row.label}
+              shouldVisuallyHideLabel
+            />
+          </div>
+        ),
+      },
+    ],
+  })
+  return <DataView label={label} isWithinBox {...dataViewProps} />
+}
+
 /** @internal */
 export const PayrollEditEmployeePresentation = ({
   onSave,
@@ -332,6 +451,25 @@ export const PayrollEditEmployeePresentation = ({
     }
   }
 
+  const PRIMARY_EARNING_NAMES = new Set(
+    [
+      COMPENSATION_NAME_BONUS,
+      COMPENSATION_NAME_COMMISSION,
+      COMPENSATION_NAME_CORRECTION_PAYMENT,
+    ].map(n => n.toLowerCase()),
+  )
+  const toFixedAmountRow = (item: { name?: string | null }): FixedAmountRow => ({
+    name: item.name!,
+    label: getFixedCompensationLabel(item.name ?? undefined) ?? item.name!,
+    fieldName: `fixedCompensations.${item.name}`,
+  })
+  const primaryEarningRows: FixedAmountRow[] = additionalEarnings
+    .filter(item => PRIMARY_EARNING_NAMES.has((item.name ?? '').toLowerCase()))
+    .map(toFixedAmountRow)
+  const otherEarningRows: FixedAmountRow[] = additionalEarnings
+    .filter(item => !PRIMARY_EARNING_NAMES.has((item.name ?? '').toLowerCase()))
+    .map(toFixedAmountRow)
+
   const defaultValues = {
     hourlyCompensations: (() => {
       const hourlyCompensations: PayrollEditEmployeeFormValues['hourlyCompensations'] = {}
@@ -406,6 +544,14 @@ export const PayrollEditEmployeePresentation = ({
     resolver: zodResolver(PayrollEditEmployeeFormSchema),
     defaultValues,
   })
+
+  const initialHasOvertimeValues = hourlyJobs.some(job =>
+    [COMPENSATION_NAME_OVERTIME, COMPENSATION_NAME_DOUBLE_OVERTIME].some(
+      name => parseFloat(defaultValues.hourlyCompensations[job.uuid]?.[name] ?? '0') > 0,
+    ),
+  )
+  const [forceShowOvertime, setForceShowOvertime] = useState(initialHasOvertimeValues)
+  const isOvertimeRevealed = forceShowOvertime
 
   const {
     fields: reimbursementFields,
@@ -649,33 +795,48 @@ export const PayrollEditEmployeePresentation = ({
         <Form>
           {hourlyJobs.length > 0 && (
             <div className={styles.fieldGroup}>
-              <Heading as="h3">{t('regularHoursTitle')}</Heading>
-              {hourlyJobs.map(hourlyJob => (
-                <Flex key={hourlyJob.uuid} flexDirection="column" gap={8}>
-                  {hourlyJobs.length > 1 && <Heading as="h4">{hourlyJob.title}</Heading>}
-                  <Grid gridTemplateColumns={{ base: '1fr', small: [320, 320] }} gap={20}>
-                    {HOURS_COMPENSATION_NAMES.map(compensationName => {
-                      const employeeHourlyCompensation = findMatchingCompensation(
-                        hourlyJob.uuid,
-                        compensationName,
-                      )
-                      if (employeeHourlyCompensation) {
-                        return (
-                          <TextInputField
-                            key={compensationName}
-                            type="number"
-                            min={0}
-                            adornmentEnd={t('hoursUnit')}
-                            isRequired
-                            label={getCompensationLabel(compensationName)}
-                            name={`hourlyCompensations.${hourlyJob.uuid}.${employeeHourlyCompensation.name}`}
-                          />
-                        )
-                      }
-                    })}
-                  </Grid>
-                </Flex>
-              ))}
+              {hourlyJobs.length > 1 && <Heading as="h3">{t('regularHoursTitle')}</Heading>}
+              {hourlyJobs.map(hourlyJob => {
+                const rows: HourRow[] = HOURS_COMPENSATION_NAMES.flatMap(compensationName => {
+                  const match = findMatchingCompensation(hourlyJob.uuid, compensationName)
+                  if (!match) return []
+                  return [
+                    {
+                      compensationName,
+                      label: getCompensationLabel(compensationName) ?? compensationName,
+                      fieldName: `hourlyCompensations.${hourlyJob.uuid}.${match.name!}`,
+                    },
+                  ]
+                })
+
+                const boxTitle =
+                  hourlyJobs.length > 1
+                    ? (hourlyJob.title ?? t('regularHoursTitle'))
+                    : t('regularHoursTitle')
+
+                return (
+                  <HoursDataView
+                    key={hourlyJob.uuid}
+                    rows={rows}
+                    label={t('regularHoursTitle')}
+                    title={boxTitle}
+                    isOvertimeRevealed={isOvertimeRevealed}
+                    onAddOvertime={() => {
+                      setForceShowOvertime(true)
+                    }}
+                  />
+                )
+              })}
+            </div>
+          )}
+          {primaryEarningRows.length > 0 && (
+            <div className={styles.fieldGroup}>
+              <Box header={<BoxHeader title={t('additionalEarningsTitle')} />} withPadding={false}>
+                <FixedAmountsDataView
+                  rows={primaryEarningRows}
+                  label={t('additionalEarningsTitle')}
+                />
+              </Box>
             </div>
           )}
           {timeOff.length > 0 && (
@@ -721,25 +882,11 @@ export const PayrollEditEmployeePresentation = ({
               </Box>
             </div>
           )}
-          {additionalEarnings.length > 0 && (
+          {otherEarningRows.length > 0 && (
             <div className={styles.fieldGroup}>
-              <Heading as="h4">{t('additionalEarningsTitle')}</Heading>
-              <Grid
-                gridTemplateColumns={{ base: '1fr', small: [320, 320], large: [320, 320, 320] }}
-                gap={20}
-              >
-                {additionalEarnings.map(fixedCompensation => (
-                  <TextInputField
-                    key={fixedCompensation.name}
-                    type="number"
-                    min={0}
-                    adornmentStart="$"
-                    isRequired
-                    label={getFixedCompensationLabel(fixedCompensation.name)}
-                    name={`fixedCompensations.${fixedCompensation.name}`}
-                  />
-                ))}
-              </Grid>
+              <Box header={<BoxHeader title={t('otherEarningsTitle')} />} withPadding={false}>
+                <FixedAmountsDataView rows={otherEarningRows} label={t('otherEarningsTitle')} />
+              </Box>
             </div>
           )}
           {showLegacyReimbursementField && (

--- a/src/i18n/en/Payroll.PayrollEditEmployee.json
+++ b/src/i18n/en/Payroll.PayrollEditEmployee.json
@@ -3,8 +3,13 @@
   "breadcrumbLabel": "{{firstName}} {{lastName}}",
   "grossPayLabel": "Gross pay (excluding reimbursements)",
   "grossPayLabelMobile": "Gross pay: {{grossPay}} (excluding reimbursements)",
-  "regularHoursTitle": "Regular hours",
+  "regularHoursTitle": "Regular and overtime hours",
   "hoursUnit": "Hours",
+  "addOvertimeCta": "Add overtime",
+  "hoursColumns": {
+    "type": "Hour type",
+    "hours": "Hours"
+  },
   "saveCta": "Save",
   "cancelCta": "Cancel",
   "compensationNames": {
@@ -24,6 +29,11 @@
     "hours": "Hours"
   },
   "additionalEarningsTitle": "Additional earnings",
+  "otherEarningsTitle": "Other",
+  "fixedAmountColumns": {
+    "type": "Type",
+    "amount": "Amount"
+  },
   "reimbursementTitle": "Reimbursements",
   "reimbursementDescriptionLabel": "Description",
   "reimbursementDescriptionPlaceholder": "e.g., Office supplies",

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -6434,10 +6434,18 @@ export namespace Translations {
     grossPayLabel: string
     /** @defaultValue `"Gross pay: {{grossPay}} (excluding reimbursements)"` */
     grossPayLabelMobile: string
-    /** @defaultValue `"Regular hours"` */
+    /** @defaultValue `"Regular and overtime hours"` */
     regularHoursTitle: string
     /** @defaultValue `"Hours"` */
     hoursUnit: string
+    /** @defaultValue `"Add overtime"` */
+    addOvertimeCta: string
+    hoursColumns: {
+      /** @defaultValue `"Hour type"` */
+      type: string
+      /** @defaultValue `"Hours"` */
+      hours: string
+    }
     /** @defaultValue `"Save"` */
     saveCta: string
     /** @defaultValue `"Cancel"` */
@@ -6470,6 +6478,14 @@ export namespace Translations {
     }
     /** @defaultValue `"Additional earnings"` */
     additionalEarningsTitle: string
+    /** @defaultValue `"Other"` */
+    otherEarningsTitle: string
+    fixedAmountColumns: {
+      /** @defaultValue `"Type"` */
+      type: string
+      /** @defaultValue `"Amount"` */
+      amount: string
+    }
     /** @defaultValue `"Reimbursements"` */
     reimbursementTitle: string
     /** @defaultValue `"Description"` */


### PR DESCRIPTION
## Summary
- Second of two stacked PRs for SDK-1134. Based on #2466 (merge that one first).
- Redesigns the Edit payroll screen's sections — Regular and overtime hours, Time off, Additional earnings, Other — as bordered `Box` cards with `DataView` tables, matching the design-mode reference (`sdk-app/src/design/components/payroll/PayrollEditEmployee/`).
- Overtime and Double overtime rows are hidden behind an "Add overtime" button unless the employee already has non-zero overtime hours (mirrors the design reference's reveal behavior).
- Splits the combined "Additional earnings" section into "Additional earnings" (Bonus, Commission, Correction payment) and a new "Other" section (Cash tips, Paycheck tips).
- Reorders sections so **Additional earnings renders above Time off** (an explicit deviation from the design reference, called out during review) — "Other" and "Reimbursements" keep their existing relative position.
- UI only. The per-workweek hours/earnings split (Regular Rate of Pay) stays in the design prototype and is tracked as separate follow-up work — no new API fields or split-calculation logic here.

## Test plan
- [x] `npm run test -- --run src/components/Payroll/PayrollEditEmployee` — 70/70 passing
- [x] `npm run test -- --run` (full suite) — 3539/3542 passing (1 pre-existing expected-fail; 2 unrelated `CreatePayment.test.tsx` failures were full-suite timing flakiness, confirmed passing in isolation)
- [x] `npx tsc --noEmit` and `npx eslint` clean on changed files
- [x] `npm run i18n:generate` — new translation keys generated (`hoursColumns`, `addOvertimeCta`, `otherEarningsTitle`, `fixedAmountColumns`)
- [ ] Manual Storybook pass against the design reference (`npm run storybook` → Domain/Payroll/PayrollEditEmployee) recommended before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)