### PR TITLE
fix(Contractor): tailor W-9 TIN section copy to individual vs. business

### DIFF
--- a/docs/reference/Translations/index.md
+++ b/docs/reference/Translations/index.md
@@ -1982,14 +1982,15 @@ Translation keys for the `Contractor.SignatureForm` i18n namespace.
 | <a id="property-contractorsignatureformsectioninstructions"></a> `sectionInstructions` | |
 | `sectionInstructions.address` | `"See sections 5-7 of IRS Form W-9 for instructions."` |
 | `sectionInstructions.certification` | `"See Part 2 of the IRS Form W-9 for instructions."` |
+| `sectionInstructions.ein` | `"Your EIN is required as a business contractor. See Part 1 of the IRS Form W-9 for instructions."` |
 | `sectionInstructions.exemptions` | `"See section 4 of IRS Form W-9 for instructions."` |
-| `sectionInstructions.tin` | `"For individuals, this is generally your social security number (SSN). For other entities, this will be your employer identification number (EIN)."` |
-| `sectionInstructions.tinSecondary` | `"See Part 1 of the IRS Form W-9 for instructions."` |
+| `sectionInstructions.ssn` | `"Your SSN is required as an individual contractor. See Part 1 of the IRS Form W-9 for instructions."` |
 | <a id="property-contractorsignatureformsections"></a> `sections` | |
 | `sections.address` | `"Address"` |
 | `sections.certification` | `"Certification"` |
+| `sections.ein` | `"Employer identification number (EIN)"` |
 | `sections.exemptions` | `"Exemptions"` |
-| `sections.tin` | `"Taxpayer Identification Number (TIN)"` |
+| `sections.ssn` | `"Social security number (SSN)"` |
 | <a id="property-contractorsignatureformsignaturerequired"></a> `signatureRequired` | `"Signature required"` |
 | <a id="property-contractorsignatureformsigncta"></a> `signCta` | `"Sign"` |
 | <a id="property-contractorsignatureformsigningcta"></a> `signingCta` | `"Signing…"` |

--- a/src/components/Contractor/Documents/SignatureForm/SignatureForm.tsx
+++ b/src/components/Contractor/Documents/SignatureForm/SignatureForm.tsx
@@ -309,14 +309,15 @@ function W9Fields({ hookResult }: W9FieldsProps) {
         </Flex>
       </Components.Box>
 
-      {/* Taxpayer Identification Number */}
       {(Fields.Ssn || Fields.Ein) && (
         <Components.Box
           header={
             <Flex flexDirection="column" gap={2}>
-              <Components.Heading as="h3">{t('sections.tin')}</Components.Heading>
+              <Components.Heading as="h3">
+                {Fields.Ssn ? t('sections.ssn') : t('sections.ein')}
+              </Components.Heading>
               <Components.Text variant="supporting">
-                {t('sectionInstructions.tin')} {t('sectionInstructions.tinSecondary')}
+                {Fields.Ssn ? t('sectionInstructions.ssn') : t('sectionInstructions.ein')}
               </Components.Text>
             </Flex>
           }

--- a/src/i18n/en/Contractor.SignatureForm.json
+++ b/src/i18n/en/Contractor.SignatureForm.json
@@ -5,14 +5,15 @@
   "sections": {
     "exemptions": "Exemptions",
     "address": "Address",
-    "tin": "Taxpayer Identification Number (TIN)",
+    "ssn": "Social security number (SSN)",
+    "ein": "Employer identification number (EIN)",
     "certification": "Certification"
   },
   "sectionInstructions": {
     "exemptions": "See section 4 of IRS Form W-9 for instructions.",
     "address": "See sections 5-7 of IRS Form W-9 for instructions.",
-    "tin": "For individuals, this is generally your social security number (SSN). For other entities, this will be your employer identification number (EIN).",
-    "tinSecondary": "See Part 1 of the IRS Form W-9 for instructions.",
+    "ssn": "Your SSN is required as an individual contractor. See Part 1 of the IRS Form W-9 for instructions.",
+    "ein": "Your EIN is required as a business contractor. See Part 1 of the IRS Form W-9 for instructions.",
     "certification": "See Part 2 of the IRS Form W-9 for instructions."
   },
   "certificationIntro": "Under penalties of perjury, I certify that:",

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -2720,8 +2720,10 @@ export namespace Translations {
       exemptions: string
       /** @defaultValue `"Address"` */
       address: string
-      /** @defaultValue `"Taxpayer Identification Number (TIN)"` */
-      tin: string
+      /** @defaultValue `"Social security number (SSN)"` */
+      ssn: string
+      /** @defaultValue `"Employer identification number (EIN)"` */
+      ein: string
       /** @defaultValue `"Certification"` */
       certification: string
     }
@@ -2730,10 +2732,10 @@ export namespace Translations {
       exemptions: string
       /** @defaultValue `"See sections 5-7 of IRS Form W-9 for instructions."` */
       address: string
-      /** @defaultValue `"For individuals, this is generally your social security number (SSN). For other entities, this will be your employer identification number (EIN)."` */
-      tin: string
-      /** @defaultValue `"See Part 1 of the IRS Form W-9 for instructions."` */
-      tinSecondary: string
+      /** @defaultValue `"Your SSN is required as an individual contractor. See Part 1 of the IRS Form W-9 for instructions."` */
+      ssn: string
+      /** @defaultValue `"Your EIN is required as a business contractor. See Part 1 of the IRS Form W-9 for instructions."` */
+      ein: string
       /** @defaultValue `"See Part 2 of the IRS Form W-9 for instructions."` */
       certification: string
     }


### PR DESCRIPTION
## Summary
- Split the W-9 TIN section heading and helper copy so individual contractors see SSN-specific text and business contractors see EIN-specific text
- Replace shared `sections.tin` / `sectionInstructions.tin` translation keys with per-TIN `ssn` and `ein` variants and regenerate i18n types

## Demo

<img width="829" height="237" alt="Screenshot 2026-07-27 at 2 17 39 PM" src="https://github.com/user-attachments/assets/7008d62c-8175-47f7-9cad-124bb39fc169" />
<img width="661" height="258" alt="Screenshot 2026-07-27 at 2 20 40 PM" src="https://github.com/user-attachments/assets/0e6c25bb-601e-4049-935d-f94feb45123f" />


## Test plan
- [ ] Sign a W-9 as an individual contractor — heading reads "Social security number (SSN)" with SSN-specific instructions
- [ ] Sign a W-9 as a business contractor — heading reads "Employer identification number (EIN)" with EIN-specific instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)