### PR TITLE
fix(onboarding): drop robot3 final states for step-completion signals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,14 @@ const date = normalizeToDate(existingRecord.effectiveDate)
 const wireValue = formatDateToStringDate(pickedDate)
 ```
 
+### State Machines (robot3)
+
+Multi-step components are driven by `robot3` state machines rendered through `<Flow>` (`src/components/Flow/Flow.tsx`). `Flow` re-emits every event to the upstream `onEvent` regardless of whether the local machine has a transition for it — so a parent already receives a step's completion signal without the child machine needing to transition anywhere for it.
+
+- **Guided flows** — top-level `*Flow` orchestrators driving a linear, wizard-style sequence with a real end (`OnboardingFlow`, `TimeOffFlow`) — may use a robot3 final state (`final()`, or an equivalent zero-transition `state()`) for their terminal step, since the parent app is expected to unmount the whole flow once it completes.
+- **Hub-and-spoke flows** — orchestrators the user can navigate through freely with no natural "end" — should not use a final state, since there's no terminal step to model one around.
+- **Public, standalone components with their own internal state machine** (a step component like `Compensation`, `Deductions`, or `DocumentSigner` that can also be mounted directly by a partner) must **not** model completion as a final state, guided or not. A robot3 final state has no transitions out — if the host doesn't unmount the component immediately after its completion event fires, every further interaction becomes a silent no-op while the last-rendered screen keeps looking interactive (SDK-1169). Let the completion event bubble via `onEvent` without transitioning the local machine, so a host that keeps the component mounted past completion keeps a fully working screen instead of a dead one.
+
 ### Component & Feature Conventions
 
 Durable conventions that apply SDK-wide to any component or feature:

--- a/src/components/Employee/Compensation/onboarding/Compensation.test.tsx
+++ b/src/components/Employee/Compensation/onboarding/Compensation.test.tsx
@@ -502,6 +502,38 @@ describe('Compensation', () => {
       })
     })
 
+    // Regression test for SDK-1169: after leaving and returning to a still-mounted
+    // Compensation component, "Add new job"/"Edit" silently stopped navigating.
+    // Root cause: `done` is a robot3 final state (no transitions out), so a host that
+    // doesn't unmount Compensation once `employee/compensation/done` fires is left
+    // showing a jobs list whose controls can never navigate again. The fix clears the
+    // rendered component on the DONE transition so a still-mounted host renders
+    // nothing (fails loud) instead of a dead, seemingly-interactive jobs list.
+    it('SDK-1169: renders nothing once DONE fires, rather than leaving a dead jobs list up, if the host fails to unmount', async () => {
+      const user = userEvent.setup()
+      const onEvent = vi.fn()
+
+      renderWithProviders(
+        <Compensation employeeId="employee-uuid" startDate="2024-12-24" onEvent={onEvent} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('data-view')).toBeInTheDocument()
+      })
+
+      const continueButton = screen.getByRole('button', { name: 'Continue' })
+      await user.click(continueButton)
+
+      await waitFor(() => {
+        expect(onEvent).toHaveBeenCalledWith(componentEvents.EMPLOYEE_COMPENSATION_DONE, undefined)
+      })
+
+      // The host never unmounted <Compensation>. Once DONE has fired, the jobs list —
+      // and its now-inert Add/Edit controls — must not still be on screen.
+      expect(screen.queryByTestId('data-view')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Job actions' })).not.toBeInTheDocument()
+    })
+
     it('should not show delete option for the primary job', async () => {
       const user = userEvent.setup()
 

--- a/src/components/Employee/Compensation/onboarding/Compensation.test.tsx
+++ b/src/components/Employee/Compensation/onboarding/Compensation.test.tsx
@@ -503,13 +503,14 @@ describe('Compensation', () => {
     })
 
     // Regression test for SDK-1169: after leaving and returning to a still-mounted
-    // Compensation component, "Add new job"/"Edit" silently stopped navigating.
-    // Root cause: `done` is a robot3 final state (no transitions out), so a host that
-    // doesn't unmount Compensation once `employee/compensation/done` fires is left
-    // showing a jobs list whose controls can never navigate again. The fix clears the
-    // rendered component on the DONE transition so a still-mounted host renders
-    // nothing (fails loud) instead of a dead, seemingly-interactive jobs list.
-    it('SDK-1169: renders nothing once DONE fires, rather than leaving a dead jobs list up, if the host fails to unmount', async () => {
+    // Compensation component, "Add new job"/"Edit" silently stopped navigating. Root
+    // cause: `done` was modeled as a robot3 final state (no transitions out), so a host
+    // that doesn't unmount Compensation once `employee/compensation/done` fires was
+    // left with a jobs list whose controls could never navigate again. The fix removes
+    // the terminal state entirely — Flow re-emits the DONE event to the parent
+    // regardless of whether the local machine transitions, so a host that keeps this
+    // component mounted past completion keeps a fully working jobs list instead.
+    it('SDK-1169: keeps Add new job/Edit working after DONE fires, if the host fails to unmount', async () => {
       const user = userEvent.setup()
       const onEvent = vi.fn()
 
@@ -528,10 +529,17 @@ describe('Compensation', () => {
         expect(onEvent).toHaveBeenCalledWith(componentEvents.EMPLOYEE_COMPENSATION_DONE, undefined)
       })
 
-      // The host never unmounted <Compensation>. Once DONE has fired, the jobs list —
-      // and its now-inert Add/Edit controls — must not still be on screen.
-      expect(screen.queryByTestId('data-view')).not.toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: 'Job actions' })).not.toBeInTheDocument()
+      // The host never unmounted <Compensation>. Edit must still work after DONE fires.
+      const cards = screen.getAllByTestId('data-card')
+      const nonPrimaryJobCard = cards.find(
+        card => card.textContent && card.textContent.includes('An additional job'),
+      )!
+      await user.click(within(nonPrimaryJobCard).getByRole('button', { name: 'Job actions' }))
+      await user.click(screen.getByRole('menuitem', { name: 'Edit' }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Edit job')).toBeInTheDocument()
+      })
     })
 
     it('should not show delete option for the primary job', async () => {

--- a/src/components/Employee/Compensation/onboarding/compensationStateMachine.test.ts
+++ b/src/components/Employee/Compensation/onboarding/compensationStateMachine.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { createMachine, interpret, type SendFunction } from 'robot3'
+import { compensationStateMachine } from './compensationStateMachine'
+import type { CompensationFlowContextInterface } from './CompensationFlowComponents'
+import { componentEvents } from '@/shared/constants'
+
+function createTestMachine() {
+  return createMachine(
+    'viewJobs',
+    compensationStateMachine,
+    (initialContext: CompensationFlowContextInterface) => ({
+      ...initialContext,
+      component: () => null,
+      employeeId: 'test-employee',
+      startDate: '2024-12-24',
+      currentJobId: null,
+    }),
+  )
+}
+
+function createService() {
+  const machine = createTestMachine()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return interpret(machine, () => {}, {} as any)
+}
+
+function send(service: ReturnType<typeof createService>, type: string, payload?: unknown) {
+  ;(service.send as SendFunction<string>)({ type, payload })
+}
+
+describe('compensationStateMachine', () => {
+  it('reaches the final done state on EMPLOYEE_COMPENSATION_DONE from viewJobs', () => {
+    const service = createService()
+
+    send(service, componentEvents.EMPLOYEE_COMPENSATION_DONE)
+
+    expect(service.machine.current).toBe('done')
+  })
+
+  // Regression test for SDK-1169: Add new job/Edit silently stopped navigating after
+  // leaving and returning to a still-mounted Compensation component. Root cause:
+  // `done` is a robot3 final state (no transitions out), so if the host doesn't
+  // unmount Compensation once EMPLOYEE_COMPENSATION_DONE fires, every subsequent
+  // event is a documented robot3 no-op and the machine can never advance.
+  it('SDK-1169: drops EMPLOYEE_JOB_ADD/EMPLOYEE_JOB_EDIT once DONE has fired, if the machine keeps running', () => {
+    const service = createService()
+
+    send(service, componentEvents.EMPLOYEE_JOB_ADD)
+    expect(service.machine.current).toBe('editJob')
+
+    send(service, componentEvents.EMPLOYEE_COMPENSATION_RETURN_TO_LIST)
+    expect(service.machine.current).toBe('viewJobs')
+
+    send(service, componentEvents.EMPLOYEE_COMPENSATION_DONE)
+    expect(service.machine.current).toBe('done')
+
+    send(service, componentEvents.EMPLOYEE_JOB_ADD)
+    expect(service.machine.current).toBe('done')
+
+    send(service, componentEvents.EMPLOYEE_JOB_EDIT, { uuid: 'job-2' })
+    expect(service.machine.current).toBe('done')
+  })
+
+  it('SDK-1169: clears the rendered component once DONE fires, so a still-mounted host renders nothing rather than a dead jobs list', () => {
+    const service = createService()
+
+    send(service, componentEvents.EMPLOYEE_COMPENSATION_DONE)
+
+    expect(service.machine.current).toBe('done')
+    expect(service.context.component).toBeNull()
+  })
+})

--- a/src/components/Employee/Compensation/onboarding/compensationStateMachine.test.ts
+++ b/src/components/Employee/Compensation/onboarding/compensationStateMachine.test.ts
@@ -29,21 +29,17 @@ function send(service: ReturnType<typeof createService>, type: string, payload?:
 }
 
 describe('compensationStateMachine', () => {
-  it('reaches the final done state on EMPLOYEE_COMPENSATION_DONE from viewJobs', () => {
+  // Regression test for SDK-1169: Add new job/Edit silently stopped navigating after
+  // leaving and returning to a still-mounted Compensation component. `done` used to be
+  // a robot3 final state (no transitions out), so once EMPLOYEE_COMPENSATION_DONE
+  // fired, every subsequent event was a documented robot3 no-op and the machine could
+  // never advance. EMPLOYEE_COMPENSATION_DONE now has no transition at all: the
+  // machine stays in `viewJobs`, and Flow re-emits the event to the parent regardless.
+  it('SDK-1169: keeps handling EMPLOYEE_JOB_ADD/EMPLOYEE_JOB_EDIT after DONE fires', () => {
     const service = createService()
 
     send(service, componentEvents.EMPLOYEE_COMPENSATION_DONE)
-
-    expect(service.machine.current).toBe('done')
-  })
-
-  // Regression test for SDK-1169: Add new job/Edit silently stopped navigating after
-  // leaving and returning to a still-mounted Compensation component. Root cause:
-  // `done` is a robot3 final state (no transitions out), so if the host doesn't
-  // unmount Compensation once EMPLOYEE_COMPENSATION_DONE fires, every subsequent
-  // event is a documented robot3 no-op and the machine can never advance.
-  it('SDK-1169: drops EMPLOYEE_JOB_ADD/EMPLOYEE_JOB_EDIT once DONE has fired, if the machine keeps running', () => {
-    const service = createService()
+    expect(service.machine.current).toBe('viewJobs')
 
     send(service, componentEvents.EMPLOYEE_JOB_ADD)
     expect(service.machine.current).toBe('editJob')
@@ -52,21 +48,10 @@ describe('compensationStateMachine', () => {
     expect(service.machine.current).toBe('viewJobs')
 
     send(service, componentEvents.EMPLOYEE_COMPENSATION_DONE)
-    expect(service.machine.current).toBe('done')
-
-    send(service, componentEvents.EMPLOYEE_JOB_ADD)
-    expect(service.machine.current).toBe('done')
+    expect(service.machine.current).toBe('viewJobs')
 
     send(service, componentEvents.EMPLOYEE_JOB_EDIT, { uuid: 'job-2' })
-    expect(service.machine.current).toBe('done')
-  })
-
-  it('SDK-1169: clears the rendered component once DONE fires, so a still-mounted host renders nothing rather than a dead jobs list', () => {
-    const service = createService()
-
-    send(service, componentEvents.EMPLOYEE_COMPENSATION_DONE)
-
-    expect(service.machine.current).toBe('done')
-    expect(service.context.component).toBeNull()
+    expect(service.machine.current).toBe('editJob')
+    expect(service.context.currentJobId).toBe('job-2')
   })
 })

--- a/src/components/Employee/Compensation/onboarding/compensationStateMachine.ts
+++ b/src/components/Employee/Compensation/onboarding/compensationStateMachine.ts
@@ -1,4 +1,4 @@
-import { reduce, state, state as final, transition } from 'robot3'
+import { reduce, state, transition } from 'robot3'
 import {
   EditCompensationContextual,
   JobsListContextual,
@@ -8,17 +8,20 @@ import {
 import { componentEvents } from '@/shared/constants'
 import type { MachineEventType, MachineTransition } from '@/types/Helpers'
 
-/** @internal */
+/**
+ * `EMPLOYEE_COMPENSATION_DONE` deliberately has no transition out of `initialEditJob` or
+ * `viewJobs`. `Flow` re-emits every event to the upstream `onEvent` regardless of whether the
+ * local machine has a matching transition, so the parent flow still advances/unmounts this
+ * component on that signal. Modeling completion as a robot3 final state instead left `component`
+ * pointing at a step whose controls could never fire another transition — if a host doesn't
+ * unmount immediately, the screen would look interactive but be permanently dead (SDK-1169).
+ * Staying put means a host that keeps this component mounted past completion keeps a fully
+ * working jobs list instead.
+ *
+ * @internal
+ */
 export const compensationStateMachine = {
   initialEditJob: state<MachineTransition>(
-    transition(
-      componentEvents.EMPLOYEE_COMPENSATION_DONE,
-      'done',
-      reduce((ctx: CompensationFlowContextInterface): CompensationFlowContextInterface => ({
-        ...ctx,
-        component: null,
-      })),
-    ),
     transition(
       componentEvents.EMPLOYEE_COMPENSATION_RETURN_TO_LIST,
       'viewJobs',
@@ -53,14 +56,6 @@ export const compensationStateMachine = {
         }),
       ),
     ),
-    transition(
-      componentEvents.EMPLOYEE_COMPENSATION_DONE,
-      'done',
-      reduce((ctx: CompensationFlowContextInterface): CompensationFlowContextInterface => ({
-        ...ctx,
-        component: null,
-      })),
-    ),
   ),
   editJob: state<MachineTransition>(
     transition(
@@ -82,5 +77,4 @@ export const compensationStateMachine = {
       })),
     ),
   ),
-  done: final(),
 }

--- a/src/components/Employee/Compensation/onboarding/compensationStateMachine.ts
+++ b/src/components/Employee/Compensation/onboarding/compensationStateMachine.ts
@@ -11,7 +11,14 @@ import type { MachineEventType, MachineTransition } from '@/types/Helpers'
 /** @internal */
 export const compensationStateMachine = {
   initialEditJob: state<MachineTransition>(
-    transition(componentEvents.EMPLOYEE_COMPENSATION_DONE, 'done'),
+    transition(
+      componentEvents.EMPLOYEE_COMPENSATION_DONE,
+      'done',
+      reduce((ctx: CompensationFlowContextInterface): CompensationFlowContextInterface => ({
+        ...ctx,
+        component: null,
+      })),
+    ),
     transition(
       componentEvents.EMPLOYEE_COMPENSATION_RETURN_TO_LIST,
       'viewJobs',
@@ -46,7 +53,14 @@ export const compensationStateMachine = {
         }),
       ),
     ),
-    transition(componentEvents.EMPLOYEE_COMPENSATION_DONE, 'done'),
+    transition(
+      componentEvents.EMPLOYEE_COMPENSATION_DONE,
+      'done',
+      reduce((ctx: CompensationFlowContextInterface): CompensationFlowContextInterface => ({
+        ...ctx,
+        component: null,
+      })),
+    ),
   ),
   editJob: state<MachineTransition>(
     transition(

--- a/src/components/Employee/Deductions/onboarding/stateMachine.test.ts
+++ b/src/components/Employee/Deductions/onboarding/stateMachine.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { createMachine, interpret, type SendFunction } from 'robot3'
+import { deductionsMachine } from './stateMachine'
+import type { DeductionsContextInterface } from './deductionsContextualComponents'
+import { componentEvents } from '@/shared/constants'
+
+function createTestMachine() {
+  return createMachine('list', deductionsMachine, (initialContext: DeductionsContextInterface) => ({
+    ...initialContext,
+    component: () => null,
+    employeeId: 'test-employee',
+  }))
+}
+
+function createService() {
+  const machine = createTestMachine()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return interpret(machine, () => {}, {} as any)
+}
+
+function send(service: ReturnType<typeof createService>, type: string, payload?: unknown) {
+  ;(service.send as SendFunction<string>)({ type, payload })
+}
+
+describe('deductionsMachine', () => {
+  // Regression test for SDK-1169: `done` used to be a robot3 final state (no
+  // transitions out) reached from `list` on EMPLOYEE_DEDUCTION_DONE. A host that kept
+  // this component mounted past that signal was left with a deductions list whose
+  // Add/Edit controls could never fire another transition. EMPLOYEE_DEDUCTION_DONE now
+  // has no transition at all: the machine stays in `list`, and Flow re-emits the event
+  // to the parent regardless.
+  it('SDK-1169: keeps handling EMPLOYEE_DEDUCTION_ADD/EMPLOYEE_DEDUCTION_EDIT after DONE fires', () => {
+    const service = createService()
+
+    send(service, componentEvents.EMPLOYEE_DEDUCTION_DONE)
+    expect(service.machine.current).toBe('list')
+
+    send(service, componentEvents.EMPLOYEE_DEDUCTION_ADD)
+    expect(service.machine.current).toBe('form')
+
+    send(service, componentEvents.EMPLOYEE_DEDUCTION_CANCEL)
+    expect(service.machine.current).toBe('list')
+
+    send(service, componentEvents.EMPLOYEE_DEDUCTION_DONE)
+    expect(service.machine.current).toBe('list')
+
+    send(service, componentEvents.EMPLOYEE_DEDUCTION_EDIT, { uuid: 'deduction-2' })
+    expect(service.machine.current).toBe('form')
+    expect(service.context.editingDeductionId).toBe('deduction-2')
+  })
+})

--- a/src/components/Employee/Deductions/onboarding/stateMachine.ts
+++ b/src/components/Employee/Deductions/onboarding/stateMachine.ts
@@ -1,4 +1,4 @@
-import { state, transition, reduce, state as final } from 'robot3'
+import { state, transition, reduce } from 'robot3'
 import type { DeductionsContextInterface, EventPayloads } from './deductionsContextualComponents'
 import {
   DeductionsListContextual,
@@ -7,7 +7,18 @@ import {
 import { componentEvents } from '@/shared/constants'
 import type { MachineEventType, MachineTransition } from '@/types/Helpers'
 
-/** @internal */
+/**
+ * `EMPLOYEE_DEDUCTION_DONE` deliberately has no transition out of `list`. `Flow` re-emits every
+ * event to the upstream `onEvent` regardless of whether the local machine has a matching
+ * transition, so the parent flow still advances/unmounts this component on that signal. Modeling
+ * completion as a robot3 final state instead left `component` pointing at a step whose controls
+ * could never fire another transition — if a host doesn't unmount immediately, the screen would
+ * look interactive but be permanently dead (see SDK-1169, the same bug in
+ * `Compensation`'s onboarding machine). Staying in `list` means a host that keeps this component
+ * mounted past completion keeps a fully working deductions list instead.
+ *
+ * @internal
+ */
 export const deductionsMachine = {
   list: state<MachineTransition>(
     transition(
@@ -33,7 +44,6 @@ export const deductionsMachine = {
         }),
       ),
     ),
-    transition(componentEvents.EMPLOYEE_DEDUCTION_DONE, 'done'),
   ),
   form: state<MachineTransition>(
     transition(
@@ -73,5 +83,4 @@ export const deductionsMachine = {
       })),
     ),
   ),
-  done: final(),
 }

--- a/src/components/Employee/Documents/onboarding/DocumentSigner/stateMachine.test.ts
+++ b/src/components/Employee/Documents/onboarding/DocumentSigner/stateMachine.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { createMachine, interpret, type SendFunction } from 'robot3'
+import { documentSignerMachine } from './stateMachine'
+import type { DocumentSignerContextInterface } from './documentSignerStateMachine'
+import { componentEvents } from '@/shared/constants'
+
+function createTestMachine() {
+  return createMachine(
+    'index',
+    documentSignerMachine,
+    (initialContext: DocumentSignerContextInterface) => ({
+      ...initialContext,
+      component: () => null,
+      employeeId: 'test-employee',
+    }),
+  )
+}
+
+function createService() {
+  const machine = createTestMachine()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return interpret(machine, () => {}, {} as any)
+}
+
+function send(service: ReturnType<typeof createService>, type: string, payload?: unknown) {
+  ;(service.send as SendFunction<string>)({ type, payload })
+}
+
+describe('documentSignerMachine', () => {
+  // Regression test for SDK-1169: `done` used to be a robot3 final state (no
+  // transitions out) reached from `index` on EMPLOYEE_FORMS_DONE. A host that kept
+  // this component mounted past that signal was left with a document list whose
+  // "view form to sign" controls could never fire another transition.
+  // EMPLOYEE_FORMS_DONE now has no transition at all: the machine stays in `index`,
+  // and Flow re-emits the event to the parent regardless.
+  it('SDK-1169: keeps handling EMPLOYEE_VIEW_FORM_TO_SIGN after DONE fires', () => {
+    const service = createService()
+
+    send(service, componentEvents.EMPLOYEE_FORMS_DONE)
+    expect(service.machine.current).toBe('index')
+
+    send(service, componentEvents.EMPLOYEE_VIEW_FORM_TO_SIGN, {
+      uuid: 'form-1',
+      name: 'some_form',
+    })
+    expect(service.machine.current).toBe('signatureForm')
+    expect(service.context.formId).toBe('form-1')
+
+    send(service, componentEvents.CANCEL)
+    expect(service.machine.current).toBe('index')
+
+    send(service, componentEvents.EMPLOYEE_FORMS_DONE)
+    expect(service.machine.current).toBe('index')
+
+    send(service, componentEvents.EMPLOYEE_VIEW_FORM_TO_SIGN, {
+      uuid: 'form-2',
+      name: 'another_form',
+    })
+    expect(service.machine.current).toBe('signatureForm')
+    expect(service.context.formId).toBe('form-2')
+  })
+})

--- a/src/components/Employee/Documents/onboarding/DocumentSigner/stateMachine.ts
+++ b/src/components/Employee/Documents/onboarding/DocumentSigner/stateMachine.ts
@@ -1,4 +1,4 @@
-import { state, transition, reduce, state as final } from 'robot3'
+import { state, transition, reduce } from 'robot3'
 import type { DocumentSignerContextInterface, EventPayloads } from './documentSignerStateMachine'
 import {
   SignatureFormContextual,
@@ -9,7 +9,18 @@ import {
 import { componentEvents, I9_FORM_NAME } from '@/shared/constants'
 import type { MachineEventType, MachineTransition } from '@/types/Helpers'
 
-/** @internal */
+/**
+ * `EMPLOYEE_FORMS_DONE` deliberately has no transition out of `index`. `Flow` re-emits every
+ * event to the upstream `onEvent` regardless of whether the local machine has a matching
+ * transition, so the parent flow still advances/unmounts this component on that signal. Modeling
+ * completion as a robot3 final state instead left `component` pointing at a step whose controls
+ * could never fire another transition — if a host doesn't unmount immediately, the screen would
+ * look interactive but be permanently dead (see SDK-1169, the same bug in
+ * `Compensation`'s onboarding machine). Staying in `index` means a host that keeps this
+ * component mounted past completion keeps a fully working document list instead.
+ *
+ * @internal
+ */
 export const documentSignerMachine = {
   employmentEligibility: state<MachineTransition>(
     transition(
@@ -48,7 +59,6 @@ export const documentSignerMachine = {
         },
       ),
     ),
-    transition(componentEvents.EMPLOYEE_FORMS_DONE, 'done'),
   ),
   signatureForm: state<MachineTransition>(
     transition(
@@ -100,5 +110,4 @@ export const documentSignerMachine = {
       ),
     ),
   ),
-  done: final(),
 }


### PR DESCRIPTION
## Summary
- Fixes SDK-1169: `EmployeeOnboarding.Compensation`'s `done` state was a robot3 final state (no transitions out). Reaching it left `context.component` pointing at the last-rendered step, so a host that doesn't unmount `Compensation` right after `employee/compensation/done` fires was left with a jobs list whose "Add new job"/"Edit" controls look interactive but silently no-op forever (final states can't process further events in robot3).
- Fix: removes the completion transition and the now-unreachable `done` state entirely, for all three components that shared this exact shape of bug — `Compensation`, `Deductions`, and `DocumentSigner`. `Flow` already re-emits every event to the upstream `onEvent` regardless of whether the local machine has a matching transition, so the parent flow still advances/unmounts on the completion event without the local machine needing to transition anywhere. A still-mounted host now keeps a fully working screen instead of a dead one.
- Adds `CLAUDE.md` guidance codifying the rule going forward: guided top-level `*Flow` orchestrators may use a robot3 final state for their terminal step, but public standalone components with their own internal state machine must not — since a host that doesn't unmount immediately after the completion event turns every further interaction into a silent no-op.
- Adds regression tests at the machine level for all three components, plus a React integration test for `Compensation` simulating a host that never unmounts.

## Demo

`sdk-app` running on main vs this branch. Go to `Compensations` or `Deductions` in _employee onboarding_, hit the continue button, and then try to do anything else.

main gets stuck; local lets you keep going. `DocumentSigner` is technically also affected but there isn't really a good state where continue is enabled _and_ there are actions still pending for you to click

https://github.com/user-attachments/assets/a6a74ecc-e2a6-4fbf-a3df-68075bf7aa1c


## Known trade-off
A still-mounted host whose "Continue"/completion control remains visible (the same buggy scenario this fixes) can fire the completion event more than once if clicked repeatedly, since the local machine no longer transitions away from that state. In the normal path, the parent already unmounts on the first event, so this only surfaces in the same edge case the fix addresses.

## Test plan
- [x] `npm run test -- --run` across the touched Compensation/Deductions/DocumentSigner suites — all passing, no regressions in existing tests
- [x] Verified the regression tests fail without the fix and pass with it
- [x] `npx eslint` + `tsc --noEmit` clean on touched files
- [x] Confirmed no `invoke()` usage anywhere in the codebase, so no parent machine depends on these components' `.final` flag for its own completion detection
- [x] Confirmed the outer `onboardingExecutionStateMachine.ts` has its own independent transitions on the completion events, untouched by this change — step advancement through the guided onboarding flow is unaffected by construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
