### PR TITLE
ci: whitelist verification commands + add /rebase workflow for Claude Code

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,7 +44,12 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
+          # Pre-approve the verification commands Claude needs to run non-interactively.
+          # Without these, Claude cannot self-verify changes in CI (there is no human to
+          # approve the Bash prompt) and reports that it was unable to run the test suite.
+          # Scope is intentionally limited to read-only verification scripts (see package.json);
+          # e2e/storybook/publish/release scripts are excluded on purpose.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+          claude_args: >-
+            --allowed-tools
+            "Bash(npm ci),Bash(npm install),Bash(npm run test:*),Bash(npm run lint:check),Bash(npm run format:check),Bash(npm run tsc),Bash(npm run build)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,12 +44,22 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Pre-approve the verification commands Claude needs to run non-interactively.
-          # Without these, Claude cannot self-verify changes in CI (there is no human to
-          # approve the Bash prompt) and reports that it was unable to run the test suite.
-          # Scope is intentionally limited to read-only verification scripts (see package.json);
+          # Pre-approve the commands Claude needs to run non-interactively. Without these,
+          # Claude hits a Bash approval prompt it cannot clear in CI (there is no human to
+          # approve it) and reports that it was unable to run the command.
+          #
+          # Scope is intentionally limited to:
+          #   - read-only verification scripts from package.json (test/lint/format/tsc/build)
+          #   - npm ci/install, since deps are not installed by the action
+          #   - read-only git inspection (status/diff/log/show/branch/fetch/remote)
           # e2e/storybook/publish/release scripts are excluded on purpose.
+          #
+          # NOTE: history-rewriting git operations (rebase, force-push) and edits to files
+          # under .github/workflows/ CANNOT be enabled here. Rebase/force-push are blocked in
+          # Claude's system prompt, and workflow-file writes require a GitHub App permission the
+          # Claude app deliberately lacks. See the FAQ:
+          # https://github.com/anthropics/claude-code-action/blob/main/docs/faq.md
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           claude_args: >-
             --allowed-tools
-            "Bash(npm ci),Bash(npm install),Bash(npm run test:*),Bash(npm run lint:check),Bash(npm run format:check),Bash(npm run tsc),Bash(npm run build)"
+            "Bash(npm ci),Bash(npm install),Bash(npm run test:*),Bash(npm run lint:check),Bash(npm run format:check),Bash(npm run tsc),Bash(npm run build),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git branch:*),Bash(git fetch:*),Bash(git remote:*)"

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -108,13 +108,40 @@ jobs:
               exit 1
             fi
 
-            conflicts=$(git diff --name-only --diff-filter=U)
-            if [ -n "$conflicts" ]; then
+            # Capture the conflicted set for control flow + the scope guard below.
+            # NUL-delimited because git filenames may contain newlines/spaces.
+            mapfile -d '' conflicted < <(git diff -z --name-only --diff-filter=U)
+
+            if [ "${#conflicted[@]}" -gt 0 ]; then
+              # SECURITY: do NOT interpolate the conflicted filenames into the prompt.
+              # Filenames are attacker-controlled (a crafted name can carry prompt-
+              # injection text). Pass no untrusted data — Claude discovers the conflicts
+              # itself via its own tools. Its toolset excludes Bash, so it can only edit
+              # files, not run commands.
               npx --yes @anthropic-ai/claude-code -p \
-                "You are resolving git merge conflicts during a rebase. These files contain conflict markers (<<<<<<<, =======, >>>>>>>): $conflicts. Edit each file to a single coherent resolution that preserves the intent of both sides, and remove all conflict markers. Do NOT run any git commands." \
+                "A git rebase is in progress in this repository and has stopped on merge conflicts. Some tracked files contain conflict markers (lines starting with <<<<<<<, =======, or >>>>>>>). Find every such file and edit it to a single coherent resolution that preserves the intent of both sides, removing all conflict markers. Only edit files that contain conflict markers. Do NOT run any git commands." \
                 --allowedTools "Edit,Read,Write,Glob,Grep" \
                 --permission-mode acceptEdits \
                 --max-turns 30
