### PR TITLE
test: add payment configs mock handler and improve transition test

### DIFF
--- a/src/components/Payroll/TransitionCreation/TransitionCreation.test.tsx
+++ b/src/components/Payroll/TransitionCreation/TransitionCreation.test.tsx
@@ -221,15 +221,12 @@ describe('TransitionCreation', () => {
 
       await user.click(screen.getByRole('button', { name: /continue/i }))
 
-      await waitFor(
-        () => {
-          expect(defaultProps.onEvent).toHaveBeenCalledWith(
-            'transition/created',
-            expect.objectContaining({ payrollUuid: 'transition-payroll-uuid-1' }),
-          )
-        },
-        { timeout: 5000 },
-      )
+      await waitFor(() => {
+        expect(defaultProps.onEvent).toHaveBeenCalledWith(
+          'transition/created',
+          expect.objectContaining({ payrollUuid: 'transition-payroll-uuid-1' }),
+        )
+      })
     })
   })
 })

--- a/src/components/Payroll/TransitionCreation/TransitionCreation.test.tsx
+++ b/src/components/Payroll/TransitionCreation/TransitionCreation.test.tsx
@@ -212,14 +212,24 @@ describe('TransitionCreation', () => {
       await user.type(within(checkDateGroup).getByRole('spinbutton', { name: /day/i }), '15')
       await user.type(within(checkDateGroup).getByRole('spinbutton', { name: /year/i }), '2026')
 
-      await user.click(screen.getByRole('button', { name: /continue/i }))
-
       await waitFor(() => {
-        expect(defaultProps.onEvent).toHaveBeenCalledWith(
-          'transition/created',
-          expect.objectContaining({ payrollUuid: 'transition-payroll-uuid-1' }),
+        expect(within(checkDateGroup).getByRole('spinbutton', { name: /year/i })).toHaveAttribute(
+          'aria-valuenow',
+          '2026',
         )
       })
+
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      await waitFor(
+        () => {
+          expect(defaultProps.onEvent).toHaveBeenCalledWith(
+            'transition/created',
+            expect.objectContaining({ payrollUuid: 'transition-payroll-uuid-1' }),
+          )
+        },
+        { timeout: 5000 },
+      )
     })
   })
 })

--- a/src/test/mocks/apis/company.ts
+++ b/src/test/mocks/apis/company.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw'
 import { API_BASE_URL } from '@/test/constants'
+import { getFixture } from '@/test/mocks/fixtures/getFixture'
 
 export const getCompany = http.get(`${API_BASE_URL}/v1/companies/:company_id`, ({ params }) =>
   HttpResponse.json({
@@ -106,6 +107,14 @@ export const getIndustrySelection = http.get(
         sic_codes: ['7371'],
       },
     }),
+)
+
+export const getPaymentConfigs = http.get(
+  `${API_BASE_URL}/v1/companies/:company_uuid/payment_configs`,
+  async () => {
+    const responseFixture = await getFixture('get-v1-companies-company_uuid-payment_configs')
+    return HttpResponse.json(responseFixture)
+  },
 )
 
 export const updateIndustrySelection = http.put(

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -32,6 +32,7 @@ import {
   getCompany,
   getCompanyOnboardingStatus,
   getIndustrySelection,
+  getPaymentConfigs,
   updateIndustrySelection,
 } from './apis/company'
 import { getEmployeeFederalTaxes, updateEmployeeFederalTaxes } from './apis/employee_federal_taxes'
@@ -42,6 +43,7 @@ export const handlers = [
   getCompany,
   getCompanyOnboardingStatus,
   getIndustrySelection,
+  getPaymentConfigs,
   updateIndustrySelection,
   ...EmployeeHandlers,
   getEmployeeOnboardingStatus,


### PR DESCRIPTION
## Summary

Adds mock API handler for the payment configs endpoint and improves test reliability in the TransitionCreation component by adding an explicit wait for year input value synchronization.

## Changes

- Added `getPaymentConfigs` mock handler for `GET /v1/companies/:company_uuid/payment_configs` endpoint that loads response data from a fixture file
- Registered the new handler in the mock handlers list
- Added `waitFor` assertion in TransitionCreation test to ensure the year spinbutton value is synchronized before proceeding with form submission

## Testing

Existing tests pass. The new mock handler is automatically used by tests that call the payment configs endpoint via the mock service worker setup. The TransitionCreation test improvement ensures the year input has the expected value before the continue button is clicked, reducing flakiness from timing issues.

https://claude.ai/code/session_0115RDitt4U8ajpBnBNd8W8o