### PR TITLE
feat(SDK-1128): finish HistoricalPaymentSummary + PaymentSummaryBlock extraction

### DIFF
--- a/src/components/Contractor/Payments/HistoricalPaymentSummary/HistoricalPaymentSummary.test.tsx
+++ b/src/components/Contractor/Payments/HistoricalPaymentSummary/HistoricalPaymentSummary.test.tsx
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HttpResponse, type HttpResponseResolver } from 'msw'
+import { HistoricalPaymentSummary } from './HistoricalPaymentSummary'
+import { server } from '@/test/mocks/server'
+import { renderWithProviders } from '@/test-utils/renderWithProviders'
+import { handleGetContractorsList } from '@/test/mocks/apis/contractors'
+import {
+  handleCreateContractorPaymentGroup,
+  handlePreviewContractorPaymentGroup,
+} from '@/test/mocks/apis/contractor_payment_groups'
+import { componentEvents } from '@/shared/constants'
+
+const COMPANY_ID = 'company-123'
+const CHECK_DATE = '2026-07-15'
+
+const hourlyContractor = {
+  uuid: 'contractor-1',
+  company_uuid: COMPANY_ID,
+  wage_type: 'Hourly',
+  type: 'Individual',
+  first_name: 'Ada',
+  last_name: 'Lovelace',
+  is_active: true,
+  onboarding_status: 'onboarding_completed',
+  hourly_rate: '50.00',
+  payment_method: 'Direct Deposit',
+}
+
+const contractorPayments = [
+  {
+    contractorUuid: 'contractor-1',
+    paymentMethod: 'Historical Payment' as const,
+    hours: '10',
+    bonus: '0',
+    reimbursement: '0',
+  },
+]
+
+const previewResolver = vi.fn<HttpResponseResolver>(async ({ request }) => {
+  const requestBody = (await request.json()) as {
+    check_date?: string
+    contractor_payments?: Array<Record<string, unknown>>
+  }
+  return HttpResponse.json({
+    check_date: requestBody.check_date,
+    creation_token: 'preview-token-123',
+    contractor_payments: requestBody.contractor_payments?.map((payment, index) => ({
+      ...payment,
+      uuid: `preview-payment-${index}`,
+      wage_type: 'Hourly',
+      hourly_rate: '50.00',
+      wage_total: '500.00',
+    })),
+    totals: { amount: '500.00' },
+  })
+})
+
+const createResolver = vi.fn<HttpResponseResolver>(async ({ request }) => {
+  const requestBody = (await request.json()) as {
+    check_date?: string
+    contractor_payments?: Array<Record<string, unknown>>
+  }
+  return HttpResponse.json(
+    {
+      uuid: 'created-group-uuid',
+      check_date: requestBody.check_date,
+      contractor_payments: requestBody.contractor_payments?.map((payment, index) => ({
+        ...payment,
+        uuid: `payment-${index}`,
+        wage_type: 'Hourly',
+        hourly_rate: '50.00',
+        wage_total: '500.00',
+      })),
+      totals: { amount: '500.00' },
+    },
+    { status: 201 },
+  )
+})
+
+const renderScreen = (onEvent = vi.fn()) => {
+  server.use(
+    handleGetContractorsList(() =>
+      HttpResponse.json([hourlyContractor], {
+        headers: { 'x-total-pages': '1', 'x-total-count': '1' },
+      }),
+    ),
+    handlePreviewContractorPaymentGroup(previewResolver),
+    handleCreateContractorPaymentGroup(createResolver),
+  )
+  renderWithProviders(
+    <HistoricalPaymentSummary
+      companyId={COMPANY_ID}
+      checkDate={CHECK_DATE}
+      contractorPayments={contractorPayments}
+      onEvent={onEvent}
+    />,
+  )
+  return { onEvent }
+}
+
+describe('HistoricalPaymentSummary', () => {
+  it('previews the entered payments and renders the review screen', async () => {
+    renderScreen()
+
+    expect(await screen.findByRole('heading', { name: 'Review and submit' })).toBeInTheDocument()
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Submit historical payment' })).toBeInTheDocument()
+    expect(previewResolver).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates the payment group on submit and shows the created summary', async () => {
+    const user = userEvent.setup()
+    const { onEvent } = renderScreen()
+
+    await user.click(await screen.findByRole('button', { name: 'Submit historical payment' }))
+
+    await waitFor(() => {
+      expect(createResolver).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.getByRole('heading', { name: 'Payment summary' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument()
+
+    expect(onEvent).toHaveBeenCalledWith(
+      componentEvents.CONTRACTOR_HISTORICAL_PAYMENT_CREATED,
+      expect.objectContaining({ uuid: 'created-group-uuid' }),
+    )
+  })
+
+  it('emits exit when Done is clicked after creation', async () => {
+    const user = userEvent.setup()
+    const { onEvent } = renderScreen()
+
+    await user.click(await screen.findByRole('button', { name: 'Submit historical payment' }))
+    await user.click(await screen.findByRole('button', { name: 'Done' }))
+
+    expect(onEvent).toHaveBeenCalledWith(componentEvents.CONTRACTOR_HISTORICAL_PAYMENT_EXIT)
+  })
+})

--- a/src/components/Contractor/Payments/HistoricalPaymentSummary/HistoricalPaymentSummary.tsx
+++ b/src/components/Contractor/Payments/HistoricalPaymentSummary/HistoricalPaymentSummary.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useContractorsListSuspense } from '@gusto/embedded-api/react-query/contractorsList'
+import { useContractorPaymentGroupsPreviewMutation } from '@gusto/embedded-api/react-query/contractorPaymentGroupsPreview'
+import { useContractorPaymentGroupsCreateMutation } from '@gusto/embedded-api/react-query/contractorPaymentGroupsCreate'
+import type { ContractorPaymentGroupPreview } from '@gusto/embedded-api/models/components/contractorpaymentgrouppreview'
+import type { ContractorPaymentGroup } from '@gusto/embedded-api/models/components/contractorpaymentgroup'
+import type { PostV1CompaniesCompanyIdContractorPaymentGroupsContractorPayments as ContractorPayments } from '@gusto/embedded-api/models/operations/postv1companiescompanyidcontractorpaymentgroups'
+import { RFCDate } from '@gusto/embedded-api/types/rfcdate'
+import { PaymentSummaryBlock } from '../shared/PaymentSummaryBlock'
+import { useHistoricalPaymentSummaryDictionary } from './useFormDictionary'
+import { Flex, FlexItem, Loading } from '@/components/Common'
+import { BaseComponent, useBase, type BaseComponentInterface } from '@/components/Base'
+import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
+import { useComponentDictionary, useI18n } from '@/i18n'
+import { useDateFormatter } from '@/hooks/useDateFormatter'
+import { componentEvents } from '@/shared/constants'
+
+/**
+ * Props for {@link HistoricalPaymentSummary}.
+ *
+ * @alpha
+ */
+export interface HistoricalPaymentSummaryProps extends BaseComponentInterface<'Contractor.Payments.HistoricalPaymentSummary'> {
+  /** UUID of the company recording the historical payment. */
+  companyId: string
+  /** The check date selected on the first step, as a `YYYY-MM-DD` string. */
+  checkDate: string
+  /** The contractor payments entered on the previous step. */
+  contractorPayments: ContractorPayments[]
+}
+
+/**
+ * Final step of the historical contractor payment flow: review the entered amounts and submit.
+ *
+ * @remarks
+ * Fixed to the `Historical Payment` payment method, so there is no debit account, debit date, or
+ * wire-transfer information to review — this records that a payment already happened, it does not
+ * move money.
+ *
+ * @events
+ * | Event | Description | Data |
+ * | ----- | ----------- | ---- |
+ * | `contractor/historicalPayments/created` | The historical payment was successfully recorded. | The created contractor payment group. |
+ * | `contractor/historicalPayments/exit` | The user clicked Done after the payment was recorded. | — |
+ *
+ * @param props - See {@link HistoricalPaymentSummaryProps}.
+ * @returns The rendered review-and-submit screen.
+ * @alpha
+ */
+export function HistoricalPaymentSummary(props: HistoricalPaymentSummaryProps) {
+  return (
+    <BaseComponent {...props} componentName="Contractor.Payments.HistoricalPaymentSummary">
+      <Root {...props} />
+    </BaseComponent>
+  )
+}
+
+function Root({
+  companyId,
+  checkDate,
+  contractorPayments,
+  dictionary,
+  onEvent,
+}: HistoricalPaymentSummaryProps) {
+  useI18n('Contractor.Payments.HistoricalPaymentSummary')
+  useComponentDictionary('Contractor.Payments.HistoricalPaymentSummary', dictionary)
+  const { t } = useTranslation('Contractor.Payments.HistoricalPaymentSummary')
+  const { Heading, Text, Button, Alert } = useComponentContext()
+  const { baseSubmitHandler } = useBase()
+  const { formatLongWithYear } = useDateFormatter()
+  const paymentSummaryDictionary = useHistoricalPaymentSummaryDictionary()
+
+  const contractorIds = useMemo(
+    () => contractorPayments.map(payment => payment.contractorUuid),
+    [contractorPayments],
+  )
+  const { data: contractorList } = useContractorsListSuspense({ companyUuid: companyId })
+  const contractors = (contractorList.contractors || []).filter(contractor =>
+    contractorIds.includes(contractor.uuid),
+  )
+
+  const { mutateAsync: previewPaymentGroup } = useContractorPaymentGroupsPreviewMutation()
+  const { mutateAsync: createPaymentGroup, isPending: isCreating } =
+    useContractorPaymentGroupsCreateMutation()
+
+  const [preview, setPreview] = useState<ContractorPaymentGroupPreview | null>(null)
+  const [createdGroup, setCreatedGroup] = useState<ContractorPaymentGroup | null>(null)
+  const hasRequestedPreviewRef = useRef(false)
+
+  useEffect(() => {
+    if (hasRequestedPreviewRef.current) return
+    hasRequestedPreviewRef.current = true
+
+    void baseSubmitHandler(null, async () => {
+      const response = await previewPaymentGroup({
+        request: {
+          companyId,
+          requestBody: {
+            checkDate: new RFCDate(checkDate),
+            contractorPayments,
+          },
+        },
+      })
+      setPreview(response.contractorPaymentGroupPreview || null)
+    })
+  }, [baseSubmitHandler, companyId, checkDate, contractorPayments, previewPaymentGroup])
+
+  const handleSubmit = async () => {
+    const creationToken = preview?.creationToken
+    if (!creationToken) return
+
+    await baseSubmitHandler(null, async () => {
+      const response = await createPaymentGroup({
+        request: {
+          companyId,
+          requestBody: {
+            checkDate: new RFCDate(checkDate),
+            creationToken,
+            contractorPayments,
+          },
+        },
+      })
+      const created = response.contractorPaymentGroup || {}
+      setCreatedGroup(created)
+      onEvent(componentEvents.CONTRACTOR_HISTORICAL_PAYMENT_CREATED, created)
+    })
+  }
+
+  const handleDone = () => {
+    onEvent(componentEvents.CONTRACTOR_HISTORICAL_PAYMENT_EXIT)
+  }
+
+  if (createdGroup) {
+    return (
+      <Flex flexDirection="column" gap={24}>
+        <Alert status="success" label={t('successTitle')}>
+          <Text>
+            {t('successMessage', { count: createdGroup.contractorPayments?.length ?? 0 })}
+          </Text>
+        </Alert>
+
+        <Flex justifyContent="space-between" alignItems="flex-start">
+          <Flex flexDirection="column" gap={2}>
+            <Heading as="h2">{t('createdTitle')}</Heading>
+            <Text variant="supporting">
+              {t('createdSubtitle', { checkDate: formatLongWithYear(checkDate) })}
+            </Text>
+          </Flex>
+          <FlexItem>
+            <Button onClick={handleDone} variant="primary">
+              {t('doneCta')}
+            </Button>
+          </FlexItem>
+        </Flex>
+
+        <PaymentSummaryBlock
+          contractorPaymentGroup={createdGroup}
+          contractors={contractors}
+          showDebitColumns={false}
+          dictionary={paymentSummaryDictionary}
+        />
+      </Flex>
+    )
+  }
+
+  if (!preview) {
+    return <Loading />
+  }
+
+  return (
+    <Flex flexDirection="column" gap={24}>
+      <Flex justifyContent="space-between" alignItems="flex-start">
+        <Flex flexDirection="column" gap={2}>
+          <Heading as="h2">{t('reviewTitle')}</Heading>
+          <Text variant="supporting">
+            {t('reviewSubtitle', { checkDate: formatLongWithYear(checkDate) })}
+          </Text>
+        </Flex>
+        <FlexItem>
+          <Button onClick={handleSubmit} variant="primary" isLoading={isCreating}>
+            {t('submitCta')}
+          </Button>
+        </FlexItem>
+      </Flex>
+
+      <PaymentSummaryBlock
+        contractorPaymentGroup={preview}
+        contractors={contractors}
+        showDebitColumns={false}
+        dictionary={paymentSummaryDictionary}
+      />
+    </Flex>
+  )
+}

--- a/src/components/Contractor/Payments/HistoricalPaymentSummary/index.ts
+++ b/src/components/Contractor/Payments/HistoricalPaymentSummary/index.ts
@@ -1,0 +1,4 @@
+export {
+  HistoricalPaymentSummary,
+  type HistoricalPaymentSummaryProps,
+} from './HistoricalPaymentSummary'

--- a/src/components/Contractor/Payments/HistoricalPaymentSummary/useFormDictionary.ts
+++ b/src/components/Contractor/Payments/HistoricalPaymentSummary/useFormDictionary.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { PaymentSummaryBlockDictionary } from '../shared/PaymentSummaryBlock'
+
+/**
+ * Resolves `PaymentSummaryBlock`'s text against `HistoricalPaymentSummary`'s own
+ * `Contractor.Payments.HistoricalPaymentSummary` namespace, so partner overrides on that namespace
+ * flow into the shared block.
+ *
+ * @internal
+ */
+export function useHistoricalPaymentSummaryDictionary(): PaymentSummaryBlockDictionary {
+  const { t } = useTranslation('Contractor.Payments.HistoricalPaymentSummary')
+
+  return useMemo<PaymentSummaryBlockDictionary>(
+    () => ({
+      paymentSummaryTitle: t('paymentSummaryTitle'),
+      totalAmount: t('totalAmount'),
+      contractorPayDate: t('contractorPayDate'),
+      contractorPaymentsTitle: t('contractorPaymentsTitle'),
+      contractor: t('contractor'),
+      wageType: t('wageType'),
+      paymentMethod: t('paymentMethod'),
+      paymentMethods: {
+        directDeposit: t('paymentMethods.directDeposit'),
+        check: t('paymentMethods.check'),
+        historicalPayment: t('paymentMethods.historicalPayment'),
+      },
+      hours: t('hours'),
+      wage: t('wage'),
+      bonus: t('bonus'),
+      reimbursement: t('reimbursement'),
+      total: t('total'),
+      totalsLabel: t('totalsLabel'),
+      notAvailable: t('notAvailable'),
+    }),
+    [t],
+  )
+}

--- a/src/components/Contractor/Payments/PaymentSummary/PaymentSummaryPresentation.tsx
+++ b/src/components/Contractor/Payments/PaymentSummary/PaymentSummaryPresentation.tsx
@@ -1,20 +1,15 @@
 import { useTranslation } from 'react-i18next'
 import type { ContractorPaymentGroup } from '@gusto/embedded-api/models/components/contractorpaymentgroup'
-import type { ContractorPaymentForGroup } from '@gusto/embedded-api/models/components/contractorpaymentforgroup'
-import { useMemo } from 'react'
 import type { Contractor } from '@gusto/embedded-api/models/components/contractor'
 import type { CompanyBankAccount } from '@gusto/embedded-api/models/components/companybankaccount'
 import type { InternalAlert } from '../types'
-import { getContractorDisplayName } from '../../shared/helpers'
-import { DataView, Flex } from '@/components/Common'
+import { PaymentSummaryBlock } from '../shared/PaymentSummaryBlock'
+import { usePaymentSummaryDictionary } from './useFormDictionary'
+import { Flex } from '@/components/Common'
 import { useComponentContext } from '@/contexts/ComponentAdapter/useComponentContext'
 import { useI18n } from '@/i18n'
-import { formatHoursDisplay } from '@/components/Payroll/helpers'
-import useNumberFormatter from '@/hooks/useNumberFormatter'
 import { ConfirmWireDetails } from '@/components/Payroll/ConfirmWireDetails'
 import type { EventType } from '@/shared/constants'
-
-const ZERO_HOURS_DISPLAY = '0.000'
 
 interface PaymentSummaryPresentationProps {
   contractorPaymentGroup: ContractorPaymentGroup
@@ -41,32 +36,9 @@ export const PaymentSummaryPresentation = ({
   const { Button, Text, Heading, Alert } = useComponentContext()
   useI18n('Contractor.Payments.PaymentSummary')
   const { t } = useTranslation('Contractor.Payments.PaymentSummary')
-  const currencyFormatter = useNumberFormatter()
-
-  const formatWageType = (contractor: ContractorPaymentForGroup) => {
-    if (contractor.wageType === 'Hourly' && contractor.hourlyRate) {
-      return `Hourly ${currencyFormatter(Number(contractor.hourlyRate))}/hr`
-    }
-    return contractor.wageType
-  }
+  const dictionary = usePaymentSummaryDictionary()
 
   const contractorPayments = contractorPaymentGroup.contractorPayments || []
-
-  const totals = useMemo(() => {
-    if (contractorPayments.length === 0) {
-      return { wageAmount: 0, bonusAmount: 0, reimbursementAmount: 0, totalAmount: 0 }
-    }
-    return contractorPayments.reduce(
-      (acc, contractor) => {
-        acc.wageAmount += Number(contractor.wage || '0')
-        acc.bonusAmount += Number(contractor.bonus || '0')
-        acc.reimbursementAmount += Number(contractor.reimbursement || '0')
-        acc.totalAmount += Number(contractor.wageTotal || '0')
-        return acc
-      },
-      { wageAmount: 0, bonusAmount: 0, reimbursementAmount: 0, totalAmount: 0 },
-    )
-  }, [contractorPayments])
 
   return (
     <Flex flexDirection="column" gap={24}>
@@ -111,107 +83,12 @@ export const PaymentSummaryPresentation = ({
         </Button>
       </Flex>
 
-      {/* Payment Summary Table */}
-      <Flex flexDirection="column" gap={32}>
-        <DataView
-          columns={[
-            {
-              title: t('totalAmount'),
-              render: () => currencyFormatter(Number(contractorPaymentGroup.totals?.amount || '0')),
-            },
-            {
-              title: t('debitAmount'),
-              render: () =>
-                currencyFormatter(Number(contractorPaymentGroup.totals?.debitAmount || '0')),
-            },
-            {
-              title: t('debitAccount'),
-              render: () => bankAccount?.hiddenAccountNumber ?? t('notAvailable'),
-            },
-            {
-              title: t('debitDate'),
-              render: () => contractorPaymentGroup.debitDate || t('notAvailable'),
-            },
-            {
-              title: t('contractorPayDate'),
-              render: () => contractorPaymentGroup.checkDate || t('notAvailable'),
-            },
-          ]}
-          data={[contractorPaymentGroup]}
-          label={t('paymentSummaryTitle')}
-        />
-
-        {/* Contractor Payments Table */}
-        {contractorPayments.length > 0 && (
-          <DataView
-            columns={[
-              {
-                title: t('contractor'),
-                render: contractorPayment =>
-                  getContractorDisplayName(
-                    contractors.find(
-                      contractor => contractor.uuid === contractorPayment.contractorUuid,
-                    ),
-                  ),
-              },
-              {
-                title: t('wageType'),
-                render: contractorPayment => formatWageType(contractorPayment),
-              },
-              {
-                title: t('paymentMethod'),
-                render: contractorPayment =>
-                  contractorPayment.paymentMethod === 'Direct Deposit'
-                    ? t('paymentMethods.directDeposit')
-                    : contractorPayment.paymentMethod === 'Check'
-                      ? t('paymentMethods.check')
-                      : contractorPayment.paymentMethod || t('notAvailable'),
-              },
-              {
-                title: t('hours'),
-                justify: 'end',
-                render: contractorPayment =>
-                  contractorPayment.wageType === 'Hourly' && contractorPayment.hours
-                    ? formatHoursDisplay(parseFloat(contractorPayment.hours))
-                    : ZERO_HOURS_DISPLAY,
-              },
-              {
-                title: t('wage'),
-                justify: 'end',
-                render: contractorPayment =>
-                  currencyFormatter(Number(contractorPayment.wage || '0')),
-              },
-              {
-                title: t('bonus'),
-                justify: 'end',
-                render: contractorPayment =>
-                  currencyFormatter(Number(contractorPayment.bonus || '0')),
-              },
-              {
-                title: t('reimbursement'),
-                justify: 'end',
-                render: contractorPayment =>
-                  currencyFormatter(Number(contractorPayment.reimbursement || '0')),
-              },
-              {
-                title: t('total'),
-                justify: 'end',
-                render: contractorPayment =>
-                  currencyFormatter(Number(contractorPayment.wageTotal || '0')),
-              },
-            ]}
-            data={contractorPayments}
-            footer={() => ({
-              'column-0': t('totalsLabel'),
-              'column-4': currencyFormatter(totals.wageAmount || 0),
-              'column-5': currencyFormatter(totals.bonusAmount || 0),
-              'column-6': currencyFormatter(totals.reimbursementAmount || 0),
-              'column-7': currencyFormatter(totals.totalAmount || 0),
-            })}
-            label={t('contractorPaymentsTitle')}
-          />
-        )}
-      </Flex>
+      <PaymentSummaryBlock
+        contractorPaymentGroup={contractorPaymentGroup}
+        contractors={contractors}
+        bankAccount={bankAccount}
+        dictionary={dictionary}
+      />
     </Flex>
   )
 }

--- a/src/components/Contractor/Payments/PaymentSummary/useFormDictionary.ts
+++ b/src/components/Contractor/Payments/PaymentSummary/useFormDictionary.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { PaymentSummaryBlockDictionary } from '../shared/PaymentSummaryBlock'
+
+/**
+ * Resolves `PaymentSummaryBlock`'s text against `PaymentSummary`'s own
+ * `Contractor.Payments.PaymentSummary` namespace, so partner overrides on that namespace flow
+ * into the shared block.
+ *
+ * @internal
+ */
+export function usePaymentSummaryDictionary(): PaymentSummaryBlockDictionary {
+  const { t } = useTranslation('Contractor.Payments.PaymentSummary')
+
+  return useMemo<PaymentSummaryBlockDictionary>(
+    () => ({
+      paymentSummaryTitle: t('paymentSummaryTitle'),
+      totalAmount: t('totalAmount'),
+      debitAmount: t('debitAmount'),
+      debitAccount: t('debitAccount'),
+      debitDate: t('debitDate'),
+      contractorPayDate: t('contractorPayDate'),
+      contractorPaymentsTitle: t('contractorPaymentsTitle'),
+      contractor: t('contractor'),
+      wageType: t('wageType'),
+      paymentMethod: t('paymentMethod'),
+      paymentMethods: {
+        directDeposit: t('paymentMethods.directDeposit'),
+        check: t('paymentMethods.check'),
+        historicalPayment: t('paymentMethods.historicalPayment'),
+      },
+      hours: t('hours'),
+      wage: t('wage'),
+      bonus: t('bonus'),
+      reimbursement: t('reimbursement'),
+      total: t('total'),
+      totalsLabel: t('totalsLabel'),
+      notAvailable: t('notAvailable'),
+    }),
+    [t],
+  )
+}

--- a/src/components/Contractor/Payments/shared/PaymentSummaryBlock/PaymentSummaryBlock.tsx
+++ b/src/components/Contractor/Payments/shared/PaymentSummaryBlock/PaymentSummaryBlock.tsx
@@ -1,0 +1,238 @@
+import { useMemo } from 'react'
+import type { Contractor } from '@gusto/embedded-api/models/components/contractor'
+import type { CompanyBankAccount } from '@gusto/embedded-api/models/components/companybankaccount'
+import { getContractorDisplayName } from '../../../shared/helpers'
+import { DataView, Flex } from '@/components/Common'
+import { formatHoursDisplay } from '@/components/Payroll/helpers'
+import useNumberFormatter from '@/hooks/useNumberFormatter'
+
+const ZERO_HOURS_DISPLAY = '0.000'
+
+/**
+ * The subset of a contractor payment record `PaymentSummaryBlock` renders. Both
+ * `ContractorPaymentForGroup` (post-creation) and `ContractorPaymentForGroupPreview` (pre-creation)
+ * satisfy this structurally, so the block works for a not-yet-submitted preview and an
+ * already-created group alike.
+ *
+ * @internal
+ */
+export interface PaymentSummaryBlockContractorPayment {
+  contractorUuid?: string
+  wageType?: string
+  hourlyRate?: string
+  paymentMethod?: string
+  hours?: string
+  wage?: string
+  bonus?: string
+  reimbursement?: string
+  wageTotal?: string
+}
+
+/**
+ * The subset of a contractor payment group `PaymentSummaryBlock` renders. Both
+ * `ContractorPaymentGroup` and `ContractorPaymentGroupPreview` satisfy this structurally.
+ *
+ * @internal
+ */
+export interface PaymentSummaryBlockGroup {
+  checkDate?: string
+  debitDate?: string
+  totals?: {
+    amount?: string
+    debitAmount?: string
+  }
+  contractorPayments?: PaymentSummaryBlockContractorPayment[]
+}
+
+/**
+ * Every string `PaymentSummaryBlock` renders. There is no default copy or namespace of its own —
+ * `PaymentSummaryBlock` is `@internal`, so each caller (`PaymentSummary`, `HistoricalPaymentSummary`)
+ * must fully resolve this from its own public namespace and pass it down, rather than this
+ * component owning a namespace that would show up in the SDK's public translation types without
+ * ever being a real partner override surface.
+ *
+ * @internal
+ */
+export interface PaymentSummaryBlockDictionary {
+  paymentSummaryTitle: string
+  totalAmount: string
+  /** Required when `showDebitColumns` is `true`. */
+  debitAmount?: string
+  /** Required when `showDebitColumns` is `true`. */
+  debitAccount?: string
+  /** Required when `showDebitColumns` is `true`. */
+  debitDate?: string
+  contractorPayDate: string
+  contractorPaymentsTitle: string
+  contractor: string
+  wageType: string
+  paymentMethod: string
+  paymentMethods: {
+    directDeposit: string
+    check: string
+    historicalPayment: string
+  }
+  hours: string
+  wage: string
+  bonus: string
+  reimbursement: string
+  total: string
+  totalsLabel: string
+  notAvailable: string
+}
+
+/** @internal */
+export interface PaymentSummaryBlockProps {
+  contractorPaymentGroup: PaymentSummaryBlockGroup
+  contractors: Contractor[]
+  bankAccount?: CompanyBankAccount
+  /** Whether to show the debit amount, debit account, and debit date columns. Defaults to `true`. */
+  showDebitColumns?: boolean
+  dictionary: PaymentSummaryBlockDictionary
+}
+
+/** @internal */
+export const PaymentSummaryBlock = ({
+  contractorPaymentGroup,
+  contractors,
+  bankAccount,
+  showDebitColumns = true,
+  dictionary,
+}: PaymentSummaryBlockProps) => {
+  const currencyFormatter = useNumberFormatter()
+
+  const formatWageType = (contractor: PaymentSummaryBlockContractorPayment) => {
+    if (contractor.wageType === 'Hourly' && contractor.hourlyRate) {
+      return `Hourly ${currencyFormatter(Number(contractor.hourlyRate))}/hr`
+    }
+    return contractor.wageType
+  }
+
+  const formatPaymentMethod = (paymentMethod?: string) => {
+    switch (paymentMethod) {
+      case 'Direct Deposit':
+        return dictionary.paymentMethods.directDeposit
+      case 'Check':
+        return dictionary.paymentMethods.check
+      case 'Historical Payment':
+        return dictionary.paymentMethods.historicalPayment
+      default:
+        return paymentMethod || dictionary.notAvailable
+    }
+  }
+
+  const contractorPayments = contractorPaymentGroup.contractorPayments || []
+
+  const totals = useMemo(() => {
+    return contractorPayments.reduce(
+      (acc, contractorPayment) => {
+        acc.wageAmount += Number(contractorPayment.wage || '0')
+        acc.bonusAmount += Number(contractorPayment.bonus || '0')
+        acc.reimbursementAmount += Number(contractorPayment.reimbursement || '0')
+        acc.totalAmount += Number(contractorPayment.wageTotal || '0')
+        return acc
+      },
+      { wageAmount: 0, bonusAmount: 0, reimbursementAmount: 0, totalAmount: 0 },
+    )
+  }, [contractorPayments])
+
+  return (
+    <Flex flexDirection="column" gap={32}>
+      <DataView
+        columns={[
+          {
+            title: dictionary.totalAmount,
+            render: () => currencyFormatter(Number(contractorPaymentGroup.totals?.amount || '0')),
+          },
+          ...(showDebitColumns
+            ? [
+                {
+                  title: dictionary.debitAmount ?? '',
+                  render: () =>
+                    currencyFormatter(Number(contractorPaymentGroup.totals?.debitAmount || '0')),
+                },
+                {
+                  title: dictionary.debitAccount ?? '',
+                  render: () => bankAccount?.hiddenAccountNumber ?? dictionary.notAvailable,
+                },
+                {
+                  title: dictionary.debitDate ?? '',
+                  render: () => contractorPaymentGroup.debitDate || dictionary.notAvailable,
+                },
+              ]
+            : []),
+          {
+            title: dictionary.contractorPayDate,
+            render: () => contractorPaymentGroup.checkDate || dictionary.notAvailable,
+          },
+        ]}
+        data={[contractorPaymentGroup]}
+        label={dictionary.paymentSummaryTitle}
+      />
+
+      {contractorPayments.length > 0 && (
+        <DataView
+          columns={[
+            {
+              title: dictionary.contractor,
+              render: contractorPayment =>
+                getContractorDisplayName(
+                  contractors.find(
+                    contractor => contractor.uuid === contractorPayment.contractorUuid,
+                  ),
+                ),
+            },
+            {
+              title: dictionary.wageType,
+              render: contractorPayment => formatWageType(contractorPayment),
+            },
+            {
+              title: dictionary.paymentMethod,
+              render: contractorPayment => formatPaymentMethod(contractorPayment.paymentMethod),
+            },
+            {
+              title: dictionary.hours,
+              justify: 'end',
+              render: contractorPayment =>
+                contractorPayment.wageType === 'Hourly' && contractorPayment.hours
+                  ? formatHoursDisplay(parseFloat(contractorPayment.hours))
+                  : ZERO_HOURS_DISPLAY,
+            },
+            {
+              title: dictionary.wage,
+              justify: 'end',
+              render: contractorPayment => currencyFormatter(Number(contractorPayment.wage || '0')),
+            },
+            {
+              title: dictionary.bonus,
+              justify: 'end',
+              render: contractorPayment =>
+                currencyFormatter(Number(contractorPayment.bonus || '0')),
+            },
+            {
+              title: dictionary.reimbursement,
+              justify: 'end',
+              render: contractorPayment =>
+                currencyFormatter(Number(contractorPayment.reimbursement || '0')),
+            },
+            {
+              title: dictionary.total,
+              justify: 'end',
+              render: contractorPayment =>
+                currencyFormatter(Number(contractorPayment.wageTotal || '0')),
+            },
+          ]}
+          data={contractorPayments}
+          footer={() => ({
+            'column-0': dictionary.totalsLabel,
+            'column-4': currencyFormatter(totals.wageAmount || 0),
+            'column-5': currencyFormatter(totals.bonusAmount || 0),
+            'column-6': currencyFormatter(totals.reimbursementAmount || 0),
+            'column-7': currencyFormatter(totals.totalAmount || 0),
+          })}
+          label={dictionary.contractorPaymentsTitle}
+        />
+      )}
+    </Flex>
+  )
+}

--- a/src/components/Contractor/Payments/shared/PaymentSummaryBlock/index.ts
+++ b/src/components/Contractor/Payments/shared/PaymentSummaryBlock/index.ts
@@ -1,0 +1,7 @@
+export {
+  PaymentSummaryBlock,
+  type PaymentSummaryBlockProps,
+  type PaymentSummaryBlockDictionary,
+  type PaymentSummaryBlockGroup,
+  type PaymentSummaryBlockContractorPayment,
+} from './PaymentSummaryBlock'

--- a/src/components/Contractor/exports/contractorManagement.ts
+++ b/src/components/Contractor/exports/contractorManagement.ts
@@ -42,6 +42,10 @@ export {
 export { PaymentHistory, type PaymentHistoryProps } from '../Payments/PaymentHistory/PaymentHistory'
 export { PaymentSummary, type PaymentSummaryProps } from '../Payments/PaymentSummary'
 export {
+  HistoricalPaymentSummary,
+  type HistoricalPaymentSummaryProps,
+} from '../Payments/HistoricalPaymentSummary'
+export {
   PaymentStatement,
   type PaymentStatementProps,
 } from '../Payments/PaymentStatement/PaymentStatement'

--- a/src/i18n/en/Contractor.Payments.HistoricalPaymentSummary.json
+++ b/src/i18n/en/Contractor.Payments.HistoricalPaymentSummary.json
@@ -1,0 +1,30 @@
+{
+  "reviewTitle": "Review and submit",
+  "reviewSubtitle": "Historical payment for {{checkDate}}",
+  "submitCta": "Submit historical payment",
+  "createdTitle": "Payment summary",
+  "createdSubtitle": "Historical payment for {{checkDate}}",
+  "doneCta": "Done",
+  "successTitle": "Historical payment recorded successfully",
+  "successMessage_one": "{{count}} contractor payment has been recorded.",
+  "successMessage_other": "{{count}} contractor payments have been recorded.",
+  "paymentSummaryTitle": "Payment Summary",
+  "totalAmount": "Total Amount",
+  "contractorPayDate": "Contractor Pay Date",
+  "contractorPaymentsTitle": "Contractor Payments",
+  "contractor": "Contractor",
+  "wageType": "Wage Type",
+  "paymentMethod": "Payment Method",
+  "paymentMethods": {
+    "directDeposit": "Direct Deposit",
+    "check": "Check",
+    "historicalPayment": "Historical Payment"
+  },
+  "hours": "Hours",
+  "wage": "Wage",
+  "bonus": "Bonus",
+  "reimbursement": "Reimbursement",
+  "total": "Total",
+  "totalsLabel": "Totals",
+  "notAvailable": "N/A"
+}

--- a/src/i18n/en/Contractor.Payments.PaymentSummary.json
+++ b/src/i18n/en/Contractor.Payments.PaymentSummary.json
@@ -22,7 +22,8 @@
   "paymentMethod": "Payment Method",
   "paymentMethods": {
     "directDeposit": "Direct Deposit",
-    "check": "Check"
+    "check": "Check",
+    "historicalPayment": "Historical Payment"
   },
   "hours": "Hours",
   "wage": "Wage",

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -2890,6 +2890,8 @@ export namespace Translations {
       directDeposit: string
       /** @defaultValue `"Check"` */
       check: string
+      /** @defaultValue `"Historical Payment"` */
+      historicalPayment: string
     }
     /** @defaultValue `"Hours"` */
     hours: string

--- a/src/i18n/types.d.ts
+++ b/src/i18n/types.d.ts
@@ -55,6 +55,7 @@ export interface Resources {
   'Contractor.Payments.CreatePayment': Translations.ContractorPaymentsCreatePayment
   'Contractor.Payments.HistoricalPaymentAmounts': Translations.ContractorPaymentsHistoricalPaymentAmounts
   'Contractor.Payments.HistoricalPaymentContractors': Translations.ContractorPaymentsHistoricalPaymentContractors
+  'Contractor.Payments.HistoricalPaymentSummary': Translations.ContractorPaymentsHistoricalPaymentSummary
   'Contractor.Payments.PaymentHistory': Translations.ContractorPaymentsPaymentHistory
   'Contractor.Payments.PaymentStatement': Translations.ContractorPaymentsPaymentStatement
   'Contractor.Payments.PaymentSummary': Translations.ContractorPaymentsPaymentSummary
@@ -2750,6 +2751,63 @@ export namespace Translations {
     dateTooEarlyError: string
     /** @defaultValue `"Continue"` */
     continueButton: string
+  }
+  /** Translation keys for the `Contractor.Payments.HistoricalPaymentSummary` i18n namespace. */
+  export interface ContractorPaymentsHistoricalPaymentSummary {
+    /** @defaultValue `"Review and submit"` */
+    reviewTitle: string
+    /** @defaultValue `"Historical payment for {{checkDate}}"` */
+    reviewSubtitle: string
+    /** @defaultValue `"Submit historical payment"` */
+    submitCta: string
+    /** @defaultValue `"Payment summary"` */
+    createdTitle: string
+    /** @defaultValue `"Historical payment for {{checkDate}}"` */
+    createdSubtitle: string
+    /** @defaultValue `"Done"` */
+    doneCta: string
+    /** @defaultValue `"Historical payment recorded successfully"` */
+    successTitle: string
+    /** @defaultValue `"{{count}} contractor payment has been recorded."` */
+    successMessage_one: string
+    /** @defaultValue `"{{count}} contractor payments have been recorded."` */
+    successMessage_other: string
+    /** @defaultValue `"Payment Summary"` */
+    paymentSummaryTitle: string
+    /** @defaultValue `"Total Amount"` */
+    totalAmount: string
+    /** @defaultValue `"Contractor Pay Date"` */
+    contractorPayDate: string
+    /** @defaultValue `"Contractor Payments"` */
+    contractorPaymentsTitle: string
+    /** @defaultValue `"Contractor"` */
+    contractor: string
+    /** @defaultValue `"Wage Type"` */
+    wageType: string
+    /** @defaultValue `"Payment Method"` */
+    paymentMethod: string
+    paymentMethods: {
+      /** @defaultValue `"Direct Deposit"` */
+      directDeposit: string
+      /** @defaultValue `"Check"` */
+      check: string
+      /** @defaultValue `"Historical Payment"` */
+      historicalPayment: string
+    }
+    /** @defaultValue `"Hours"` */
+    hours: string
+    /** @defaultValue `"Wage"` */
+    wage: string
+    /** @defaultValue `"Bonus"` */
+    bonus: string
+    /** @defaultValue `"Reimbursement"` */
+    reimbursement: string
+    /** @defaultValue `"Total"` */
+    total: string
+    /** @defaultValue `"Totals"` */
+    totalsLabel: string
+    /** @defaultValue `"N/A"` */
+    notAvailable: string
   }
   /** Translation keys for the `Contractor.Payments.PaymentHistory` i18n namespace. */
   export interface ContractorPaymentsPaymentHistory {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -320,6 +320,8 @@ export const contractorHistoricalPaymentEvents = {
   CONTRACTOR_HISTORICAL_PAYMENT_CONTRACTORS_SELECTED:
     'contractor/historicalPayments/contractorsSelected',
   CONTRACTOR_HISTORICAL_PAYMENT_AMOUNTS_SUBMITTED: 'contractor/historicalPayments/amountsSubmitted',
+  CONTRACTOR_HISTORICAL_PAYMENT_CREATED: 'contractor/historicalPayments/created',
+  CONTRACTOR_HISTORICAL_PAYMENT_EXIT: 'contractor/historicalPayments/exit',
 } as const
 
 /**


### PR DESCRIPTION
## Summary
- Extracts `PaymentSummaryBlock`, an internal dictionary-driven block (same pattern as `SetPaymentAmounts`/`EditContractorPaymentPresentation`), from `PaymentSummaryPresentation`'s two `DataView` tables so they can be reused with historical copy and no debit/wire columns. `PaymentSummary`'s public props/behavior are unchanged.
- Adds `HistoricalPaymentSummary`: previews the entered contractor payments, shows a review-and-submit screen, creates the payment group on submit, and shows the created summary with a Done action. Fires `contractor/historicalPayments/created` on submit and `contractor/historicalPayments/exit` on Done.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean (one pre-existing, unrelated warning)
- [x] `npm run build` passes
- [x] `npm run test -- --run src/components/Contractor/Payments` — all passing, including new `HistoricalPaymentSummary.test.tsx` (preview → review, submit → created, done → exit)