### PR TITLE
feat(CI): tag E2E requests with X-Gusto-Client header

### DIFF
--- a/e2e/globalSetup.ts
+++ b/e2e/globalSetup.ts
@@ -2,6 +2,7 @@ import { resolve } from 'path'
 import { resolve as dnsResolve } from 'dns/promises'
 import { existsSync, readFileSync, readdirSync, writeFileSync } from 'fs'
 import * as dotenv from 'dotenv'
+import { CI_HEADERS } from './utils/ciHeaders'
 import { refreshTokenIfNeeded, createFreshDemo } from './scripts/refreshToken'
 import type { ScenarioContext } from './scenario/context'
 import { makeApi, provisionScenario } from './scenario/runner'
@@ -68,6 +69,7 @@ async function checkGWSFlowsHealth(): Promise<{ ok: boolean; detail: string }> {
     const response = await fetch(targetUrl, {
       signal: AbortSignal.timeout(15000),
       redirect: 'follow',
+      headers: CI_HEADERS,
     })
     if (response.ok || response.status === 404) {
       return { ok: true, detail: `status ${response.status}` }
@@ -182,7 +184,7 @@ async function isExistingStateValid(state: Partial<E2EState>): Promise<boolean> 
   try {
     const response = await fetch(
       `${GWS_FLOWS_BASE}/fe_sdk/${flowToken}/v1/companies/${state.companyId}/locations`,
-      { signal: AbortSignal.timeout(5000) },
+      { signal: AbortSignal.timeout(5000), headers: CI_HEADERS },
     )
     if (!response.ok) return false
 
@@ -197,7 +199,7 @@ async function isExistingStateValid(state: Partial<E2EState>): Promise<boolean> 
 }
 
 async function fetchFromApi<T>(endpoint: string): Promise<T> {
-  const response = await fetch(`${GWS_FLOWS_BASE}${endpoint}`)
+  const response = await fetch(`${GWS_FLOWS_BASE}${endpoint}`, { headers: CI_HEADERS })
   if (!response.ok) {
     throw new Error(`API request failed: ${response.status} ${response.statusText}`)
   }
@@ -207,7 +209,7 @@ async function fetchFromApi<T>(endpoint: string): Promise<T> {
 async function postToApi<T>(endpoint: string, data: Record<string, unknown>): Promise<T> {
   const response = await fetch(`${GWS_FLOWS_BASE}${endpoint}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...CI_HEADERS },
     body: JSON.stringify(data),
   })
   if (!response.ok) {
@@ -220,7 +222,7 @@ async function postToApi<T>(endpoint: string, data: Record<string, unknown>): Pr
 async function putToApi<T>(endpoint: string, data: Record<string, unknown>): Promise<T> {
   const response = await fetch(`${GWS_FLOWS_BASE}${endpoint}`, {
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...CI_HEADERS },
     body: JSON.stringify(data),
   })
   if (!response.ok) {

--- a/e2e/scenario/runner.ts
+++ b/e2e/scenario/runner.ts
@@ -2,6 +2,7 @@ import { resolve, relative } from 'node:path'
 import type { ScenarioContext } from './context'
 import { loadScenario } from './loader'
 import { createDemoAndProvision } from '../../sdk-app/scripts/demo-provisioner'
+import { CI_HEADERS } from '../utils/ciHeaders'
 import type {
   Scenario,
   EmployeeDecoration,
@@ -31,9 +32,8 @@ export function makeApi(gwsFlowsBase: string, flowToken: string): ApiClient {
     const url = `${base}${path}`
     const response = await fetch(url, {
       method,
-      ...(body
-        ? { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
-        : {}),
+      headers: body ? { 'Content-Type': 'application/json', ...CI_HEADERS } : { ...CI_HEADERS },
+      ...(body ? { body: JSON.stringify(body) } : {}),
     })
     if (!response.ok) {
       const errorBody = await response.text().catch(() => '')

--- a/e2e/scripts/refreshToken.ts
+++ b/e2e/scripts/refreshToken.ts
@@ -1,6 +1,7 @@
 import { chromium } from '@playwright/test'
 import { writeFileSync, readFileSync, existsSync } from 'fs'
 import { resolve } from 'path'
+import { CI_HEADERS } from '../utils/ciHeaders'
 
 const DEFAULT_GWS_FLOWS_HOST = 'https://flows.gusto-demo.com'
 const GWS_FLOWS_BASE = process.env.E2E_GWS_FLOWS_HOST || DEFAULT_GWS_FLOWS_HOST
@@ -140,6 +141,7 @@ async function extractTokenFromPage(flowType: string = 'react_sdk_demo'): Promis
       try {
         const companyResponse = await fetch(`${GWS_FLOWS_BASE}/fe_sdk/${flowToken}/v1/companies`, {
           signal: AbortSignal.timeout(10000),
+          headers: CI_HEADERS,
         })
         if (companyResponse.ok) {
           const companies = await companyResponse.json()
@@ -228,7 +230,7 @@ async function testToken(flowToken: string, companyId: string): Promise<boolean>
   try {
     const response = await fetch(
       `${GWS_FLOWS_BASE}/fe_sdk/${flowToken}/v1/companies/${companyId}/locations`,
-      { signal: AbortSignal.timeout(5000) },
+      { signal: AbortSignal.timeout(5000), headers: CI_HEADERS },
     )
     return response.ok
   } catch {

--- a/e2e/utils/api.ts
+++ b/e2e/utils/api.ts
@@ -1,9 +1,13 @@
+import { CI_HEADERS } from './ciHeaders'
+
 export function getGWSFlowsBase(): string {
   return process.env.E2E_GWS_FLOWS_HOST || 'https://flows.gusto-demo.com'
 }
 
 export async function fetchApi<T>(endpoint: string): Promise<T> {
-  const response = await fetch(`${getGWSFlowsBase()}${endpoint}`)
+  const response = await fetch(`${getGWSFlowsBase()}${endpoint}`, {
+    headers: CI_HEADERS,
+  })
   if (!response.ok) {
     const errorBody = await response.text().catch(() => '')
     throw new Error(`API GET ${endpoint} failed (${response.status}): ${errorBody}`)
@@ -14,7 +18,7 @@ export async function fetchApi<T>(endpoint: string): Promise<T> {
 export async function postApi<T>(endpoint: string, data: Record<string, unknown>): Promise<T> {
   const response = await fetch(`${getGWSFlowsBase()}${endpoint}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...CI_HEADERS },
     body: JSON.stringify(data),
   })
   if (!response.ok) {
@@ -27,7 +31,7 @@ export async function postApi<T>(endpoint: string, data: Record<string, unknown>
 export async function putApi<T>(endpoint: string, data: Record<string, unknown>): Promise<T> {
   const response = await fetch(`${getGWSFlowsBase()}${endpoint}`, {
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...CI_HEADERS },
     body: JSON.stringify(data),
   })
   if (!response.ok) {

--- a/e2e/utils/ciHeaders.ts
+++ b/e2e/utils/ciHeaders.ts
@@ -1,3 +1,3 @@
-export const CI_HEADERS: Record<string, string> = process.env.CI
-  ? { 'X-Gusto-Client': 'sdk-ci' }
-  : {}
+export const CI_HEADERS: Record<string, string> = {
+  'X-Gusto-Client': process.env.CI ? 'sdk-ci' : 'sdk-local',
+}

--- a/e2e/utils/ciHeaders.ts
+++ b/e2e/utils/ciHeaders.ts
@@ -1,0 +1,3 @@
+export const CI_HEADERS: Record<string, string> = process.env.CI
+  ? { 'X-Gusto-Client': 'sdk-ci' }
+  : {}

--- a/e2e/vite.config.ts
+++ b/e2e/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
         target: gwsFlowsHost,
         changeOrigin: true,
         secure: false,
-        headers: process.env.CI ? { 'X-Gusto-Client': 'sdk-ci' } : {},
+        headers: { 'X-Gusto-Client': process.env.CI ? 'sdk-ci' : 'sdk-local' },
       },
     },
   },

--- a/e2e/vite.config.ts
+++ b/e2e/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
         target: gwsFlowsHost,
         changeOrigin: true,
         secure: false,
+        headers: process.env.CI ? { 'X-Gusto-Client': 'sdk-ci' } : {},
       },
     },
   },

