### PR TITLE
fix: format generated component registry with Prettier to stop diff churn

### DIFF
--- a/sdk-app/scripts/analyze-component-props.ts
+++ b/sdk-app/scripts/analyze-component-props.ts
@@ -18,6 +18,7 @@
 import { resolve } from 'path'
 import { writeFileSync } from 'fs'
 import { Project, SyntaxKind, type Type } from 'ts-morph'
+import { format, resolveConfig } from 'prettier'
 
 const ROOT = resolve(import.meta.dirname, '../..')
 const OUTPUT = resolve(import.meta.dirname, '../src/generated-registry-data.ts')
@@ -159,7 +160,7 @@ function analyzeComponents(): Record<string, ComponentData> {
   return results
 }
 
-function generate() {
+async function generate() {
   console.log('Analyzing component interfaces...\n')
 
   const results = analyzeComponents()
@@ -186,6 +187,13 @@ function generate() {
   }
   output += `}\n`
 
+  // Format with the repo's Prettier config before writing — otherwise this
+  // hand-built output (single-line arrays) diffs against the previously
+  // committed, Prettier-formatted file every time this script re-runs, even
+  // when the underlying component data hasn't changed.
+  const prettierConfig = await resolveConfig(OUTPUT)
+  output = await format(output, { ...prettierConfig, filepath: OUTPUT })
+
   writeFileSync(OUTPUT, output)
   console.log(`\nGenerated: ${OUTPUT}`)
   console.log(`  ${sortedKeys.length} components analyzed`)
@@ -199,4 +207,4 @@ function generate() {
   }
 }
 
-generate()
+await generate()


### PR DESCRIPTION
## Summary

`sdk-app/scripts/analyze-component-props.ts` regenerates `sdk-app/src/generated-registry-data.ts` on every `npm run sdk-app` startup, but writes it as unwrapped, single-line array literals. The committed file is Prettier-formatted, so every dev-app startup produced a spurious diff on this generated file even when no component data actually changed.

## Changes

- `analyze-component-props.ts` now formats its output with the repo's Prettier config before writing, matching the existing pattern in `build/deriveExternalModels.ts`.

## Testing

- Ran `npx tsx sdk-app/scripts/analyze-component-props.ts` twice in a row — output is idempotent and produces zero diff against the committed `generated-registry-data.ts`.
- `npx tsc --noEmit -p .` and `npx eslint sdk-app/scripts/analyze-component-props.ts` — clean.