### PR TITLE
docs: reconcile license on Apache 2.0 (SDK-1114)

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,13 @@
+# Disclaimer
+
+- **No warranty under the open source license.** The Apache License 2.0 grant in this repository carries no warranties or conditions of any kind — see [LICENSE](./LICENSE).
+
+- **Not compliance advice.** Nothing in this repository constitutes payroll, tax, legal, or compliance advice, and it does not guarantee compliance with any law or regulation. You are responsible for your own implementation and compliance obligations.
+
+- **The API and Services are separately governed.** Access to and use of the Gusto Embedded Payroll API and related Gusto services are governed by your applicable agreements with Gusto, including the [Gusto Developer Terms of Service](https://gusto.com/legal/terms/developer-terms-of-service) and the [Embedded Payroll API Policy](https://docs.gusto.com/embedded-payroll/page/api-policy). This repository's open source license covers **only the source code in this repository** and grants no rights to Gusto's API, services, or trademarks.
+
+- **Production access requires onboarding.** Running this software against live Gusto systems requires a Gusto Embedded account and credentials. Production use is subject to commercial, security, and implementation review — contact the Gusto Embedded partnerships team.
+
+- **Trademarks.** "Gusto" and the Gusto logo are trademarks of Gusto, Inc. The Apache License 2.0 grants no right to use Gusto's name or marks.
+
+- **Your agreement with Gusto controls.** Nothing in this file limits, modifies, or supersedes the terms of any written agreement between you and Gusto. Where this disclaimer and such an agreement conflict, that agreement governs.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,201 @@
-Copyright 2024 Gusto
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 ZenPayroll, Inc. dba Gusto
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -65,3 +65,9 @@ See the [SDK Dev App README](sdk-app/README.md) for full setup and usage details
   - [Off-Cycle Payroll (Bonus & Correction)](docs/workflows-overview/off-cycle-payroll.md)
   - [Dismissal Payroll](docs/workflows-overview/dismissal-payroll.md)
   - [Transition Payroll](docs/workflows-overview/transition-payroll.md)
+
+## License
+
+Licensed under the Apache License 2.0 — see [LICENSE](LICENSE). Use of the Gusto Embedded Payroll API and related Gusto services is governed separately; see [DISCLAIMER.md](DISCLAIMER.md).
+
+For the terms that apply to contributions, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "module": "./dist/index.js",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
@@ -28,7 +28,8 @@
     "dist",
     "docs/guides/endpoint-inventory.json",
     "./README.md",
-    "./CHANGELOG.md"
+    "./CHANGELOG.md",
+    "./DISCLAIMER.md"
   ],
   "scripts": {
     "build": "npm run build:clean && vite build",


### PR DESCRIPTION
## Summary

This repo declared two different licenses. `LICENSE` held MIT text and `package.json` said `"MIT"`, while `CONTRIBUTING.md` stated Apache License 2.0 and bound contributions "consistent with Section 5 of that license." Section 5 ("Submission of Contributions") is an **Apache-2.0** clause — MIT has no Section 5 — so the inbound=outbound contribution agreement rested on terms the controlling `LICENSE` file never granted. Net effect: an ambiguous license of record for a public, npm-published package.

This resolves on **Apache 2.0**, matching the sibling public repo [embedded-react-sdk-demo-app](https://github.com/Gusto/embedded-react-sdk-demo-app) so both public repos share one license and one legal entity. It also makes the existing `CONTRIBUTING.md` wording correct as written, rather than rewriting the contribution terms.

> [!IMPORTANT]
> **This is a deliberate MIT → Apache-2.0 relicense of a published package and needs repo-owner / Legal sign-off before merge.** SDK-1114 was filed as blocked on exactly that decision. See "For legal review" below.

## Changes

- **`LICENSE`** — full Apache License 2.0 text, copied byte-for-byte from the demo app's `LICENSE` (verified: identical git blob SHA `1e72ff3c`), carrying its attribution `Copyright 2026 ZenPayroll, Inc. dba Gusto`.
- **`package.json`** — `license` → `Apache-2.0` (SPDX); added `./DISCLAIMER.md` to `files` so it ships in the tarball. npm force-includes `LICENSE` on its own.
- **`DISCLAIMER.md`** (new) — adapted from the demo app's legal-reviewed disclaimer, rescoped for a production SDK: dropped its "reference implementation / illustrative and educational purposes / not production-ready" framing, and narrowed the license carve-out to the API, services, and trademarks (here the SDK *is* the repository, so the license does cover this source).
- **`README.md`** — new `## License` section. The README previously made no license statement at all.
- **`CONTRIBUTING.md`** — intentionally untouched; its Apache 2.0 + Section 5 wording is now backed by `LICENSE:130`.

## For legal review

Three points a reviewer shouldn't have to rediscover:

1. **Copyright ownership.** Only the owner can relicense. All 2,253 commits are authored by `dependabot[bot]`, `@gusto.com` addresses, or personal addresses belonging to Gusto engineers — no apparent third-party copyright holders whose consent would be needed. Worth a human confirming that read. MIT permits sublicensing, so any inbound MIT contributions can be distributed in an Apache-2.0 work regardless.
2. **Warranty language is consistent with the commercial terms.** The [Developer Terms of Service](https://gusto.com/legal/terms/developer-terms-of-service) already provide developer tools and materials on an "AS IS" and "AS AVAILABLE" basis with all faults. `DISCLAIMER.md` adds a precedence clause ("Your agreement with Gusto controls") so the notice can't be read as limiting warranties or commitments in a partner's written agreement.
3. **One interaction to confirm.** The Developer ToS restrict users from taking "any action that subject the Developer Tools to any third party terms, including but not limited to, open source software license terms." That clause governs partner conduct, and Gusto as copyright owner is free to license its own code as it chooses — so not a conflict on its face. But it's the kind of interaction that applies to the SDK in a way it never applied to the demo app's sample code, and it should be confirmed rather than assumed.

Note also that `DISCLAIMER.md` here was drafted by adaptation, not by Legal. The demo app's equivalent went through an OSS legal review ([demo-app#71](https://github.com/Gusto/embedded-react-sdk-demo-app/pull/71)); this one warrants the same.

## Impact on consumers

- Versions **`0.53.0` and earlier stay MIT on npm permanently** — npm won't retroactively relabel published tarballs, and MIT grants already made are irrevocable. Consumers can pin an older version and retain MIT terms.
- The new `license` field only reaches the registry on the **next release**. This is a `docs:` commit, so it triggers no version bump during 0.x; if the switch needs to be visible on npm promptly, pair it with a version-bumping release.
- Downstream restatements are outside this repo: `docs.gusto.com/embedded-payroll`, the developer portal, partner agreements/SOWs, and any SBOM or license-scan attestations partners hold may still say "MIT." Whoever owns those surfaces should check them.

## Related

- Jira ticket: [SDK-1114](https://gustohq.atlassian.net/browse/SDK-1114)
- Reference repo: [Gusto/embedded-react-sdk-demo-app](https://github.com/Gusto/embedded-react-sdk-demo-app)
- Prior disclaimer legal review: [demo-app#71](https://github.com/Gusto/embedded-react-sdk-demo-app/pull/71)

## Testing

No source changes, so the unit and E2E suites are unaffected. Verification was documentary:

```bash
npm run format:check
npm run docs:lint && npm run docs:lint:markdown && npm run docs:lint:spell
```

All pass (front matter 106 files, markdownlint 0 issues, cspell 0 issues). To confirm the reconciliation:

```bash
grep -rn -i "\bMIT\b" LICENSE package.json README.md CONTRIBUTING.md DISCLAIMER.md   # no matches
grep -n "Section 5\|5. Submission" LICENSE CONTRIBUTING.md                            # clause now exists in LICENSE
npm pkg get license                                                                   # "Apache-2.0"
npm pack --dry-run                                                                    # lists LICENSE + DISCLAIMER.md
```

Also worth eyeballing that `LICENSE` and `DISCLAIMER.md` render correctly on GitHub, and that GitHub's auto-detected license badge on the repo flips to Apache-2.0 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-1114]: https://gustohq.atlassian.net/browse/SDK-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