### PR TITLE
feat: add @claude-local workflow for local PR automation

### DIFF
--- a/.github/scripts/claude-local/claude-pr.sh
+++ b/.github/scripts/claude-local/claude-pr.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# claude-pr.sh — run local Claude Code against a GitHub PR in an isolated worktree.
+# Usage: claude-pr.sh <pr-number> <instruction…>
+# Example: claude-pr.sh 2493 "rebase onto main and resolve any conflicts"
+set -euo pipefail
+
+PR="${1:?usage: claude-pr.sh <pr-number> <instruction…>}"; shift
+INSTRUCTION="$*"
+[ -n "${INSTRUCTION}" ] || { echo "error: no instruction given" >&2; exit 1; }
+
+command -v gh     >/dev/null || { echo "error: gh CLI not found" >&2; exit 1; }
+command -v claude >/dev/null || { echo "error: claude CLI not found" >&2; exit 1; }
+gh auth status    >/dev/null 2>&1 || { echo "error: run 'gh auth login' first" >&2; exit 1; }
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BRANCH="$(gh pr view "$PR" --json headRefName -q .headRefName)"
+WORKTREE="${REPO_ROOT}/.claude/worktrees/pr-${PR}"
+
+# git must never drop into an interactive editor in headless mode (rebase todo, merge msg)
+export GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true
+
+echo ">> fetching PR #$PR (branch: $BRANCH)"
+git -C "$REPO_ROOT" fetch origin "$BRANCH"
+git -C "$REPO_ROOT" worktree remove --force "$WORKTREE" 2>/dev/null || true
+git -C "$REPO_ROOT" worktree add "$WORKTREE" "origin/$BRANCH"
+cd "$WORKTREE"
+
+# The `claude` shim resolves node via mise from the repo's .nvmrc; make sure that
+# pinned toolchain is actually installed or the shim dies before Claude starts.
+# Idempotent: instant no-op once the version exists.
+if command -v mise >/dev/null; then
+  echo ">> ensuring pinned toolchain (mise install)…"
+  mise install
+fi
+
+read -r -d '' PROMPT <<EOF || true
+You are working on GitHub PR #$PR (branch: $BRANCH), checked out fresh in the current worktree directory.
+
+Use the gh CLI to pull any context you need — do not assume, look it up:
+  gh pr view $PR             # title, body, state, checks
+  gh pr diff $PR             # the diff
+  gh pr view $PR --comments  # review + conversation comments
+
+Requested task (from the triggering GitHub comment):
+$INSTRUCTION
+
+Work only in this worktree. Do NOT push or comment on the PR unless the task explicitly says to.
+When finished, summarize what you changed and flag anything that needs a human.
+EOF
+
+echo ">> handing off to Claude Code…"
+# Scoped allowlist (not bypassPermissions): permits git ops, gh reads, and file edits
+# without prompting, while keeping the blast radius bounded.
+claude -p "$PROMPT" \
+  --allowedTools "Bash(git:*),Bash(gh pr view:*),Bash(gh pr diff:*),Read,Edit,Grep,Glob"
+
+echo
+echo ">> done. Worktree left for inspection at: $WORKTREE"
+echo ">> remove with: git -C \"$REPO_ROOT\" worktree remove --force \"$WORKTREE\""

--- a/.github/scripts/claude-local/runner-setup.sh
+++ b/.github/scripts/claude-local/runner-setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# runner-setup.sh — one-time, per-person onboarding for @claude-local.
+# Team-agnostic: detects YOUR GitHub login and registers a runner labeled with it,
+# so @claude-local comments you make route to this machine and nobody else's.
+#
+# Usage:  REPO=Gusto/embedded-react-sdk ./runner-setup.sh
+# Requires: macOS, admin on the repo (to mint a runner registration token).
+set -euo pipefail
+
+REPO="${REPO:?set REPO, e.g. REPO=Gusto/embedded-react-sdk}"
+RUNNER_DIR="${RUNNER_DIR:-$HOME/actions-runner}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "== 1/5  Dependencies =="
+install_if_missing() { command -v "$1" >/dev/null || { echo ">> installing $1"; eval "$2"; }; }
+command -v brew   >/dev/null || { echo "error: Homebrew required (https://brew.sh)"; exit 1; }
+install_if_missing mise   "brew install mise"
+install_if_missing gh     "brew install gh"
+install_if_missing claude "curl -fsSL https://claude.ai/install.sh | bash"
+
+echo "== 2/5  Auth checks =="
+gh auth status >/dev/null 2>&1 || { echo ">> run 'gh auth login' then re-run"; exit 1; }
+LOGIN="$(gh api user -q .login)"
+echo ">> GitHub login: $LOGIN"
+echo ">> make sure you're also logged into Claude Code (run 'claude' once interactively if unsure)"
+
+echo "== 3/5  Install worker script =="
+mkdir -p "$HOME/bin"
+cp "$SCRIPT_DIR/claude-pr.sh" "$HOME/bin/claude-pr"
+chmod +x "$HOME/bin/claude-pr"
+echo ">> installed $HOME/bin/claude-pr  (ensure ~/bin is on your PATH)"
+
+echo "== 4/5  Download GitHub Actions runner =="
+mkdir -p "$RUNNER_DIR" && cd "$RUNNER_DIR"
+if [ ! -x ./run.sh ]; then
+  TAG="$(gh api repos/actions/runner/releases/latest -q .tag_name)"; VER="${TAG#v}"
+  ARCH="$(uname -m)"; [ "$ARCH" = "arm64" ] && A=arm64 || A=x64
+  curl -fsSLo runner.tar.gz "https://github.com/actions/runner/releases/download/${TAG}/actions-runner-osx-${A}-${VER}.tar.gz"
+  tar xzf runner.tar.gz && rm runner.tar.gz
+fi
+
+echo "== 5/5  Register runner labeled '$LOGIN' =="
+TOKEN="$(gh api -X POST "repos/${REPO}/actions/runners/registration-token" -q .token)"
+./config.sh --url "https://github.com/${REPO}" --token "$TOKEN" \
+  --labels "self-hosted,${LOGIN}" --name "${LOGIN}-local" --unattended --replace
+./svc.sh install && ./svc.sh start
+
+echo
+echo ">> Done. Comment '@claude-local <task>' on a PR in ${REPO} to run it here."
+echo ">> Manage the service:  (cd $RUNNER_DIR && ./svc.sh status|stop|start)"

