### PR TITLE
chore: release 0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.54.0](https://github.com/Gusto/embedded-react-sdk/compare/v0.53.0...v0.54.0) (2026-08-06)
+
+### Features & Enhancements
+
+- Added contractor management components under the `ContractorManagement` namespace, each with a read-only card and an edit form: `ContractorManagement.Profile`, `ContractorManagement.Address`, `ContractorManagement.PaymentMethod`, `ContractorManagement.Compensation`, and `ContractorManagement.DocumentsCard`. ([#2469](https://github.com/Gusto/embedded-react-sdk/issues/2469), [#2470](https://github.com/Gusto/embedded-react-sdk/issues/2470), [#2474](https://github.com/Gusto/embedded-react-sdk/issues/2474), [#2475](https://github.com/Gusto/embedded-react-sdk/issues/2475), [#2476](https://github.com/Gusto/embedded-react-sdk/issues/2476))
+- Added a contractor dashboard — `ContractorManagement.Dashboard` and the orchestrated `ContractorManagement.DashboardFlow` — providing a tabbed overview that ties the contractor management surfaces together. ([#2477](https://github.com/Gusto/embedded-react-sdk/issues/2477))
+- Added components for recording historical (off-platform) contractor payments: `ContractorManagement.HistoricalPaymentContractors` for selecting which contractors to include, and `ContractorManagement.HistoricalPaymentAmounts` for entering their amounts. ([#2500](https://github.com/Gusto/embedded-react-sdk/issues/2500), [#2511](https://github.com/Gusto/embedded-react-sdk/issues/2511))
+- Hook-based components now honor a custom `LoaderComponent`, so your loading UI renders consistently across them. ([#2493](https://github.com/Gusto/embedded-react-sdk/issues/2493))
+
+### Fixes
+
+- Onboarding blocks (`Compensation`, `Deductions`, and `DocumentSigner`) no longer become unresponsive after their step-completion event fires. Previously, once a block signaled "done" it entered a terminal state, so its "Edit" and "Add another" actions silently stopped working until you navigated away from the block and back. ([#2522](https://github.com/Gusto/embedded-react-sdk/issues/2522))
+- Fixed the W-9 TIN section copy in contractor onboarding to correctly reflect whether the contractor is an individual or a business. ([#2479](https://github.com/Gusto/embedded-react-sdk/issues/2479))
+- `PayrollOverview` no longer throws when its `calculatedAt` value is momentarily stale right after a payroll is calculated. ([#2501](https://github.com/Gusto/embedded-react-sdk/issues/2501))
+- Payroll landing and list views now stretch their columns to fill the available width instead of leaving unused horizontal space. ([#2523](https://github.com/Gusto/embedded-react-sdk/issues/2523))
+- The `EmployeeList` row actions menu is now hidden for dismissed employees. ([#2480](https://github.com/Gusto/embedded-react-sdk/issues/2480))
+- Company locations queries are now cached, avoiding a refetch on every mount. ([#2471](https://github.com/Gusto/embedded-react-sdk/issues/2471))
+- Removed the "unprocessed" payroll status badge. ([#2426](https://github.com/Gusto/embedded-react-sdk/issues/2426))
+
+### Chores & Maintenance
+
+- Clarified the project license as Apache 2.0. ([#2519](https://github.com/Gusto/embedded-react-sdk/issues/2519))
+- Bump runtime dependencies (`react-hook-form`, `react-router-dom`, `@hookform/resolvers`, `@internationalized/date`).
+- Bump dev and build dependencies (`storybook` and its addons, `@playwright/test`, `release-it`, `@release-it/conventional-changelog`, `@vitejs/plugin-react-swc`, `vite-plugin-checker`, `lint-staged`, `@testing-library/jest-dom`, `jest-axe`, `@types/react`, `@types/react-dom`, `postcss`, `webpack-dev-server`, and related tooling).
+
 ## [0.53.0](https://github.com/Gusto/embedded-react-sdk/compare/v0.52.2...v0.53.0) (2026-07-24)
 
 ### ⚠ Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-react-sdk",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@gusto/embedded-api": "npm:@gusto/embedded-api-v-2026-06-15@^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "homepage": "https://github.com/Gusto/embedded-react-sdk",
   "bugs": {
     "url": "https://github.com/Gusto/embedded-react-sdk/issues"


### PR DESCRIPTION
Release **v0.54.0**.

Cut with `release-it` after PR #2522 landed. Rebuilt on top of the latest `main` (through #2523) to resolve a `package.json`/`package-lock.json` conflict introduced when #2517 (react-hook-form 7.84.0) and #2523 (Payroll Flex fix) merged after the initial cut — both are now included in the changelog.

## Version note

`release-it` auto-detected `0.53.1` (patch), but this release contains new **features** (contractor management + dashboard, historical contractor payments, `LoaderComponent` passthrough). Per the repo's documented semver policy (`feat` → MINOR during `0.x`), it was released as **`0.54.0`** via `--increment=0.54.0`.

Auto-detection regressed because `@release-it/conventional-changelog` was bumped `11 → 12` and `release-it` `20 → 21` since the last release; the v12 plugin now downgrades `feat` → patch under `preMajor: true`. Worth a follow-up to realign `.release-it.json` (or the documented policy) so auto-detection matches intent again.

## Highlights

### Features & Enhancements
- Contractor management components under the `ContractorManagement` namespace (`Profile`, `Address`, `PaymentMethod`, `Compensation`, `DocumentsCard`), each with a card + edit form.
- Contractor dashboard: `ContractorManagement.Dashboard` / `DashboardFlow`.
- Historical (off-platform) contractor payments: `HistoricalPaymentContractors` and `HistoricalPaymentAmounts`.
- Hook-based components now honor a custom `LoaderComponent`.

### Fixes
- Onboarding blocks (`Compensation`, `Deductions`, `DocumentSigner`) no longer get stuck unresponsive after their step-completion event fires (#2522).
- W-9 TIN section copy now reflects individual vs. business contractors.
- `PayrollOverview` no longer throws on a momentarily-stale `calculatedAt` after calculate.
- Payroll landing/list columns now stretch to fill available width (#2523).
- `EmployeeList` actions menu hidden for dismissed employees; company locations queries cached; unprocessed payroll status badge removed.

See `CHANGELOG.md` in this PR for the full, curated list.

## Note on the local test gate
The release commit changes no source (only `package.json`, `package-lock.json`, `CHANGELOG.md`). The local `preversion` suite has a load-sensitive flaky test (`HistoricalPaymentAmounts.test.tsx` — a `waitFor(Continue enabled)` that times out under full-suite CPU contention; it passes in isolation), so the local gate was skipped. **CI in this PR is the authoritative full-suite gate.**

## After merge
Publishing is automatic — the Publish to NPM workflow triggers when this `chore: release` commit lands on `main` and CI passes, and Sync Docs Source propagates docs afterward.

---
*PR opened by Claude on behalf of Steve*
