### PR TITLE
ci: drop Cursor cloud agent step from publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -82,32 +82,3 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Read SDK version
-        id: version
-        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-
-      # Launch a Cursor cloud agent in the demo repo to integrate the version
-      # we just published. The agent runs the demo repo's update-embedded-react-sdk
-      # skill end to end (upgrade and open a PR; the PR notifies codeowners via
-      # GitHub). jq builds the JSON body so the prompt's backticks are encoded safely.
-      - name: Launch demo-app upgrade agent
-        env:
-          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
-          SDK_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          PROMPT="Use the \`update-embedded-react-sdk\` skill to upgrade @gusto/embedded-react-sdk to ${SDK_VERSION} (just published to npm). The target version is ${SDK_VERSION}. Run the skill end to end, including opening the PR."
-          jq -n --arg prompt "$PROMPT" '{
-            prompt: { text: $prompt },
-            repos: [
-              {
-                url: "https://github.com/Gusto/embedded-react-sdk-demo-app",
-                startingRef: "main"
-              }
-            ],
-            autoCreatePR: true,
-            skipReviewerRequest: true
-          }' | curl --fail-with-body -sS https://api.cursor.com/v1/agents \
-            -H "Authorization: Bearer $CURSOR_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d @-


### PR DESCRIPTION
## What

Removes the **Launch demo-app upgrade agent** step from the NPM publish workflow, along with the **Read SDK version** step that only existed to feed it.

## Why

We are no longer on Cursor. The step fires a Cursor cloud agent via `api.cursor.com`, which now fails on every publish:

```
{"error":{"code":"plan_required","message":"Cloud Agent is not available for free users. Please upgrade to Pro."}}
```

This drops the step until we migrate the demo-app upgrade flow to Claude. The publish workflow now ends at the NPM publish step. Nothing else referenced `steps.version.outputs.version` or `CURSOR_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)