### PR TITLE
fix: remove duplicate compensationRateFormats key in en/common.json

### DIFF
--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -85,27 +85,6 @@
     "yearly": "{{amount}} per year",
     "paycheck": "{{amount}} per paycheck"
   },
-  "compensationRateFormats": {
-    "hourly": "{{amount}} per hour",
-    "weekly": "{{amount}} per week",
-    "monthly": "{{amount}} per month",
-    "yearly": "{{amount}} per year",
-    "paycheck": "{{amount}} per paycheck"
-  },
-  "compensationRateFormats": {
-    "hourly": "{{amount}} per hour",
-    "weekly": "{{amount}} per week",
-    "monthly": "{{amount}} per month",
-    "yearly": "{{amount}} per year",
-    "paycheck": "{{amount}} per paycheck"
-  },
-  "compensationRateFormats": {
-    "hourly": "{{amount}} per hour",
-    "weekly": "{{amount}} per week",
-    "monthly": "{{amount}} per month",
-    "yearly": "{{amount}} per year",
-    "paycheck": "{{amount}} per paycheck"
-  },
   "validations": {
     "accountName": "Account name is required",
     "routingNumber": "Routing number should be a number (9 digits)",


### PR DESCRIPTION
## Summary

`en/common.json` defined `compensationRateFormats` four times. JSON object literals silently collapse duplicate keys to the last occurrence, so the first three copies were dead weight.

## Changes

- Removed the three redundant `compensationRateFormats` blocks, keeping a single definition

## Testing

- Verified no other locale's `common.json` has the same duplication (`grep -c '"compensationRateFormats"' src/i18n/*/common.json`)