### PR TITLE
chore: release 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.55.0](https://github.com/Gusto/embedded-react-sdk/compare/v0.54.1...v0.55.0) (2026-08-13)
+
+### Features & Enhancements
+
+- Add optional `signatoryId` prop to `Company.OnboardingFlow`, forwarded to the document-signing step. When set and matching the company's current signatory, the SDK pre-populates form fields and enables document signing. ([#2561](https://github.com/Gusto/embedded-react-sdk/issues/2561))
+
+### Chores & Maintenance
+
+- Bump dev dependencies (`release-it`, `@testing-library/jest-dom`)
+
 ## [0.54.1](https://github.com/Gusto/embedded-react-sdk/compare/v0.54.0...v0.54.1) (2026-08-13)
 
 - drop Cursor cloud agent step from publish workflow ([#2530](https://github.com/Gusto/embedded-react-sdk/issues/2530)) ([9fe07f1](https://github.com/Gusto/embedded-react-sdk/commit/9fe07f1c9517f85cd45238e8e5fa6cef48309588))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.54.1",
+  "version": "0.55.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gusto/embedded-react-sdk",
-      "version": "0.54.1",
+      "version": "0.55.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@gusto/embedded-api": "npm:@gusto/embedded-api-v-2026-06-15@^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/embedded-react-sdk",
-  "version": "0.54.1",
+  "version": "0.55.0",
   "homepage": "https://github.com/Gusto/embedded-react-sdk",
   "bugs": {
     "url": "https://github.com/Gusto/embedded-react-sdk/issues"


### PR DESCRIPTION
Automated release PR for v0.55.0. Review the changelog and merge to publish.

## Changelog

### Features & Enhancements

- Add optional `signatoryId` prop to `Company.OnboardingFlow`, forwarded to the document-signing step. When set and matching the company's current signatory, the SDK pre-populates form fields and enables document signing. ([#2561](https://github.com/Gusto/embedded-react-sdk/issues/2561))

### Chores & Maintenance

- Bump dev dependencies (`release-it`, `@testing-library/jest-dom`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcMup7PL6HBdpQ2eB6iBt4)_