### PR TITLE
test: re-enable contractor self-onboarding canary

### DIFF
--- a/e2e/tests/contractor/94-self-onboarding-individual-submit.spec.ts
+++ b/e2e/tests/contractor/94-self-onboarding-individual-submit.spec.ts
@@ -10,11 +10,7 @@ test.describe.serial('ContractorCanary 04 — individual self-onboarding end-to-
     })
   })
 
-  // Quarantined: a recent demo-backend proxy regression stopped forwarding the
-  // client IP on proxied requests, so the upstream API can no longer resolve
-  // signed_by_ip_address for the W-9 sign call and rejects it with 422.
-  // Re-enable once the proxy fix ships to the demo backend.
-  test.fixme('drives the seeded individual contractor through self-onboarding to "You\'re all set!"', async ({
+  test('drives the seeded individual contractor through self-onboarding to "You\'re all set!"', async ({
     page,
     scenario,
   }) => {


### PR DESCRIPTION
Removes the fixme quarantine from 94-self-onboarding-individual-submit now that it's no longer needed.