### PR TITLE
chore: restrict Claude Code workflow to trusted authors

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,26 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association)
+      )
     runs-on:
       group: gusto-ubuntu-default
     permissions:


### PR DESCRIPTION
## Summary

Follow-up to review feedback on #2079: the `Claude Code` workflow's `if:` gate only matched the `@claude` string and did no author/membership check. Since `Gusto/embedded-react-sdk` is a **public** repo, any GitHub user could satisfy that condition by commenting `@claude`, and these triggers (`issue_comment` / `pull_request_review` / `issues`) run in the base-repo context with access to the `CLAUDE_CODE_OAUTH_TOKEN` secret.

`anthropics/claude-code-action@v1` already refuses to act for users **without repo write access** by default, so a stranger couldn't actually drive Claude — but that protection was invisible in the workflow and still started a runner.

## Change

Add an explicit `author_association` guard (`OWNER` / `MEMBER` / `COLLABORATOR`) to each event clause in `.github/workflows/claude.yml`. `CONTRIBUTOR` is intentionally excluded — it only means the user has had a PR merged once, not that they're trusted.

This is defense-in-depth on top of the action's built-in write-access check:
- The runner no longer spins up at all for untrusted users.
- The trust boundary is now visible to reviewers reading the workflow.
- Matches [Anthropic's recommended pattern](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md).

Each event type reads its association from a different payload path (`comment` vs `review` vs `issue`) — that's intentional, not a copy-paste slip.

## Notes

`author_association` reflects the association on this repo, so a Gusto teammate with repo write access still reports as `MEMBER`/`COLLABORATOR` even if their org membership is private — legitimate maintainers won't be locked out.

*Posted by Claude on behalf of Steve*