### PR TITLE
fix(ci): use gusto-ubuntu-default runner for RC workflows

### DIFF
--- a/.github/workflows/publish-rc.yaml
+++ b/.github/workflows/publish-rc.yaml
@@ -18,7 +18,8 @@ on:
         type: string
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: gusto-ubuntu-default
     permissions:
       contents: write
       id-token: write
@@ -158,8 +159,8 @@ jobs:
 
           echo "Publishing RC version: $RC_VERSION from $REF_TYPE: $REF_NAME"
 
-          # Update package.json with RC version (disable git operations)
-          npm version $RC_VERSION --no-git-tag-version --no-git-commit-hooks
+          # Update package.json with RC version (disable git operations and lifecycle scripts)
+          npm version $RC_VERSION --no-git-tag-version --ignore-scripts
 
           # Set environment variable for later steps
           echo "RC_VERSION=$RC_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/unpublish-rc.yaml
+++ b/.github/workflows/unpublish-rc.yaml
@@ -25,7 +25,8 @@ on:
         type: string
 jobs:
   unpublish:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: gusto-ubuntu-default
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

- Switches `publish-rc` and `unpublish-rc` workflows from `ubuntu-latest` to `group: gusto-ubuntu-default`, matching the pattern used by `publish`, `prepare-release`, and all other workflows that need to access the repo
- Replaces `--no-git-commit-hooks` with `--ignore-scripts` on the `npm version` call to skip both the `preversion` (redundant test run, ~8 min wasted) and `postversion` (`git push`) lifecycle scripts

## Context

RC publish failed because `npm version` triggers the `postversion: "git push"` script in package.json, and GitHub-hosted runner IPs are blocked by Gusto's org IP allow list:

```
remote: The repository owner has an IP allow list enabled, and 57.151.130.1 is not permitted to access this repository.
```

Failed run: https://github.com/Gusto/embedded-react-sdk/actions/runs/31649904084/job/94291727024


🤖 Generated with [Claude Code](https://claude.com/claude-code)