--- a/sdk-app/scripts/demo-provisioner.ts
+++ b/sdk-app/scripts/demo-provisioner.ts
@@ -80,9 +80,10 @@ export async function createDemoAndProvision(
     'demo[company_name]': `SDK Dev ${new Date().toISOString().slice(0, 10)}`,
   })
 
+  const ciHeaders = process.env.CI ? { 'X-Gusto-Client': 'sdk-ci' } : {}
   const createRes = await fetch(`${safeHost}/demos`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...ciHeaders },
     body: formBody.toString(),
     redirect: 'follow',
   })
@@ -112,6 +113,7 @@ export async function createDemoAndProvision(
     try {
       const pollRes = await fetch(`${safeHost}/demos/${demoId}`, {
         signal: AbortSignal.timeout(10000),
+        headers: ciHeaders,
       })
       const html = await pollRes.text()
       const linkMatch = html.match(/https?:\/\/[^"]*\/flows\/([a-zA-Z0-9_-]{20,})/)

--- a/sdk-app/scripts/demo-provisioner.ts
+++ b/sdk-app/scripts/demo-provisioner.ts
@@ -80,7 +80,7 @@ export async function createDemoAndProvision(
     'demo[company_name]': `SDK Dev ${new Date().toISOString().slice(0, 10)}`,
   })
 
-  const ciHeaders = process.env.CI ? { 'X-Gusto-Client': 'sdk-ci' } : {}
+  const ciHeaders = { 'X-Gusto-Client': process.env.CI ? 'sdk-ci' : 'sdk-local' }
   const createRes = await fetch(`${safeHost}/demos`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...ciHeaders },


### PR DESCRIPTION
## Summary

Adds `X-Gusto-Client` to every outbound request the E2E infrastructure makes to `flows.gusto-demo.com`, so SDK traffic is identifiable on the backend. The value distinguishes who is making the request:

- `sdk-ci` — GitHub Actions (`CI=true`)
- `sdk-local` — a developer running E2E or sdk-app against demo locally

## Changes

- New `e2e/utils/ciHeaders.ts` — single source of truth for the header
- All Node.js `fetch` call sites in E2E scripts spread `CI_HEADERS` (`globalSetup`, `runner`, `api` utils, `refreshToken`, `demo-provisioner`)
- Vite proxy in `e2e/vite.config.ts` injects the header server-side on all browser-initiated `/fe_sdk/*` requests forwarded to gws-flows

## Testing

- `npm run test -- --run` — 325 test files, all pass
- Local E2E (`CI` unset): header is `sdk-local`
- CI (`CI=true`): header is `sdk-ci`