### PR TITLE
ci: run Claude Code workflow on gusto-ubuntu-default runner

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,8 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on:
+      group: gusto-ubuntu-default
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Summary

Moves the `@claude` GitHub Action ([.github/workflows/claude.yml](.github/workflows/claude.yml)) off the default `ubuntu-latest` GitHub-hosted runner and onto the `gusto-ubuntu-default` managed runner group, so it can pass Gusto's org-level IP allow list.

## Changes

- `claude.yml`: `runs-on: ubuntu-latest` → `runs-on: { group: gusto-ubuntu-default }`

## Why

Tagging `@claude` triggered the workflow, but it failed after obtaining its App token with:

> `Failed to check permissions: ... the `Gusto` organization has an IP allow list enabled, and your IP address is not permitted to access this resource.`

The action authenticates as the `gusto-claude-assistant` GitHub App (OIDC → app token) and then calls the GitHub REST API to check the commenter's permissions. That call goes out from the runner's egress IP. On `ubuntu-latest` the IP is dynamic and not on Gusto's allow list, so it's rejected. The built-in `GITHUB_TOKEN` is exempt from the IP allow list (which is why normal CI on `ubuntu-latest` works), but the App token is not.

Every other workflow in this repo that makes App/authenticated calls to Gusto resources — `publish`, `pull-translations`, `check-manual-translations`, `prepare-release`, `push-sources` — already runs on `gusto-ubuntu-default`, whose egress IPs are allow-listed. This change brings the Claude job in line.

This was the second of two blockers. The first (the org Actions allowlist pinning an outdated `oven-sh/setup-bun` SHA that `claude-code-action@v1` had moved past) was resolved separately by Product Security adding the current SHA to the allowlist.

## Related

- Depends on the org Actions allowlist update for `oven-sh/setup-bun` (handled by Product Security in #security-help).

## Testing

`@claude`-on-comment events always run the workflow definition from the **default branch**, so this fix only takes effect once merged to `main`. After merge, tag `@claude` on any open PR and confirm the run gets past the "check permissions" step (the previously failing point).

---

*Posted by Claude on behalf of Steve*

🤖 Generated with [Claude Code](https://claude.com/claude-code)