### PR TITLE
feat: add signatoryId prop to company OnboardingFlow

### DIFF
--- a/.reports/embedded-react-sdk.api.md
+++ b/.reports/embedded-react-sdk.api.md
@@ -3928,6 +3928,7 @@ interface OnboardingFlowProps extends BaseComponentInterface<never> {
 interface OnboardingFlowProps_2 extends BaseComponentInterface<never> {
     companyId: string;
     defaultValues?: RequireAtLeastOne<OnboardingFlowDefaultValues>;
+    signatoryId?: string;
 }
 
 // @public

--- a/docs/reference/company/onboarding/onboarding-flow.md
+++ b/docs/reference/company/onboarding/onboarding-flow.md
@@ -50,6 +50,7 @@ Props for the company onboarding flow orchestrator.
 | `companyId` | `string` | The associated company identifier. |
 | `onEvent` | [`OnEventType`](../../events.md#oneventtype)\<[`EventType`](../../events.md#eventtype), `unknown`\> | Callback invoked each time the component emits an event — user interactions, successful API responses, step transitions, or errors. Receives the event type constant and an optional payload whose shape varies by event. See the [Event Handling guide](https://docs.gusto.com/embedded-payroll/docs/event-handling) and each component's event table for the full list of emitted events. |
 | `defaultValues?` | [`RequireAtLeastOne`](../../blocks.md#requireatleastone)\<[`OnboardingFlowDefaultValues`](blocks.md#onboardingflowdefaultvalues)\> | Default values applied to individual flow step components (federal taxes, pay schedule). |
+| `signatoryId?` | `string` | ID of the signatory. Forwarded to the document-signing step. When set and it matches the company's current signatory, the SDK treats the user as the signatory: form fields are pre-populated and document signing is enabled. |
 
 _Inherits `children`, `className`, `dictionary`, `FallbackComponent`, `LoaderComponent` from [BaseComponentInterface](../../blocks.md#basecomponentinterface)._
 

--- a/src/components/Company/OnboardingFlow/OnboardingFlow.tsx
+++ b/src/components/Company/OnboardingFlow/OnboardingFlow.tsx
@@ -70,7 +70,12 @@ export type { OnboardingFlowProps, OnboardingFlowDefaultValues } from './Onboard
  * }
  * ```
  */
-export const OnboardingFlow = ({ companyId, onEvent, defaultValues }: OnboardingFlowProps) => {
+export const OnboardingFlow = ({
+  companyId,
+  signatoryId,
+  onEvent,
+  defaultValues,
+}: OnboardingFlowProps) => {
   const onboardingFlow = useMemo(
     () =>
       createMachine(
@@ -80,10 +85,11 @@ export const OnboardingFlow = ({ companyId, onEvent, defaultValues }: Onboarding
           ...initialContext,
           component: OnboardingOverviewContextual,
           companyId,
+          signatoryId,
           defaultValues,
         }),
       ),
-    [companyId, defaultValues],
+    [companyId, signatoryId, defaultValues],
   )
   return <Flow machine={onboardingFlow} onEvent={onEvent} />
 }

--- a/src/components/Company/OnboardingFlow/OnboardingFlowComponents.tsx
+++ b/src/components/Company/OnboardingFlow/OnboardingFlowComponents.tsx
@@ -39,12 +39,20 @@ export type OnboardingFlowDefaultValues = RequireAtLeastOne<{
 export interface OnboardingFlowProps extends BaseComponentInterface<never> {
   /** The associated company identifier. */
   companyId: string
+  /**
+   * ID of the signatory. Forwarded to the document-signing step. When set and
+   * it matches the company's current signatory, the SDK treats the user as
+   * the signatory: form fields are pre-populated and document signing is
+   * enabled.
+   */
+  signatoryId?: string
   /** Default values applied to individual flow step components (federal taxes, pay schedule). */
   defaultValues?: RequireAtLeastOne<OnboardingFlowDefaultValues>
 }
 /** @internal */
 export interface OnboardingFlowContextInterface extends FlowContextInterface {
   companyId: string
+  signatoryId?: string
   defaultValues?: OnboardingFlowDefaultValues
 }
 
@@ -105,8 +113,14 @@ export function StateTaxesContextual() {
 }
 /** @internal */
 export function DocumentSignerContextual() {
-  const { companyId, onEvent } = useFlow<OnboardingFlowContextInterface>()
-  return <DocumentSigner onEvent={onEvent} companyId={ensureRequired(companyId)} />
+  const { companyId, signatoryId, onEvent } = useFlow<OnboardingFlowContextInterface>()
+  return (
+    <DocumentSigner
+      onEvent={onEvent}
+      companyId={ensureRequired(companyId)}
+      signatoryId={signatoryId}
+    />
+  )
 }
 /** @internal */
 export function OnboardingOverviewContextual() {


### PR DESCRIPTION
## Summary
- Adds optional `signatoryId` prop to `Company.OnboardingFlow`, threading it down to the `DocumentSigner` step
- Lets partners identify the current user as the signatory so the SDK can pre-populate form fields and enable document signing
- Addresses a gap where the SDK assumed any user reaching DocumentSigner could manage the signatory, with no way for partners to scope that behavior

## Context
The embedded API's signatory endpoints are gated by `signatories:manage` scope on the company token, but there's no per-user scoping. Partners who want to restrict signatory management to specific users (e.g. business owners) had no way to signal that through the SDK's onboarding flow. `DocumentSigner` already accepted `signatoryId` as a prop, but `OnboardingFlow` didn't forward it.

## Test plan
- [x] Verify `OnboardingFlow` renders normally without `signatoryId` (backwards compatible)
- [x] Verify passing `signatoryId` threads it to `DocumentSigner` and pre-populates signatory fields when it matches the company's current signatory
- [x] Type check passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*(Claude)*

https://github.com/user-attachments/assets/27dbf6dc-1e20-4cbd-ac6c-47559e3f5560


https://github.com/user-attachments/assets/eca84745-5ec3-4f59-a2a5-279b42dfc352