--- a/.github/workflows/claude-local.yml
+++ b/.github/workflows/claude-local.yml
@@ -1,0 +1,39 @@
+# Progressive enhancement: runs ALONGSIDE the existing @claude cloud action.
+# @claude        -> unchanged, GitHub-hosted, reviews/comments (cannot rebase/merge)
+# @claude-local  -> routes to the COMMENTER's own machine to do what the cloud action can't
+#
+# Two layers of authorization (this is a PUBLIC repo — untrusted users can comment):
+#   1. author_association guard — only OWNER/MEMBER/COLLABORATOR can trigger a job at
+#      all. Mirrors the trusted-authors guard on the main @claude workflow (PR #2503).
+#      Blocks drive-by commenters (NONE/CONTRIBUTOR/FIRST_TIME_CONTRIBUTOR) up front.
+#   2. runner-label routing — the job targets a runner labeled with the commenter's
+#      login, so it can ONLY execute on a machine that person personally registered
+#      (see scripts/claude-local/runner-setup.sh). No allowlist of names → team-agnostic.
+name: claude-local
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  run:
+    # startsWith (not contains) so a plain @claude mention never trips this job.
+    # author_association gate keeps randos on this public repo from spawning jobs.
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '@claude-local') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: [self-hosted, '${{ github.event.comment.user.login }}']
+    # Least privilege: the relay uses each person's own local `gh` auth, not this
+    # workflow token, so the run needs nothing beyond reading the repo.
+    permissions:
+      contents: read
+    timeout-minutes: 30 # reap orphan jobs when the commenter has no runner
+    steps:
+      - name: Relay to local Claude
+        env:
+          PR: ${{ github.event.issue.number }}
+          BODY: ${{ github.event.comment.body }} # via env, never inline — avoids shell injection
+        run: |
+          INSTRUCTION="${BODY#@claude-local}"
+          ~/bin/claude-pr "$PR" "$INSTRUCTION"


### PR DESCRIPTION
## What

Adds `@claude-local` — a progressive enhancement that runs **alongside** the existing `@claude` cloud action (unchanged). Commenting `@claude-local <task>` on a PR routes the work to the **commenter's own machine**, where Claude Code runs it in an isolated git worktree.

## Why

The cloud `@claude` GitHub Action deliberately **cannot rebase, merge, or resolve conflicts**. This automates the thing we'd otherwise do by hand given that restriction: pull the PR context locally and let our own Claude Code do the rebase/conflict work.

## How it works

```
@claude-local rebase onto main   (PR comment)
        │
        ▼
claude-local.yml (GitHub) validates author + routes to runner labeled with the commenter's login
        │
        ▼
commenter's self-hosted runner  →  ~/bin/claude-pr
        │
        ▼
fetch PR → isolated worktree → mise install → claude -p (scoped tools)
```

- `.github/workflows/claude-local.yml` — cloud-side dispatcher
- `.github/scripts/claude-local/claude-pr.sh` — local worker (fetch → worktree → Claude)
- `.github/scripts/claude-local/runner-setup.sh` — one-time per-person onboarding

## Security (public repo)

Defense in depth — either layer alone stops abuse:

1. **`author_association` guard** — only `OWNER`/`MEMBER`/`COLLABORATOR` can trigger a job, mirroring the trusted-authors guard from #2503. Drive-by commenters are filtered before any job is created.
2. **Runner-label routing** — a job can only ever execute on a runner the commenter personally registered, so it can't run on anyone else's machine.

Plus least-privilege `permissions: contents: read` (the relay uses each person's own local `gh` auth, not the workflow token).

## Status: draft

Verified end-to-end locally (fetch → worktree → clean rebase → headless `claude -p` using `gh`). **Enabling it for real requires each participant to register a self-hosted runner** (managed via AIT-CPE), which is the actual gate — hence draft, for approach review first. Team setup/how-to will live in an internal doc rather than a repo README to keep it low-profile.

---
*PR opened by Claude on behalf of Steve.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