+
+              # Defense in depth: conflict file *contents* are attacker-controlled too, so
+              # a hijacked resolution could try to write a backdoor elsewhere. Refuse to
+              # continue if anything outside the conflicted set was modified or created.
+              mapfile -d '' changed < <(git diff -z --name-only; git ls-files -z --others --exclude-standard)
+              for f in "${changed[@]}"; do
+                [ -z "$f" ] && continue
+                in_scope=false
+                for c in "${conflicted[@]}"; do
+                  [ "$f" = "$c" ] && { in_scope=true; break; }
+                done
+                if ! $in_scope; then
+                  echo "Resolution modified a file outside the conflict set: $f"
+                  git rebase --abort || true
+                  echo "result=out-of-scope-edit" >> "$GITHUB_OUTPUT"
+                  exit 1
+                fi
+              done
+
               git add -A
             fi
 

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Rebase onto main (Claude resolves conflicts)
         id: rebase
         env:
-          GIT_EDITOR: "true" # accept existing commit messages non-interactively
+          GIT_EDITOR: 'true' # accept existing commit messages non-interactively
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           set -uo pipefail

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,153 @@
+name: Rebase PR
+
+# Comment "/rebase" on a pull request to rebase its branch onto the latest main
+# and force-push the result. This is a deterministic git workflow that owns every
+# history-rewriting operation (rebase, --continue, force-push) in shell steps.
+# Claude is invoked ONLY to resolve merge conflicts (editing the conflicted files);
+# it never runs a git command. This separation is why this works where the tagged
+# @claude action cannot: the action blocks destructive git ops in its system prompt,
+# but that only governs what Claude runs — not what a `run:` step runs.
+
+on:
+  issue_comment:
+    types: [created]
+
+# Serialize multiple /rebase comments on the same PR so they can't race the force-push.
+concurrency:
+  group: rebase-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  rebase:
+    # Only on PR comments (a PR is an issue under the hood), only for the /rebase
+    # keyword, and only from trusted authors. The author gate matters because this
+    # event runs in the base-repo context with a write-scoped token.
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/rebase') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on:
+      group: gusto-ubuntu-default
+    permissions:
+      contents: read # git write happens via REBASE_TOKEN below, not GITHUB_TOKEN
+      pull-requests: write # post the result comment
+      issues: write # add the 👀 reaction to the triggering comment
+    steps:
+      - name: Acknowledge with a reaction
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes --silent || true
+
+      - name: Resolve PR branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # issue_comment payloads carry the PR number but not its head branch — look it up.
+          data=$(gh pr view "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --json headRefName,isCrossRepository)
+          branch=$(echo "$data" | jq -r .headRefName)
+          cross=$(echo "$data" | jq -r .isCrossRepository)
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "cross=$cross" >> "$GITHUB_OUTPUT"
+
+      - name: Reject fork PRs
+        if: steps.pr.outputs.cross == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
+            --body "🚫 \`/rebase\` can't rebase a fork PR — the workflow can't push to another repo's branch. Please rebase locally.
+
+          *(Rebase bot)*"
+          exit 1
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.branch }}
+          fetch-depth: 0 # full history — rebase needs every commit
+          # TODO(token): REBASE_TOKEN must be a credential with `contents: write`
+          # (and `workflows: write` so it can also rebase conflicts inside
+          # .github/workflows/**). Options: grant the existing gusto-claude-assistant
+          # GitHub App those scopes and mint an app token here, or store a fine-grained
+          # PAT as this secret. The default GITHUB_TOKEN is intentionally NOT used —
+          # it can't force-push under branch protection or touch workflow files.
+          token: ${{ secrets.REBASE_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Rebase onto main (Claude resolves conflicts)
+        id: rebase
+        env:
+          GIT_EDITOR: "true" # accept existing commit messages non-interactively
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          set -uo pipefail
+          git config user.name "gusto-claude-assistant[bot]"
+          git config user.email "gusto-claude-assistant[bot]@users.noreply.github.com"
+
+          git fetch origin main
+
+          # First attempt. If it's clean, the loop below is skipped entirely.
+          git rebase origin/main || true
+
+          # While a rebase is in progress, hand each conflicted stop to Claude to
+          # resolve, then let the shell continue the rebase. Claude only edits files.
+          attempts=0
+          while [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; do
+            attempts=$((attempts + 1))
+            if [ "$attempts" -gt 20 ]; then
+              echo "Too many conflict rounds; aborting."
+              git rebase --abort || true
+              echo "result=too-complex" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+
+            conflicts=$(git diff --name-only --diff-filter=U)
+            if [ -n "$conflicts" ]; then
+              npx --yes @anthropic-ai/claude-code -p \
+                "You are resolving git merge conflicts during a rebase. These files contain conflict markers (<<<<<<<, =======, >>>>>>>): $conflicts. Edit each file to a single coherent resolution that preserves the intent of both sides, and remove all conflict markers. Do NOT run any git commands." \
+                --allowedTools "Edit,Read,Write,Glob,Grep" \
+                --permission-mode acceptEdits \
+                --max-turns 30
+              git add -A
+            fi
+
+            git rebase --continue || true
+          done
+
+          # Guard: if Claude left conflict markers behind, git considers the rebase
+          # "done" but the tree is broken — fail loudly instead of force-pushing it.
+          if git grep -nE '^(<{7}|>{7}) ' -- . ; then
+            echo "Unresolved conflict markers remain; refusing to push."
+            echo "result=unresolved" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          git push --force-with-lease
+          echo "result=ok" >> "$GITHUB_OUTPUT"
+
+      - name: Report success
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
+            --body "✅ Rebased \`${{ steps.pr.outputs.branch }}\` onto \`main\` and force-pushed.
+
+          *(Rebase bot)*"
+
+      - name: Report failure
+        if: failure() && steps.pr.outputs.cross != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" --repo "${{ github.repository }}" \
+            --body "⚠️ Couldn't complete the rebase automatically — likely conflicts too complex to resolve safely. Please rebase locally. See the [run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
+
+          *(Rebase bot)*"


### PR DESCRIPTION
## Summary

Two related improvements to the `@claude` GitHub automation in this repo:

1. **Whitelist verification + read-only git commands** so the tagged-`@claude` bot can actually self-verify PRs in CI instead of stalling on an unclearable Bash approval prompt.
2. **Add a `/rebase` workflow** so a PR can be rebased onto latest `main` (with conflict resolution) by commenting `/rebase` — no local pull-down required.

## Changes

### `claude.yml` — allowlist
Populate the previously-empty `claude_args` with `--allowed-tools` covering:
- `npm ci` / `npm install` (deps aren't installed by the action)
- `npm run test:*`, `lint:check`, `format:check`, `tsc`, `build`
- read-only git inspection: `git status/diff/log/show/branch/fetch/remote`

Excludes e2e/storybook/publish/release scripts on purpose. History-rewriting git ops and `.github/workflows/**` edits are intentionally **not** here — they can't be enabled via allowlist (blocked in Claude's system prompt / GitHub App permissions respectively).

### `rebase.yml` — new comment-triggered workflow
Comment **`/rebase`** on a PR → the branch rebases onto `main` and force-pushes itself, then comments the result.

- **Deterministic git, LLM only for conflicts.** The workflow owns every history-rewriting op (`rebase`, `--continue`, `push --force-with-lease`) in shell steps. Claude is invoked **only** to edit conflicted files — it never runs a git command. That separation is why this works where the tagged action can't (the action's system-prompt block governs what *Claude* runs, not what a `run:` step runs).
- **Gated** to PR comments from trusted authors (`OWNER`/`MEMBER`/`COLLABORATOR`), mirroring the `claude.yml` author gate. Fork PRs are rejected.

## ⚠️ Requires before `/rebase` works
- [ ] **`REBASE_TOKEN` secret** with `contents: write` (+ `workflows: write` for conflicts inside `.github/workflows/**`). Either grant the existing `gusto-claude-assistant` App those scopes, or add a fine-grained PAT. Currently a `TODO` stub — the default `GITHUB_TOKEN` can't force-push under branch protection or touch workflow files.
- [ ] **CODEOWNER review** from `@Gusto/dev-productivity-web` (owns `.github/workflows/**`).
- [ ] Heads-up to Security given prior precedent on Claude workflows running on GitHub-hosted runners.

## Testing
- Allowlist: validated the `claude_args` YAML collapses to the expected single CLI string.
- `/rebase`: structure mirrors the working `claude.yml` trigger; end-to-end verification is gated on the `REBASE_TOKEN` above.

---
*Posted by Claude on behalf of Steve*