### PR TITLE
test(e2e): quarantine contractor self-onboarding canary

### DIFF
--- a/e2e/tests/contractor/94-self-onboarding-individual-submit.spec.ts
+++ b/e2e/tests/contractor/94-self-onboarding-individual-submit.spec.ts
@@ -10,7 +10,11 @@ test.describe.serial('ContractorCanary 04 — individual self-onboarding end-to-
     })
   })
 
-  test('drives the seeded individual contractor through self-onboarding to "You\'re all set!"', async ({
+  // Quarantined: a recent demo-backend proxy regression stopped forwarding the
+  // client IP on proxied requests, so the upstream API can no longer resolve
+  // signed_by_ip_address for the W-9 sign call and rejects it with 422.
+  // Re-enable once the proxy fix ships to the demo backend.
+  test.fixme('drives the seeded individual contractor through self-onboarding to "You\'re all set!"', async ({
     page,
     scenario,
   }) => {


### PR DESCRIPTION
## Summary
- The `94-self-onboarding-individual-submit` contractor E2E canary has been failing identically on every recent CI run, across unrelated branches (including dependabot-only bumps), so this isn't test flakiness.
- Root cause: a regression in the demo-backend proxy stopped forwarding the client IP on proxied requests. The SDK's W-9 sign call intentionally sends an empty `signedByIpAddress` and relies on the proxy to supply it via a forwarded header; without that header the upstream API now rejects the sign request with a 422 (`signed_by_ip_address is invalid`), so `Continue` never enables and the canary times out.
- Marking the test `fixme` unblocks our CI while the proxy fix is prepared and rolled out separately. Re-enable once that ships.

## Test plan
- [ ] CI passes with the canary marked fixme (shows up as a distinct "fixme" entry in the Playwright report, not silently skipped)
- [ ] Re-enable this test once the demo-backend proxy fix is deployed and confirm it passes again