### PR TITLE
chore: use conventional-commit title for Lokalise PRs

### DIFF
--- a/.github/workflows/pull-translations.yaml
+++ b/.github/workflows/pull-translations.yaml
@@ -16,3 +16,4 @@ jobs:
           lokalise_api_token: ${{ secrets.LOKALISE_API_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           file_format: json
+          pr_title: 'chore: sync translations from Lokalise'


### PR DESCRIPTION
Our "Validate PR Title" check (commitlint) requires a conventional-commit format title. `pull_translations`'s default title (`[Lokalise] New translation available`) has no `type:` prefix and fails that check, which is what's blocking #2570 from merging.

Passes `pr_title: 'chore: sync translations from Lokalise'` explicitly, using the new input added in Gusto/embedded-i18n-actions#42.

**Depends on** Gusto/embedded-i18n-actions#42 merging first — until then, `pr_title` is an unrecognized input for the `@main` ref (harmless warning, no failure) and the workflow falls back to the old non-conventional title.